### PR TITLE
updated IOBuffer impl to use native Java ByteArrayOutputStream; added test

### DIFF
--- a/lib/puma/io_buffer.rb
+++ b/lib/puma/io_buffer.rb
@@ -1,45 +1,86 @@
-require 'java'
-
-# Conservative native JRuby/Java implementation of IOBuffer
-# backed by a ByteArrayOutputStream and conversion between
-# Ruby String and Java bytes
 module Puma
-  class JavaIOBuffer < java.io.ByteArrayOutputStream
-    field_reader :buf
-  end
-
-  class IOBuffer
-    BUF_DEFAULT_SIZE = 4096
-
-    def initialize
-      @buf = JavaIOBuffer.new(BUF_DEFAULT_SIZE)
+  if RUBY_PLATFORM == 'java'
+    require 'java'
+  
+    class ByteArrayOutputStream < java.io.ByteArrayOutputStream
+      field_reader :buf
     end
 
-    def reset
-      @buf.reset
+     # Conservative native JRuby/Java implementation of IOBuffer
+     # backed by a ByteArrayOutputStream and conversion between
+     # Ruby String and Java bytes
+    class JavaIOBuffer
+      BUF_DEFAULT_SIZE = 4096
+
+      def initialize
+        @buf = ByteArrayOutputStream.new(BUF_DEFAULT_SIZE)
+      end
+
+      def reset
+        @buf.reset
+      end
+
+      def <<(str)
+        bytes = str.to_java_bytes
+        @buf.write(bytes, 0, bytes.length)
+      end
+
+      def append(*strs)
+        strs.each { |s| self << s; }
+      end
+
+      def to_s
+        String.from_java_bytes @buf.to_byte_array
+      end
+
+      alias_method :to_str, :to_s
+
+      def used
+        @buf.size
+      end
+
+      def capacity
+        @buf.buf.length
+      end
     end
 
-    def <<(str)
-      bytes = str.to_java_bytes
-      @buf.write(bytes, 0, bytes.length)
+    IOBuffer = JavaIOBuffer
+
+  else
+
+    class PortableIOBuffer
+      def initialize
+        @buf = ""
+      end
+
+      def reset
+        @buf = ""
+      end
+
+      def <<(str)
+        @buf << str
+      end
+
+      def append(*strs)
+        strs.each { |s| @buf << s }
+      end
+
+      def to_s
+        @buf
+      end
+
+      alias_method :to_str, :to_s
+
+      def used
+        @buf.size
+      end
+
+      def capacity
+        @buf.size
+      end
     end
 
-    def append(*strs)
-      strs.each { |s| self << s; }
-    end
+    IOBuffer = PortableIOBuffer
 
-    def to_s
-      String.from_java_bytes @buf.to_byte_array
-    end
-
-    alias_method :to_str, :to_s
-
-    def used
-      @buf.size
-    end
-
-    def capacity
-      @buf.buf.length
-    end
   end
 end

--- a/test/test_iobuffer.rb
+++ b/test/test_iobuffer.rb
@@ -9,7 +9,7 @@ class TestIOBuffer < Test::Unit::TestCase
 
   def test_initial_size
     assert_equal 0, iobuf.used
-    assert iobuf.capacity > 0
+    assert iobuf.capacity >= 0
   end
 
   def test_append_op


### PR DESCRIPTION
Re:

> Evan Phoenix ‏@evanphx
> Puma users on JRuby! Help me write a Java version of https://github.com/puma/puma/blob/just-dash-w/ext/puma_http11/io_buffer.c!

Hey, here is a simple implementation backed by a Java ByteArrayOutputStream - the traditional Java data structure for an auto-growing sink for byte IO.  From the JDK source I'm looking at ByteArrayOutputStream is hardcoded to grow by a factor of 2, so YMMV, but that's a given anyway.

Side note: This impl does not make assumptions about the buffer content - it converts to/from Ruby Strings and Java bytes.  I'm not familiar with Puma, but from what I can see IOBuffer is used strictly for HTTP plaintext headers (coming from Ruby Strings I assume).  If that's the case, there is an alternate trivial native Java impl based on Java's StringBuilder, which only operates on Strings.
