### PR TITLE
Describe config file finding behavior in 2.8.0 and how to disable it

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ You can also provide a configuration file which Puma will use with the `-C` (or 
 
     $ puma -C /path/to/config
 
+By default, if no configuration file is specifed, Puma will look for a configuration file at config/puma.rb. If an environment is specified, either via the `-e` and `--environment` flags, or through the `RACK_ENV` environment variable, the default file location will be config/puma/environment_name.rb.
+
+If you want to prevent Puma from looking for a configuration file in those locations, provide a dash as the argument to the `-C` (or `--config`) flag:
+
+    $ puma -C "-"
+
 Take the following [sample configuration](https://github.com/puma/puma/blob/master/examples/config.rb) as inspiration or check out [configuration.rb](https://github.com/puma/puma/blob/master/lib/puma/configuration.rb) to see all available options.
 
 ## Restart


### PR DESCRIPTION
This is simply an update in the documentation to describe the configuration file finding behavior that was introduced in 2.8 in response to #438. 

It also describes how to run puma without a configuration file (by disabling the autoloading). This is useful on development machines.
