### PR TITLE
Set a more explicit SERVER_SOFTWARE Rack variable

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -28,7 +28,7 @@ module Puma
 
         "QUERY_STRING".freeze => "",
         SERVER_PROTOCOL => HTTP_11,
-        SERVER_SOFTWARE => PUMA_VERSION,
+        SERVER_SOFTWARE => PUMA_SERVER_STRING,
         GATEWAY_INTERFACE => CGI_VER
       }
 

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -101,7 +101,8 @@ module Puma
 
     PUMA_VERSION = VERSION = "3.0.2".freeze
     CODE_NAME = "Plethora of Penguin Pinatas".freeze
-
+    PUMA_SERVER_STRING = ['puma', PUMA_VERSION, CODE_NAME].join(' ').freeze
+    
     FAST_TRACK_KA_TIMEOUT = 0.2
 
     # The default number of seconds for another request within a persistent


### PR DESCRIPTION
When you need to have a switch in an infrastructure middleware (streaming, events and sockets) you might have to make runtime decisions based on the server that is being used. The Rack env header is the only way for the underlying Rack app to see which server it is being run on. Previously it would only contain the puma version string, which is insufficient.

Concrete example - in one of my middleware gems I need to switch based on the server used, and also need to output the server name and version to the log which is output from within the application.

This adds 1 frozen and preallocated constant.