### PR TITLE
Updated start command for rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ First, make sure Puma is in your Gemfile:
 
 Then start your server with the `rails` command:
 
-    $ rails s puma
+    $ rails s Puma
 
 ### Rackup
 


### PR DESCRIPTION
changed `rails s puma` to `rails s Puma`. Using the former results in: 

```
rack/handler.rb:21:in `const_get': wrong constant name puma (NameError)
```

Using ruby-1.9.3-p149 and rails 3.0.10
