### PR TITLE
Add RSTRING_NOT_MODIFIED for Rubinius

### DIFF
--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -2,6 +2,9 @@
  * Copyright (c) 2005 Zed A. Shaw
  * You can redistribute it and/or modify it under the same terms as Ruby.
  */
+
+#define RSTRING_NOT_MODIFIED 1
+
 #include "ruby.h"
 #include "ext_help.h"
 #include <assert.h>


### PR DESCRIPTION
As far as I could tell, the buffer given to the http parser isn't
modified. Because it is not modified, we can use the
RSTRING_NOT_MODIFIED header to ensure that Rubinius hasn't do the extra
work to copy the data back and forth.
