### PR TITLE
Correctly report phased-restart availability and log when phased-restart is not available.

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -499,8 +499,11 @@ module Puma
     end
 
     def phased_restart
-      return restart unless @runner.respond_to? :phased_restart
-      return restart unless @runner.phased_restart
+      unless @runner.respond_to?(:phased_restart) and @runner.phased_restart
+        log "* phased-restart called but not available, restarting normally."
+        return restart
+      end
+      true
     end
 
     def stats


### PR DESCRIPTION
Additionally log when phased-restart is not available before performing a standard restart.

Sponsored-by: CentroNet Marketing
