### PR TITLE
Clean out a threads local data before doing work

### DIFF
--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -89,6 +89,10 @@ module Puma
 
           break unless continue
 
+          Thread.current.keys.each do |key|
+            Thread.current[key] = nil unless key == :__recursive_key__
+          end
+
           block.call(work, *extra)
         end
 

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -153,4 +153,28 @@ class TestThreadPool < Test::Unit::TestCase
 
     assert_equal 1, pool.spawned
   end
+
+  def test_cleanliness
+    values = []
+    n = 100
+    mutex = Mutex.new
+
+    finished = false
+
+    pool = new_pool(1,1) {
+      mutex.synchronize { values.push Thread.current[:foo] }
+      Thread.current[:foo] = :hai
+      Thread.pass until finished
+    }
+
+    n.times { pool << 1 }
+
+    finished = true
+
+    pause
+
+    assert_equal n,  values.length
+
+    assert_equal [], values.compact
+  end
 end


### PR DESCRIPTION
When performing work in the thread pool, the thread pool has any thread variables left from the last time it was used.
