### PR TITLE
thread_pool: fix race condition when shutting down workers

### DIFF
--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -235,20 +235,18 @@ module Puma
     # Tell all threads in the pool to exit and wait for them to finish.
     #
     def shutdown
-      @mutex.synchronize do
+      threads = @mutex.synchronize do
         @shutdown = true
         @not_empty.broadcast
         @not_full.broadcast
 
         @auto_trim.stop if @auto_trim
         @reaper.stop if @reaper
+        # dup workers so that we join them all safely
+        @workers.dup
       end
 
-      # Use this instead of #each so that we don't stop in the middle
-      # of each and see a mutated object mid #each
-      if !@workers.empty?
-          @workers.first.join until @workers.empty?
-      end
+      threads.each(&:join)
 
       @spawned = 0
       @workers = []

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -160,7 +160,7 @@ module Puma
     end
 
     # If there are dead threads in the pool make them go away while decreasing
-    # spwaned counter so that new healty threads could be created again.
+    # spawned counter so that new healthy threads could be created again.
     def reap
       @mutex.synchronize do
         dead_workers = @workers.reject(&:alive?)


### PR DESCRIPTION
The following backtrace appeared in my error logs:
```
Exception handling servers: undefined method `join' for nil:NilClass (NoMethodError)
/var/lib/gems/2.2.0/bundler/gems/puma-2.14.0/lib/puma/thread_pool.rb:250:in `shutdown'
/var/lib/gems/2.2.0/bundler/gems/puma-2.14.0/lib/puma/server.rb:814:in `graceful_shutdown'
/var/lib/gems/2.2.0/bundler/gems/puma-2.14.0/lib/puma/server.rb:338:in `handle_servers'
/var/lib/gems/2.2.0/bundler/gems/puma-2.14.0/lib/puma/server.rb:296:in `block in run'
```
This signals a problem in thread_pool.rb:250, where the code below lives:
```ruby
if !@workers.empty?
  @workers.first.join until @workers.empty?
end
```
Since at that point `@mutex` is not held, `@workers` can and does in fact get modified by threads shutting down. There is a race condition where the worker disappears between the time of check and the time of use because of the code below in thread_pool.rb:111, when the worker is exiting:
```ruby
mutex.synchronize do
  @spawned -= 1
  @workers.delete th
end
```

I have fixed this by `dup`ing the worker threads array inside the critical section and using `each` to iterate and join all workers.