### PR TITLE
Socket activation

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -68,6 +68,8 @@ module Puma
             end
             @inherited_fds[url] = sock
           end
+          ENV.delete k
+          ENV.delete 'LISTEN_PID'
         end
       end
 


### PR DESCRIPTION
Added a systemd compatibile socket activation, it's based on LISTEN_FDS and LISTEN_PID environment variables passed by systemd.

To test it you can use following systemd units:

puma.service

```
[Unit]
Description=puma daemon

[Service]
User=urban
WorkingDirectory=/home/urban/puma
SyslogIdentifier=puma-test
ExecStart=/bin/ruby -rubygems -Ilib bin/puma -b unix:///run/puma.sock -b tcp://0.0.0.0:8000 test/hello.ru

[Install]
WantedBy=multi-user.target
```

puma.socket

```
[Unit]
Description=puma socket

[Socket]
ListenStream=/run/puma.sock
ListenStream=0.0.0.0:8000

[Install]
WantedBy=sockets.target
```

Here are example logs how it works - we don't have puma running right now, just added files from above to `/etc/systemd/system` and ran `systemctl daemon-reload`.

```
$ sudo systemctl start puma.socket

Apr 05 01:43:47 avalanche.fail.pl systemd[1]: Starting puma socket.
Apr 05 01:43:47 avalanche.fail.pl systemd[1]: Listening on puma socket.
```

```
$ curl http://localhost:8000/

Apr 05 01:43:52 avalanche.fail.pl systemd[1]: Starting puma daemon...
Apr 05 01:43:52 avalanche.fail.pl systemd[1]: Started puma daemon.
Apr 05 01:43:52 avalanche.fail.pl puma-test[17406]: Puma 2.0.0.b7 starting...
Apr 05 01:43:52 avalanche.fail.pl puma-test[17406]: * Min threads: 0, max threads: 16
Apr 05 01:43:52 avalanche.fail.pl puma-test[17406]: * Environment: development
Apr 05 01:43:52 avalanche.fail.pl puma-test[17406]: * Inherited unix:///run/puma.sock
Apr 05 01:43:52 avalanche.fail.pl puma-test[17406]: * Inherited tcp://0.0.0.0:8000
Apr 05 01:43:52 avalanche.fail.pl puma-test[17406]: Use Ctrl-C to stop
Apr 05 01:43:52 avalanche.fail.pl puma-test[17406]: 10.0.0.242 - - [05/Apr/2013 01:43:52] "GET / HTTP/1.1" 200 - 0.0008
```
