### PR TITLE
Allow listening socket to be configured via Capistrano variable

### DIFF
--- a/lib/puma/capistrano.rb
+++ b/lib/puma/capistrano.rb
@@ -11,13 +11,14 @@ Capistrano::Configuration.instance.load do
   _cset(:puma_cmd) { "#{fetch(:bundle_cmd, 'bundle')} exec puma" }
   _cset(:pumactl_cmd) { "#{fetch(:bundle_cmd, 'bundle')} exec pumactl" }
   _cset(:puma_state) { "#{shared_path}/sockets/puma.state" }
+  _cset(:puma_socket) { "unix://#{shared_path}/sockets/puma.sock" }
   _cset(:puma_role) { :app }
 
   namespace :puma do
     desc 'Start puma'
     task :start, :roles => lambda { fetch(:puma_role) }, :on_no_matching_servers => :continue do
       puma_env = fetch(:rack_env, fetch(:rails_env, 'production'))
-      run "cd #{current_path} && #{fetch(:puma_cmd)} -q -d -e #{puma_env} -b 'unix://#{shared_path}/sockets/puma.sock' -S #{fetch(:puma_state)} --control 'unix://#{shared_path}/sockets/pumactl.sock'", :pty => false
+      run "cd #{current_path} && #{fetch(:puma_cmd)} -q -d -e #{puma_env} -b '#{fetch(:puma_socket)}' -S #{fetch(:puma_state)} --control 'unix://#{shared_path}/sockets/pumactl.sock'", :pty => false
     end
 
     desc 'Stop puma'


### PR DESCRIPTION
At the moment listening socket is strictly bind to local machine, which may not be the case with standalone balancer.
This PR allows configuration of listening socket via `puma_socket` variable.
