### PR TITLE
fix: stop leaking sockets on restart (affects ruby 1.9.3 or before)

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -117,7 +117,7 @@ module Puma
         require 'puma/jruby_restart'
         JRubyRestart.chdir_exec(@restart_dir, @restart_argv)
       else
-        redirects = {}
+        redirects = {:close_others => true}
         @binder.listeners.each_with_index do |(l,io),i|
           ENV["PUMA_INHERIT_#{i}"] = "#{io.to_i}:#{l}"
           redirects[io.to_i] = io.to_i


### PR DESCRIPTION
Using puma on ruby 1.9.3, when I restart the server by using `kill -USR2`, it doesn't close sockets and therefore it leaks sockets.  On ruby 2.0.0 this leak problem doesn't happen.

This is because ruby 2.0 `Kernel#exec` has its option `:close_others` implicitly set to `true`.  Any version before 2.0 should have this option explicitly.

I'll be sending a  reproducing code for this problem later.
