### PR TITLE
Allow configuring pumactl with config.rb, closes #331

### DIFF
--- a/test/shell/run.sh
+++ b/test/shell/run.sh
@@ -1,7 +1,17 @@
+ERROR=0
+
 if ruby -rubygems t1.rb > /dev/null 2>&1; then
   echo "t1 OK"
-  exit 0
 else
   echo "t1 FAIL"
-  exit 1
+  ERROR=1
 fi
+
+if ruby -rubygems t2.rb > /dev/null 2>&1; then
+  echo "t2 OK"
+else
+  echo "t2 FAIL"
+  ERROR=2
+fi
+
+exit $ERROR

--- a/test/shell/t1.rb
+++ b/test/shell/t1.rb
@@ -8,8 +8,8 @@ sleep 1
 
 log = File.read("t1-stdout")
 
-File.unlink "t1-stdout"
-File.unlink "t1-pid"
+File.unlink "t1-stdout" if File.file? "t1-stdout"
+File.unlink "t1-pid" if File.file? "t1-pid"
 
 if log =~ %r!GET / HTTP/1\.1!
   exit 0

--- a/test/shell/t2.rb
+++ b/test/shell/t2.rb
@@ -1,0 +1,17 @@
+system "ruby -rubygems -I../../lib ../../bin/pumactl -F t2_conf.rb start"
+sleep 5
+system "curl http://localhost:10103/"
+
+system "ruby -rubygems -I../../lib ../../bin/pumactl -F t2_conf.rb stop"
+
+sleep 1
+
+log = File.read("t2-stdout")
+
+File.unlink "t2-stdout" if File.file? "t2-stdout"
+
+if log =~ %r(GET / HTTP/1\.1) && !File.file?("t2-pid")
+  exit 0
+else
+  exit 1
+end

--- a/test/shell/t2_conf.rb
+++ b/test/shell/t2_conf.rb
@@ -1,0 +1,5 @@
+stdout_redirect "t2-stdout"
+pidfile "t2-pid"
+bind "tcp://0.0.0.0:10103"
+rackup File.expand_path('../hello.ru', File.dirname(__FILE__))
+daemonize


### PR DESCRIPTION
example:
  echo "pidfile '/tmp/app.pid'; rackup 'config.ru'" > /etc/puma/app.rb
  pumactl -F /etc/puma/app.rb start # starts an app and store pid in /tmp/app.pid
  pumactl -F /etc/puma/app.rb stop  # stops the started earlier app

Integration test t2 included: rake test:integration
Also fixed discrepancy in naming options :pidfile/:pid_file and :state/:status_file

This PR closes #331
