### PR TITLE
puma/cli: support specifying STD{OUT,ERR} redirections and append mode

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -410,6 +410,18 @@ module Puma
           @cli_options[:tag] = arg
         end
 
+        o.on "--redirect-stdout FILE", "Redirect STDOUT to a specific file" do |arg|
+          @cli_options[:redirect_stdout] = arg
+        end
+
+        o.on "--redirect-stderr FILE", "Redirect STDERR to a specific file" do |arg|
+          @cli_options[:redirect_stderr] = arg
+        end
+
+        o.on "--[no-]redirect-append", "Append to redirected files" do |val|
+          @cli_options[:redirect_append] = val
+        end
+
         o.banner = "puma <options> <rackup file>"
 
         o.on_tail "-h", "--help", "Show help" do


### PR DESCRIPTION
Currently the only way to specify stdout/stderr redirections is through Puma's config file. This can be cumbersome in some environments where you would rather use a command line switch. Do this for both and also add a boolean option for append mode.