### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Puma: A Ruby Web Server Built For Concurrency
 
-[![Build Status](https://secure.travis-ci.org/puma/puma.png)](http://travis-ci.org/puma/puma) [![Dependency Status](https://gemnasium.com/puma/puma.png)](https://gemnasium.com/puma/puma)
+[![Build Status](https://secure.travis-ci.org/puma/puma.png)](http://travis-ci.org/puma/puma) [![Dependency Status](https://gemnasium.com/puma/puma.png)](https://gemnasium.com/puma/puma) <a href="https://codeclimate.com/github/puma/puma"><img src="https://codeclimate.com/github/puma/puma.png" /></a>
 
 ## Description
 


### PR DESCRIPTION
Hey Everyone!

It looks like someone added Puma to Code Climate a few months back, and I thought you might want to know.

I work at Code Climate -- we do automated code reviews for Ruby and JavaScript using static analysis -- and we're completely free for open source. You can view your metrics here: https://codeclimate.com/github/puma/puma

In case you want this information to be available to contributors, this PR just adds a dynamic badge to the README (similar to Travis) that displays the code quality GPA

If you have any questions, let me know.

I hope you find Code Climate useful.

Cheers,
Mike
