### PR TITLE
Loading the rackup file before binding to the port.

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -417,6 +417,8 @@ module Puma
       log "* Min threads: #{min_t}, max threads: #{max_t}"
       log "* Environment: #{ENV['RACK_ENV']}"
 
+      app = @config.app
+
       @binder.parse @options[:binds], self
 
       unless @config.app_configured?
@@ -430,7 +432,7 @@ module Puma
 
       write_state
 
-      server = Puma::Server.new @config.app, @events
+      server = Puma::Server.new app, @events
       server.binder = @binder
       server.min_threads = min_t
       server.max_threads = max_t


### PR DESCRIPTION
Fixes #276. Just making the call to load the rackup file before binding to the port like it was done in the 1.6 version. This is my first time looking at the puma code, so please let me know if there is an issue with doing it this way that I overlooked. Cheers!
