### PR TITLE
Allow setting CA certificates without setting a verify mode

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -164,8 +164,9 @@ module Puma
               unless params['ca']
                 @events.error "Please specify the SSL ca via 'ca='"
               end
-              ctx.ca = params['ca']
             end
+            
+            ctx.ca = params['ca']
 
             if  params['verify_mode']
               ctx.verify_mode = case params['verify_mode']


### PR DESCRIPTION
The CA setting is how we can include intermediate keys, but the binder won't set it unless you force client certs.