### PR TITLE
Add before_fork hooks option.

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -379,6 +379,10 @@ module Puma
       @cli.write_state
 
       @master_read, @worker_write = read, @wakeup
+
+      hooks = @options[:before_fork]
+      hooks.each { |h| h.call }
+
       spawn_workers
 
       Signal.trap "SIGINT" do

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -19,6 +19,7 @@ module Puma
       @options[:mode] ||= :http
       @options[:binds] ||= []
       @options[:on_restart] ||= []
+      @options[:before_fork] ||= []
       @options[:before_worker_shutdown] ||= []
       @options[:before_worker_boot] ||= []
       @options[:before_worker_fork] ||= []

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -156,6 +156,19 @@ module Puma
       @options[:workers] = count.to_i
     end
 
+    # *Cluster mode only* Code to run immediately before master process
+    # forks workers (once on boot). These hooks can block if necessary
+    # to wait for background operations unknown to puma to finish before
+    # the process terminates.
+    # This can be used to close any connections to remote servers (database, redis, ...)
+    # that were opened when preloading the code
+    #
+    # This can be called multiple times to add hooks.
+    #
+    def before_fork(&block)
+      @options[:before_fork] << block
+    end
+
     # *Cluster mode only* Code to run immediately before a worker shuts
     # down (after it has finished processing HTTP requests). These hooks
     # can block if necessary to wait for background operations unknown


### PR DESCRIPTION
This is usefull to close database or other remote connections
that were opened during the preload_app phase of the master process.

Fixes #303 