### PR TITLE
Upstart autodetect ruby managers

### DIFF
--- a/tools/jungle/upstart/puma.conf
+++ b/tools/jungle/upstart/puma.conf
@@ -32,21 +32,33 @@ instance ${app}
 script
 # this script runs in /bin/sh by default
 # respawn as bash so we can source in rbenv/rvm
-exec /bin/bash <<EOT
-  export HOME=/home/apps
+# quoted heredoc to tell /bin/sh not to interpret
+# variables
+exec /bin/bash <<'EOT'
+  # set HOME to the setuid user's home, there doesn't seem to be a better, portable way
+  export HOME="$(eval echo ~$(id -un))"
 
-  # Pick your poison :) Or none if you're using a system wide installed Ruby.
-  # rbenv
-  # source /home/apps/.bash_profile
-  # OR
-  # source /home/apps/.profile
-  #
-  # rvm
-  # source /home/apps/.rvm/scripts/rvm
+  cd $app
+
+  if [ -d "$HOME/.rbenv/bin" ]; then
+    export PATH="$HOME/.rbenv/bin:$PATH"
+  elif [ -f  /etc/profile.d/rvm.sh ]; then
+    source /etc/profile.d/rvm.sh
+  elif [ -f /usr/local/rvm/scripts/rvm ]; then
+    source /etc/profile.d/rvm.sh
+  elif [ -f "$HOME/.rvm/scripts/rvm" ]; then
+    source "$HOME/.rvm/scripts/rvm"
+  elif [ -f /usr/local/share/chruby/chruby.sh ]; then
+    source /usr/local/share/chruby/chruby.sh
+    if [ -f /usr/local/share/chruby/auto.sh ]; then
+      source /usr/local/share/chruby/auto.sh
+    fi
+    # if you aren't using auto, set your version here
+    # chruby 2.0.0
+  fi
 
   logger -t puma "Starting server: $app"
 
-  cd $app
-  exec bundle exec puma -C config/puma.rb
+  exec bundle exec puma -C config/puma/production.rb
 EOT
 end script


### PR DESCRIPTION
- HOME is now picked up automatically from setuid.
- script will try rbenv, rvm, then chruby automatically.
- quoted heredoc to prevent /bin/sh interpreting variables early
- setuid/setgid by default so $HOME can be set reliably
