### PR TITLE
Add capistrano restart error handling and try to start.

### DIFF
--- a/lib/puma/capistrano.rb
+++ b/lib/puma/capistrano.rb
@@ -28,7 +28,12 @@ Capistrano::Configuration.instance.load do
 
     desc 'Restart puma'
     task :restart, :roles => lambda { puma_role }, :on_no_matching_servers => :continue do
-      run "cd #{current_path} && #{pumactl_cmd} -S #{state_path} restart"
+      begin
+        run "cd #{current_path} && #{pumactl_cmd} -S #{state_path} restart"
+      rescue Capistrano::CommandError => ex
+        puts "Failed to restart puma: #{ex}\nAssuming not started."
+        start
+      end
     end
 
     desc 'Restart puma (phased restart)'


### PR DESCRIPTION
This was partially solved by #346.
As for now if puma is not started and `puma:restart` is executed the task may still fail due to inability to connect to control socket and possibly some more cases. It seems to me that it is reasonable to assume puma not running if restart fails.
