### PR TITLE
Fix error message in DSL that was slightly inaccurate

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -132,7 +132,7 @@ module Puma
       min = Integer(min)
       max = Integer(max)
       if min > max
-        raise "The minimum (#{min}) number of threads must be less than the max (#{max})"
+        raise "The minimum (#{min}) number of threads must be less than or equal to the max (#{max})"
       end
 
       @options[:min_threads] = min


### PR DESCRIPTION
An equal number of min and max threads is fine by the code around this
message.