### PR TITLE
Ignore multiple duplicate port declarations

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -64,6 +64,8 @@ module Puma
       unless @options[:tag]
         @options[:tag] = infer_tag
       end
+
+      @options[:binds].uniq!
     end
 
     def infer_tag

--- a/test/config/app.rb
+++ b/test/config/app.rb
@@ -1,3 +1,5 @@
+port ENV['PORT'] if ENV['PORT']
+
 app do |env|
   [200, {}, ["embedded app"]]
 end


### PR DESCRIPTION
Right now if you specify a port via `-p $PORT` and via a `config/puma.rb` then puma will incorrectly try to bind to the same port twice and will fail.

This PR calls `uniq!` on the array to remove duplicate ports from the `binds` array. It also emits a warning when `binds` or `port` is called with an already existing port specified:

```
Warning :binds or :port specified twice: "test/config/app.rb:1:in `_load_from'"
```