### PR TITLE
Make pumactl load config/puma.rb by default

### DIFF
--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -66,7 +66,15 @@ module Puma
       command = argv.shift
       @options[:command] = command if command
 
-      Puma::Configuration.new(@options).load if @options[:config_file]
+      unless @options[:config_file] == '-'
+        if @options[:config_file].nil? and File.exist?('config/puma.rb')
+          @options[:config_file] = 'config/puma.rb'
+        end
+
+        if @options[:config_file]
+          Puma::Configuration.new(@options).load
+        end
+      end
 
       # check present of command
       unless @options[:command]


### PR DESCRIPTION
`config/puma/#{env}.rb` isn't tried because there is no environment option for pumactl, though this could be added.