### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ and then
 $ bundle exec cap puma:start
 $ bundle exec cap puma:restart
 $ bundle exec cap puma:stop
-$ bundle exec cap puma:phased_restart
+$ bundle exec cap puma:phased-restart
 ```
 
 ## Contributing


### PR DESCRIPTION
Fixed typo in puma README. The external capistrano-puma gem requires the phased restart task to be invoked with:

```ruby
bundle exec cap puma:phased-restart
```