### PR TITLE
Edit rackup start command on readme.md to rackup -s Puma.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Then start your server with the `rails` command:
 
 You can pass it as an option to `rackup`:
 
-    $ rackup -s puma
+    $ rackup -s Puma
 
 Alternatively, you can modify your `config.ru` to choose Puma by default, by adding the following as the first line:
 


### PR DESCRIPTION
**Steps to reproduce:**
Create file `config.ru` in app root with the following content. (http://guides.rubyonrails.org/v2.3.11/rails_on_rack.html#rackup)

```
require "config/environment"
use Rails::Rack::LogTailer
use Rails::Rack::Static
run ActionController::Dispatcher.new
```

Run rackup using puma the web server.

```
rackup -s puma
```

**Expected Result:**
Application runs with puma as it's web server.

**Actual Result:**

```
.bundle/gems/rack-1.1.6/lib/rack/handler.rb:21:in `const_get': wrong constant name puma (NameError)
```

**Solution:**
Run with `rackup -s Puma`, **NOT** `rackup -s puma`
