### PR TITLE
Get puma env from rack_env or rails_env in capistrano recipe

### DIFF
--- a/lib/puma/capistrano.rb
+++ b/lib/puma/capistrano.rb
@@ -8,7 +8,7 @@ Capistrano::Configuration.instance.load do
   namespace :puma do
     desc "Start puma"
     task :start, :roles => lambda { fetch(:puma_role) }, :on_no_matching_servers => :continue do
-      puma_env = fetch(:stage, "production")
+      puma_env = fetch(:rack_env, fetch(:rails_env, "production"))
       run "cd #{current_path} && #{fetch(:bundle_cmd, "bundle")} exec puma -d -e #{puma_env} -b 'unix://#{shared_path}/sockets/puma.sock' -S #{shared_path}/sockets/puma.state --control 'unix://#{shared_path}/sockets/pumactl.sock'", :pty => false
     end
 


### PR DESCRIPTION
rails_env is used by default in capistrano

https://github.com/capistrano/capistrano/blob/master/lib/capistrano/recipes/deploy.rb#L32
