### PR TITLE
Typo BUNDLER_GEMFILE -> BUNDLE_GEMFILE

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -183,7 +183,7 @@ module Puma
 
       # If we're not running under a Bundler context, then
       # report the info about the context we will be using
-      if !ENV['BUNDLER_GEMFILE'] and File.exist?("Gemfile")
+      if !ENV['BUNDLE_GEMFILE'] and File.exist?("Gemfile")
         log "+ Gemfile in context: #{File.expand_path("Gemfile")}"
       end
 


### PR DESCRIPTION
I was wondering why puma was logging that I wasn't using puma via bundle exec when it was the case. Turns out `ENV['BUNDLER_GEMFILE']` does not exists, `ENV['BUNDLE_GEMFILE']` does: 

`ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)`
