### PR TITLE
configuration: allow empty tags to mean no tag desired

### DIFF
--- a/examples/config.rb
+++ b/examples/config.rb
@@ -144,6 +144,9 @@
 # Additional text to display in process listing
 #
 # tag 'app name'
+#
+# If you do not specify a tag, Puma will infer it. If you do not want Puma
+# to add a tag, use an empty string.
 
 # Change the default timeout of workers
 #

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -266,7 +266,7 @@ module Puma
   private
     def title
       buffer = "puma #{Puma::Const::VERSION} (#{@options[:binds].join(',')})"
-      buffer << " [#{@options[:tag]}]" if @options[:tag]
+      buffer << " [#{@options[:tag]}]" if @options[:tag] && !@options[:tag].empty?
       buffer
     end
 

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -186,7 +186,7 @@ module Puma
 
     def worker(index, master)
       title = "puma: cluster worker #{index}: #{master}"
-      title << " [#{@options[:tag]}]" if @options[:tag]
+      title << " [#{@options[:tag]}]" if @options[:tag] && !@options[:tag].empty?
       $0 = title
 
       Signal.trap "SIGINT", "IGNORE"


### PR DESCRIPTION
This allows you to use `tag ""` in the config file to avoid
inferring a tag.

This is useful for example in cluster mode with phased restarts
where you might want the master process to just specify the puma
version and nothing else.

Later in `on_worker_boot` you would manually modify the process
title to suit your needs if you need more specific tags.