### PR TITLE
Shorten the gemspec description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 ## Description
 
+Puma is a simple, fast, threaded, and highly concurrent HTTP 1.1 server for Ruby/Rack applications. Puma is intended for use in both development and production environments. In order to get the best throughput, it is highly recommended that you use a  Ruby implementation with real threads like Rubinius or JRuby.
+
+## Built For Speed &amp; Concurrency
+
 Puma is a simple, fast, and highly concurrent HTTP 1.1 server for Ruby web applications. It can be used with any application that supports Rack, and is considered the replacement for Webrick and Mongrel. It was designed to be the go-to server for [Rubinius](http://rubini.us), but also works well with JRuby and MRI. Puma is intended for use in both development and production environments.
 
 Under the hood, Puma processes requests using a C-optimized Ragel extension (inherited from Mongrel) that provides fast, accurate HTTP 1.1 protocol parsing in a portable way. Puma then serves the request in a thread from an internal thread pool (which you can control). This allows Puma to provide real concurrency for your web application!


### PR DESCRIPTION
Shorten the gemspec description to include important things like threaded, fast,
concurrent and best used with Rubinius/JRuby, but exclude a lot of the other
details. People can read up on those details on GitHub.

Also rip out the markdown because rubygems.org isn't parsing it.
