### PR TITLE
allow umask for unix:/// style control urls

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -42,6 +42,7 @@ module Puma
         @options[:control_auth_token] = auth_token if auth_token
 
         @options[:control_auth_token] = :none if opts[:no_token]
+        @options[:control_url_umask] = opts[:umask] if opts[:umask]
       end
     end
 

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -52,8 +52,9 @@ module Puma
       when "unix"
         log "* Starting control server on #{str}"
         path = "#{uri.host}#{uri.path}"
+        mask = @options[:control_url_umask]
 
-        control.add_unix_listener path
+        control.add_unix_listener path, mask
       else
         error "Invalid control URI: #{str}"
       end


### PR DESCRIPTION
this lets us rely on unix permissions to control access to the control_url.

cc @zendesk/rules