### PR TITLE
Fix Clang support by deleting -multiply-definedsuppress flag from DLDFLAGS

### DIFF
--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -3,6 +3,7 @@ require 'mkmf'
 dir_config("puma_http11")
 
 $defs.push "-Wno-deprecated-declarations"
+$DLDFLAGS.delete "-multiply_definedsuppress"
 $libs += " -lssl -lcrypto "
 
 create_makefile("puma/puma_http11")


### PR DESCRIPTION
`-multiply_definedsuppress` flag breaks the build on the newest Clang (which comes with OS X Mavericks).

Here is the error that happens:

```
linking shared-object puma/puma_http11.bundle
clang: error: unknown argument: '-multiply_definedsuppress' [-Wunused-command-line-argument-hard-error-in-future]
clang: note: this will be a hard error (cannot be downgraded to a warning) in the future
make: *** [puma_http11.bundle] Error 1
```

My version of `clang` is:

```
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 5.1 (clang-503.0.38) (based on LLVM 3.4svn)
Target: x86_64-apple-darwin13.1.0
Thread model: posix
```

This commit tells `extconf.rb` to delete this flag from DLDFLAGS variable in Makefile.
