### PR TITLE
Rack::Request.scheme should return https if running SSLServer

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -114,6 +114,7 @@ module Puma
         s.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
       end
       s.listen backlog
+      @proto_env[HTTPS_KEY] = HTTPS
       @ios << OpenSSL::SSL::SSLServer.new(s, ctx)
     end
 


### PR DESCRIPTION
Don't think I'm getting the right value for Rack::Request.scheme when running Puma using ssl.

To test - config.ru:

```
class Test
  def call(env)
    request = Rack::Request.new(env)
    return [200, {}, ["#{request.scheme}"]]
  end
end
run Test.new
```

Starting with: `puma -b tcp://127.0.0.1:3000 config.ru` and hitting `http://localhost:3000` returns `http`.

Starting with

```
puma -b 'ssl://127.0.0.1:3000?key=puma/puma_keypair.pem&cert=puma/cert_puma.pem' config.ru
```

and hitting `https://localhost:3000` still returns `http`.

Setting HTTPS_KEY when using ssl server returns the proper rack.url_scheme
