### PR TITLE
Make cap recipe handle tmp/sockets; fixes #228

### DIFF
--- a/lib/puma/capistrano.rb
+++ b/lib/puma/capistrano.rb
@@ -3,6 +3,11 @@ Capistrano::Configuration.instance.load do
   after 'deploy:start', 'puma:start'
   after 'deploy:restart', 'puma:restart'
 
+  # Ensure the tmp/sockets directory is created by the deploy:setup task and
+  # symlinked in by the deploy:update task. This is not handled by Capistrano
+  # v2 but is fixed in v3.
+  shared_children.push('tmp/sockets')
+
   _cset(:puma_cmd) { "#{fetch(:bundle_cmd, 'bundle')} exec puma" }
   _cset(:pumactl_cmd) { "#{fetch(:bundle_cmd, 'bundle')} exec pumactl" }
   _cset(:puma_state) { "#{shared_path}/sockets/puma.state" }


### PR DESCRIPTION
From inspecting the Capistrano code, adding "tmp/sockets" to `shared_children` appears to be the officially supported way of dealing with this (and a lot less effort than handling it with our own recipes).
