### PR TITLE
Fix running puma under jruby

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -346,7 +346,7 @@ module Puma
 
       @config.load
 
-      if @options[:workers]
+      if @options[:workers] > 0
         unsupported "worker mode not supported on JRuby and Windows",
                     jruby? || windows?
       end


### PR DESCRIPTION
Fix "ERROR: worker mode not supported on JRuby and Windows" with default puma.rb config.
