### PR TITLE
Don't crash when given a non-standard HTTP code

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -412,7 +412,7 @@ module Puma
             lines << HTTP_11_200
           else
             lines.append "HTTP/1.1 ", status.to_s, " ",
-                         HTTP_STATUS_CODES[status], line_ending
+                         fetch_status_code(status), line_ending
 
             no_body ||= status < 200 || STATUS_WITH_NO_ENTITY_BODY[status]
           end
@@ -427,7 +427,7 @@ module Puma
             lines << HTTP_10_200
           else
             lines.append "HTTP/1.0 ", status.to_s, " ",
-                         HTTP_STATUS_CODES[status], line_ending
+                         fetch_status_code(status), line_ending
 
             no_body ||= status < 200 || STATUS_WITH_NO_ENTITY_BODY[status]
           end
@@ -515,6 +515,11 @@ module Puma
 
       return keep_alive
     end
+
+    def fetch_status_code(status)
+      HTTP_STATUS_CODES.fetch(status) { 'CUSTOM' }
+    end
+    private :fetch_status_code
 
     # Given the requset +env+ from +client+ and the partial body +body+
     # plus a potential Content-Length value +cl+, finish reading

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -221,4 +221,32 @@ class TestPumaServer < Test::Unit::TestCase
 
     assert_not_match(/don't leak me bro/, data)
   end
+
+  def test_custom_http_codes_10
+    @server.app = proc { |env| [449, {}, [""]] }
+
+    @server.add_tcp_listener @host, @port
+    @server.run
+
+    sock = TCPSocket.new @host, @port
+    sock << "GET / HTTP/1.0\r\n\r\n"
+
+    data = sock.read
+
+    assert_equal "HTTP/1.0 449 CUSTOM\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
+  end
+
+  def test_custom_http_codes_11
+    @server.app = proc { |env| [449, {}, [""]] }
+
+    @server.add_tcp_listener @host, @port
+    @server.run
+
+    sock = TCPSocket.new @host, @port
+    sock << "GET / HTTP/1.1\r\n\r\n"
+
+    data = sock.read
+
+    assert_equal "HTTP/1.1 449 CUSTOM\r\nContent-Length: 0\r\n\r\n", data
+  end
 end


### PR DESCRIPTION
We are using 449 in an app, because it's actually appropriate for the situation. The Rack codes don't include that because it's non-standard (MSFT extension).

This was crashing puma and returning a 500 because turning `nil` into a `String` is super hard for ruby. The error message was bizarre so took a while to track down. We ended up adding the 449 k/v pair to the `Rack::Utils` hash, and that solves the problem.

Going forward, there is this solution, or the call to `fetch` should just raise a more appropriate error and suggest a way to fix the problem (use a different code, or register a new code, which would need supporting code).
