### PR TITLE
Make `plugin :tmp_restart` behavior correct in Windows.

### DIFF
--- a/lib/puma/plugin.rb
+++ b/lib/puma/plugin.rb
@@ -58,8 +58,21 @@ module Puma
   Plugins = PluginRegistry.new
 
   class Plugin
+    # Matches
+    #  "C:/Ruby22/lib/ruby/gems/2.2.0/gems/puma-3.0.1/lib/puma/plugin/tmp_restart.rb:3:in `<top (required)>'"
+    #  AS
+    #  C:/Ruby22/lib/ruby/gems/2.2.0/gems/puma-3.0.1/lib/puma/plugin/tmp_restart.rb
+    CALLER_FILE = /
+      \A       # start of string
+      .+       # file path (one or more characters)
+      (?=      # stop previous match when
+        :\d+     # a colon is followed by one or more digits
+        :in      # followed by a colon followed by in
+      )
+    /x
+
     def self.extract_name(ary)
-      path = ary.first.split(":").first
+      path = ary.first[CALLER_FILE]
 
       m = %r!puma/plugin/([^/]*)\.rb$!.match(path)
       return m[1]


### PR DESCRIPTION
It won't allow `touch tmp/restart.txt` work correctly in windows, but at least will make out of stock `config/puma.rb` file behavior correct.

```ruby
# Allow puma to be restarted by `rails restart` command.
plugin :tmp_restart
```

Inspired by below PR.

https://github.com/rails-api/active_model_serializers/pull/1014