### PR TITLE
Improve Travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: ruby
-script: "TESTOPTS=-v rake test"
-jdk:
-  - oraclejdk7
+cache: bundler
+script: "TESTOPTS=-v bundle exec rake test"
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
-  - 2.1.1
+  - 2.1
   - 2.2
   - jruby-19mode
   - jruby-head


### PR DESCRIPTION
- JDK 7 is default on Travis
- cache dependencies
- use always the latest Ruby 2.1.x