### PR TITLE
Fix example config text

### DIFF
--- a/examples/config.rb
+++ b/examples/config.rb
@@ -119,14 +119,14 @@
 # This can be called multiple times to add hooks.
 #
 # after_worker_boot do
-#   puts 'On worker boot...'
+#   puts 'After worker boot...'
 # end
 
 # Code to run when a worker shutdown.
 #
 #
 # on_worker_shutdown do
-#   puts 'On worker boot...'
+#   puts 'On worker shutdown...'
 # end
 
 # Allow workers to reload bundler context when master process is issued


### PR DESCRIPTION
Update example config with correct text for `on_worker_*` blocks