### PR TITLE
Add config to customize the default error message

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -327,6 +327,15 @@ module Puma
       def preload_app!(answer=true)
         @options[:preload_app] = answer
       end
+
+      # Use +obj+ or +block+ as the low lever error handler. This allows a config file to
+      # change the default error on the server.
+      #
+      def lowlevel_error_handler(obj=nil, &block)
+        obj ||= block
+        raise "Provide either a #call'able or a block" unless obj
+        @options[:lowlevel_error_handler] = obj
+      end
     end
   end
 end

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -330,7 +330,7 @@ module Puma
 
     # :nodoc:
     def handle_check
-      cmd = @check.read(1) 
+      cmd = @check.read(1)
 
       case cmd
       when STOP_COMMAND
@@ -707,6 +707,10 @@ module Puma
     # A fallback rack response if +@app+ raises as exception.
     #
     def lowlevel_error(e)
+      if handler = @options[:lowlevel_error_handler]
+        return handler.call(e)
+      end
+
       if @leak_stack_on_error
         [500, {}, ["Puma caught this error: #{e.message} (#{e.class})\n#{e.backtrace.join("\n")}"]]
       else

--- a/test/config/app.rb
+++ b/test/config/app.rb
@@ -1,3 +1,7 @@
 app do |env|
   [200, {}, ["embedded app"]]
 end
+
+lowlevel_error_handler do |err|
+  [200, {}, ["error page"]]
+end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -13,4 +13,14 @@ class TestConfigFile < Test::Unit::TestCase
 
     assert_equal [200, {}, ["embedded app"]], app.call({})
   end
+
+  def test_lowleve_error_handler_DSL
+    opts = { :config_file => "test/config/app.rb" }
+    conf = Puma::Configuration.new opts
+    conf.load
+
+    app = conf.options[:lowlevel_error_handler]
+
+    assert_equal [200, {}, ["error page"]], app.call({})
+  end
 end


### PR DESCRIPTION
Add a `lowlevel_error_handler`, so we can customize the default error message.

example:

``` ruby
lowlevel_error_handler do
  [302, {'Content-Type' => 'text', 'Location' => 'foo.html'}, ['302 found']]
end
```

[fix #458]
