### PR TITLE
Use nil instead of empty strings when initializing proto env hash

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -62,9 +62,9 @@ module Puma
         "rack.multithread".freeze => true,
         "rack.multiprocess".freeze => false,
         "rack.run_once".freeze => true,
-        "SCRIPT_NAME".freeze => "",
-        "CONTENT_TYPE".freeze => "",
-        "QUERY_STRING".freeze => "",
+        "SCRIPT_NAME".freeze => nil,
+        "CONTENT_TYPE".freeze => nil,
+        "QUERY_STRING".freeze => nil,
         SERVER_PROTOCOL => HTTP_11,
         SERVER_SOFTWARE => PUMA_VERSION,
         GATEWAY_INTERFACE => CGI_VER


### PR DESCRIPTION
Here (and possibly elsewhere), Rack assumes that `env['CONTENT_TYPE']` won't be truthy unless it's properly set:

```
# rack-1.2.5/lib/rack/request.rb
def media_type
  content_type && content_type.split(/\s*[;,]\s*/, 2).first.downcase
end
```

Therefore if you initialize it to an empty string, you may see errors like:

```
Exception `NoMethodError' at rack-1.2.5/lib/rack/request.rb:44 - undefined method `downcase' for nil:NilClass
```
