### PR TITLE
Initial Seperation of CLI and Server Launcher work

### DIFF
--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -12,3 +12,4 @@ require 'thread'
 # Ruby Puma
 require 'puma/const'
 require 'puma/server'
+require 'puma/launcher'

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -51,9 +51,6 @@ module Puma
 
       setup_options
 
-      @binder = Binder.new(@events)
-      @binder.import_from_env
-
       begin
         @parser.parse! @argv
         @cli_options[:rackup] = @argv.shift if @argv.last
@@ -61,11 +58,9 @@ module Puma
         exit 1
       end
 
-      @launcher = Puma::Launcher.new(@cli_options)
+      @launcher = Puma::Launcher.new(@cli_options, events: @events)
 
-      @launcher.events  = self.events
       @launcher.config  = self.config
-      @launcher.binder  = self.binder
       @launcher.argv    = @argv
 
       @launcher.setup(@options)
@@ -119,7 +114,9 @@ module Puma
     ## BACKWARDS COMPAT FOR TESTS
 
     # The Binder object containing the sockets bound to.
-    attr_reader :binder
+    def binder
+      @launcher.binder
+    end
 
     # The Configuration object used.
     attr_reader :config

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -47,8 +47,6 @@ module Puma
       @status = nil
       @runner = nil
 
-      @config = nil
-
       setup_options
 
       begin
@@ -59,11 +57,6 @@ module Puma
       end
 
       @launcher = Puma::Launcher.new(@cli_options, events: @events, argv: @argv)
-
-      @launcher.config  = self.config
-
-      @launcher.setup(@options)
-
     end
 
     ## BACKWARDS COMPAT FOR TESTS
@@ -118,10 +111,14 @@ module Puma
     end
 
     # The Configuration object used.
-    attr_reader :config
+    def config
+      @launcher.config
+    end
 
     # The Hash of options used to configure puma.
-    attr_reader :options
+    def options
+      @launcher.options
+    end
 
     # The Events object used to output information.
     attr_reader :events
@@ -139,54 +136,10 @@ module Puma
       Puma.windows?
     end
 
-<<<<<<< HEAD
     def env
-      @options[:environment] || @cli_options[:environment] || ENV['RACK_ENV'] || 'development'
+      @launcher.env
     end
 
-    def write_state
-      write_pid
-
-      path = @options[:state]
-      return unless path
-
-      state = { 'pid' => Process.pid }
-      cfg = @config.dup
-
-      KEYS_NOT_TO_PERSIST_IN_STATE.each { |k| cfg.options.delete(k) }
-      state['config'] = cfg
-
-      require 'yaml'
-      File.open(path, 'w') { |f| f.write state.to_yaml }
-    end
-
-    # If configured, write the pid of the current process out
-    # to a file.
-    #
-    def write_pid
-      path = @options[:pidfile]
-      return unless path
-
-      File.open(path, 'w') { |f| f.puts Process.pid }
-      cur = Process.pid
-      at_exit do
-        delete_pidfile if cur == Process.pid
-      end
-    end
-
-    def delete_pidfile
-      path = @options[:pidfile]
-      File.unlink(path) if path && File.exist?(path)
-    end
-
-    def graceful_stop
-      @runner.stop_blocked
-      log "=== puma shutdown: #{Time.now} ==="
-      log "- Goodbye!"
-    end
-
-=======
->>>>>>> Initial Seperation of CLI and Server Launcher work
     def jruby_daemon_start
       @launcher.jruby_daemon_start
     end
@@ -233,7 +186,6 @@ module Puma
 
     def setup_options
       @cli_options = {}
-      @options = {}
 
       @parser = OptionParser.new do |o|
         o.on "-b", "--bind URI", "URI to bind to (tcp://, unix://, ssl://)" do |arg|

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -45,7 +45,6 @@ module Puma
       @events = events
 
       @status = nil
-      @runner = nil
 
       setup_options
 

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -58,10 +58,9 @@ module Puma
         exit 1
       end
 
-      @launcher = Puma::Launcher.new(@cli_options, events: @events)
+      @launcher = Puma::Launcher.new(@cli_options, events: @events, argv: @argv)
 
       @launcher.config  = self.config
-      @launcher.argv    = @argv
 
       @launcher.setup(@options)
 

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -26,11 +26,7 @@ module Puma
   # Handles invoke a Puma::Server in a command line style.
   #
   class CLI
-    KEYS_NOT_TO_PERSIST_IN_STATE = [
-      :logger, :lowlevel_error_handler,
-      :before_worker_shutdown, :before_worker_boot, :before_worker_fork,
-      :after_worker_boot, :before_fork, :on_restart
-    ]
+    KEYS_NOT_TO_PERSIST_IN_STATE = Launcher::KEYS_NOT_TO_PERSIST_IN_STATE
 
     # Create a new CLI object using +argv+ as the command line
     # arguments.

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -1,17 +1,6 @@
 require 'optparse'
 require 'uri'
 
-require 'puma/server'
-require 'puma/const'
-require 'puma/configuration'
-require 'puma/binder'
-require 'puma/detect'
-require 'puma/daemon_ext'
-require 'puma/util'
-require 'puma/single'
-require 'puma/cluster'
-
-require 'puma/commonlogger'
 require 'puma/launcher'
 
 module Puma

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -51,7 +51,7 @@ module Puma
         exit 1
       end
 
-      @launcher = Puma::Launcher.new(@cli_options, events: @events, argv: @argv)
+      @launcher = Puma::Launcher.new(@cli_options, :events => @events, :argv => @argv)
     end
 
     ## BACKWARDS COMPAT FOR TESTS

--- a/lib/puma/detect.rb
+++ b/lib/puma/detect.rb
@@ -1,4 +1,11 @@
 module Puma
   IS_JRUBY = defined?(JRUBY_VERSION)
-end
 
+  def self.jruby?
+    IS_JRUBY
+  end
+
+  def self.windows?
+    RUBY_PLATFORM =~ /mswin32|ming32/
+  end
+end

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -1,9 +1,16 @@
+require 'puma/binder'
+
 module Puma
   class Launcher
-    def initialize(cli_options = {})
+    def initialize(cli_options = {}, launcher_options = {})
       @cli_options = cli_options
       @runner      = nil
+      @events      = launcher_options[:events] or raise "must provide :events key"
+      @binder      = Binder.new(@events)
+      @binder.import_from_env
     end
+
+    attr_reader :binder, :events
 
     ## THIS STUFF IS NEEDED FOR RUNNER
 
@@ -28,10 +35,6 @@ module Puma
 
     def binder
       @binder
-    end
-
-    def events
-      @events
     end
 
     # Delegate +error+ to +@events+
@@ -84,7 +87,7 @@ module Puma
       end
     end
 
-    attr_accessor :options, :binder, :config, :events, :argv
+    attr_accessor :options, :binder, :config, :argv
     ## THIS STUFF IS NEEDED FOR RUNNER
 
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -1,12 +1,12 @@
-require 'puma/binder'
+ require 'puma/binder'
 
 module Puma
   class Launcher
 
-    def initialize(cli_options = {}, launcher_options = {})
+    def initialize(input_options, launcher_args = {})
       @runner        = nil
-      @events        = launcher_options[:events] or raise "must provide :events key"
-      @argv          = launcher_options[:argv] || "puma"
+      @events        = launcher_args[:events] or raise "must provide :events key"
+      @argv          = launcher_args[:argv] || "puma"
       @original_argv = @argv.dup
       @config        = nil
 
@@ -14,19 +14,19 @@ module Puma
       @binder.import_from_env
 
       # Final internal representation of options is stored here
-      # cli_options will be parsed
+      # input_options will be parsed to populate this hash.
       @options       = {}
       generate_restart_data
 
       @env = @options[:environment] || ENV['RACK_ENV'] || 'development'
 
-      if cli_options[:config_file] == '-'
-        cli_options[:config_file] = nil
+      if input_options[:config_file] == '-'
+        input_options[:config_file] = nil
       else
-        cli_options[:config_file] ||= %W(config/puma/#{@env}.rb config/puma.rb).find { |f| File.exist?(f) }
+        input_options[:config_file] ||= %W(config/puma/#{@env}.rb config/puma.rb).find { |f| File.exist?(f) }
       end
 
-      @config = Puma::Configuration.new(cli_options)
+      @config = Puma::Configuration.new(input_options)
 
       # Advertise the Configuration
       Puma.cli_config = @config

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -139,8 +139,6 @@ module Puma
     attr_accessor :options, :binder, :config
     ## THIS STUFF IS NEEDED FOR RUNNER
 
-    attr_accessor :runner
-
     def stop
       @status = :stop
       @runner.stop

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -1,8 +1,29 @@
  require 'puma/binder'
 
 module Puma
+  # Puam::Launcher is the single entry point for starting a Puma server based on user
+  # configuration. It is responsible for taking user supplied arguments and resolving them
+  # with configuration in `config/puma.rb` or `config/puma/<env>.rb`.
+  #
+  # It is responsible for either launching a cluster of Puma workers or a single
+  # puma server.
   class Launcher
-
+    # Returns an instance of Launcher
+    #
+    # +input_options+ A Hash of options that is supplied by a user, typically through
+    # a CLI. These options are evaluated and merged with other configuration such as
+    # `config/puma.rb` file to generate the configuration options needed to run a Puma server.
+    #
+    # +launcher_args+ A Hash that currently has one required key `:events`, this is expected to
+    # hold an object similar to an `Puma::Events.stdio`, this object will be responsible for
+    # broadcasting Puma's internal state to a logging destination. An optional key `:argv` can
+    # be supplied, this should be an array of strings, these arguments are re-used when restarting
+    # the puma server.
+    #
+    # Examples:
+    #
+    #   options = { min_threads: 1, max_threads: 10 }
+    #   Puma::Launcher.new(options, argv: Puma::Events.stdio).run
     def initialize(input_options, launcher_args = {})
       @runner        = nil
       @events        = launcher_args[:events] or raise "must provide :events key"

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -23,6 +23,7 @@ module Puma
     # Examples:
     #
     #   options = { min_threads: 1, max_threads: 10 }
+    #   options[:app] = ->(env) { [200, {}, ["hello world"]] }
     #   Puma::Launcher.new(options, argv: Puma::Events.stdio).run
     def initialize(input_options, launcher_args = {})
       @runner        = nil

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -27,7 +27,7 @@ module Puma
     def initialize(input_options, launcher_args = {})
       @runner        = nil
       @events        = launcher_args[:events] or raise "must provide :events key"
-      @argv          = launcher_args[:argv] || "puma"
+      @argv          = launcher_args[:argv] || []
       @original_argv = @argv.dup
       @config        = nil
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -1,0 +1,288 @@
+module Puma
+  class Launcher
+    def initialize(cli_options = {})
+      @cli_options = cli_options
+      @runner      = nil
+    end
+
+    ## THIS STUFF IS NEEDED FOR RUNNER
+
+    # Delegate +log+ to +@events+
+    #
+    def log(str)
+      @events.log str
+    end
+
+    def config
+      @config
+    end
+
+    def stats
+      @runner.stats
+    end
+
+    def halt
+      @status = :halt
+      @runner.halt
+    end
+
+    def binder
+      @binder
+    end
+
+    def events
+      @events
+    end
+
+    def write_state
+      write_pid
+
+      path = @options[:state]
+      return unless path
+
+      state = { 'pid' => Process.pid }
+      cfg = @config.dup
+
+      [
+        :logger,
+        :before_worker_shutdown, :before_worker_boot, :before_worker_fork,
+        :after_worker_boot,
+        :on_restart, :lowlevel_error_handler
+      ].each { |k| cfg.options.delete(k) }
+      state['config'] = cfg
+
+      require 'yaml'
+      File.open(path, 'w') { |f| f.write state.to_yaml }
+    end
+
+    def delete_pidfile
+      path = @options[:pidfile]
+      File.unlink(path) if path && File.exist?(path)
+    end
+
+    # If configured, write the pid of the current process out
+    # to a file.
+    #
+    def write_pid
+      path = @options[:pidfile]
+      return unless path
+
+      File.open(path, 'w') { |f| f.puts Process.pid }
+      cur = Process.pid
+      at_exit do
+        delete_pidfile if cur == Process.pid
+      end
+    end
+
+    attr_accessor :options, :binder, :config, :events
+    ## THIS STUFF IS NEEDED FOR RUNNER
+
+    def setup(options)
+      @options = options
+      parse_options
+
+      dir = @options[:directory]
+      Dir.chdir(dir) if dir
+
+      prune_bundler if prune_bundler?
+
+      set_rack_environment
+
+      if clustered?
+        @events.formatter = Events::PidFormatter.new
+        @options[:logger] = @events
+
+        @runner = Cluster.new(self)
+      else
+        @runner = Single.new(self)
+      end
+
+      @status = :run
+    end
+
+
+
+    attr_accessor :runner
+
+    def stop
+      @status = :stop
+      @runner.stop
+    end
+
+    def restart
+      @status = :restart
+      @runner.restart
+    end
+
+    def run
+      setup_signals
+      set_process_title
+      @runner.run
+
+      case @status
+      when :halt
+        log "* Stopping immediately!"
+      when :run, :stop
+        graceful_stop
+      when :restart
+        log "* Restarting..."
+        @runner.before_restart
+        restart!
+      when :exit
+        # nothing
+      end
+    end
+
+
+    def clustered?
+      @options[:workers] > 0
+    end
+
+    def jruby?
+      # remove eventually
+      IS_JRUBY
+    end
+
+    def windows?
+      # remove eventually
+      RUBY_PLATFORM =~ /mswin32|ming32/
+    end
+
+
+    def prune_bundler
+      return unless defined?(Bundler)
+      puma = Bundler.rubygems.loaded_specs("puma")
+      dirs = puma.require_paths.map { |x| File.join(puma.full_gem_path, x) }
+      puma_lib_dir = dirs.detect { |x| File.exist? File.join(x, '../bin/puma-wild') }
+
+      unless puma_lib_dir
+        log "! Unable to prune Bundler environment, continuing"
+        return
+      end
+
+      deps = puma.runtime_dependencies.map do |d|
+        spec = Bundler.rubygems.loaded_specs(d.name)
+        "#{d.name}:#{spec.version.to_s}"
+      end
+
+      log '* Pruning Bundler environment'
+      home = ENV['GEM_HOME']
+      Bundler.with_clean_env do
+        ENV['GEM_HOME'] = home
+        ENV['PUMA_BUNDLER_PRUNED'] = '1'
+        wild = File.expand_path(File.join(puma_lib_dir, "../bin/puma-wild"))
+        args = [Gem.ruby, wild, '-I', dirs.join(':'), deps.join(',')] + @original_argv
+        Kernel.exec(*args)
+      end
+    end
+
+  private
+    def unsupported(str)
+      @events.error(str)
+      raise UnsupportedOption
+    end
+
+    def parse_options
+      find_config
+
+      @config = Puma::Configuration.new @cli_options
+
+      # Advertise the Configuration
+      Puma.cli_config = @config
+
+      @config.load
+
+      @options = @config.options
+
+      if clustered? && (jruby? || windows?)
+        unsupported 'worker mode not supported on JRuby or Windows'
+      end
+
+      if @options[:daemon] && windows?
+        unsupported 'daemon mode not supported on Windows'
+      end
+    end
+
+    def find_config
+      if @cli_options[:config_file] == '-'
+        @cli_options[:config_file] = nil
+      else
+        @cli_options[:config_file] ||= %W(config/puma/#{env}.rb config/puma.rb).find { |f| File.exist?(f) }
+      end
+    end
+
+    def graceful_stop
+      @runner.stop_blocked
+      log "=== puma shutdown: #{Time.now} ==="
+      log "- Goodbye!"
+    end
+
+    def set_process_title
+      Process.respond_to?(:setproctitle) ? Process.setproctitle(title) : $0 = title
+    end
+
+    def title
+      buffer = "puma #{Puma::Const::VERSION} (#{@options[:binds].join(',')})"
+      buffer << " [#{@options[:tag]}]" if @options[:tag] && !@options[:tag].empty?
+      buffer
+    end
+
+    def set_rack_environment
+      @options[:environment] = env
+      ENV['RACK_ENV'] = env
+    end
+
+    def env
+      @options[:environment]       ||
+        @cli_options[:environment] ||
+        ENV['RACK_ENV']            ||
+        'development'
+    end
+
+    def prune_bundler?
+      @options[:prune_bundler] && clustered? && !@options[:preload_app]
+    end
+
+    def setup_signals
+      begin
+        Signal.trap "SIGUSR2" do
+          restart
+        end
+      rescue Exception
+        log "*** SIGUSR2 not implemented, signal based restart unavailable!"
+      end
+
+      begin
+        Signal.trap "SIGUSR1" do
+          phased_restart
+        end
+      rescue Exception
+        log "*** SIGUSR1 not implemented, signal based restart unavailable!"
+      end
+
+      begin
+        Signal.trap "SIGTERM" do
+          stop
+        end
+      rescue Exception
+        log "*** SIGTERM not implemented, signal based gracefully stopping unavailable!"
+      end
+
+      begin
+        Signal.trap "SIGHUP" do
+          redirect_io
+        end
+      rescue Exception
+        log "*** SIGHUP not implemented, signal based logs reopening unavailable!"
+      end
+
+      if jruby?
+        Signal.trap("INT") do
+          @status = :exit
+          graceful_stop
+          exit
+        end
+      end
+    end
+  end
+end

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -3,10 +3,13 @@ require 'puma/binder'
 module Puma
   class Launcher
     def initialize(cli_options = {}, launcher_options = {})
-      @cli_options = cli_options
-      @runner      = nil
-      @events      = launcher_options[:events] or raise "must provide :events key"
-      @binder      = Binder.new(@events)
+      @cli_options   = cli_options
+      @runner        = nil
+      @events        = launcher_options[:events] or raise "must provide :events key"
+      @argv          = launcher_options[:argv] || "puma"
+      @original_argv = @argv.dup
+
+      @binder        = Binder.new(@events)
       @binder.import_from_env
     end
 
@@ -87,7 +90,7 @@ module Puma
       end
     end
 
-    attr_accessor :options, :binder, :config, :argv
+    attr_accessor :options, :binder, :config
     ## THIS STUFF IS NEEDED FOR RUNNER
 
 
@@ -346,8 +349,6 @@ module Puma
       end
 
       @restart_dir ||= Dir.pwd
-
-      @original_argv = @argv.nil? ? "puma" : @argv.dup
 
       require 'rubygems'
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -1,4 +1,14 @@
- require 'puma/binder'
+require 'puma/server'
+require 'puma/const'
+require 'puma/configuration'
+require 'puma/binder'
+require 'puma/detect'
+require 'puma/daemon_ext'
+require 'puma/util'
+require 'puma/single'
+require 'puma/cluster'
+
+require 'puma/commonlogger'
 
 module Puma
   # Puam::Launcher is the single entry point for starting a Puma server based on user
@@ -56,7 +66,7 @@ module Puma
       @config = Puma::Configuration.new(input_options)
 
       # Advertise the Configuration
-      Puma.cli_config = @config
+      Puma.cli_config = @config if defined?(Puma.cli_config)
 
       @config.load
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -176,6 +176,10 @@ module Puma
       @runner.stop
     end
 
+    def connected_port
+      @binder.connected_port
+    end
+
     def restart
       @status = :restart
       @runner.restart

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -8,6 +8,11 @@ module Puma
   # It is responsible for either launching a cluster of Puma workers or a single
   # puma server.
   class Launcher
+    KEYS_NOT_TO_PERSIST_IN_STATE = [
+       :logger, :lowlevel_error_handler,
+       :before_worker_shutdown, :before_worker_boot, :before_worker_fork,
+       :after_worker_boot, :before_fork, :on_restart
+     ]
     # Returns an instance of Launcher
     #
     # +input_options+ A Hash of options that is supplied by a user, typically through
@@ -127,12 +132,7 @@ module Puma
       state = { 'pid' => Process.pid }
       cfg = @config.dup
 
-      [
-        :logger,
-        :before_worker_shutdown, :before_worker_boot, :before_worker_fork,
-        :after_worker_boot,
-        :on_restart, :lowlevel_error_handler
-      ].each { |k| cfg.options.delete(k) }
+      KEYS_NOT_TO_PERSIST_IN_STATE.each { |k| cfg.options.delete(k) }
       state['config'] = cfg
 
       require 'yaml'

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -5,8 +5,8 @@ module Rack
   module Handler
     module Puma
       DEFAULT_OPTIONS = {
-        :Host => '0.0.0.0',
-        :Port => 8080,
+        :Host    => '0.0.0.0',
+        :Port    => 8080,
         :Threads => '0:16',
         :Verbose => false,
         :Silent => false
@@ -15,7 +15,7 @@ module Rack
       def self.run(app, options = {})
         options  = DEFAULT_OPTIONS.merge(options)
 
-        if options[:Verbose]
+        if options.delete(:Verbose)
           app = Rack::CommonLogger.new(app, STDOUT)
         end
 
@@ -23,30 +23,22 @@ module Rack
           ENV['RACK_ENV'] = options[:environment].to_s
         end
 
-        events_hander = options[:Silent] ? ::Puma::Events.strings : ::Puma::Events.stdio
-        server   = ::Puma::Server.new(app, events_hander)
-        min, max = options[:Threads].split(':', 2)
+        options[:binds] ||= []
+        options[:binds] << "tcp://#{ options.delete(:Host) }:#{ options.delete(:Port) }"
+        options[:min_threads], options[:max_threads] = options.delete(:Threads).split(':', 2)
+        options[:app] = app
+        events        = options.delete(:Silent) ? ::Puma::Events.strings : ::Puma::Events.stdio
 
-        log = events_hander.stdout
+        launcher = ::Puma::Launcher.new(options, events: events)
 
-        log.puts "Puma #{::Puma::Const::PUMA_VERSION} starting..."
-        log.puts "* Min threads: #{min}, max threads: #{max}"
-        log.puts "* Environment: #{ENV['RACK_ENV']}"
-        log.puts "* Listening on tcp://#{options[:Host]}:#{options[:Port]}"
-
-        server.add_tcp_listener options[:Host], options[:Port]
-        server.min_threads = min
-        server.max_threads = max
-        yield server if block_given?
-
+        yield launcher if block_given?
         begin
-          server.run.join
+          launcher.run
         rescue Interrupt
-          log.puts "* Gracefully stopping, waiting for requests to finish"
-          server.stop(true)
-          log.puts "* Goodbye!"
+          puts "* Gracefully stopping, waiting for requests to finish"
+          launcher.stop
+          puts "* Goodbye!"
         end
-
       end
 
       def self.valid_options

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -29,7 +29,7 @@ module Rack
         options[:app] = app
         events        = options.delete(:Silent) ? ::Puma::Events.strings : ::Puma::Events.stdio
 
-        launcher = ::Puma::Launcher.new(options, events: events)
+        launcher = ::Puma::Launcher.new(options, :events => events)
 
         yield launcher if block_given?
         begin

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -5,11 +5,8 @@ module Rack
   module Handler
     module Puma
       DEFAULT_OPTIONS = {
-        :Host    => '0.0.0.0',
-        :Port    => 8080,
-        :Threads => '0:16',
         :Verbose => false,
-        :Silent => false
+        :Silent  => false
       }
 
       def self.run(app, options = {})
@@ -23,9 +20,9 @@ module Rack
           ENV['RACK_ENV'] = options[:environment].to_s
         end
 
-        options[:binds] ||= []
-        options[:binds] << "tcp://#{ options.delete(:Host) }:#{ options.delete(:Port) }"
-        options[:min_threads], options[:max_threads] = options.delete(:Threads).split(':', 2)
+        if options[:Threads]
+          options[:min_threads], options[:max_threads] = options.delete(:Threads).split(':', 2)
+        end
         options[:app] = app
         events        = options.delete(:Silent) ? ::Puma::Events.strings : ::Puma::Events.stdio
 

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -82,6 +82,7 @@ class TestCLI < Test::Unit::TestCase
     cli.send(:parse_options)
 
     t = Thread.new { cli.run }
+    t.abort_on_exception = true
 
     wait_booted
 
@@ -105,6 +106,7 @@ class TestCLI < Test::Unit::TestCase
     cli.send(:parse_options)
 
     t = Thread.new { cli.run }
+    t.abort_on_exception = true
 
     wait_booted
 

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -17,7 +17,7 @@ class TestCLI < Test::Unit::TestCase
 
     @wait, @ready = IO.pipe
 
-    @events = Events.strings
+    @events = Puma::Events.strings
     @events.on_booted { @ready << "!" }
   end
 

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -137,7 +137,7 @@ class TestCLI < Test::Unit::TestCase
   end
 
   def test_state_file_callback_filtering
-    cli = Puma::CLI.new [ "--config", "test/config/state_file_testing_config.rb", 
+    cli = Puma::CLI.new [ "--config", "test/config/state_file_testing_config.rb",
                           "--state", @tmp_path ]
     cli.send( :parse_options )
     cli.write_state

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -1,4 +1,7 @@
 require 'test/unit'
+require 'test/testhelp'
+require 'puma'
+require 'rack/handler/puma'
 
 class TestPumaUnixSocket < Test::Unit::TestCase
   def test_handler
@@ -7,4 +10,45 @@ class TestPumaUnixSocket < Test::Unit::TestCase
     handler = Rack::Handler.get('Puma')
     assert_equal Rack::Handler::Puma, handler
   end
+end
+
+class TestPathHandler < Test::Unit::TestCase
+  def app
+    Proc.new {|env| @input = env; [200, {}, ["hello world"]]}
+  end
+
+  def setup
+    @input = nil
+  end
+
+  def in_handler(app, options = {})
+    options[:Port] ||= 9998
+    @server = nil
+    thread = Thread.new do
+      Rack::Handler::Puma.run(app, options) do |s|
+        @server = s
+      end
+    end
+    thread.abort_on_exception = true
+
+    # Wait for server to boot
+    Timeout.timeout(10) do
+      until @server && @server.running
+        sleep 0.01
+      end
+    end
+    yield @server
+  ensure
+    @server.stop(true) if @server
+    thread.join if thread
+  end
+
+
+  def test_handler_boots
+    in_handler(app) do |server|
+      hit(["http://0.0.0.0:9998/test"])
+      assert_equal("/test", @input["PATH_INFO"])
+    end
+  end
+
 end

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -33,14 +33,16 @@ class TestPathHandler < Test::Unit::TestCase
 
     # Wait for server to boot
     Timeout.timeout(10) do
-      until @server && @server.running
-        sleep 0.01
+      until @server
+        sleep 1
       end
     end
+    sleep 1
+
     yield @server
   ensure
-    @server.stop(true) if @server
-    thread.join if thread
+    @server.stop if @server
+    thread.join  if thread
   end
 
 

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -42,10 +42,10 @@ class TestRackServer < Test::Unit::TestCase
 
   def setup
     @valid_request = "GET / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
-    
+
     @simple = lambda { |env| [200, { "X-Header" => "Works" }, ["Hello"]] }
     @server = Puma::Server.new @simple
-    @server.add_tcp_listener "127.0.0.1", 9998
+    @server.add_tcp_listener "127.0.0.1", 0
 
     @stopped = false
   end
@@ -65,7 +65,7 @@ class TestRackServer < Test::Unit::TestCase
 
     @server.run
 
-    hit(['http://127.0.0.1:9998/test'])
+    hit(["http://127.0.0.1:#{ @server.connected_port }/test"])
 
     stop
 
@@ -82,7 +82,7 @@ class TestRackServer < Test::Unit::TestCase
 
     big = "x" * (1024 * 16)
 
-    Net::HTTP.post_form URI.parse('http://127.0.0.1:9998/test'),
+    Net::HTTP.post_form URI.parse("http://127.0.0.1:#{ @server.connected_port }/test"),
                  { "big" => big }
 
     stop
@@ -97,7 +97,7 @@ class TestRackServer < Test::Unit::TestCase
     @server.app = lambda { |env| input = env; @simple.call(env) }
     @server.run
 
-    hit(['http://127.0.0.1:9998/test/a/b/c'])
+    hit(["http://127.0.0.1:#{ @server.connected_port }/test/a/b/c"])
 
     stop
 
@@ -114,7 +114,7 @@ class TestRackServer < Test::Unit::TestCase
 
     @server.run
 
-    hit(['http://127.0.0.1:9998/test'])
+    hit(["http://127.0.0.1:#{ @server.connected_port }/test"])
 
     stop
 
@@ -130,7 +130,7 @@ class TestRackServer < Test::Unit::TestCase
 
     @server.run
 
-    hit(['http://127.0.0.1:9998/test'])
+    hit(["http://127.0.0.1:#{ @server.connected_port }/test"])
 
     stop
 

--- a/test/test_ws.rb
+++ b/test/test_ws.rb
@@ -1,5 +1,5 @@
 # Copyright (c) 2011 Evan Phoenix
-# Copyright (c) 2005 Zed A. Shaw 
+# Copyright (c) 2005 Zed A. Shaw
 
 require 'test/testhelp'
 
@@ -19,11 +19,11 @@ class WebServerTest < Test::Unit::TestCase
 
   def setup
     @valid_request = "GET / HTTP/1.1\r\nHost: www.zedshaw.com\r\nContent-Type: text/plain\r\n\r\n"
-    
+
     @tester = TestHandler.new
 
     @server = Server.new @tester, Events.strings
-    @server.add_tcp_listener "127.0.0.1", 9998
+    @server.add_tcp_listener "127.0.0.1", 0
 
     @server.run
   end
@@ -33,14 +33,14 @@ class WebServerTest < Test::Unit::TestCase
   end
 
   def test_simple_server
-    hit(['http://127.0.0.1:9998/test'])
+    hit(["http://127.0.0.1:#{ @server.connected_port }/test"])
     assert @tester.ran_test, "Handler didn't really run"
   end
 
 
   def do_test(string, chunk, close_after=nil, shutdown_delay=0)
     # Do not use instance variables here, because it needs to be thread safe
-    socket = TCPSocket.new("127.0.0.1", 9998);
+    socket = TCPSocket.new("127.0.0.1", @server.connected_port);
     request = StringIO.new(string)
     chunks_out = 0
 


### PR DESCRIPTION
This is a WIP. This was the minimum I could do to get all tests to pass without changing any tests. Eventually I think we want all high level process controls to come from launcher, I also think we want another separate object that gets passed to Runner/Single/Cluster that will maintain a relationship with the Launcher. We could use this as the object that also gets exposed to the app like the Embeddable class we talked about earlier. 

Moving forwards i'm planning to port out the CLI tests to only test that they are parsing the correct config and launching servers. I'll port all low level unit tests over to the launcher. Making this change we could either keep all the public methods in CLI that delegate to `@launcher`, I'm guessing not many people are using the internals of CLI and we can take them out. It's your call though.

Wanted to kick this over the fence and see if you had any strong reactions or feelings about this approach.