### PR TITLE
Proper 'Connection' header handling compatible with HTTP/1.0 and HTTP/1.1

### DIFF
--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -106,7 +106,7 @@ class TestPersistent < Test::Unit::TestCase
 
     @client << @http10_request
 
-    assert_equal "HTTP/1.0 200 OK\r\nX-Header: Works\r\nConnection: close\r\n\r\n", lines(4)
+    assert_equal "HTTP/1.0 200 OK\r\nX-Header: Works\r\n\r\n", lines(3)
     assert_equal "HelloChunked", @client.read
   end
 
@@ -132,7 +132,7 @@ class TestPersistent < Test::Unit::TestCase
     @client << @http10_request
     sz = @body[0].size.to_s
 
-    assert_equal "HTTP/1.0 200 OK\r\nX-Header: Works\r\nConnection: close\r\nContent-Length: #{sz}\r\n\r\n", lines(5)
+    assert_equal "HTTP/1.0 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
     assert_equal "Hello", @client.read(5)
   end
 

--- a/test/test_unix_socket.rb
+++ b/test/test_unix_socket.rb
@@ -8,31 +8,31 @@ require 'socket'
 # (or Windows)
 unless defined?(JRUBY_VERSION) || RbConfig::CONFIG["host_os"] =~ /mingw|mswin/
   class TestPumaUnixSocket < Test::Unit::TestCase
-  
+
     App = lambda { |env| [200, {}, ["Works"]] }
-  
+
     Path = "test/puma.sock"
-  
+
     def setup
       @server = Puma::Server.new App
       @server.add_unix_listener Path
       @server.run
     end
-  
+
     def teardown
       @server.stop(true)
       File.unlink Path if File.exist? Path
     end
-  
+
     def test_server
       sock = UNIXSocket.new Path
-  
+
       sock << "GET / HTTP/1.0\r\nHost: blah.com\r\n\r\n"
-  
-      expected = "HTTP/1.0 200 OK\r\nConnection: close\r\nContent-Length: 5\r\n\r\nWorks"
-  
+
+      expected = "HTTP/1.0 200 OK\r\nContent-Length: 5\r\n\r\nWorks"
+
       assert_equal expected, sock.read(expected.size)
-  
+
       sock.close
     end
   end


### PR DESCRIPTION
Hi,

I hope you find this pull request useful. It includes a fix which makes puma handle the 'Connection' header properly. 

In the current state, when you make an HTTP/1.1 request with the 'Connection' header set to 'close', you expect it to always respond with the 'Connection: close'. It's not the case if the server responds with a 204 status code or any other code without a body. The response won't include the 'Connection' header at all. This behavior can cause potential issues, such as writing to a socket that's already closed if some proxy server rewrites the 'Connection' header to 'close' and a client expects the connection to last for more than one request. Even though the [HTTP/1.1 Message and Routing RFC - Persistence](http://tools.ietf.org/html/rfc7230#section-6.3) states that *connection can be closed at any time, with or without intention* it's always nice to inform a client about the server intention to close the connection. 

The pull request changes the current state to behave in the following way:

* If the received protocol is HTTP/1.1, and no 'Connection' header is present, or the header is set to 'keep-alive', the connection will persist and the header won't be present in the response
* If the received protocol is HTTP/1.1, and the 'Connection' header is present and is set to 'close', the connection will not persist and the response will include the 'Connection' header set to 'close'
* If the received protocol is HTTP/1.0, and no 'Connection' header is present, or the header is set to 'close', the connection will not persist and the header won't be present in the response
* If the received protocol is HTTP/1.0, and the 'Connection' header is present and is set to 'keep-alive', the connection will persist and the response will include the 'Connection' header set to 'keep-alive'

Hope that make sense.

Kind Regards