### PR TITLE
Fix the JRuby version in `allow_failures` section of `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - rvm: jruby-head
-    - rvm: jruby-9.0.4.0
+    - rvm: jruby-9.0.5.0
     - rvm: rbx-2
     - rvm: ruby-head


### PR DESCRIPTION
This is a missing update of 0d56a311.