### PR TITLE
Handle BrokenPipe, StandardError and IOError in fat_wrote and break out

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -763,6 +763,8 @@ module Puma
         rescue Errno::EAGAIN, Errno::EWOULDBLOCK
           IO.select(nil, [io], nil, 1)
           retry
+        rescue  Errno::EPIPE, SystemCallError, IOError
+          return false
         end
 
         return if n == str.bytesize


### PR DESCRIPTION
This fixes issue #368, #360, #274
