### PR TITLE
Fixed number of arguments in Puma::Events#unknown_error

### DIFF
--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -33,7 +33,7 @@ module Puma
     # +server+ is the Server object, +env+ the request, +error+ an exception
     # object, and +kind+ some additional info.
     #
-    def unknown_error(server, error, kind="Unknown")
+    def unknown_error(server, env, error, kind="Unknown")
       if error.respond_to? :render
         error.render "#{Time.now}: #{kind} error", @stderr
       else


### PR DESCRIPTION
The method is actually called with 4 arguments : https://github.com/puma/puma/blob/master/lib/puma/server.rb#L289
Even the documentation of it mentions the `env` argument.
