### PR TITLE
Capistrano. Add phased_restart and accept config file per stage. Phase phased_restart by default after deploy:restart

### DIFF
--- a/lib/puma/capistrano.rb
+++ b/lib/puma/capistrano.rb
@@ -31,7 +31,7 @@ Capistrano::Configuration.instance.load do
     end
     
     desc 'Restart puma (phased restart)'
-    task :phased_restart, roles: lambda { puma_role }, on_no_matching_servers: :continue do
+    task :phased_restart, :roles => lambda { fetch(:puma_role) }, :on_no_matching_servers => :continue do
       run "cd #{current_path} && #{pumactl_cmd} -S #{puma_state} phased-restart"
     end
   end


### PR DESCRIPTION
Hi guys,

To the subject
- Phased restart from #314
- Default puma:phased_restart after deploy:restart
- Config separation by stage name (I want to run on Vagrant if the ENV=production)

Will appreciate any critics.

Thank you,
N
