### PR TITLE
CLI help typo

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -148,7 +148,7 @@ module Puma
           $LOAD_PATH.unshift(*arg.split(':'))
         end
 
-        o.on "-p", "--port PORT", "Define what port TCP port to bind to",
+        o.on "-p", "--port PORT", "Define the TCP port to bind to",
                                   "Use -b for more advanced options" do |arg|
           @options[:binds] << "tcp://#{Configuration::DefaultTCPHost}:#{arg}"
         end


### PR DESCRIPTION
Fix a small typo in the CLI help.
