### PR TITLE
Adds support for using puma config file in capistrano deploys.

### DIFF
--- a/lib/puma/capistrano.rb
+++ b/lib/puma/capistrano.rb
@@ -17,18 +17,49 @@ Capistrano::Configuration.instance.load do
   namespace :puma do
     desc 'Start puma'
     task :start, :roles => lambda { fetch(:puma_role) }, :on_no_matching_servers => :continue do
-      puma_env = fetch(:rack_env, fetch(:rails_env, 'production'))
-      run "cd #{current_path} && #{fetch(:puma_cmd)} -q -d -e #{puma_env} -b '#{fetch(:puma_socket)}' -S #{fetch(:puma_state)} --control 'unix://#{shared_path}/sockets/pumactl.sock'", :pty => false
+      run "cd #{current_path} && #{fetch(:puma_cmd)} #{start_options}", :pty => false
     end
 
     desc 'Stop puma'
     task :stop, :roles => lambda { fetch(:puma_role) }, :on_no_matching_servers => :continue do
-      run "cd #{current_path} && #{fetch(:pumactl_cmd)} -S #{fetch(:puma_state)} stop"
+      run "cd #{current_path} && #{fetch(:pumactl_cmd)} -S #{state_path} stop"
     end
 
     desc 'Restart puma'
     task :restart, :roles => lambda { fetch(:puma_role) }, :on_no_matching_servers => :continue do
-      run "cd #{current_path} && #{fetch(:pumactl_cmd)} -S #{fetch(:puma_state)} restart"
+      run "cd #{current_path} && #{fetch(:pumactl_cmd)} -S #{state_path} restart"
     end
+  end
+
+  def start_options
+    if config_file
+      "-q -d -e #{puma_env} -C #{config_file}"
+    else
+      "-q -d -e #{puma_env} -b '#{fetch(:puma_socket)}' -S #{state_path} --control 'unix://#{shared_path}/sockets/pumactl.sock'"
+    end
+  end
+
+  def config_file
+    @_config_file ||= begin
+      file = fetch(:puma_config_file, nil)
+      file = "./config/puma/#{puma_env}.rb" if !file && File.exists?("./config/puma/#{puma_env}.rb")
+      file
+    end
+  end
+
+  def puma_env
+    fetch(:rack_env, fetch(:rails_env, 'production'))
+  end
+
+  def state_path
+    (config_file ? configuration.options[:state] : nil) || fetch(:puma_state)
+  end
+
+  def configuration
+    require 'puma/configuration'
+
+    config = Puma::Configuration.new(:config_file => config_file)
+    config.load
+    config
   end
 end


### PR DESCRIPTION
- Unless `puma_config_file` given `./config/puma/<env>.rb` is used.
- Fallback to using `puma_*` variables if config file cannot be found.
- If path to state file is not given then then `fetch(:puma_state)` is used.

Seems to work well in both modes. Any suggestions are more than welcome!
