### PR TITLE
Update default of NEWRELIC_DISPACHER for New Relic

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -35,7 +35,7 @@ module Puma
 
       @config = nil
 
-      ENV['NEWRELIC_DISPATCHER'] ||= "puma"
+      ENV['NEWRELIC_DISPATCHER'] ||= "Puma"
 
       setup_options
       generate_restart_data


### PR DESCRIPTION
Current [`NEWRELIC_DISPACHER` default value](https://github.com/puma/puma/blob/3c93cc423f8e3a1a438b3a528b2c342c753dae3d/lib/puma/cli.rb#L38) is not works in Rails 4.2 with Puma, New Relic on Heroku.

Not works:

    $ heroku config:add NEWRELIC_DISPACHER=puma

Works:

    $ heroku config:add NEWRELIC_DISPACHER=Puma

So I've updated the default of  `NEWRELIC_DISPACHER`.