### PR TITLE
Output results from 'stat's command when using pumactl

### DIFF
--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -157,6 +157,7 @@ module Puma
         end
 
         message "Command #{@options[:command]} sent success"
+        message response.last if @options[:command] == "stats"
       end
       
       @server.close


### PR DESCRIPTION
It looks like version 2 broke this functionality that definitely existed in 1.6. All this does is print the `running` and `backlog` again.

![output](http://new.tinygrab.com/f6d40149f2e749d450d4ed8208c4334b980b3eb1f0.png)
