### PR TITLE
Log the current time when Puma shuts down.

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -322,6 +322,7 @@ module Puma
 
     def graceful_stop
       @runner.stop_blocked
+      log "=== puma shutdown: #{Time.now} ==="
       log "- Goodbye!"
     end
 


### PR DESCRIPTION
Hi,

My team occasionally observe Puma shutting down in our CI environment. We can't see any strange behaviour in the logs so we think that the process is being killed somehow.

We think that logging when Puma shuts down will help us investigate further.

Currently, Puma logs the time when it starts:

``` shell
=== puma startup: 2014-06-27 13:13:48 +0100 ===
```

but not when it shuts down:

``` shell
- Gracefully stopping, waiting for requests to finish
- Goodbye!
```

This simple patch fixes that (tested locally), and looks like this:

``` shell
- Gracefully stopping, waiting for requests to finish
- Puma shutdown: 2014-07-01 14:13:10 +0100
- Goodbye!
```

Many thanks,
Ben
