### PR TITLE
Fix issue with non-String header values.

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -458,8 +458,12 @@ module Puma
             next
           end
 
-          vs.split(NEWLINE).each do |v|
-            lines.append k, colon, v, line_ending
+          if vs.respond_to?(:to_s)
+            vs.to_s.split(NEWLINE).each do |v|
+              lines.append k, colon, v, line_ending
+            end
+          else
+            lines.append k, colon, line_ending
           end
         end
 


### PR DESCRIPTION
Non-String header values were causing an exception:

```
Read error: #<NoMethodError: undefined method `split' for nil:NilClass>
/app/vendor/bundle/ruby/2.0.0/gems/puma-2.4.0/lib/puma/server.rb:448:in `each'
```

This fixes that by converting the value, if possible, to a String. If not possible, the header is not sent.

I tested this change on both v2.4.0 and v2.4.1.
