### PR TITLE
Upstart jungle use config/puma.rb instead

### DIFF
--- a/tools/jungle/upstart/puma.conf
+++ b/tools/jungle/upstart/puma.conf
@@ -59,6 +59,6 @@ exec /bin/bash <<'EOT'
 
   logger -t puma "Starting server: $app"
 
-  exec bundle exec puma -C config/puma/production.rb
+  exec bundle exec puma -C config/puma.rb
 EOT
 end script


### PR DESCRIPTION
Not really sure why it is loading production.rb since the README and the init.d script says it expects config.rb instead.

Patch attached simply reflects this.
