### PR TITLE
allow binding to IPv6 addresses

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -163,6 +163,7 @@ module Puma
     # allow to accumulate before returning connection refused.
     #
     def add_tcp_listener(host, port, optimize_for_latency=true, backlog=1024)
+      host = host[1..-2] if host[0..0] == '['
       s = TCPServer.new(host, port)
       if optimize_for_latency
         s.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)


### PR DESCRIPTION
this fails, and is standard:
puma -b 'tcp://[2001:6e8:288::a]:9999'
this fails. and is non-standard but potentially acceptable to puma as port is mandatory argument:
puma -b 'tcp://2001:6e8:288::a:9999'

commit fixes the first issue, but is ghetto as hell, should be 1.8 .. 2.0 friendly
