### PR TITLE
Add reload_worker_directory to pumactl

### DIFF
--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -48,6 +48,13 @@ module Puma
             return rack_response(200, OK_STATUS)
           end
 
+        when /\/reload-worker-directory$/
+          if !@cli.reload_worker_directory
+            return rack_response(404, '{ "error": "reload_worker_directory not available" }')
+          else
+            return rack_response(200, OK_STATUS)
+          end
+
         when /\/stats$/
           return rack_response(200, @cli.stats)
         else

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -522,6 +522,10 @@ module Puma
       @runner.restart
     end
 
+    def reload_worker_directory
+      @runner.reload_worker_directory if @runner.respond_to?(:reload_worker_directory)
+    end
+
     def phased_restart
       unless @runner.respond_to?(:phased_restart) and @runner.phased_restart
         log "* phased-restart called but not available, restarting normally."

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -98,9 +98,9 @@ module Puma
     end
 
     def next_worker_index
-      all_positions =  0...@options[:workers] 
+      all_positions =  0...@options[:workers]
       occupied_positions = @workers.map { |w| w.index }
-      available_positions = all_positions.to_a - occupied_positions 
+      available_positions = all_positions.to_a - occupied_positions
       available_positions.first
     end
 
@@ -246,6 +246,13 @@ module Puma
     def halt
       @status = :halt
       wakeup!
+    end
+
+    def reload_worker_directory
+      if dir = @options[:worker_directory]
+        log "+ Changing to #{dir}"
+        Dir.chdir dir
+      end
     end
 
     def stats

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -7,7 +7,7 @@ require 'socket'
 module Puma
   class ControlCLI
 
-    COMMANDS = %w{halt restart phased-restart start stats status stop}
+    COMMANDS = %w{halt restart phased-restart start stats status stop reload-worker-directory}
 
     def is_windows?
       RUBY_PLATFORM =~ /(win|w)32$/ ? true : false
@@ -199,6 +199,10 @@ module Puma
 
       when "stats"
         puts "Stats not available via pid only"
+        return
+
+      when "reload-worker-directory"
+        puts "reload-worker-directory not available via pid only"
         return
 
       when "phased-restart"


### PR DESCRIPTION
This allows to renew the code directory for newly spawn workers from the master process, all from `pumactl`. 

Provides a harmless workaround to https://github.com/puma/puma/pull/469 and https://github.com/puma/puma/issues/468.

This way when I perform a deploy with a `phased-restart` (using symlink deployment), and only after I _ensure this is a good release_, then I do `pumactl reload-worker-directory`. All workers automatically spawn by the master process will use the new code.

I perform two checks to _ensure this is a good release_. First I poll `pumactl stats` until I see the number of `workers` equal the number of `booted_workers`. Then I make a call to some private `\release` path to get the code git release it's running. Then I'm sure every worker is up and they are running the new code.

My current restart output looks like this: 

```
...
Command phased-restart sent success
Wait to let puma start its thing...
[2014-02-25 15:03:11] I saw all puma's workers up! 
[2014-02-25 15:03:11] I saw current release on server! 
Command reload-worker-directory sent success
...
```