### PR TITLE
Add thread reaping to thread pool

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -39,6 +39,7 @@ module Puma
     attr_accessor :max_threads
     attr_accessor :persistent_timeout
     attr_accessor :auto_trim_time
+    attr_accessor :reaping_time
     attr_accessor :first_data_timeout
 
     # Create a server for the rack app +app+.
@@ -60,6 +61,7 @@ module Puma
       @min_threads = 0
       @max_threads = 16
       @auto_trim_time = 1
+      @reaping_time = 1
 
       @thread = nil
       @thread_pool = nil
@@ -272,6 +274,10 @@ module Puma
       if queue_requests
         @reactor = Reactor.new self, @thread_pool
         @reactor.run_in_thread
+      end
+
+      if @reaping_time
+        @thread_pool.auto_reap!(@reaping_time)
       end
 
       if @auto_trim_time

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -179,4 +179,51 @@ class TestThreadPool < Test::Unit::TestCase
 
     assert_equal [], values.compact
   end
+
+  def test_reap_only_dead_threads
+    pool = new_pool(2,2) { Thread.current.kill }
+
+    assert_equal 2, pool.spawned
+
+    pool << 1
+
+    pause
+
+    assert_equal 2, pool.spawned
+
+    pool.reap
+
+    assert_equal 1, pool.spawned
+
+    pool << 2
+
+    pause
+
+    assert_equal 1, pool.spawned
+
+    pool.reap
+
+    assert_equal 0, pool.spawned
+  end
+
+  def test_auto_reap_dead_threads
+    pool = new_pool(2,2) { Thread.current.kill }
+
+    assert_equal 2, pool.spawned
+
+    pool << 1
+    pool << 2
+
+    pause
+
+    assert_equal 2, pool.spawned
+
+    pool.auto_reap! 1
+
+    sleep 1
+
+    pause
+
+    assert_equal 0, pool.spawned
+  end
 end


### PR DESCRIPTION
Hi there.

# The Problem

As already discussed in #691 and #681 Puma does not recover from dead threads. Even though this is a fairly uncommon state and might only happen in edge cases. One of these edge cases seems to be using [rack-timeout](https://github.com/heroku/rack-timeout) as you can see in https://github.com/heroku/rack-timeout/issues/76 and https://github.com/rails/rails/issues/1627#issuecomment-76172622.

To reproduce this behavior use the following example rack app:

```ruby
# dummy.ru
class SimpleRacktimeout # stand-in for a more complex Rails app using all kind of different non rubycode ressouces
  def initialize(app)
    @app = app
  end

  def call(env)
    p '########### HELLO FROM APP ###########'
    begin
      app_thread     = Thread.current
      timeout_thread = Thread.start do
        app_thread.raise(Exception)
      end

      `sleep 1`
    ensure
     timeout_thread.kill
     timeout_thread.join
   end
  end
end

app = Rack::Builder.new do |b|
  b.use SimpleRacktimeout
  b.run lambda { |_env| [200, {}, ['ok']] }
end.to_app

run app
```

Start it with `puma -w 1 -b tcp://localhost -p 9292 -t 3:3 dummy.ru`. And then force Puma to concurrently serve more requests than it has (healthy) threads available by using Apache Benchmark `ab -n 8 -c 4 http://127.0.0.1:9292/`.

# Solution

This PR implements a thread reaping mechanism based on the auto trim functionality. It decreases the `@spawned` counter in the `ThreadPool` in order to allow it to spawn new threads.

# Alternative Solution

Instead you can use `th.abort_on_exception = true` in https://github.com/puma/puma/blob/master/lib/puma/thread_pool.rb#L112 which also solves the problem described above. We decided for the former solution because removing dead threads from the pool seemed a cleaner approach.

As mentioned in #691 we are not sure if and how active record connections in dead threads will be cleaned up.

> - any idea about how to kill active record connections of dead threads?

/cc @partyschaum
