### PR TITLE
Remove NEWRELIC_DISPATCHER env variable

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -42,8 +42,6 @@ module Puma
 
       @config = nil
 
-      ENV['NEWRELIC_DISPATCHER'] ||= "Puma"
-
       setup_options
       generate_restart_data
 


### PR DESCRIPTION
It looks like this environment variable was originally [added in 2012](https://github.com/puma/puma/commit/2280b68d987bfe17f00bb92c772b971a4f073ca6) to get the newrelic_rpm gem to automatically start. Since then, built-in methods for discovering the dispatcher in an environment were added (see [here](https://github.com/newrelic/rpm/blob/master/lib/new_relic/local_environment.rb) generally, and [this commit](https://github.com/newrelic/rpm/commit/8536128d90f54c2b3c93e9608f5aeed5dddf1663) for adding dispatcher detection for Puma specifically). As a result, I think this environment variable no longer needs to be set in Puma.

There was [a change](https://github.com/puma/puma/commit/542919771a249dbccda37c7fd636025c22778a06) by @Tomohiro merged to Puma a few months ago that changed this variable from `puma` to `Puma` because something had stopped working with Rails 4.2 + New Relic + Heroku. I _think_ that may have in response to [this change that stopped reporting from the Puma master process](https://github.com/newrelic/rpm/commit/5077882a4413d2e25644fa9676882cd20502f034)--I set up a quick test of Rails 4.2 + New Relic + Heroku with the variable as `puma` instead of `Puma` and that appeared to successfully report data to New Relic, but I'm happy to investigate further if there was another issue going on with the harvest thread auto-starting logic. Overall though, it seems like this should be issue that we fix in newrelic_rpm and not in Puma :)