### PR TITLE
Fix uninitialized constant error

### DIFF
--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -1,4 +1,5 @@
 require 'puma/util'
+require 'puma/minissl'
 
 module Puma
   class Reactor


### PR DESCRIPTION
Otherwise I continuously get the error

```
Error in reactor loop escaped: uninitialized constant
Puma::MiniSSL::SSLError (NameError)
/path/to/puma-2.12.2-java/lib/puma/reactor.rb:72:in `block in run_internal'
/path/to/puma-2.12.2-java/lib/puma/reactor.rb:41:in `each'
/path/to/puma-2.12.2-java/lib/puma/reactor.rb:41:in `run_internal'
/path/to/puma-2.12.2-java/lib/puma/reactor.rb:137:in `block in run_in_thread'
```

It does not seem to affect functionality but it's annoying.