### PR TITLE
Set Rack run_once to false

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -15,7 +15,7 @@ module Puma
         "rack.errors".freeze => events.stderr,
         "rack.multithread".freeze => true,
         "rack.multiprocess".freeze => false,
-        "rack.run_once".freeze => true,
+        "rack.run_once".freeze => false,
         "SCRIPT_NAME".freeze => ENV['SCRIPT_NAME'] || "",
 
         # Rack blows up if this is an empty string, and Rack::Lint


### PR DESCRIPTION
According to http://rack.rubyforge.org/doc/SPEC.html run_once should be set to false.

Otherwise, when I use dalli store, I got responses mixed between concurrent requests. I can reproduce it with this app: https://github.com/kazjote/puma_test. 

I start puma with:

``` bash
bundle exec puma -t 4:8 -b tcp://0.0.0.0:9290 -e production
```

and run script https://gist.github.com/kazjote/5118020
