### PR TITLE
`preload_app!` instead of `preload_app`

### DIFF
--- a/examples/config.rb
+++ b/examples/config.rb
@@ -132,7 +132,7 @@
 # Preload the application before starting the workers; this conflicts with
 # phased restart feature. (off by default)
 
-# preload_app
+# preload_app!
 
 # Additional text to display in process listing
 #


### PR DESCRIPTION
The correct property name is `preload_app!`, right?
