### PR TITLE
SSL support for JRuby

### DIFF
--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -36,15 +36,18 @@ ms_conn* engine_alloc(VALUE klass, VALUE* obj) {
   return conn;
 }
 
-VALUE engine_init_server(VALUE self, VALUE key, VALUE cert) {
+VALUE engine_init_server(VALUE self, VALUE mini_ssl_ctx) {
   VALUE obj;
   SSL_CTX* ctx;
   SSL* ssl;
 
   ms_conn* conn = engine_alloc(self, &obj);
 
-  StringValue(key);
-  StringValue(cert);
+  ID sym_key = rb_intern("key");
+  VALUE key = rb_funcall(mini_ssl_ctx, sym_key, 0);
+
+  ID sym_cert = rb_intern("cert");
+  VALUE cert = rb_funcall(mini_ssl_ctx, sym_cert, 0);
 
   ctx = SSL_CTX_new(SSLv23_server_method());
   conn->ctx = ctx;
@@ -184,7 +187,7 @@ void Init_mini_ssl(VALUE puma) {
 
   eError = rb_define_class_under(mod, "SSLError", rb_eStandardError);
 
-  rb_define_singleton_method(eng, "server", engine_init_server, 2);
+  rb_define_singleton_method(eng, "server", engine_init_server, 1);
   rb_define_singleton_method(eng, "client", engine_init_client, 0);
 
   rb_define_method(eng, "inject", engine_inject, 1);

--- a/test/test_minissl.rb
+++ b/test/test_minissl.rb
@@ -1,25 +1,29 @@
 require 'test/unit'
-
-unless defined? JRUBY_VERSION
-
 require 'puma'
 require 'puma/minissl'
 
 class TestMiniSSL < Test::Unit::TestCase
 
-  def test_raises_with_invalid_key_file
-    ctx = Puma::MiniSSL::Context.new
+  if defined?(JRUBY_VERSION)
+    def test_raises_with_invalid_keystore_file
+      ctx = Puma::MiniSSL::Context.new
 
-    exception = assert_raise(ArgumentError) { ctx.key = "/no/such/key" }
-    assert_equal("No such key file '/no/such/key'", exception.message)
+      exception = assert_raise(ArgumentError) { ctx.keystore = "/no/such/keystore" }
+      assert_equal("No such keystore file '/no/such/keystore'", exception.message)
+    end
+  else
+    def test_raises_with_invalid_key_file
+      ctx = Puma::MiniSSL::Context.new
+
+      exception = assert_raise(ArgumentError) { ctx.key = "/no/such/key" }
+      assert_equal("No such key file '/no/such/key'", exception.message)
+    end
+
+    def test_raises_with_invalid_cert_file
+      ctx = Puma::MiniSSL::Context.new
+
+      exception = assert_raise(ArgumentError) { ctx.cert = "/no/such/cert" }
+      assert_equal("No such cert file '/no/such/cert'", exception.message)
+    end
   end
-
-  def test_raises_with_invalid_cert_file
-    ctx = Puma::MiniSSL::Context.new
-
-    exception = assert_raise(ArgumentError) { ctx.cert = "/no/such/cert" }
-    assert_equal("No such cert file '/no/such/cert'", exception.message)
-  end
-end
-
 end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -18,46 +18,11 @@ class TestPumaServer < Test::Unit::TestCase
 
     @events = Puma::Events.new STDOUT, STDERR
     @server = Puma::Server.new @app, @events
-
-    if defined?(JRUBY_VERSION)
-      @ssl_key =  File.expand_path "../../examples/puma/keystore.jks", __FILE__
-      @ssl_cert = @ssl_key
-    else
-      @ssl_key =  File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
-      @ssl_cert = File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
-    end
   end
 
   def teardown
     @server.stop(true)
   end
-
-  def test_url_scheme_for_https
-    ctx = Puma::MiniSSL::Context.new
-
-    ctx.key = @ssl_key
-    ctx.cert = @ssl_cert
-
-    ctx.verify_mode = Puma::MiniSSL::VERIFY_NONE
-
-    @server.add_ssl_listener @host, @port, ctx
-    @server.run
-
-    http = Net::HTTP.new @host, @port
-    http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-
-    body = nil
-    http.start do
-      req = Net::HTTP::Get.new "/", {}
-
-      http.request(req) do |rep|
-        body = rep.body
-      end
-    end
-
-    assert_equal "https", body
-  end unless defined? JRUBY_VERSION
 
   def test_proper_stringio_body
     data = nil

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -1,0 +1,91 @@
+require "rbconfig"
+require 'test/unit'
+require 'socket'
+require 'openssl'
+
+require 'puma/minissl'
+require 'puma/server'
+
+require 'net/https'
+
+class TestPumaServerSSL < Test::Unit::TestCase
+
+  def setup
+    @port = 3212
+    @host = "127.0.0.1"
+
+    @app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
+
+    ctx = Puma::MiniSSL::Context.new
+
+    if defined?(JRUBY_VERSION)
+      ctx.keystore =  File.expand_path "../../examples/puma/keystore.jks", __FILE__
+      ctx.keystore_pass = 'blahblah'
+    else
+      ctx.key =  File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
+      ctx.cert = File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
+    end
+
+    ctx.verify_mode = Puma::MiniSSL::VERIFY_NONE
+
+    @events = Puma::Events.new STDOUT, STDERR
+    @server = Puma::Server.new @app, @events
+    @server.add_ssl_listener @host, @port, ctx
+    @server.run
+
+    @http = Net::HTTP.new @host, @port
+    @http.use_ssl = true
+    @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+  end
+
+  def teardown
+    @server.stop(true)
+  end
+
+  def test_url_scheme_for_https
+    body = nil
+    @http.start do
+      req = Net::HTTP::Get.new "/", {}
+
+      @http.request(req) do |rep|
+        body = rep.body
+      end
+    end
+
+    assert_equal "https", body
+  end
+
+  def test_very_large_return
+    giant = "x" * 2056610
+
+    @server.app = proc do
+      [200, {}, [giant]]
+    end
+
+    body = nil
+    @http.start do
+      req = Net::HTTP::Get.new "/"
+      @http.request(req) do |rep|
+        body = rep.body
+      end
+    end
+
+    assert_equal giant.bytesize, body.bytesize
+  end
+
+  def test_form_submit
+    body = nil
+    @http.start do
+      req = Net::HTTP::Post.new '/'
+      req.set_form_data('a' => '1', 'b' => '2')
+
+      @http.request(req) do |rep|
+        body = rep.body
+      end
+
+    end
+
+    assert_equal "https", body
+  end
+
+end


### PR DESCRIPTION
- Implement MiniSSL for JRuby
- Modify `Binder` and `MiniSSL::Context` to to accommodate the fact
  that Java SSL demands a java keystore rather than a key/cert pair
- Change the MiniSSL native extension interface to take a
  `MiniSSL::Context` rather than a key/cert pair so that each extension
  can grab keys off the context as appropriate

We've been running a build of this and it's been solid, but if/when any issues surface or maintenance is needed, @mention me any time and I'd be glad to help.

Let me know if you have any questions at all, and thanks!
