### PR TITLE
Skip empty parts when chunking

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -663,6 +663,7 @@ module Puma
         begin
           res_body.each do |part|
             if chunked
+              next if part.bytesize.zero?
               fast_write client, part.bytesize.to_s(16)
               fast_write client, line_ending
               fast_write client, part

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -101,6 +101,15 @@ class TestPersistent < Test::Unit::TestCase
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n7\r\nChunked\r\n0\r\n\r\n", lines(10)
   end
 
+  def test_chunked_with_empty_part
+    @body << ""
+    @body << "Chunked"
+
+    @client << @valid_request
+
+    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n7\r\nChunked\r\n0\r\n\r\n", lines(10)
+  end
+
   def test_no_chunked_in_http10
     @body << "Chunked"
 


### PR DESCRIPTION
A zero-length chunk has a protocol-significant meaning: it signals the end of the response. An empty part in a Rack body has no such meaning, so we should just skip it.

Currently, the empty part will get sent to the client, terminating the response -- and any following response parts, plus the real terminator, will be left buffered for the next request.