### PR TITLE
Change umask examples to more permissive values

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If you're preloading your application and using ActiveRecord, it's recommend you
         ActiveRecord::Base.establish_connection
       end
     end
-    
+
 When you use preload_app, your new code goes all in the master process, and is then copied in the workers (meaning it’s only compatible with cluster mode). General rule is to use preload_app when your workers die often and need fast starts. If you don’t have many workers, you probably should not use preload_app.
 
 Note that preload_app can’t be used with phased restart, since phased restart kills and restarts workers one-by-one, and preload_app is all about copying the code of master into the workers.
@@ -133,7 +133,7 @@ Want to use UNIX Sockets instead of TCP (which can provide a 5-10% performance b
 
 If you need to change the permissions of the UNIX socket, just add a umask parameter:
 
-    $ puma -b 'unix:///var/run/puma.sock?umask=0777'
+    $ puma -b 'unix:///var/run/puma.sock?umask=0111'
 
 Need a bit of security? Use SSL sockets!
 

--- a/examples/config.rb
+++ b/examples/config.rb
@@ -73,7 +73,7 @@
 #
 # bind 'tcp://0.0.0.0:9292'
 # bind 'unix:///var/run/puma.sock'
-# bind 'unix:///var/run/puma.sock?umask=0777'
+# bind 'unix:///var/run/puma.sock?umask=0111'
 # bind 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert'
 
 # Instead of “bind 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert'” you


### PR DESCRIPTION
The existing umask examples default to no permissions at all, which doesn't seem particularly useful to anybody. This changes the examples to read/write, which should be a better baseline.
