### PR TITLE
Change position of `cd` so that rvm gemset is loaded

### DIFF
--- a/tools/jungle/upstart/puma.conf
+++ b/tools/jungle/upstart/puma.conf
@@ -38,8 +38,6 @@ exec /bin/bash <<'EOT'
   # set HOME to the setuid user's home, there doesn't seem to be a better, portable way
   export HOME="$(eval echo ~$(id -un))"
 
-  cd $app
-
   if [ -d "$HOME/.rbenv/bin" ]; then
     export PATH="$HOME/.rbenv/bin:$PATH"
   elif [ -f  /etc/profile.d/rvm.sh ]; then
@@ -57,6 +55,7 @@ exec /bin/bash <<'EOT'
     # chruby 2.0.0
   fi
 
+  cd $app
   logger -t puma "Starting server: $app"
 
   exec bundle exec puma -C config/puma.rb


### PR DESCRIPTION
I got an error in my production environment because it was not loading the right ruby and gemset.
