### PR TITLE
Swap `and` for `&&` in cli.rb

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -318,7 +318,7 @@ module Puma
                     jruby? || windows?
       end
 
-      if @options[:daemon] and windows?
+      if @options[:daemon] && windows?
         unsupported "daemon mode not supported on Windows"
       end
     end
@@ -340,7 +340,7 @@ module Puma
         s_env = File.stat(dir)
         s_pwd = File.stat(Dir.pwd)
 
-        if s_env.ino == s_pwd.ino and s_env.dev == s_pwd.dev
+        if s_env.ino == s_pwd.ino && s_env.dev == s_pwd.dev
           @restart_dir = dir
           @options[:worker_directory] = dir
         end
@@ -564,7 +564,7 @@ module Puma
     end
 
     def phased_restart
-      unless @runner.respond_to?(:phased_restart) and @runner.phased_restart
+      unless @runner.respond_to?(:phased_restart) && @runner.phased_restart
         log "* phased-restart called but not available, restarting normally."
         return restart
       end


### PR DESCRIPTION
Maybe these don't do what we think they do...

Shot in the dark here, but I think maybe these `and`'s are being used as boolean operators when [they're not](http://devblog.avdi.org/2010/08/02/using-and-and-or-in-ruby/). Maybe I'm wrong though, so please educate me if so :)

I didn't search the code base for this, wanted to see if I'm write here.
