### PR TITLE
add pretty process name

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -200,6 +200,9 @@ module Puma
           @options[:workers] = arg.to_i
         end
 
+        o.on "--tag NAME", "Additional text to display in process listing" do |arg|
+          @options[:tag] = arg
+        end
       end
 
       @parser.banner = "puma <options> <rackup file>"
@@ -459,6 +462,7 @@ module Puma
       end
 
       setup_signals
+      set_process_title
 
       @status = :run
 
@@ -537,6 +541,17 @@ module Puma
     def halt
       @status = :halt
       @runner.halt
+    end
+
+  private
+    def title
+      buffer = "puma #{Puma::Const::VERSION} (#{@options[:binds].join(',')})"
+      buffer << " [#{@options[:tag]}]" if @options[:tag]
+      buffer
+    end
+
+    def set_process_title
+      Process.respond_to?(:setproctitle) ? Process.setproctitle(title) : $0 = title
     end
   end
 end


### PR DESCRIPTION
Hi, I'm new to Puma, looks great so far :)

I noticed the lack of a pretty process name, this is my attempt to add a simple (static) one, very similar to what Thin server does.
This also accepts an optional --tag parameter for additional text (useful to recognize different apps)

fixes #415 
