### PR TITLE
Check for OPENSSL_NO_ECDH before using ECDH

### DIFF
--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -147,11 +147,13 @@ VALUE engine_init_server(VALUE self, VALUE mini_ssl_ctx) {
   DH *dh = get_dh1024();
   SSL_CTX_set_tmp_dh(ctx, dh);
 
+#ifndef OPENSSL_NO_ECDH
   EC_KEY *ecdh = EC_KEY_new_by_curve_name(NID_secp521r1);
   if (ecdh) {
     SSL_CTX_set_tmp_ecdh(ctx, ecdh);
     EC_KEY_free(ecdh);
   }
+#endif
 
   ssl = SSL_new(ctx);
   conn->ssl = ssl;


### PR DESCRIPTION
Trying to build puma > 2.9.2 on CentOS 6 gives the following errors due to lack of OpenSSL EC support in RHEL (patent issues):

```
Installing puma 2.12.3 (was 2.9.2) with native extensions

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    /usr/bin/ruby extconf.rb
checking for BIO_read() in -lcrypto... yes
checking for SSL_CTX_new() in -lssl... yes
creating Makefile

make "DESTDIR=" clean

make "DESTDIR="
compiling mini_ssl.c
In file included from mini_ssl.c:3:
/usr/include/ruby/ruby-2.1.0/ruby/backward/rubyio.h:2:2: warning: #warning use "ruby/io.h" instead of "rubyio.h"
mini_ssl.c: In function ‘engine_init_server’:
mini_ssl.c:150: error: ‘EC_KEY’ undeclared (first use in this function)
mini_ssl.c:150: error: (Each undeclared identifier is reported only once
mini_ssl.c:150: error: for each function it appears in.)
mini_ssl.c:150: error: ‘ecdh’ undeclared (first use in this function)
mini_ssl.c:150: warning: implicit declaration of function ‘EC_KEY_new_by_curve_name’
mini_ssl.c:153: warning: implicit declaration of function ‘EC_KEY_free’
mini_ssl.c: In function ‘engine_read’:
mini_ssl.c:241: warning: unused variable ‘n’
mini_ssl.c: In function ‘engine_peercert’:
mini_ssl.c:340: warning: pointer targets in passing argument 1 of ‘rb_str_new’ differ in signedness
/usr/include/ruby/ruby-2.1.0/ruby/intern.h:704: note: expected ‘const char *’ but argument is of type ‘unsigned char *’
make: *** [mini_ssl.o] Error 1

make failed, exit code 2
```

Lightttpd had a similar issue: http://redmine.lighttpd.net/boards/2/topics/4335 and http://redmine.lighttpd.net/issues/2335

Adding a compile time check for OPENSSL_NO_ECDH solves the problem for us.