### PR TITLE
Change #rubyforge_name to #group_name

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,8 +8,8 @@ Hoe.plugin :git
 Hoe.plugin :ignore
 
 HOE = Hoe.spec "puma" do
-  self.rubyforge_name = 'puma'
-  self.readme_file    = "README.md"
+  self.group_name  = 'puma'
+  self.readme_file = "README.md"
   self.urls = %w!http://puma.io https://github.com/puma/puma!
 
   license "BSD"


### PR DESCRIPTION
`#rubyforge_name` method is no longer supported after this commit: https://github.com/seattlerb/hoe/commit/6ff62f15b3629f2fb4029ad0d1d78d50

So if you do `bundle install` now, Rakefile for Puma doesn’t work (apparantely):

```
rake aborted!
NoMethodError: undefined method `rubyforge_name=' for #<Hoe:0x007fb3c11c8550>
/Users/somu/Documents/puma/Rakefile:11:in `block in <top (required)>'
/Library/Ruby/Gems/2.0.0/gems/hoe-3.10.0/lib/hoe.rb:389:in `instance_eval'
/Library/Ruby/Gems/2.0.0/gems/hoe-3.10.0/lib/hoe.rb:389:in `spec'
/Users/somu/Documents/puma/Rakefile:10:in `<top (required)>'
(See full trace by running task with --trace)
```

This commit changes deprecated `#rubyforge_name` to newer `#group_name` method.
