### PR TITLE
Add before_boot hook for Clustered mode

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -254,6 +254,12 @@ module Puma
       @cli.write_state
 
       @master_read, @worker_write = read, @wakeup
+
+      # Invoke any pre-boot hooks so they can get
+      # things in shape before spawning any workers
+      hooks = @options[:before_boot]
+      hooks.each { |h| h.call }
+
       spawn_workers
 
       Signal.trap "SIGINT" do

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -20,6 +20,7 @@ module Puma
       @options[:binds] ||= []
       @options[:on_restart] ||= []
       @options[:worker_boot] ||= []
+      @options[:before_boot] ||= []
     end
 
     attr_reader :options
@@ -295,6 +296,14 @@ module Puma
       #
       def on_worker_boot(&block)
         @options[:worker_boot] << block
+      end
+      
+      # *Cluster mode only* Code to run before workers are spawned. 
+      #
+      # This can be called multiple times to add hooks.
+      #
+      def before_boot(&block)
+        @options[:before_boot] << block
       end
 
       # The directory to operate out of.


### PR DESCRIPTION
Adds a call to any `before_boot` hooks before spawning workers.

Refs #303
