### PR TITLE
Write body to stream when not using a TempFile

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -573,10 +573,10 @@ module Puma
       if remain > MAX_BODY
         stream = Tempfile.new(Const::PUMA_TMP_BASE)
         stream.binmode
-        stream.write body
       else
         stream = StringIO.new body
       end
+      stream.write body
 
       # Read an odd sized chunk so we can read even sized ones
       # after this


### PR DESCRIPTION
Since fix #79 (and v1.2.2), puma breaks file uploads in my apps. I’ve tested with rails 3.2.3, carrierwave and devise. Every time I try to send a file via a form, all the related informations are lost and the request is transformed to a POST (instead of a PUT for example).

I just added `stream.write body` after the test as it were done before fix, without touching anything else. It now works great in my apps, and test suite is still green :)
