### PR TITLE
Override REMOTE_ADDR header if set_remote_address has been used

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -495,7 +495,7 @@ module Puma
       # intermediary acting on behalf of the actual source client."
       #
 
-      unless env.key?(REMOTE_ADDR)
+      if !env.key?(REMOTE_ADDR) || @options[:remote_address_header] || @options[:remote_address_value]
         begin
           addr = client.peerip
         rescue Errno::ENOTCONN


### PR DESCRIPTION
Hi,

This fixes an issue where `set_remote_address` is ignored if a proxy service adds the `REMOTE_ADDR` HTTP header but `set_remote_address` is configured to use a different HTTP header, i.e, `CLIENT_IP`

If this change is approved, when would it be possible to get a new gem version released? 

Please let me know what you think. 

Thanks. 