### PR TITLE
cluster: add worker_boot_timeout option

### DIFF
--- a/examples/config.rb
+++ b/examples/config.rb
@@ -149,6 +149,12 @@
 #
 # worker_timeout 60
 
+# Change the default worker timeout for booting
+#
+# If unspecified, this defaults to the value of worker_timeout.
+#
+# worker_boot_timeout 60
+
 # === Puma control rack application ===
 
 # Start the puma control rack application on "url". This application can

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -136,6 +136,7 @@ module Puma
       any = false
 
       @workers.each do |w|
+        next if !w.booted? && !w.ping_timeout?(@options[:worker_boot_timeout])
         if w.ping_timeout?(@options[:worker_timeout])
           log "! Terminating timed out worker: #{w.pid}"
           w.kill

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -27,6 +27,7 @@ module Puma
       @conf[:before_worker_fork] ||= []
       @conf[:after_worker_boot] ||= []
       @conf[:worker_timeout] ||= DefaultWorkerTimeout
+      @conf[:worker_boot_timeout] ||= @conf[:worker_timeout]
       @conf[:worker_shutdown_timeout] ||= DefaultWorkerShutdownTimeout
 
       @options = {}

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -261,6 +261,11 @@ module Puma
       @options[:worker_timeout] = timeout
     end
 
+    # *Cluster mode only* Set the timeout for workers to boot
+    def worker_boot_timeout(timeout)
+      @options[:worker_boot_timeout] = timeout
+    end
+
     # *Cluster mode only* Set the timeout for worker shutdown
     def worker_shutdown_timeout(timeout)
       @options[:worker_shutdown_timeout] = timeout


### PR DESCRIPTION
In some cases, booting workers can take a bit too long, specially if they contend for some scarce resource. If other than this you set up your workers to have a rather low ping timeout, you are in for some problems, because that timeout also applies to the booting phase.

This PR introduces a `worker_boot_timeout` option to control the timeout for workers to boot. This way you don't tie the boot timeout to the ping timeout. Not specifying it defaults to the previous behavior of killing a worker that has not pinged in time (by setting it to `worker_timeout`).