### PR TITLE
CHG: make jungle for init.d support rbenv

### DIFF
--- a/tools/jungle/init.d/puma
+++ b/tools/jungle/init.d/puma
@@ -36,6 +36,7 @@ RUNPUMA=/usr/local/bin/run-puma
 #
 do_start() {
   log_daemon_msg "=> Running the jungle..."
+  config_bundler # `/usr/local/bin/run-puma also need correct PATH to run bundle`
   for i in $JUNGLE; do
     dir=`echo $i | cut -d , -f 1`
     user=`echo $i | cut -d , -f 2`

--- a/tools/jungle/init.d/puma
+++ b/tools/jungle/init.d/puma
@@ -105,7 +105,11 @@ do_stop_one() {
       log_daemon_msg "---> Puma $1 isn't running."
     else
       log_daemon_msg "---> About to kill PID `cat $PIDFILE`"
-      pumactl --state $STATEFILE stop
+      if config_bundler; then
+        cd $1 && bundle exec pumactl --state $STATEFILE stop
+      else
+        pumactl --state $STATEFILE stop
+      fi
       # Many daemons don't delete their pidfiles when they exit.
       rm -f $PIDFILE $STATEFILE
     fi
@@ -135,7 +139,11 @@ do_restart_one() {
   
   if [ -e $PIDFILE ]; then
     log_daemon_msg "--> About to restart puma $1"
-    pumactl --state $dir/tmp/puma/state restart
+    if config_bundler; then
+      cd $1 && bundle exec pumactl --state $dir/tmp/puma/state restart
+    else
+      pumactl --state $dir/tmp/puma/state restart
+    fi
     # kill -s USR2 `cat $PIDFILE`
     # TODO Check if process exist
   else
@@ -175,7 +183,11 @@ do_status_one() {
   
   if [ -e $PIDFILE ]; then
     log_daemon_msg "--> About to status puma $1"
-    pumactl --state $dir/tmp/puma/state stats
+    if config_bundler; then
+      cd $1 && bundle exec pumactl --state $dir/tmp/puma/state stats
+    else
+      pumactl --state $dir/tmp/puma/state stats
+    fi
     # kill -s USR2 `cat $PIDFILE`
     # TODO Check if process exist
   else
@@ -239,6 +251,33 @@ do_remove() {
     sed -i "\\:^$1:d" $CONFIG
     log_daemon_msg "Removed a Puma from the jungle: $1."
   fi
+}
+
+config_bundler() {
+  HOME="$(eval echo ~$(id -un))"
+  if [ -d "/usr/local/rbenv/bin" ]; then
+    PATH="/usr/local/rbenv/bin:/usr/local/rbenv/shims:$PATH"
+    return 0
+  elif [ -d "$HOME/.rbenv/bin" ]; then
+    PATH="$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH"
+    return 0
+  # TODO: test rvm
+  # elif [ -f  /etc/profile.d/rvm.sh ]; then
+  #   source /etc/profile.d/rvm.sh
+  # elif [ -f /usr/local/rvm/scripts/rvm ]; then
+  #   source /etc/profile.d/rvm.sh
+  # elif [ -f "$HOME/.rvm/scripts/rvm" ]; then
+  #   source "$HOME/.rvm/scripts/rvm"
+  # TODO: don't know what to do with chruby
+  # elif [ -f /usr/local/share/chruby/chruby.sh ]; then
+  #   source /usr/local/share/chruby/chruby.sh
+  #   if [ -f /usr/local/share/chruby/auto.sh ]; then
+  #     source /usr/local/share/chruby/auto.sh
+  #   fi
+  # if you aren't using auto, set your version here
+  # chruby 2.0.0
+  fi
+  return 1
 }
 
 case "$1" in

--- a/tools/jungle/init.d/puma
+++ b/tools/jungle/init.d/puma
@@ -23,6 +23,7 @@ SCRIPTNAME=/etc/init.d/$NAME
 CONFIG=/etc/puma.conf
 JUNGLE=`cat $CONFIG`
 RUNPUMA=/usr/local/bin/run-puma
+USE_LOCAL_BUNDLE=0
 
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh
@@ -36,7 +37,6 @@ RUNPUMA=/usr/local/bin/run-puma
 #
 do_start() {
   log_daemon_msg "=> Running the jungle..."
-  config_bundler # `/usr/local/bin/run-puma also need correct PATH to run bundle`
   for i in $JUNGLE; do
     dir=`echo $i | cut -d , -f 1`
     user=`echo $i | cut -d , -f 2`
@@ -106,7 +106,7 @@ do_stop_one() {
       log_daemon_msg "---> Puma $1 isn't running."
     else
       log_daemon_msg "---> About to kill PID `cat $PIDFILE`"
-      if config_bundler; then
+      if [ "$USE_LOCAL_BUNDLE" -eq 1 ]; then
         cd $1 && bundle exec pumactl --state $STATEFILE stop
       else
         pumactl --state $STATEFILE stop
@@ -140,7 +140,7 @@ do_restart_one() {
   
   if [ -e $PIDFILE ]; then
     log_daemon_msg "--> About to restart puma $1"
-    if config_bundler; then
+    if [ "$USE_LOCAL_BUNDLE" -eq 1 ]; then
       cd $1 && bundle exec pumactl --state $dir/tmp/puma/state restart
     else
       pumactl --state $dir/tmp/puma/state restart
@@ -184,7 +184,7 @@ do_status_one() {
   
   if [ -e $PIDFILE ]; then
     log_daemon_msg "--> About to status puma $1"
-    if config_bundler; then
+    if [ "$USE_LOCAL_BUNDLE" -eq 1 ]; then
       cd $1 && bundle exec pumactl --state $dir/tmp/puma/state stats
     else
       pumactl --state $dir/tmp/puma/state stats
@@ -258,9 +258,12 @@ config_bundler() {
   HOME="$(eval echo ~$(id -un))"
   if [ -d "/usr/local/rbenv/bin" ]; then
     PATH="/usr/local/rbenv/bin:/usr/local/rbenv/shims:$PATH"
+    USE_LOCAL_BUNDLE=1
     return 0
   elif [ -d "$HOME/.rbenv/bin" ]; then
     PATH="$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH"
+    eval "$(rbenv init -)"
+    USE_LOCAL_BUNDLE=1
     return 0
   # TODO: test rvm
   # elif [ -f  /etc/profile.d/rvm.sh ]; then
@@ -278,8 +281,11 @@ config_bundler() {
   # if you aren't using auto, set your version here
   # chruby 2.0.0
   fi
+
   return 1
 }
+
+config_bundler
 
 case "$1" in
   start)

--- a/tools/jungle/init.d/puma
+++ b/tools/jungle/init.d/puma
@@ -258,6 +258,7 @@ config_bundler() {
   HOME="$(eval echo ~$(id -un))"
   if [ -d "/usr/local/rbenv/bin" ]; then
     PATH="/usr/local/rbenv/bin:/usr/local/rbenv/shims:$PATH"
+    eval "$(rbenv init -)"
     USE_LOCAL_BUNDLE=1
     return 0
   elif [ -d "$HOME/.rbenv/bin" ]; then


### PR DESCRIPTION
Hi

Inspired by jungle/upstart/puma.conf, I modified jungle/init.d/puma, make it supporting rbenv.
Conditions about rvm and chruby are commented out because I haven't test them.
This commit have passed `bundle exec rake` tests.
Hope it helps event if you decide to support rbenv by different approach and reject this PR.

Best,
Snow