### PR TITLE
First change the directory to use the correct Gemfile.

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -448,6 +448,10 @@ module Puma
         exit 1
       end
 
+      if dir = @options[:directory]
+        Dir.chdir dir
+      end
+
       if prune_bundler? && defined?(Bundler)
         puma = Bundler.rubygems.loaded_specs("puma")
 
@@ -474,10 +478,6 @@ module Puma
         end
 
         log "! Unable to prune Bundler environment, continuing"
-      end
-
-      if dir = @options[:directory]
-        Dir.chdir dir
       end
 
       set_rack_environment


### PR DESCRIPTION
I set the prune_bundler option for a graceful restart and during the deployment with capistrano I found out that puma used allways the Gemfile from the previous release. 
After a day of trying to fix it with several different deployments and options.
I found out that puma does the prune_bundler option before changing the directory.
So the old Gemfile is used which seams wrong to me.

Can anyone look at my fix and help me with that?
Thanks in advance.
