### PR TITLE
make phased restarts faster

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -136,7 +136,7 @@ module Puma
       @workers.count { |w| !w.booted? } == 0
     end
 
-    def check_workers(force)
+    def check_workers(force=false)
       return if !force && @next_check && @next_check >= Time.now
 
       @next_check = Time.now + 5


### PR DESCRIPTION
Have the worker send the master "tPID" immediately before it shuts down; this lets the master move on to booting the next worker immediately, instead of waiting for the next iteration of the select() loop.

cc @zendesk/rules