### PR TITLE
Add a configuration option that prevents puma from queueing requests.

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -222,6 +222,14 @@ module Puma
       end
     end # IS_JRUBY
 
+    def finish
+      return true if @ready
+      until try_to_finish
+        IO.select([@to_io], nil, nil)
+      end
+      true
+    end
+
     def read_body
       # Read an odd sized chunk so we can read even sized ones
       # after this

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -27,7 +27,6 @@ module Puma
       @options[:after_worker_boot] ||= []
       @options[:worker_timeout] ||= DefaultWorkerTimeout
       @options[:worker_shutdown_timeout] ||= DefaultWorkerShutdownTimeout
-      @options[:queue_requests] ||= true
     end
 
     attr_reader :options

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -27,6 +27,7 @@ module Puma
       @options[:after_worker_boot] ||= []
       @options[:worker_timeout] ||= DefaultWorkerTimeout
       @options[:worker_shutdown_timeout] ||= DefaultWorkerShutdownTimeout
+      @options[:queue_requests] ||= true
     end
 
     attr_reader :options
@@ -401,6 +402,23 @@ module Puma
       # *Cluster mode only* Set the timeout for worker shutdown
       def worker_shutdown_timeout(timeout)
         @options[:worker_shutdown_timeout] = timeout
+      end
+
+      # When set to true (the default), workers accept all requests
+      # and queue them before passing them to the handlers.
+      # When set to false, each worker process accepts exactly as
+      # many requests as it is configured to simultaneously handle.
+      #
+      # Queueing requests generally improves performance. In some
+      # cases, such as a single threaded application, it may be
+      # better to ensure requests get balanced across workers.
+      #
+      # Note that setting this to false disables HTTP keepalive and
+      # slow clients will occupy a handler thread while the request
+      # is being sent. A reverse proxy, such as nginx, can handle
+      # slow clients and queue requests before they reach puma.
+      def queue_requests(answer=true)
+        @options[:queue_requests] = answer
       end
     end
   end

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -87,9 +87,9 @@ module Puma
               @waiting += 1
               not_full.signal
               not_empty.wait mutex
+              @waiting -= 1
             end
 
-            @waiting -= 1
             work = todo.shift if continue
           end
 
@@ -128,7 +128,6 @@ module Puma
 
         if @waiting < @todo.size and @spawned < @max
           spawn_thread
-          @waiting+=1
         end
 
         @not_empty.signal


### PR DESCRIPTION
Issue https://github.com/puma/puma/issues/612

This adds a configuration option queue_requests

With queue_requests set to true (the default), workers accept all
requests and queue them before passing them to the handlers.
With it set to false, each worker process accepts exactly as
many requests as it is configured to simultaneously handle.

In combination with threads 1, 1 this ensures that requests
are balanced across workers in a single threaded application.
This can avoid deadlocks when a single threaded app sends a
request to itself. (For example, to generate a PDF.)