### PR TITLE
More reliable loading of JRuby ext

### DIFF
--- a/ext/puma_http11/PumaHttp11Service.java
+++ b/ext/puma_http11/PumaHttp11Service.java
@@ -1,3 +1,5 @@
+package puma;
+
 import java.io.IOException;
         
 import org.jruby.Ruby;


### PR DESCRIPTION
I had trouble building a JRuby version of the gem from master. It appears that the puma_http11.jar file got moved at some point, and loading jar-based extensions this way is very sensitive to the path used. Because the require is now "puma/puma_http11", JRuby will look for a class named "puma.PumaHttp11Service". The current service was not in the "puma" package, so it would not load.

Since that mechanism is too path sensitive, we've started to discourage it. This patch changes how the extension is loaded to be more reliable.

I also could not figure out how to build a JRuby gem. Even in the released gem, there was no platform = "java". Perhaps I have forgotten how to build a gem with rake-compiler, but for the moment I added a puma-java.gemspec that includes only the files needed for JRuby and sets platform="java".
