### PR TITLE
Don't allow CRuby 2.0.0 to fail on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,3 @@ rvm:
   - rbx-19mode
   - jruby-18mode
   - jruby-19mode
-matrix:
-  allow_failures:
-    - rvm: 2.0.0


### PR DESCRIPTION
Since Ruby 2.0.0 is live we shouldn't allow it to fail.
