### PR TITLE
Add NullIO#size and test

### DIFF
--- a/lib/puma/null_io.rb
+++ b/lib/puma/null_io.rb
@@ -30,5 +30,11 @@ module Puma
     #
     def close
     end
+
+    # Always zero
+    #
+    def size
+      0
+    end
   end
 end

--- a/test/test_null_io.rb
+++ b/test/test_null_io.rb
@@ -28,4 +28,8 @@ class TestNullIO < Test::Unit::TestCase
     assert_nil nio.read(1,buf)
     assert_equal "", buf
   end
+
+  def test_size
+    assert_equal 0, nio.size
+  end
 end


### PR DESCRIPTION
It's useful to inspect `request.body.size` to see if there's anything to parse (e.g. a JSON payload), but sometimes `request.body` is a Puma::NullIO. 