### PR TITLE
Require Rack::Builder

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -1,3 +1,5 @@
+require 'rack/builder'
+
 module Puma
 
   module ConfigDefault


### PR DESCRIPTION
Fixes:

```
/opt/test/releases/20150505084239/vendor/bundle/ruby/2.2.0/gems/puma-2.11.2/lib/puma/configuration.rb:102:in `load_rackup': cannot load such file -- rack/builder (LoadError)
        from /opt/test/releases/20150505084239/vendor/bundle/ruby/2.2.0/gems/puma-2.11.2/lib/puma/configuration.rb:69:in `app'
        from /opt/test/releases/20150505084239/vendor/bundle/ruby/2.2.0/gems/puma-2.11.2/lib/puma/runner.rb:123:in `app'
        from /opt/test/releases/20150505084239/vendor/bundle/ruby/2.2.0/gems/puma-2.11.2/lib/puma/runner.rb:130:in `start_server'
        from /opt/test/releases/20150505084239/vendor/bundle/ruby/2.2.0/gems/puma-2.11.2/lib/puma/cluster.rb:213:in `worker'
        from /opt/test/releases/20150505084239/vendor/bundle/ruby/2.2.0/gems/puma-2.11.2/lib/puma/cluster.rb:109:in `block (2 levels) in spawn_workers'
        from /opt/test/releases/20150505084239/vendor/bundle/ruby/2.2.0/gems/puma-2.11.2/lib/puma/cluster.rb:109:in `fork'
        from /opt/test/releases/20150505084239/vendor/bundle/ruby/2.2.0/gems/puma-2.11.2/lib/puma/cluster.rb:109:in `block in spawn_workers'
        from /opt/test/releases/20150505084239/vendor/bundle/ruby/2.2.0/gems/puma-2.11.2/lib/puma/cluster.rb:105:in `times'
        from /opt/test/releases/20150505084239/vendor/bundle/ruby/2.2.0/gems/puma-2.11.2/lib/puma/cluster.rb:105:in `spawn_workers'
        from /opt/test/releases/20150505084239/vendor/bundle/ruby/2.2.0/gems/puma-2.11.2/lib/puma/cluster.rb:157:in `check_workers'
        from /opt/test/releases/20150505084239/vendor/bundle/ruby/2.2.0/gems/puma-2.11.2/lib/puma/cluster.rb:421:in `run'
        from /opt/test/releases/20150505084239/vendor/bundle/ruby/2.2.0/gems/puma-2.11.2/lib/puma/cli.rb:216:in `run'
        from /opt/test/releases/20150505084239/vendor/bundle/ruby/2.2.0/gems/puma-2.11.2/bin/puma-wild:31:in `<main>'
```

It happens when using phased restart and `/opt/test/releases/20150505084239` old release directory (where `puma` started) is already gone (cleaned up by `capistrano`).

This is because `rack` uses `autoload` to lazyload all rack-related files (including `rack/builder`). But in this case it's not enough, `require` is more appropriate. 

P.S. using `prune_bundler` option

@evanphx