### PR TITLE
Fixes #922 - Correctly define file encoding as UTF-8

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -1,3 +1,4 @@
+#encoding: utf-8
 module Puma
   class UnsupportedOption < RuntimeError
   end


### PR DESCRIPTION
Line 103 contains the unicode character ñ which causes this to break rake for ruby 1.9.3. 
Specifying the encoding for the file fixes this error.