### PR TITLE
changed pumactl restart for phased-restart in the init script

### DIFF
--- a/tools/jungle/init.d/puma
+++ b/tools/jungle/init.d/puma
@@ -126,7 +126,7 @@ do_restart_one() {
   
   if [ -e $PIDFILE ]; then
     log_daemon_msg "--> About to restart puma $1"
-    pumactl --state $dir/tmp/puma/state restart
+    pumactl --state $dir/tmp/puma/state phased-restart
     # kill -s USR2 `cat $PIDFILE`
     # TODO Check if process exist
   else


### PR DESCRIPTION
Since the creation of the init script, there is a new restart method called phased restart. Isn't this option better for a default init script?