### PR TITLE
Fix undefined method and variable when execute pumactl

### DIFF
--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -1,5 +1,6 @@
 require 'optparse'
 require 'puma/const'
+require 'puma/detect'
 require 'puma/configuration'
 require 'uri'
 require 'socket'

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -178,24 +178,24 @@ module Puma
       end
 
       begin
-        Process.getpgid pid
+        Process.getpgid @pid
       rescue SystemCallError
         if @command == "restart"
           start
         else
-          raise "No pid '#{pid}' found"
+          raise "No pid '#{@pid}' found"
         end
       end
 
       case @command
       when "restart"
-        Process.kill "SIGUSR2", pid
+        Process.kill "SIGUSR2", @pid
 
       when "halt"
-        Process.kill "QUIT", pid
+        Process.kill "QUIT", @pid
 
       when "stop"
-        Process.kill "SIGTERM", pid
+        Process.kill "SIGTERM", @pid
 
       when "stats"
         puts "Stats not available via pid only"
@@ -206,7 +206,7 @@ module Puma
         return
 
       when "phased-restart"
-        Process.kill "SIGUSR1", pid
+        Process.kill "SIGUSR1", @pid
 
       else
         message "Puma is started"


### PR DESCRIPTION
```ruby
$ bundle exec puma --pidfile tmp/pids/puma.pid -d
Puma starting in single mode...
* Version 3.0.1 (ruby 2.3.0-p0), codename: Plethora of Penguin Pinatas
* Min threads: 0, max threads: 16
* Environment: development
* Daemonizing...

$ bundle exec pumactl --pid tmp/pids/puma.pid stop
undefined method `windows?' for Puma:Module
```

Uhm...
This [commit](https://github.com/corrupt952/puma/commit/a90c77aacd1458e65c99cf73ce8e19e2cc05ab70) fixed it.

```
$ bundle exec pumactl --pid tmp/pids/puma.pid stop
undefined local variable or method `pid' for #<Puma::ControlCLI:0x007f185fcef968>
Did you mean?  @pid
```

This [commit](https://github.com/corrupt952/puma/commit/2a2f8dd31d67c1659a9d4831e17adfd2b650840b) fixed it.