### PR TITLE
Add `on_worker_fork` hook, which allows to mimic Unicorn's behavior

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -101,6 +101,7 @@ module Puma
         :daemon => false,
         :before_worker_shutdown => [],
         :before_worker_boot => [],
+        :before_worker_fork => [],
         :after_worker_boot => []
       }
 
@@ -229,7 +230,7 @@ module Puma
 
         cfg = @config.dup
 
-        [ :logger, :before_worker_shutdown, :before_worker_boot, :after_worker_boot, :on_restart, :lowlevel_error_handler ].each { |o| cfg.options.delete o }
+        [ :logger, :before_worker_shutdown, :before_worker_boot, :before_worker_fork, :after_worker_boot, :on_restart, :lowlevel_error_handler ].each { |o| cfg.options.delete o }
 
         state["config"] = cfg
 

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -104,6 +104,7 @@ module Puma
 
       diff.times do
         idx = next_worker_index
+        @options[:before_worker_fork].each { |h| h.call(idx) }
 
         pid = fork { worker(idx, master) }
         @cli.debug "Spawned worker: #{pid}"

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -24,6 +24,7 @@ module Puma
       @options[:on_restart] ||= []
       @options[:before_worker_shutdown] ||= []
       @options[:before_worker_boot] ||= []
+      @options[:before_worker_fork] ||= []
       @options[:after_worker_boot] ||= []
       @options[:worker_timeout] ||= DefaultWorkerTimeout
       @options[:worker_shutdown_timeout] ||= DefaultWorkerShutdownTimeout
@@ -343,6 +344,15 @@ module Puma
       #
       def on_worker_boot(&block)
         @options[:before_worker_boot] << block
+      end
+
+      # *Cluster mode only* Code to run when a master process is
+      # about to create the worker by forking itself.
+      #
+      # This can be called multiple times to add hooks.
+      #
+      def on_worker_fork(&block)
+        @options[:before_worker_fork] << block
       end
 
       # *Cluster mode only* Code to run when a worker boots to setup


### PR DESCRIPTION
http://bogomips.org/unicorn.git/tree/lib/unicorn/configurator.rb#n154
http://unicorn.bogomips.org/Unicorn/Configurator.html#method-i-before_fork

After reading both unicorn and puma cluster implementations,
I think  this hook is required when `preload_app` is used to drop
ActiveRecord connections, established in master process.