### PR TITLE
Standardize "block" usage

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -105,8 +105,8 @@ module Puma
     end
 
     def restart!
-      @options[:on_restart].each do |blk|
-        blk.call self
+      @options[:on_restart].each do |block|
+        block.call self
       end
 
       if jruby?

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -203,8 +203,8 @@ module Puma
       #
       # This can be called multiple times to add code each time.
       #
-      def on_restart(&blk)
-        @options[:on_restart] << blk
+      def on_restart(&block)
+        @options[:on_restart] << block
       end
 
       # Command to use to restart puma. This should be just how to

--- a/lib/puma/delegation.rb
+++ b/lib/puma/delegation.rb
@@ -2,8 +2,8 @@ module Puma
   module Delegation
     def forward(what, who)
       module_eval <<-CODE
-        def #{what}(*args, &blk)
-          #{who}.#{what}(*args, &blk)
+        def #{what}(*args, &block)
+          #{who}.#{what}(*args, &block)
         end
       CODE
     end

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -11,7 +11,7 @@ module Puma
     # The block passed is the work that will be performed in each
     # thread.
     #
-    def initialize(min, max, *extra, &blk)
+    def initialize(min, max, *extra, &block)
       @cond = ConditionVariable.new
       @mutex = Mutex.new
 
@@ -22,7 +22,7 @@ module Puma
 
       @min = min
       @max = max
-      @block = blk
+      @block = block
       @extra = extra
 
       @shutdown = false

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -8,9 +8,9 @@ class TestThreadPool < Test::Unit::TestCase
     @pool.shutdown if @pool
   end
 
-  def new_pool(min, max, &blk)
-    blk = proc { } unless blk
-    @pool = Puma::ThreadPool.new(min, max, &blk)
+  def new_pool(min, max, &block)
+    block = proc { } unless block
+    @pool = Puma::ThreadPool.new(min, max, &block)
   end
 
   def pause


### PR DESCRIPTION
This commit standardizes on the use of `block` over `blk`. I found the usage of
both in the code, with no real advantage of `blk`. 
