### PR TITLE
Allow binding to ipv6 addresses for ssl URIs

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -227,6 +227,7 @@ module Puma
                          optimize_for_latency=true, backlog=1024)
       require 'puma/minissl'
 
+      host = host[1..-2] if host[0..0] == '['
       s = TCPServer.new(host, port)
       if optimize_for_latency
         s.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)


### PR DESCRIPTION
Same fixe as for TCP URIs, introduced in 868671e2bc
