### PR TITLE
Updates for JRuby

### DIFF
--- a/ext/puma_http11/PumaHttp11Service.java
+++ b/ext/puma_http11/PumaHttp11Service.java
@@ -3,9 +3,9 @@ import java.io.IOException;
 import org.jruby.Ruby;
 import org.jruby.runtime.load.BasicLibraryService;
 
-import org.jruby.mongrel.Http11;
+import org.jruby.puma.Http11;
 
-public class Http11Service implements BasicLibraryService { 
+public class PumaHttp11Service implements BasicLibraryService { 
     public boolean basicLoad(final Ruby runtime) throws IOException {
         Http11.createHttp11(runtime);
         return true;

--- a/ext/puma_http11/http11_parser.java.rl
+++ b/ext/puma_http11/http11_parser.java.rl
@@ -1,4 +1,4 @@
-package org.jruby.mongrel;
+package org.jruby.puma;
 
 import org.jruby.util.ByteList;
 

--- a/ext/puma_http11/org/jruby/puma/Http11.java
+++ b/ext/puma_http11/org/jruby/puma/Http11.java
@@ -1,4 +1,4 @@
-package org.jruby.mongrel;
+package org.jruby.puma;
 
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
@@ -45,21 +45,22 @@ public class Http11 extends RubyObject {
     };
 
     public static void createHttp11(Ruby runtime) {
-        RubyModule mMongrel = runtime.defineModule("Mongrel");
-        mMongrel.defineClassUnder("HttpParserError",runtime.getClass("IOError"),runtime.getClass("IOError").getAllocator());
+        RubyModule mPuma = runtime.defineModule("Puma");
+        mPuma.defineClassUnder("HttpParserError",runtime.getClass("IOError"),runtime.getClass("IOError").getAllocator());
 
-        RubyClass cHttpParser = mMongrel.defineClassUnder("HttpParser",runtime.getObject(),ALLOCATOR);
+        RubyClass cHttpParser = mPuma.defineClassUnder("HttpParser",runtime.getObject(),ALLOCATOR);
         cHttpParser.defineAnnotatedMethods(Http11.class);
     }
 
     private Ruby runtime;
     private RubyClass eHttpParserError;
     private Http11Parser hp;
+    private RubyString body;
 
     public Http11(Ruby runtime, RubyClass clazz) {
         super(runtime,clazz);
         this.runtime = runtime;
-        this.eHttpParserError = (RubyClass)runtime.getModule("Mongrel").getConstant("HttpParserError");
+        this.eHttpParserError = (RubyClass)runtime.getModule("Puma").getConstant("HttpParserError");
         this.hp = new Http11Parser();
         this.hp.parser.http_field = http_field;
         this.hp.parser.request_method = request_method;
@@ -181,9 +182,9 @@ public class Http11 extends RubyObject {
                     }
                 }
 
-                req.setInstanceVariable("@http_body", RubyString.newString(runtime, new ByteList(hp.parser.buffer, at, length)));
+                body = RubyString.newString(runtime, new ByteList(hp.parser.buffer, at, length));
                 req.op_aset(context, runtime.newString("SERVER_PROTOCOL"),runtime.newString("HTTP/1.1"));
-                req.op_aset(context, runtime.newString("SERVER_SOFTWARE"),runtime.newString("Mongrel 1.2.0.beta.1"));
+                req.op_aset(context, runtime.newString("SERVER_SOFTWARE"),runtime.newString("Puma 1.2.0.beta.1"));
             }
         };
 
@@ -237,5 +238,10 @@ public class Http11 extends RubyObject {
     @JRubyMethod
     public IRubyObject nread() {
         return runtime.newFixnum(this.hp.parser.nread);
+    }
+    
+    @JRubyMethod
+    public IRubyObject body() {
+        return body;
     }
 }// Http11

--- a/ext/puma_http11/org/jruby/puma/Http11Parser.java
+++ b/ext/puma_http11/org/jruby/puma/Http11Parser.java
@@ -1,6 +1,6 @@
 
 // line 1 "ext/http11/http11_parser.java.rl"
-package org.jruby.mongrel;
+package org.jruby.puma;
 
 import org.jruby.util.ByteList;
 

--- a/tasks/java.rake
+++ b/tasks/java.rake
@@ -3,7 +3,7 @@ if ENV['JAVA']
   require 'rake/javaextensiontask'
 
   # build http11 java extension
-  Rake::JavaExtensionTask.new('http11', HOE.spec) do |ext|
+  Rake::JavaExtensionTask.new('puma_http11', HOE.spec) do |ext|
     ext.java_compiling do |gs|
       gs.dependencies.delete gs.dependencies.find { |d| d.name == 'daemons' }
     end

--- a/tasks/native.rake
+++ b/tasks/native.rake
@@ -1,24 +1,27 @@
-# use rake-compiler for building the extension
-require 'rake/extensiontask'
-
-# build http11 C extension
-Rake::ExtensionTask.new('puma_http11', HOE.spec) do |ext|
-  # define target for extension (supporting fat binaries)
-  if RUBY_PLATFORM =~ /mingw|mswin/ then
-    RUBY_VERSION =~ /(\d+\.\d+)/
-    ext.lib_dir = "lib/#{$1}"
-  elsif ENV['CROSS']
-    # define cross-compilation tasks when not on Windows.
-    ext.cross_compile = true
-    ext.cross_platform = ['i386-mswin32', 'i386-mingw32']
-
-    ext.cross_compiling do |gs|
-      gs.dependencies.delete gs.dependencies.find { |d| d.name == 'daemons' }
+if !ENV['JAVA']
+  
+  # use rake-compiler for building the extension
+  require 'rake/extensiontask'
+  
+  # build http11 C extension
+  Rake::ExtensionTask.new('puma_http11', HOE.spec) do |ext|
+    # define target for extension (supporting fat binaries)
+    if RUBY_PLATFORM =~ /mingw|mswin/ then
+      RUBY_VERSION =~ /(\d+\.\d+)/
+      ext.lib_dir = "lib/#{$1}"
+    elsif ENV['CROSS']
+      # define cross-compilation tasks when not on Windows.
+      ext.cross_compile = true
+      ext.cross_platform = ['i386-mswin32', 'i386-mingw32']
+  
+      ext.cross_compiling do |gs|
+        gs.dependencies.delete gs.dependencies.find { |d| d.name == 'daemons' }
+      end
     end
+  
+    # cleanup versioned library directory
+    CLEAN.include 'lib/{1.8,1.9}'
   end
-
-  # cleanup versioned library directory
-  CLEAN.include 'lib/{1.8,1.9}'
 end
 
 # ensure things are built prior testing

--- a/test/test_unix_socket.rb
+++ b/test/test_unix_socket.rb
@@ -3,32 +3,35 @@ require 'puma/server'
 
 require 'socket'
 
-class TestPumaUnixSocket < Test::Unit::TestCase
-
-  App = lambda { |env| [200, {}, ["Works"]] }
-
-  Path = "test/puma.sock"
-
-  def setup
-    @server = Puma::Server.new App
-    @server.add_unix_listener Path
-    @server.run
-  end
-
-  def teardown
-    @server.stop(true)
-    File.unlink Path if File.exists? Path
-  end
-
-  def test_server
-    sock = UNIXSocket.new Path
-
-    sock << "GET / HTTP/1.0\r\nHost: blah.com\r\n\r\n"
-
-    expected = "HTTP/1.0 200 OK\r\nConnection: close\r\nContent-Length: 5\r\n\r\nWorks"
-
-    assert_equal expected, sock.read(expected.size)
-
-    sock.close
+# UNIX sockets are not recommended on JRuby
+unless defined?(JRUBY_VERSION)
+  class TestPumaUnixSocket < Test::Unit::TestCase
+  
+    App = lambda { |env| [200, {}, ["Works"]] }
+  
+    Path = "test/puma.sock"
+  
+    def setup
+      @server = Puma::Server.new App
+      @server.add_unix_listener Path
+      @server.run
+    end
+  
+    def teardown
+      @server.stop(true)
+      File.unlink Path if File.exists? Path
+    end
+  
+    def test_server
+      sock = UNIXSocket.new Path
+  
+      sock << "GET / HTTP/1.0\r\nHost: blah.com\r\n\r\n"
+  
+      expected = "HTTP/1.0 200 OK\r\nConnection: close\r\nContent-Length: 5\r\n\r\nWorks"
+  
+      assert_equal expected, sock.read(expected.size)
+  
+      sock.close
+    end
   end
 end


### PR DESCRIPTION
Attempting to get the parser, etc updated for JRuby. Two failures currently that I'm confused about...not sure if they're new or have been there for a long time. Nothing I updated would seem to cause them.

Changes so far:
- Rename Mongrel to Puma and move files appropriately
- Add HttParser11#body method
- Fix native.rake to not attempt C ext under JRuby
- Mask out all of test_unix_socket.rb under JRuby
