### PR TITLE
Handle ENOTCONN when setting REMOTE_ADDR

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -111,6 +111,7 @@ module Puma
     PORT_80 = "80".freeze
     PORT_443 = "443".freeze
     LOCALHOST = "localhost".freeze
+    LOCALHOST_IP = "127.0.0.1".freeze
 
     SERVER_PROTOCOL = "SERVER_PROTOCOL".freeze
     HTTP_11 = "HTTP/1.1".freeze

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -457,10 +457,16 @@ module Puma
       #
 
       unless env.key?(REMOTE_ADDR)
-        addr = client.peeraddr.last
+        begin
+          addr = client.peeraddr.last
+        rescue Errno::ENOTCONN
+          # Client disconnects can result in an inability to get the
+          # peeraddr from the socket; default to localhost.
+          addr = LOCALHOST_IP
+        end
 
         # Set unix socket addrs to localhost
-        addr = "127.0.0.1" if addr.empty?
+        addr = LOCALHOST_IP if addr.empty?
 
         env[REMOTE_ADDR] = addr
       end


### PR DESCRIPTION
We're intermittently seeing the following error in Puma's [server.rb](https://github.com/puma/puma/blob/v2.11.3/lib/puma/server.rb#L460) when an IE client disconnects:

```
Read error: #<Errno::ENOTCONN: Transport endpoint is not connected - getpeername(2)>
```

This appears to be happening because the TCP socket is disconnected while Puma processes the request; in the `normalize_env` method, Puma expects the client to be connected and able to deliver remote address information via `client.peeraddr`.

The most graceful fix I could come up with here is to look for that error and set the `REMOTE_ADDR` simply to localhost. As far as I can tell, there's no graceful way in TCP/Ruby to check if the socket is connected and able to retrieve address information.

While the error is intermittent, we are able to reproduce it with our particular setup, so I'm confident this fix is working appropriately for that case.