### PR TITLE
Make sure to use bytesize instead of size (MiniSSL write)

### DIFF
--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -46,7 +46,7 @@ module Puma
       end
 
       def write(data)
-        need = data.size
+        need = data.bytesize
 
         while true
           wrote = @engine.write data
@@ -58,7 +58,7 @@ module Puma
 
           need -= wrote
 
-          return data.size if need == 0
+          return data.bytesize if need == 0
 
           data = data[need..-1]
         end


### PR DESCRIPTION
Make sure to use bytesize instead of size when writing data in
MiniSSL's write.

@engine.write reports bytes written, not characters written. Without this patch need can go negative. This happens when SSL is enabled... This patch is not enough to fix SSL in puma 2.0.1 but it helps.
