### PR TITLE
Do not suppress Content-Length on partial hijack (fixes #710)

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -610,15 +610,13 @@ module Puma
           fast_write client, lines.to_s
           return keep_alive
         end
-
-        unless response_hijack
-          if content_length
-            lines.append CONTENT_LENGTH_S, content_length.to_s, line_ending
-            chunked = false
-          elsif allow_chunked
-            lines << TRANSFER_ENCODING_CHUNKED
-            chunked = true
-          end
+        
+        if content_length
+          lines.append CONTENT_LENGTH_S, content_length.to_s, line_ending
+          chunked = false
+        elsif allow_chunked
+          lines << TRANSFER_ENCODING_CHUNKED
+          chunked = true
         end
 
         lines << line_ending


### PR DESCRIPTION
The partial hijack API does not mandate that the server
handler will be removing any headers from the response, so if
the app has set a Content-Length header it should be kept intact.

Closes #710 