### PR TITLE
pumactl - do not modify original ARGV

### DIFF
--- a/bin/pumactl
+++ b/bin/pumactl
@@ -2,7 +2,7 @@
 
 require 'puma/control_cli'
 
-cli = Puma::ControlCLI.new ARGV
+cli = Puma::ControlCLI.new ARGV.dup
 
 begin
   cli.run


### PR DESCRIPTION
ARGV used later in `lib/puma/cli.rb` to construct `restart_cmd`
close #436
