### PR TITLE
Somewhere along the way, the variable which held the new Client object i...

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -185,8 +185,8 @@ module Puma
               else
                 begin
                   if io = sock.accept_nonblock
-                    c = Client.new io, nil
-                    pool << c
+                    client = Client.new io, nil
+                    pool << client
                   end
                 rescue SystemCallError
                 end
@@ -292,8 +292,8 @@ module Puma
               else
                 begin
                   if io = sock.accept_nonblock
-                    c = Client.new io, @binder.env(sock)
-                    pool << c
+                    client = Client.new io, @binder.env(sock)
+                    pool << client
                   end
                 rescue SystemCallError
                 end
@@ -732,8 +732,8 @@ module Puma
             begin
               if io = sock.accept_nonblock
                 count += 1
-                c = Client.new io, @binder.env(sock)
-                @thread_pool << c
+                client = Client.new io, @binder.env(sock)
+                @thread_pool << client
               end
             rescue SystemCallError
             end


### PR DESCRIPTION
...n #handle_servers was changed from 'client' to 'c'. The rescue block, however, for Errno::ECONNABORTED continued to try to close 'client', rescuing ALL errors from that call and just returning nil. The simple fix, then, was to rename the 'c' variable to the more descriptive 'client', which means that the Errno::ECONNABORTED rescue will actually close the client.

We can see the old variable here

https://github.com/puma/puma/blob/000deba3c186532b62bac80d77ea9b053491dd00/lib/puma/server.rb#L239-248
