### PR TITLE
Add feature to read config from STDIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,13 @@ You can also provide a configuration file which Puma will use with the `-C` (or 
 
 By default, if no configuration file is specifed, Puma will look for a configuration file at config/puma.rb. If an environment is specified, either via the `-e` and `--environment` flags, or through the `RACK_ENV` environment variable, the default file location will be config/puma/environment_name.rb.
 
-If you want to prevent Puma from looking for a configuration file in those locations, provide a dash as the argument to the `-C` (or `--config`) flag:
+If you want to read config from STDIN, provide a dash as the argument to the `-C` (or `--config`) flag:
 
-    $ puma -C "-"
+    $ echo "bind 'tcp://0.0.0.0:3362'" | puma -C -
+
+To prevent Puma from looking for a configuration file in its default locations, pass an empty string to STDIN:
+
+    $ echo | puma -C -
 
 Take the following [sample configuration](https://github.com/puma/puma/blob/master/examples/config.rb) as inspiration or check out [configuration.rb](https://github.com/puma/puma/blob/master/lib/puma/configuration.rb) to see all available options.
 

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -276,15 +276,7 @@ module Puma
     end
 
     def find_config
-      if cfg = @options[:config_file]
-        # Allow - to disable config finding
-        if cfg == "-"
-          @options[:config_file] = nil
-          return
-        end
-
-        return
-      end
+      return if cfg = @options[:config_file]
 
       pos = ["config/puma/#{env}.rb", "config/puma.rb"]
       @options[:config_file] = pos.find { |f| File.exist? f }

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -168,7 +168,11 @@ module Puma
       end
 
       def _load_from(path)
-        instance_eval File.read(path), path, 1
+        if path == '-'
+          instance_eval STDIN.read, 'STDIN', 0
+        else
+          instance_eval File.read(path), path, 1
+        end
       end
 
       # Use +obj+ or +block+ as the Rack app. This allows a config file to


### PR DESCRIPTION
Provide a dash as the argument to the `--config` flag to read config from STDIN.
Using dash as filename is a standard way to tell the program that you want to read something from STDIN.

This will break previous behavior when `--config -` meant "do not search for a config file in its default locations".
Instead, you should use something like `echo | puma -C -` to provide an empty config.