### PR TITLE
Fix phased restart with worker shutdown timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ t/
 .rbx/
 Gemfile.lock
 .idea/
+/test/test_puma.state
+/test/test_server.sock
+/test/test_control.sock

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -491,7 +491,7 @@ module Puma
       set_rack_environment
 
       if clustered?
-        @events = PidEvents.new STDOUT, STDERR
+        @events.formatter = Events::PidFormatter.new
         @options[:logger] = @events
 
         @runner = Cluster.new(self)

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -43,12 +43,14 @@ module Puma
     end
 
     class Worker
-      def initialize(idx, pid, phase)
+      def initialize(idx, pid, phase, options)
         @index = idx
         @pid = pid
         @phase = phase
         @stage = :started
         @signal = "TERM"
+        @options = options
+        @first_term_sent = nil
         @last_checkin = Time.now
       end
 
@@ -105,7 +107,7 @@ module Puma
 
         pid = fork { worker(idx, master) }
         @cli.debug "Spawned worker: #{pid}"
-        @workers << Worker.new(idx, pid, @phase)
+        @workers << Worker.new(idx, pid, @phase, @options)
         @options[:after_worker_boot].each { |h| h.call }
       end
 

--- a/test/hello-stuck.ru
+++ b/test/hello-stuck.ru
@@ -1,0 +1,1 @@
+run lambda { |env| sleep 60; [200, {"Content-Type" => "text/plain"}, ["Hello World"]] }


### PR DESCRIPTION
This pull request fixes phased restart with worker shutdown timeout.

This is from our production stderr log:

```
.../bundle/ruby/2.1.0/gems/puma-2.10.2/lib/puma/cluster.rb:76:in `term': undefined method `[]' for nil:NilClass (NoMethodError)
from .../bundle/ruby/2.1.0/gems/puma-2.10.2/lib/puma/cluster.rb:169:in `check_workers'
from .../bundle/ruby/2.1.0/gems/puma-2.10.2/lib/puma/cluster.rb:408:in `run'
from .../bundle/ruby/2.1.0/gems/puma-2.10.2/lib/puma/cli.rb:507:in `run'
from .../bundle/ruby/2.1.0/gems/puma-2.10.2/bin/puma-wild:31:in `<main>'
```

This bug was introduced in 2.10 with [#566](https://github.com/puma/puma/pull/566/files#diff-c2ca2259d38a531715284b3ec3f4b698R76)

lib/puma/cluster.rb:76:

```ruby
if @first_term_sent && (Time.new - @first_term_sent) > @options[:worker_shutdown_timeout]
```

The problem is that `@options` are not passed down to cluster workers.

I also changed `Events` class a bit, so that it doesn't throw everything
to STDOUT/STDERR when in cluster mode.
