### PR TITLE
DSL need cli_options

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -54,6 +54,7 @@ module Puma
     end
 
     def load
+      @conf.merge! @cli_options
       DSL.load(@conf, @cli_options[:config_file])
 
       # Load the options in the right priority


### PR DESCRIPTION
use case:
```
$: puma -C puma.rb -d
```
but in puma.rb:
```
if @options[:daemon]  # *got nil, can not work*
  log_path = File.join(app_root,"log/stdout.log")
  stdout_redirect log_path , log_path
end
```