### PR TITLE
Use integers when comparing thread counts

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -258,8 +258,10 @@ module Puma
       # requests and +max+ the maximum.
       #
       def threads(min, max)
+        min = Integer(min)
+        max = Integer(max)
         if min > max
-          raise "The minimum number of threads must be less than the max"
+          raise "The minimum (#{min}) number of threads must be less than the max (#{max})"
         end
 
         @options[:min_threads] = min


### PR DESCRIPTION
When setting min & max via ENV var (PUMA_THREAD_COUNT="6:12") one will
get a RuntimeError, because "6" > "12".

``` ruby
min, max = ENV.fetch("PUMA_THREAD_COUNT", "4:8").split(":")
# or
min, max = ENV.fetch("PUMA_THREAD_COUNT", "4:8").split(":").map(&:to_i)
# but the latter feels funny to me

threads min, max
```
