### PR TITLE
Assure worker index is always within 0...@options[:workers]

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -7,7 +7,6 @@ module Puma
 
       @phase = 0
       @workers = []
-      @worker_index = 0
       @next_check = nil
 
       @phased_state = :idle
@@ -99,9 +98,10 @@ module Puma
     end
 
     def next_worker_index
-      i = @worker_index
-      @worker_index += 1
-      i
+      all_positions =  0...@options[:workers] 
+      occupied_positions = @workers.map { |w| w.index }
+      available_positions = all_positions.to_a - occupied_positions 
+      available_positions.first
     end
 
     def all_workers_booted?

--- a/test/shell/run.sh
+++ b/test/shell/run.sh
@@ -14,4 +14,11 @@ else
   ERROR=2
 fi
 
+if ruby -rubygems t3.rb > /dev/null 2>&1; then
+  echo "t3 OK"
+else
+  echo "t3 FAIL"
+  ERROR=3
+fi
+
 exit $ERROR

--- a/test/shell/t3.rb
+++ b/test/shell/t3.rb
@@ -1,0 +1,25 @@
+system "ruby -rubygems -I../../lib ../../bin/puma -p 10102 -C t3_conf.rb ../hello.ru &"
+sleep 5
+
+worker_pid_was_present = File.file? "t3-worker-2-pid"
+
+system "kill `cat t3-worker-2-pid`" # kill off a worker
+
+sleep 2
+
+worker_index_within_number_of_workers = !File.file?("t3-worker-3-pid")
+
+system "kill `cat t3-pid`" 
+
+File.unlink "t3-pid" if File.file? "t3-pid"
+File.unlink "t3-worker-0-pid" if File.file? "t3-worker-0-pid"
+File.unlink "t3-worker-1-pid" if File.file? "t3-worker-1-pid"
+File.unlink "t3-worker-2-pid" if File.file? "t3-worker-2-pid"
+File.unlink "t3-worker-3-pid" if File.file? "t3-worker-3-pid"
+
+if worker_pid_was_present and worker_index_within_number_of_workers
+  exit 0
+else
+  exit 1
+end
+

--- a/test/shell/t3_conf.rb
+++ b/test/shell/t3_conf.rb
@@ -1,0 +1,5 @@
+pidfile "t3-pid"
+workers 3
+on_worker_boot do |index|
+  File.open("t3-worker-#{index}-pid", "w") { |f| f.puts Process.pid }
+end


### PR DESCRIPTION
This addresses the minor issue I brought up in #440.

`next_worker_index` will now always be a number between 0 and the number of workers configured. 

I also added an integration test (t3.rb) that boots multiple workers and utilizes on_worker_boot. Perhaps it's testing too many things at once (multiple workers, on_worker_boot hook, index) — but it felt nice to have that code path tested.

Feel free to pull or just use as inspiration :)
