### PR TITLE
Support responses without entity body

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -1,3 +1,4 @@
+require 'set'
 
 module Puma
 
@@ -43,6 +44,9 @@ module Puma
     504  => 'Gateway Time-out',
     505  => 'HTTP Version not supported'
   }
+
+  # For some HTTP status codes the client only expects headers.
+  STATUS_WITH_NO_ENTITY_BODY = Set.new((100..199).to_a << 204 << 205 << 304)
 
   # Frequently used constants when constructing requests or responses.  Many times
   # the constant just refers to a string with the same contents.  Using these constants

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -337,6 +337,7 @@ module Puma
         end
 
         content_length = nil
+        no_body = STATUS_WITH_NO_ENTITY_BODY.include? status
 
         if res_body.kind_of? Array and res_body.size == 1
           content_length = res_body[0].size
@@ -391,6 +392,8 @@ module Puma
           when TRANSFER_ENCODING
             allow_chunked = false
             content_length = nil
+          when CONTENT_TYPE
+            next if no_body
           end
 
           vs.split(NEWLINE).each do |v|
@@ -399,6 +402,11 @@ module Puma
             client.write v
             client.write line_ending
           end
+        end
+
+        if no_body
+          client.write line_ending
+          return keep_alive
         end
 
         if include_keepalive_header


### PR DESCRIPTION
Some HTTP verbs imply that no body is sent with the response. Puma did not respect that.

This led to issues like this one:

```
$ curl localhost:9292
curl: (18) transfer closed with outstanding
read data remaining
```

This also breaks persistent connections.

Example program to program to provoke this issue:

```
proc do
  [204, {'Conten-Type' => 'text/plain'}, []]
end
```
