### PR TITLE
Define RSTRING_NOT_MODIFIED for Rubinius performance

### DIFF
--- a/ext/puma_http11/http11_parser.h
+++ b/ext/puma_http11/http11_parser.h
@@ -6,6 +6,7 @@
 #ifndef http11_parser_h
 #define http11_parser_h
 
+#define RSTRING_NOT_MODIFIED 1
 #include "ruby.h"
 
 #include <sys/types.h>

--- a/ext/puma_http11/io_buffer.c
+++ b/ext/puma_http11/io_buffer.c
@@ -1,3 +1,4 @@
+#define RSTRING_NOT_MODIFIED 1
 #include "ruby.h"
 
 #include <sys/types.h>

--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -1,3 +1,4 @@
+#define RSTRING_NOT_MODIFIED 1
 #include <ruby.h>
 #include <rubyio.h>
 #include <openssl/bio.h>


### PR DESCRIPTION
This ensures the header is defined before ruby.h is included.
