### PR TITLE
Ruby 1.8.7 compatibility fixes

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -104,9 +104,9 @@ module Puma
       rack_app, rack_options = Puma::Rack::Builder.parse_file(rackup)
       @options.merge!(rack_options)
 
-      config_ru_binds = rack_options.inject([]) do |b, (k, v)|
-        b << v if k.to_s.start_with?("bind")
-        b
+      config_ru_binds = []
+      rack_options.each do |k, v|
+        config_ru_binds << v if k.to_s.start_with?("bind")
       end
       @options[:binds] = config_ru_binds unless config_ru_binds.empty?
 

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -104,8 +104,9 @@ module Puma
       rack_app, rack_options = Puma::Rack::Builder.parse_file(rackup)
       @options.merge!(rack_options)
 
-      config_ru_binds = rack_options.each_with_object([]) do |(k, v), b|
+      config_ru_binds = rack_options.inject([]) do |b, (k, v)|
         b << v if k.to_s.start_with?("bind")
+        b
       end
       @options[:binds] = config_ru_binds unless config_ru_binds.empty?
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -25,7 +25,7 @@ class TestConfigFile < Test::Unit::TestCase
   end
 
   def test_double_bind_port
-    port = rand(30_000..40_000).to_s
+    port = (rand(10_000) + 30_000).to_s
     with_env("PORT" => port) do
       opts = { :binds => ["tcp://#{Configuration::DefaultTCPHost}:#{port}"], :config_file => "test/config/app.rb"}
       conf = Puma::Configuration.new opts

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -191,7 +191,7 @@ class TestPumaServer < Test::Unit::TestCase
   def test_prints_custom_error
     @events = Puma::Events.strings
     re = lambda { |err| [302, {'Content-Type' => 'text', 'Location' => 'foo.html'}, ['302 found']] }
-    @server = Puma::Server.new @app, @events, {lowlevel_error_handler: re}
+    @server = Puma::Server.new @app, @events, {:lowlevel_error_handler => re}
 
     @server.app = proc { |e| raise "don't leak me bro" }
     @server.add_tcp_listener @host, @port


### PR DESCRIPTION
Enumerable in 1.8.7 doesn't have each_with_object
rand() doesn't accept ranges in 1.8.7
Caught a 1.9 hash syntax in tests.