### PR TITLE
fixed jruby_restart.rb for use with bundler

### DIFF
--- a/lib/puma/jruby_restart.rb
+++ b/lib/puma/jruby_restart.rb
@@ -10,7 +10,7 @@ module Puma
 
     def self.chdir_exec(dir, cmd, *argv)
       chdir(dir)
-      argv.unshift(cmd)
+      argv.unshift(cmd) unless argv.first == cmd
       argv = ([:string] * argv.size).zip(argv).flatten
       argv <<:int
       argv << 0


### PR DESCRIPTION
When Puma is run in JRuby in without RBENV or RVM the ARGV is set differently then when using a Ruby version manager. This causes Puma to load the wrong file when issued a restart command and crash.

For example running: 

``` bash
jruby -S bundle exec puma -S tmp/status.txt
```

And issuing a restart `kill -s USR2 pid` will call `Puma::JRubyRestart.chdir_exec` setting `argv` to `["/etc/jruby/bin/jruby", "/etc/jruby/bin/puma", …]`. 

This is an issue because `argv` is prepended with `cmd` `/etc/jruby/bin/jruby` causing Puma to reload `/etc/jruby/bin/jruby` instead of the `/etc/jruby/bin/puma` script. 

I added a condition to prevent this. 
