### PR TITLE
Check for system-wide rbenv install in Upstart script

### DIFF
--- a/tools/jungle/upstart/puma.conf
+++ b/tools/jungle/upstart/puma.conf
@@ -34,11 +34,14 @@ script
 # respawn as bash so we can source in rbenv/rvm
 # quoted heredoc to tell /bin/sh not to interpret
 # variables
+
 exec /bin/bash <<'EOT'
   # set HOME to the setuid user's home, there doesn't seem to be a better, portable way
   export HOME="$(eval echo ~$(id -un))"
 
-  if [ -d "$HOME/.rbenv/bin" ]; then
+  if [ -d "/usr/local/rbenv/bin" ]; then
+    export PATH="/usr/local/rbenv/bin:/usr/local/rbenv/shims:$PATH"
+  elif [ -d "$HOME/.rbenv/bin" ]; then
     export PATH="$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH"
   elif [ -f  /etc/profile.d/rvm.sh ]; then
     source /etc/profile.d/rvm.sh

--- a/tools/jungle/upstart/puma.conf
+++ b/tools/jungle/upstart/puma.conf
@@ -35,6 +35,9 @@ script
 # quoted heredoc to tell /bin/sh not to interpret
 # variables
 
+# source ENV variables manually as Upstart doesn't, eg:
+#. /etc/environment
+
 exec /bin/bash <<'EOT'
   # set HOME to the setuid user's home, there doesn't seem to be a better, portable way
   export HOME="$(eval echo ~$(id -un))"


### PR DESCRIPTION
The Jungle Upstart script breaks if rbenv is installed system-wide rather than for a specific user so have added an extra check (for `/usr/local/rbenv/bin`) in order to set `PATH` correctly.

Also, many applications use environment variables for their config (eg. `/etc/environment`) instead of an `application.yml` or similar, but Upstart doesn't pick up on these even from common locations (` /etc/environment`,  `/etc/profile.d/*.sh`) so they need to be sourced manually in the Upstart script. Have added in a commented an example of this.