### PR TITLE
Use SSL_CTX_use_certificate_chain_file for full chain

### DIFF
--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -136,7 +136,7 @@ VALUE engine_init_server(VALUE self, VALUE mini_ssl_ctx) {
   ctx = SSL_CTX_new(SSLv23_server_method());
   conn->ctx = ctx;
 
-  SSL_CTX_use_certificate_file(ctx, RSTRING_PTR(cert), SSL_FILETYPE_PEM);
+  SSL_CTX_use_certificate_chain_file(ctx, RSTRING_PTR(cert));
   SSL_CTX_use_PrivateKey_file(ctx, RSTRING_PTR(key), SSL_FILETYPE_PEM);
 
   if (!NIL_P(ca)) {


### PR DESCRIPTION
Allows Puma to parse SSL certificate files that contain multiple chained
certificates, ordered from your certificate down to the root (like nginx).

Forgive me if there was already a way to do this. I couldn't figure it out. Previously without this patch, if I specified a chained certificate file, we would only send the top level cert and my browser would reject it.