### PR TITLE
Fix stdout/stderr logs to sync outputs

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -366,11 +366,13 @@ module Puma
       if stdout
         @io_redirected = true
         STDOUT.reopen stdout, (append ? "a" : "w")
+        STDOUT.sync = true
         STDOUT.puts "=== puma startup: #{Time.now} ==="
       end
 
       if stderr
         STDERR.reopen stderr, (append ? "a" : "w")
+        STDERR.sync = true
         STDERR.puts "=== puma startup: #{Time.now} ==="
       end
     end


### PR DESCRIPTION
stdout/stderr logs are lost on log rotation now, because they are not sync-ed.
Sync-ing should be done on each rotated log file.
