### PR TITLE
Allow to run puma in silent mode

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -644,7 +644,7 @@ module Puma
           fast_write client, lines.to_s
           return keep_alive
         end
-        
+
         if content_length
           lines.append CONTENT_LENGTH_S, content_length.to_s, line_ending
           chunked = false


### PR DESCRIPTION
We are using `puma` in `cucumber` tests as a backend server for our `Rails` application. And currently it pollutes the cucumber logs. This fix allows to start puma in silent mode. Later this fix will allow to normally do the following [fix](https://github.com/watir/watir-rails/pull/15/files). Thanks!