### PR TITLE
Allow Server#run to be optionally executed in the current thread (enabling custom threading).

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -185,10 +185,12 @@ module Puma
       @thread_pool and @thread_pool.spawned
     end
 
-    # Runs the server.  It returns the thread used so you can join it.
-    # The thread is always available via #thread to be join'd
+    # Runs the server. By default, this returns the thread used so 
+    # you can join it -- this thread is always available via #thread 
+    # to be join'd. Alternately, if you wish to run the server in the 
+    # current thread, you can 
     #
-    def run
+    def run(opts = {:in_thread => true})
       BasicSocket.do_not_reverse_lookup = true
 
       @status = :run
@@ -201,7 +203,7 @@ module Puma
         @thread_pool.auto_trim!(@auto_trim_time)
       end
 
-      @thread = Thread.new do
+      runtime = proc do
         begin
           check = @check
           sockets = @ios
@@ -234,7 +236,11 @@ module Puma
         end
       end
 
-      return @thread
+      if opts[:in_thread]
+        @thread = Thread.new &runtime
+        return @thread
+      end
+      
     end
 
     # :nodoc:


### PR DESCRIPTION
This patch unobtrusively fixes Server#run so that it can be executed in the main thread. This is primarily to allow users to wrap run in whatever thread spawning mechanism they'd like to, and enables use with Celluloid by including the Celluloid module at load time,

``` ruby
Puma::Server.send(:include, Celluloid)
```

allowing supervision of the server's runloop. Note that it does NOT change the way run needs to be called, but simply allows it to be called with an additional hash arg :in_thread => false, which will start the event loop in the calling thread. For example:

``` ruby
server = Puma::Server.new(App)
server.add_tcp_listener('localhost', 9090)
server.run(:in_thread => false) # starts runloop in Thread#current, returning nothing.
```

It may also be started the old way, with no modification:

``` ruby
server.run
```
