### PR TITLE
Allow overriding options of Configuration object

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -13,10 +13,10 @@ module Puma
   end
 
   class LeveledOptions
-    def initialize(default={})
-      @cur = {}
+    def initialize(default_options, user_options)
+      @cur = user_options
       @set = [@cur]
-      @defaults = default.dup
+      @defaults = default_options.dup
     end
 
     def initialize_copy(other)
@@ -133,12 +133,9 @@ module Puma
     end
 
     def initialize(options={}, &blk)
-      @options = LeveledOptions.new(default_options)
-      @plugins = PluginLoader.new
+      @options = LeveledOptions.new(default_options, options)
 
-      # options.each do |k,v|
-        # @options[k] = v
-      # end
+      @plugins = PluginLoader.new
 
       if blk
         configure(&blk)

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -12,7 +12,7 @@ module Rack
       def self.run(app, options = {})
         options  = DEFAULT_OPTIONS.merge(options)
 
-        conf = ::Puma::Configuration.new do |c|
+        conf = ::Puma::Configuration.new(options) do |c|
           c.quiet
 
           if options.delete(:Verbose)
@@ -69,4 +69,3 @@ module Rack
     register :puma, Puma
   end
 end
-

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -51,6 +51,12 @@ class TestConfigFile < Test::Unit::TestCase
     assert_equal [200, {}, ["error page"]], app.call({})
   end
 
+  def test_allow_users_to_override_default_options
+    conf = Puma::Configuration.new(restart_cmd: 'bin/rails server')
+
+    assert_equal 'bin/rails server', conf.options[:restart_cmd]
+  end
+
   private
 
     def with_env(env = {})


### PR DESCRIPTION
- Currently it's not possible to override the default options for
  Puma::Configuration with user provided options.
- I came across this issue while working on fixing server restart for
  Rails.
- Rails can send it's own restart command to Puma and Puma should store
  it in it's configuration object. So that Puma::Launcher can use it.
- After this patch it will be possible as user provided options will be
  taken into account in Configuration object.