### PR TITLE
More helpful fallback error message

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -597,7 +597,7 @@ module Puma
     # A fallback rack response if +@app+ raises as exception.
     #
     def lowlevel_error(e)
-      [500, {}, ["No application configured"]]
+      [500, {}, ["Puma caught this error:\n#{e.backtrace.join("\n")}"]]
     end
 
     # Wait for all outstanding requests to finish.


### PR DESCRIPTION
This prints

```
$ curl -i "http://localhost:9292/"
HTTP/1.1 500 Internal Server Error
Content-Length: 2004

Puma caught this error:
/Users/seamusabshere/.rvm/gems/ruby-1.9.3-p125/gems/rack-1.2.5/lib/rack/request.rb:44:in `media_type'
/Users/seamusabshere/.rvm/gems/ruby-1.9.3-p125/gems/rack-1.2.5/lib/rack/request.rb:116:in `form_data?'
/Users/seamusabshere/.rvm/gems/ruby-1.9.3-p125/gems/rack-1.2.5/lib/rack/request.rb:146:in `POST'
/Users/seamusabshere/.rvm/gems/ruby-1.9.3-p125/gems/rack-1.2.5/lib/rack/request.rb:167:in `params'
```

instead of just

```
No application configured
```
