### PR TITLE
Add rbenv shims to PATH in upstart conf file

### DIFF
--- a/tools/jungle/upstart/puma.conf
+++ b/tools/jungle/upstart/puma.conf
@@ -39,7 +39,7 @@ exec /bin/bash <<'EOT'
   export HOME="$(eval echo ~$(id -un))"
 
   if [ -d "$HOME/.rbenv/bin" ]; then
-    export PATH="$HOME/.rbenv/bin:$PATH"
+    export PATH="$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH"
   elif [ -f  /etc/profile.d/rvm.sh ]; then
     source /etc/profile.d/rvm.sh
   elif [ -f /usr/local/rvm/scripts/rvm ]; then


### PR DESCRIPTION
These days bundle is installed in the shims directory, so we need to have this
in the PATH for the upstart configuration to work.
