### PR TITLE
[ci skip] More explicit docs for worker_timeout

### DIFF
--- a/examples/config.rb
+++ b/examples/config.rb
@@ -148,7 +148,9 @@
 # If you do not specify a tag, Puma will infer it. If you do not want Puma
 # to add a tag, use an empty string.
 
-# Change the default timeout of workers
+# Verifies that all workers have checked in to the master process within
+# the given timeout. If not the worker process will be restarted. Default
+# value is 60 seconds.
 #
 # worker_timeout 60
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -256,7 +256,10 @@ module Puma
       @options[:tag] = string
     end
 
-    # *Cluster mode only* Set the timeout for workers
+    # *Cluster mode only* Set the timeout for workers in seconds
+    # When set the master process will terminate any workers
+    # that have not checked in within the given +timeout+.
+    # This mitigates hung processes. Default value is 60 seconds.
     def worker_timeout(timeout)
       @options[:worker_timeout] = timeout
     end


### PR DESCRIPTION
Had a customer who thought setting this was preventing against long running requests (it doesn't). These docs clarify the purpose of setting this value, that it is used to detect hung processes.