### PR TITLE
Avoid crash in strange restart conditions

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -307,7 +307,7 @@ module Puma
           if threads.first.respond_to? :backtrace
             log "! WARNING: Detected #{after.size-before.size} Thread(s) started in app boot:"
             threads.each do |t|
-              log "! #{t.inspect} - #{t.backtrace.first}"
+              log "! #{t.inspect} - #{t.backtrace ? t.backtrace.first : ''}"
             end
           else
             log "! WARNING: Detected #{after.size-before.size} Thread(s) started in app boot"


### PR DESCRIPTION
I got the following crash on my production platform :
/home/deploy/.rbenv/versions/2.2.0/gemsets/e82ef14dcf8086bc79b93c8607436f02/gems/puma-2.10.1/lib/puma/cluster.rb:298:in `block in run': undefined method `first' for nil:NilClass (NoMethodError)
	from /home/deploy/.rbenv/versions/2.2.0/gemsets/e82ef14dcf8086bc79b93c8607436f02/gems/puma-2.10.1/lib/puma/cluster.rb:297:in `each'
	from /home/deploy/.rbenv/versions/2.2.0/gemsets/e82ef14dcf8086bc79b93c8607436f02/gems/puma-2.10.1/lib/puma/cluster.rb:297:in `run'
	from /home/deploy/.rbenv/versions/2.2.0/gemsets/e82ef14dcf8086bc79b93c8607436f02/gems/puma-2.10.1/lib/puma/cli.rb:507:in `run'
	from /home/deploy/.rbenv/versions/2.2.0/gemsets/e82ef14dcf8086bc79b93c8607436f02/gems/puma-2.10.1/bin/puma:10:in `<top (required)>'
	from /home/deploy/.rbenv/versions/2.2.0/gemsets/e82ef14dcf8086bc79b93c8607436f02/bin/puma:23:in `load'
	from /home/deploy/.rbenv/versions/2.2.0/gemsets/e82ef14dcf8086bc79b93c8607436f02/bin/puma:23:in `<main>'

I add a test in the log code to avoid the crash.