### PR TITLE
Only set ctx.ca iff there is a params['ca'] to set with.

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -166,7 +166,7 @@ module Puma
               end
             end
             
-            ctx.ca = params['ca']
+            ctx.ca = params['ca'] if params['ca']
 
             if  params['verify_mode']
               ctx.verify_mode = case params['verify_mode']


### PR DESCRIPTION
ctx.ca does not deal well with being set to nil, which will be the case if
verify_mode is none and the ca param was not present in the bind line.

Specifically, you get this backtrace:

<path>/gems/ruby/2.1.0/gems/puma-2.15.0/lib/puma/minissl.rb:138:in `exist?': no implicit conversion of nil into String (TypeError)
    from <path>/gems/ruby/2.1.0/gems/puma-2.15.0/lib/puma/minissl.rb:138:in `ca='
    from <path>/gems/ruby/2.1.0/gems/puma-2.15.0/lib/puma/binder.rb:169:in `block in parse'
    from <path>/gems/ruby/2.1.0/gems/puma-2.15.0/lib/puma/binder.rb:84:in `each'
    from <path>/gems/ruby/2.1.0/gems/puma-2.15.0/lib/puma/binder.rb:84:in `parse'
    from <path>/gems/ruby/2.1.0/gems/puma-2.15.0/lib/puma/runner.rb:119:in `load_and_bind'
    from <path>/gems/ruby/2.1.0/gems/puma-2.15.0/lib/puma/single.rb:79:in `run'
    from <path>/gems/ruby/2.1.0/gems/puma-2.15.0/lib/puma/cli.rb:215:in `run'
    from <path>/gems/ruby/2.1.0/gems/puma-2.15.0/bin/puma:10:in `<top (required)>'
    from <path>/gems/ruby/2.1.0/bin/puma:23:in `load'
    from <path>/gems/ruby/2.1.0/bin/puma:23:in `<main>'