### PR TITLE
Add http logging to parse error

### DIFF
--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -397,7 +397,7 @@ VALUE HttpParser_execute(VALUE self, VALUE req_hash, VALUE data, VALUE start)
     VALIDATE_MAX_LENGTH(puma_parser_nread(http), HEADER);
 
     if(puma_parser_has_error(http)) {
-      rb_raise(eHttpParserError, "%s", "Invalid HTTP format, parsing fails.");
+      rb_raise(eHttpParserError, "%s", printf("Invalid HTTP format, parsing fails.\nHTTP:\n%s", http));
     } else {
       return INT2FIX(puma_parser_nread(http));
     }


### PR DESCRIPTION
Sometimes I get errors like the one described in
https://github.com/puma/puma/issues/650. I made this PR with the
intention of printing the malformed request to STDOUT (at least for
MRI). I hope this accomplishes that.

I think this is a better alt to the error message and I don't think
there's a downside figuring the event is (hopefully) rare and log
management can easily handle these messages nowadays.