### PR TITLE
Cast status to Integer before comparison

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -239,7 +239,7 @@ module Puma
 
     # :nodoc:
     def handle_check
-      cmd = @check.read(1) 
+      cmd = @check.read(1)
 
       case cmd
       when STOP_COMMAND
@@ -276,7 +276,7 @@ module Puma
 
           # Assumption: nparsed will always be less since data will get filled
           # with more after each parsing.  If it doesn't get more then there was
-          # a problem with the read operation on the client socket. 
+          # a problem with the read operation on the client socket.
           # Effect is to stop processing when the socket can't fill the buffer
           # for further parsing.
           while nparsed < data.length
@@ -432,6 +432,7 @@ module Puma
           status, headers, res_body = lowlevel_error(e)
         end
 
+        status = status.to_i
         content_length = nil
         no_body = false
 


### PR DESCRIPTION
I've been seeing the following error (resulting in an upstream 503):

```
2012-07-19 13:14:48 +0000: Read error: #<ArgumentError: comparison of String with 200 failed>
vendor/bundle/ruby/1.9.1/gems/puma-1.4.0/lib/puma/server.rb:480:in `<'
vendor/bundle/ruby/1.9.1/gems/puma-1.4.0/lib/puma/server.rb:480:in `handle_request'
vendor/bundle/ruby/1.9.1/gems/puma-1.4.0/lib/puma/server.rb:288:in `process_client'
vendor/bundle/ruby/1.9.1/gems/puma-1.4.0/lib/puma/server.rb:197:in `block in run'
vendor/bundle/ruby/1.9.1/gems/puma-1.4.0/lib/puma/thread_pool.rb:92:in `call'
vendor/bundle/ruby/1.9.1/gems/puma-1.4.0/lib/puma/thread_pool.rb:92:in `block in spawn_thread'
```

It looks like Puma is receiving a String for status. I can imagine this isn't the desired behavior but haven't been able to discover the cause of problem. I'm using rails 3.2.6 and rack 1.4.1.

Other web servers don't choke on the String. I've included my crude fix.
