### PR TITLE
Fix for: MiniSSL::Context and invalid SSL file paths

### DIFF
--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -79,7 +79,20 @@ module Puma::MiniSSL
   end
 
   class Context
-    attr_accessor :key, :cert, :verify_mode
+    attr_accessor :verify_mode
+
+    attr_reader :key
+    attr_reader :cert
+
+    def key=(key)
+      raise ArgumentError, "No such key file '#{key}'" unless File.exist? key
+      @key = key
+    end
+
+    def cert=(cert)
+      raise ArgumentError, "No such cert file '#{cert}'" unless File.exist? cert
+      @cert = cert
+    end
   end
 
   VERIFY_NONE = 0

--- a/test/test_minissl.rb
+++ b/test/test_minissl.rb
@@ -1,0 +1,22 @@
+require 'test/unit'
+
+require 'puma'
+require 'puma/minissl'
+
+class TestMiniSSL < Test::Unit::TestCase
+
+  def test_raises_with_invalid_key_file
+    ctx = Puma::MiniSSL::Context.new
+
+    exception = assert_raise(ArgumentError) { ctx.key = "/no/such/key" }
+    assert_equal("No such key file '/no/such/key'", exception.message)
+  end unless defined? JRUBY_VERSION
+
+  def test_raises_with_invalid_cert_file
+    ctx = Puma::MiniSSL::Context.new
+
+    exception = assert_raise(ArgumentError) { ctx.cert = "/no/such/cert" }
+    assert_equal("No such cert file '/no/such/cert'", exception.message)
+  end unless defined? JRUBY_VERSION
+
+end


### PR DESCRIPTION
Previously, MiniSSL accepted invalid paths for the key/cert file and timed out on the first request.
Now, MiniSSL raises an ArgumentError if one of these files does not exist.

See #168 for details.
