### PR TITLE
Allow for alternate locations in status app

### DIFF
--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -21,15 +21,15 @@ module Puma
         end
 
         case env['PATH_INFO']
-        when "/stop"
+        when /\/stop$/
           @server.stop
           return rack_response(200, OK_STATUS)
 
-        when "/halt"
+        when /\/halt$/
           @server.halt
           return rack_response(200, OK_STATUS)
 
-        when "/restart"
+        when /\/restart$/
           if @cli and @cli.restart_on_stop!
             @server.begin_restart
 
@@ -38,7 +38,7 @@ module Puma
             return rack_response(200, '{ "status": "not configured" }')
           end
 
-        when "/stats"
+        when /\/stats$/
           b = @server.backlog
           r = @server.running
           return rack_response(200, %Q!{ "backlog": #{b}, "running": #{r} }!)

--- a/test/test_app_status.rb
+++ b/test/test_app_status.rb
@@ -75,10 +75,14 @@ class TestAppStatus < Test::Unit::TestCase
   def test_stats
     @server.backlog = 1
     @server.running = 9
-
     status, _ , app = lint('/stats')
 
     assert_equal 200, status
     assert_equal ['{ "backlog": 1, "running": 9 }'], app.enum_for.to_a
+  end
+
+  def test_alternate_location
+    status, _ , app = lint('__alternatE_location_/stats')
+    assert_equal 200, status
   end
 end


### PR DESCRIPTION
Its quite a minor thing but I was annoyed I could not proxy the status app to another location like __status/

The idea is to be able to do:

  server {
    listen      81;
    server_name services.gsfn.local;
    root /path_to/public;
    access_log  /path_to/log/nginx.log;

```
client_body_temp_path   /path_to/tmp/nginx/client_temp;
proxy_temp_path         /path_to/tmp/nginx/proxy_temp;

location / {
  proxy_redirect off;
  proxy_set_header Host $http_host;

  if (!-f $request_filename) {
    proxy_pass http://app;
    break;
  }
}
location /__status {
  proxy_redirect off;
  proxy_set_header Host $http_host;

  if (!-f $request_filename) {
    proxy_pass http://app_status;
    break;
  }
}
```

  }

Thanks
