### PR TITLE
Capistrano. Add phased_restart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ and then
 $ bundle exec cap puma:start
 $ bundle exec cap puma:restart
 $ bundle exec cap puma:stop
+$ bundle exec cap puma:phased_restart
 ```
 
 

--- a/lib/puma/capistrano.rb
+++ b/lib/puma/capistrano.rb
@@ -8,34 +8,41 @@ Capistrano::Configuration.instance.load do
   # v2 but is fixed in v3.
   shared_children.push('tmp/sockets')
 
-  _cset(:puma_cmd) { "#{fetch(:bundle_cmd, 'bundle')} exec puma" }
+  _cset(:puma_cmd)    { "#{fetch(:bundle_cmd, 'bundle')} exec puma" }
   _cset(:pumactl_cmd) { "#{fetch(:bundle_cmd, 'bundle')} exec pumactl" }
-  _cset(:puma_state) { "#{shared_path}/sockets/puma.state" }
+  _cset(:puma_env)    { fetch(:rack_env, fetch(:rails_env, 'production')) }
+  _cset(:puma_state)  { "#{shared_path}/sockets/puma.state" }
   _cset(:puma_socket) { "unix://#{shared_path}/sockets/puma.sock" }
-  _cset(:puma_role) { :app }
+  _cset(:puma_role)   { :app }
 
   namespace :puma do
     desc 'Start puma'
-    task :start, :roles => lambda { fetch(:puma_role) }, :on_no_matching_servers => :continue do
-      run "cd #{current_path} && #{fetch(:puma_cmd)} #{start_options}", :pty => false
+    task :start, :roles => lambda { puma_role }, :on_no_matching_servers => :continue do
+      run "cd #{current_path} && #{puma_cmd} #{start_options}", :pty => false
     end
 
     desc 'Stop puma'
-    task :stop, :roles => lambda { fetch(:puma_role) }, :on_no_matching_servers => :continue do
-      run "cd #{current_path} && #{fetch(:pumactl_cmd)} -S #{state_path} stop"
+    task :stop, :roles => lambda { puma_role }, :on_no_matching_servers => :continue do
+      run "cd #{current_path} && #{pumactl_cmd} -S #{state_path} stop"
     end
 
     desc 'Restart puma'
-    task :restart, :roles => lambda { fetch(:puma_role) }, :on_no_matching_servers => :continue do
-      run "cd #{current_path} && #{fetch(:pumactl_cmd)} -S #{state_path} restart"
+    task :restart, :roles => lambda { puma_role }, :on_no_matching_servers => :continue do
+      run "cd #{current_path} && #{pumactl_cmd} -S #{state_path} restart"
     end
+
+    desc 'Restart puma (phased restart)'
+    task :phased_restart, :roles => lambda { puma_role }, :on_no_matching_servers => :continue do
+      run "cd #{current_path} && #{pumactl_cmd} -S #{state_path} phased-restart"
+    end
+
   end
 
   def start_options
     if config_file
       "-q -d -e #{puma_env} -C #{config_file}"
     else
-      "-q -d -e #{puma_env} -b '#{fetch(:puma_socket)}' -S #{state_path} --control 'unix://#{shared_path}/sockets/pumactl.sock'"
+      "-q -d -e #{puma_env} -b '#{puma_socket}' -S #{state_path} --control 'unix://#{shared_path}/sockets/pumactl.sock'"
     end
   end
 
@@ -52,7 +59,7 @@ Capistrano::Configuration.instance.load do
   end
 
   def state_path
-    (config_file ? configuration.options[:state] : nil) || fetch(:puma_state)
+    (config_file ? configuration.options[:state] : nil) || puma_state
   end
 
   def configuration


### PR DESCRIPTION
If `puma_config` is set, the specified config file will be used by `start` task, otherwise default options are used.

In addition, this PR adds `phased_restart` task.

Little refactor is also included to avoid using `fetch` when no needed.
