### PR TITLE
Default Rack handler helper

### DIFF
--- a/lib/puma/rack_default.rb
+++ b/lib/puma/rack_default.rb
@@ -1,0 +1,7 @@
+require 'rack/handler/puma'
+
+module Rack::Handler
+  def self.default(options = {})
+    Rack::Handler::Puma
+  end
+end


### PR DESCRIPTION
Quick little helper to set up Puma as the default Rack handler.  I.e. for your `Gemfile`:

``` ruby
gem "puma", require: "puma/rack_default"
```
