### PR TITLE
Fix C/JRuby hang on bad SSL handshake (fixes JRuby travis)

### DIFF
--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -161,7 +161,7 @@ void raise_error(SSL* ssl, int result) {
 VALUE engine_read(VALUE self) {
   ms_conn* conn;
   char buf[512];
-  int bytes, n;
+  int bytes, n, error;
 
   Data_Get_Struct(self, ms_conn, conn);
 
@@ -173,7 +173,8 @@ VALUE engine_read(VALUE self) {
 
   if(SSL_want_read(conn->ssl)) return Qnil;
 
-  if(SSL_get_error(conn->ssl, bytes) == SSL_ERROR_ZERO_RETURN) {
+  error = SSL_get_error(conn->ssl, bytes);
+  if(error == SSL_ERROR_ZERO_RETURN || error == SSL_ERROR_SSL) {
     rb_eof_error();
   }
 

--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -153,13 +153,7 @@ public class MiniSSL extends RubyObject {
     sslCtx.init(kmf.getKeyManagers(), null, null);
     engine = sslCtx.createSSLEngine();
 
-    IRubyObject enableSSLv3 = miniSSLContext.callMethod(threadContext, "enable_SSLv3");
-    String[] protocols;
-    if (enableSSLv3 instanceof RubyBoolean && enableSSLv3.isTrue()) {
-      protocols = new String[] { "SSLv2Hello", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2" };
-    } else {
-      protocols = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
-    }
+    String[] protocols = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
     engine.setEnabledProtocols(protocols);
     engine.setUseClientMode(false);
 

--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -308,8 +308,10 @@ public class MiniSSL extends RubyObject {
       log("read(): end dump of request data   <<<<\n");
       return str;
     } catch (Exception e) {
-      e.printStackTrace();
-      throw new RuntimeException(e);
+      if (DEBUG) {
+        e.printStackTrace();
+      }
+      throw getRuntime().newEOFError(e.getMessage());
     }
   }
 

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -95,11 +95,6 @@ module Puma
         # jruby-specific Context properties: java uses a keystore and password pair rather than a cert/key pair
         attr_reader :keystore
         attr_accessor :keystore_pass
-        attr_accessor :enable_SSLv3
-
-        def initialize
-          @enable_SSLv3 = false
-        end
 
         def keystore=(keystore)
           raise ArgumentError, "No such keystore file '#{keystore}'" unless File.exist? keystore

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -97,41 +97,4 @@ class TestPumaServerSSL < Test::Unit::TestCase
     end
   end
 
-  if defined?(JRUBY_VERSION)
-    def test_enabling_ssl_v3_support
-      @server.stop(true)
-      @ctx.enable_SSLv3 = true
-      @server = Puma::Server.new @app, @events
-      @server.add_ssl_listener @host, @port, @ctx
-      @server.run
-      @http.ssl_version='SSLv3'
-
-      body = nil
-      @http.start do
-        req = Net::HTTP::Get.new "/", {}
-
-        @http.request(req) do |rep|
-          body = rep.body
-        end
-      end
-
-      assert_equal "https", body
-    end
-
-    def test_enabling_ssl_v3_support_requires_true
-      @server.stop(true)
-      @ctx.enable_SSLv3 = "truthy but not true"
-      @server = Puma::Server.new @app, @events
-      @server.add_ssl_listener @host, @port, @ctx
-      @server.run
-      @http.ssl_version='SSLv3'
-
-      assert_raises(OpenSSL::SSL::SSLError) do
-        @http.start do
-          Net::HTTP::Get.new '/'
-        end
-      end
-    end
-  end
-
 end

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -88,16 +88,16 @@ class TestPumaServerSSL < Test::Unit::TestCase
     assert_equal "https", body
   end
 
-  if defined?(JRUBY_VERSION)
-    def test_ssl_v3_support_disabled_by_default
-      @http.ssl_version='SSLv3'
-      assert_raises(OpenSSL::SSL::SSLError) do
-        @http.start do
-          Net::HTTP::Get.new '/'
-        end
+  def test_ssl_v3_rejection
+    @http.ssl_version='SSLv3'
+    assert_raises(OpenSSL::SSL::SSLError) do
+      @http.start do
+        Net::HTTP::Get.new '/'
       end
     end
+  end
 
+  if defined?(JRUBY_VERSION)
     def test_enabling_ssl_v3_support
       @server.stop(true)
       @ctx.enable_SSLv3 = true


### PR DESCRIPTION
Both the C and JRuby SSL implementations would hang on a bad handshake because they were not producing the EOF expected in that case.  Update their error handling to behave correctly here (`test_ssl_v3_rejection` covers this for both impls).

This was the root cause of the recent hanging JRuby tests.  With the hang fixed, the test would fail because the SSLv3 handshake became "bad" when java updated to a version with SSLv3 disabled by default (see [here](http://www.oracle.com/technetwork/java/javase/documentation/cve-2014-3566-2342133.html)).  Fix this by removing `enable_SSLv3` support from JRuby (the C minissl implementation doesn't support it either since #591, so it clearly won't be missed).

Fixes #603, replaces #605.

Thanks again @evanphx.  Let me know if you have any questions.