### PR TITLE
Return success status on daemonizing to the invoking environment

### DIFF
--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -58,7 +58,7 @@ module Puma
             # Must use exit! so we don't unwind and run the ensures
             # that will be run by the new child (such as deleting the
             # pidfile)
-            exit!
+            exit!(true)
           end
 
           Signal.trap "SIGCHLD" do


### PR DESCRIPTION
Daemonizing on JRuby returned an error status to the
invoking environment due to exit! defaulting to a
return status of „false“ in constrast to exit which
defaults to „true“.
