### PR TITLE
prevent crash when all workers are gone

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -599,7 +599,7 @@ module Puma
     end
 
     def check_workers
-      while true
+      while @workers.any?
         pid = Process.waitpid(-1, Process::WNOHANG)
         break unless pid
 


### PR DESCRIPTION
Puma crashes if for some reason all workers are gone. 
All child processes can be killed by something external. This makes sure puma master does not crash and is able to respawn the missing children.

I found this by accident, I gave the puma master a USR1 signal when I had only one worker specified. Not a very useful case but it would be nice if puma would just recover from that.
