### PR TITLE
Revert from 01cb454578.

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -17,7 +17,7 @@ require 'puma/rack_patch'
 
 require 'puma/puma_http11'
 
-unless Puma.const_defined?("IOBuffer", false)
+unless Puma.const_defined? "IOBuffer"
   require 'puma/io_buffer'
 end
 


### PR DESCRIPTION
Sorry, I was mistaken.
I had convinced that second argument have been backported to ruby1.8.

@tamird Thank you for letting me know.
