### PR TITLE
typo fix: occured -> occurred

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ error-tracking service (in this example, [rollbar](http://rollbar.com)):
 ```ruby
 lowlevel_error_handler do |e|
   Rollbar.critical(e)
-  [500, {}, ["An error has occured, and engineers have been informed. Please reload the page. If you continue to have problems, contact support@example.com\n"]]
+  [500, {}, ["An error has occurred, and engineers have been informed. Please reload the page. If you continue to have problems, contact support@example.com\n"]]
 end
 ```
 

--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -87,7 +87,7 @@ module Puma
       formatter.call(str)
     end
 
-    # An HTTP parse error has occured.
+    # An HTTP parse error has occurred.
     # +server+ is the Server object, +env+ the request, and +error+ a
     # parsing exception.
     #
@@ -96,7 +96,7 @@ module Puma
       @stderr.puts "#{Time.now}: ENV: #{env.inspect}\n---\n"
     end
 
-    # An SSL error has occured.
+    # An SSL error has occurred.
     # +server+ is the Server object, +peeraddr+ peer address, +peercert+
     # any peer certificate (if present), and +error+ an exception object.
     #
@@ -105,7 +105,7 @@ module Puma
       @stderr.puts "#{Time.now}: SSL error, peer: #{peeraddr}, peer cert: #{subject}, #{error.inspect}"
     end
 
-    # An unknown error has occured.
+    # An unknown error has occurred.
     # +server+ is the Server object, +env+ the request, +error+ an exception
     # object, and +kind+ some additional info.
     #

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -764,7 +764,7 @@ module Puma
       if @leak_stack_on_error
         [500, {}, ["Puma caught this error: #{e.message} (#{e.class})\n#{e.backtrace.join("\n")}"]]
       else
-        [500, {}, ["An unhandled lowlevel error occured. The application logs may have details.\n"]]
+        [500, {}, ["An unhandled lowlevel error occurred. The application logs may have details.\n"]]
       end
     end
 


### PR DESCRIPTION
This PR fixes a minor misspelling of the word 'occurred'.