### PR TITLE
Add support for batched phased restarts

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -307,6 +307,7 @@ module Puma
         :debug => false,
         :binds => [],
         :workers => 0,
+        :phased_restart_batch_count => nil, # default is one-after-one
         :daemon => false,
         :before_worker_shutdown => [],
         :before_worker_boot => [],

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -156,6 +156,13 @@ module Puma
       @options[:workers] = count.to_i
     end
 
+    # *Cluster mode only* How many worker processes to restart at a time,
+    # when doing a phased restart.
+    #
+    def phased_restart_batch_count(count)
+      @options[:phased_restart_batch_count] = count.to_i
+    end
+
     # *Cluster mode only* Code to run immediately before a worker shuts
     # down (after it has finished processing HTTP requests). These hooks
     # can block if necessary to wait for background operations unknown


### PR DESCRIPTION
We have a large number of workers, and the one-by-one phased restart simply takes too long. Was tested in a Centos 6.6 VM.