### PR TITLE
Fix an error in puma-manager.conf

### DIFF
--- a/tools/jungle/upstart/puma-manager.conf
+++ b/tools/jungle/upstart/puma-manager.conf
@@ -20,7 +20,7 @@ stop on runlevel [06]
 
 # Set this to the number of Puma processes you want
 # to run on this machine
-env PUMA_CONF=/etc/puma.conf
+env PUMA_CONF="/etc/puma.conf"
 
 pre-start script
   for i in `cat $PUMA_CONF`; do


### PR DESCRIPTION
Added quotes to /etc/puma.conf

The upstart job was crashing with `Env must be KEY=VALUE pairs` this change fixed that, and now the script works as expected.
