### PR TITLE
Don't write lowlevel_error_handler to state

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -229,7 +229,7 @@ module Puma
 
         cfg = @config.dup
 
-        [ :logger, :before_worker_shutdown, :before_worker_boot, :after_worker_boot, :on_restart ].each { |o| cfg.options.delete o }
+        [ :logger, :before_worker_shutdown, :before_worker_boot, :after_worker_boot, :on_restart, :lowlevel_error_handler ].each { |o| cfg.options.delete o }
 
         state["config"] = cfg
 


### PR DESCRIPTION
lowlevel_error_handler should be ignored when writing state, otherwise the state file will contain: `:lowlevel_error_handler: !ruby/object:Proc {}` the user will see the infamous "allocator undefined for Proc" error when using pumactl