### PR TITLE
better error logging during startup

### DIFF
--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -112,7 +112,7 @@ module Puma
       begin
         @app = @cli.config.app
       rescue Exception => e
-        log "! Unable to load application"
+        log "! Unable to load application: #{e.class}: #{e.message}"
         raise e
       end
 


### PR DESCRIPTION
When puma is daemonized (or maybe always?) it swallows exceptions that happen during startup. This patch makes the log message slightly more useful.

Should we log the entire stacktrace too? Clutter vs. info...

Next up: track down why the other exceptions are swallowed, since I ended up having to launch it _un_daemonized to find out that I had a typo in my pidfile path...
