### PR TITLE
Reverse the order of fetching data from config to make puma config source of truth and return value from it first, if present

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -30,7 +30,7 @@ module Puma
     end
 
     def [](key)
-      @set.each do |o|
+      @set.reverse_each do |o|
         if o.key? key
           return o[key]
         end


### PR DESCRIPTION
Reverse the order of fetching data from config to make puma config source of truth and return value from it first, if present

Fixes #939

See https://github.com/puma/puma/issues/939#issuecomment-207760014