### PR TITLE
Signal not full on worker exit #876

### DIFF
--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -77,6 +77,7 @@ module Puma
               if @trim_requested > 0
                 @trim_requested -= 1
                 continue = false
+                not_full.signal
                 break
               end
 


### PR DESCRIPTION
Fixes #876.

With:
```
threads 0,1
queue_requests false
```

Sequence:
* work is added ([calling `<<` in server.rb](https://github.com/puma/puma/blob/f048f38416be48ff6a7bb2a5b192c7d7a4a4e7d1/lib/puma/server.rb#L337))
* next [`wait_until_not_full` is executed](https://github.com/puma/puma/blob/f048f38416be48ff6a7bb2a5b192c7d7a4a4e7d1/lib/puma/server.rb#L338) (and it starts waiting on `@not_full`)
* in another thread, `trim` is executed (because `@waiting` is still > 0, `@trim_requested` gets incremented, marking the worker to be trimmed)
* finally, the worker thread wakes up, decrements `@waiting`, execute the work (removing the last item from `@todo`), finishes it, an then hits the `@trim_requested` check, exiting the loop before signaling `@not_full`, so `wait_until_not_full` never exits

Couldn't figure out a test for this case...

@evanphx what do you think?

/cc @osheroff 