### PR TITLE
Prevent Bad file descriptor (Errno::EBADF) Errors on restart when running ruby 2.0 

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -127,7 +127,9 @@ module Puma
         end
 
         Dir.chdir @restart_dir
-        Kernel.exec(*argv, redirects)
+
+        argv += [redirects] unless RUBY_VERSION < '1.9'
+        Kernel.exec(*argv)
       end
     end
 


### PR DESCRIPTION
Ruby 2.0 changed the behaviour of exec to close nonstandard file descriptors by default. This causes Prevent Bad file descriptor (Errno::EBADF) when the files are referenced after the restart. 

This passes in the file descriptors in an options hash to exec to keep the files open.

Fixes #177
