### PR TITLE
Set rack_env early enough.

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -286,13 +286,7 @@ module Puma
         return
       end
 
-      pos = []
-
-      if env = (@options[:environment] || ENV['RACK_ENV'])
-        pos << "config/puma/#{env}.rb"
-      end
-
-      pos << "config/puma.rb"
+      pos = ["config/puma/#{@options[:environment]}.rb", "config/puma.rb"]
       @options[:config_file] = pos.find { |f| File.exist? f }
     end
 
@@ -449,6 +443,8 @@ module Puma
     # for it to finish.
     #
     def run
+      set_rack_environment
+
       begin
         parse_options
       rescue UnsupportedOption
@@ -486,8 +482,6 @@ module Puma
       if dir = @options[:directory]
         Dir.chdir dir
       end
-
-      set_rack_environment
 
       if clustered?
         @events = PidEvents.new STDOUT, STDERR


### PR DESCRIPTION
Making sure default environment (development) will be checked when no environment setting is set.

Also removes redundant environment check.
