### PR TITLE
Allow cluster.rb to work with gems.rb too

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -219,8 +219,12 @@ module Puma
 
       # If we're not running under a Bundler context, then
       # report the info about the context we will be using
-      if !ENV['BUNDLE_GEMFILE'] and File.exist?("Gemfile")
-        log "+ Gemfile in context: #{File.expand_path("Gemfile")}"
+      if !ENV['BUNDLE_GEMFILE']
+        if File.exist?("Gemfile")
+          log "+ Gemfile in context: #{File.expand_path("Gemfile")}"
+        elsif File.exist?("gems.rb")
+          log "+ Gemfile in context: #{File.expand_path("gems.rb")}"
+        end
       end
 
       # Invoke any worker boot hooks so they can get


### PR DESCRIPTION
Bundler has been supporting both `Gemfile` and `gems.rb` variants for quite some time.