### PR TITLE
ALLOC_N uses xmalloc, so that, use xfree for free

### DIFF
--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -268,7 +268,7 @@ void HttpParser_free(void *data) {
   TRACE();
 
   if(data) {
-    free(data);
+    xfree(data);
   }
 }
 


### PR DESCRIPTION
Currently `xfree` is alias to `ruby_xfree`, which does nothing but free. But it could be changed in a future, so that everythink, which alloced with `xmalloc` (and `ALLOC_N` uses it) should be freed with xfree.
