### PR TITLE
Fix bug setting worker_directory when using a symlink directory

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -429,7 +429,7 @@ module Puma
 
         if s_env.ino == s_pwd.ino and (jruby? or s_env.dev == s_pwd.dev)
           @restart_dir = dir
-          @cli_options[:worker_directory] = dir
+          @options[:worker_directory] = dir
         end
       end
 


### PR DESCRIPTION
Fix for issue #770 

The @cli_options variable is used to reflect the options passed from the command line.
The @options variable is the final set of options that will be used by the Runner instance
for configuration. When generating the restart data, we want to set the value in the @options
hash and not in the @cli_options hash.