### PR TITLE
show error.to_s along with backtrace for low-level error

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -605,7 +605,7 @@ module Puma
     # A fallback rack response if +@app+ raises as exception.
     #
     def lowlevel_error(e)
-      [500, {}, ["Puma caught this error:\n#{e.backtrace.join("\n")}"]]
+      [500, {}, ["Puma caught this error: #{e}\n#{e.backtrace.join("\n")}"]]
     end
 
     # Wait for all outstanding requests to finish.


### PR DESCRIPTION
I found knowing the error message helpful when I hit this.
