### PR TITLE
Add request info to standard error rescue

### DIFF
--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -106,15 +106,21 @@ module Puma
     end
 
     # An unknown error has occurred.
-    # +server+ is the Server object, +error+ an exception object, and
-    # +kind+ some additional info.
+    # +server+ is the Server object, +error+ an exception object,
+    # +kind+ some additional info, and +env+ the request.
     #
-    def unknown_error(server, error, kind="Unknown")
+    def unknown_error(server, error, kind="Unknown", env=nil)
       if error.respond_to? :render
         error.render "#{Time.now}: #{kind} error", @stderr
       else
-        @stderr.puts "#{Time.now}: #{kind} error: #{error.inspect}"
-        @stderr.puts error.backtrace.join("\n")
+        if env
+          string_block = [ "#{Time.now}: #{kind} error handling request { #{env['REQUEST_METHOD']} #{env['PATH_INFO']} }" ]
+          string_block << error.inspect
+        else
+          string_block = [ "#{Time.now}: #{kind} error: #{error.inspect}" ]
+        end
+        string_block << error.backtrace
+        @stderr.puts string_block.join("\n")
       end
     end
 

--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -106,8 +106,8 @@ module Puma
     end
 
     # An unknown error has occurred.
-    # +server+ is the Server object, +env+ the request, +error+ an exception
-    # object, and +kind+ some additional info.
+    # +server+ is the Server object, +error+ an exception object, and
+    # +kind+ some additional info.
     #
     def unknown_error(server, error, kind="Unknown")
       if error.respond_to? :render

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -588,8 +588,7 @@ module Puma
           res_body = ["Request was internally terminated early\n"]
 
         rescue StandardError => e
-          STDERR.puts "#{Time.now}: error handling request: { #{ env['REQUEST_METHOD'] } #{ env['PATH_INFO'] } }:"
-          @events.unknown_error self, e, "Rack app"
+          @events.unknown_error self, e, "Rack app", env
 
           status, headers, res_body = lowlevel_error(e, env)
         end

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -588,6 +588,7 @@ module Puma
           res_body = ["Request was internally terminated early\n"]
 
         rescue StandardError => e
+          STDERR.puts "#{Time.now}: error handling request: { #{ env['REQUEST_METHOD'] } #{ env['PATH_INFO'] } }:"
           @events.unknown_error self, e, "Rack app"
 
           status, headers, res_body = lowlevel_error(e, env)


### PR DESCRIPTION
Error backtraces should really come with this context (makes pinpointing where we should look much easier). Would be open to some discussion about how best to do the printing. Puma::Events#unknown_error could handle it... but I'd have to pass in the `env` request object.