### PR TITLE
Fix jruby server tests

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -165,7 +165,7 @@ module Puma
                 @events.error "Please specify the SSL ca via 'ca='"
               end
             end
-            
+
             ctx.ca = params['ca'] if params['ca']
 
             if  params['verify_mode']

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -59,7 +59,7 @@ class TestPumaServer < Test::Unit::TestCase
       [-1, {}, []]
     end
 
-    @server.add_tcp_listener @host, @server.connected_port
+    @server.add_tcp_listener @host, @port
     @server.run
 
     sock = TCPSocket.new @host, @server.connected_port
@@ -75,7 +75,7 @@ class TestPumaServer < Test::Unit::TestCase
       [200, {}, [giant]]
     end
 
-    @server.add_tcp_listener @host, @server.connected_port
+    @server.add_tcp_listener @host, @port
     @server.run
 
     sock = TCPSocket.new @host, @server.connected_port
@@ -96,7 +96,7 @@ class TestPumaServer < Test::Unit::TestCase
       [200, {}, [env['SERVER_PORT']]]
     end
 
-    @server.add_tcp_listener @host, @server.connected_port
+    @server.add_tcp_listener @host, @port
     @server.run
 
     req = Net::HTTP::Get.new("/")
@@ -115,7 +115,7 @@ class TestPumaServer < Test::Unit::TestCase
       [200, {}, [env['SERVER_PORT']]]
     end
 
-    @server.add_tcp_listener @host, @server.connected_port
+    @server.add_tcp_listener @host, @port
     @server.run
 
     req = Net::HTTP::Get.new("/")
@@ -159,7 +159,7 @@ class TestPumaServer < Test::Unit::TestCase
   def test_GET_with_no_body_has_sane_chunking
     @server.app = proc { |env| [200, {}, []] }
 
-    @server.add_tcp_listener @host, @server.connected_port
+    @server.add_tcp_listener @host, @port
     @server.run
 
     sock = TCPSocket.new @host, @server.connected_port


### PR DESCRIPTION
We were accidentally connecting to a `nil` port, in my previous tests. MRI will interpret this the same as port 0. Jruby will not and throws an error

```
Error: test_very_large_return(TestPumaServer): TypeError: can't convert nil into String
org/jruby/ext/socket/RubyTCPServer.java:102:in `initialize'
org/jruby/RubyIO.java:851:in `new'
```

This tests makes sure we're using a port number instead of nil.