### PR TITLE
Set worker thread name.

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -8,7 +8,6 @@ Rakefile
 bin/puma
 bin/puma-wild
 bin/pumactl
-docs/config.md
 docs/nginx.md
 docs/signals.md
 docs/systemd.md

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -68,6 +68,8 @@ module Puma
       @spawned += 1
 
       th = Thread.new do
+        # Thread name is new in Ruby 2.3
+        Thread.current.name = 'puma %03i' % @spawned if Thread.current.respond_to?(:name=)
         todo  = @todo
         block = @block
         mutex = @mutex

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -19,9 +19,11 @@ class TestThreadPool < Test::Unit::TestCase
 
   def test_append_spawns
     saw = []
+    thread_name = nil
 
     pool = new_pool(0, 1) do |work|
       saw << work
+      thread_name = Thread.current.name if Thread.current.respond_to?(:name)
     end
 
     pool << 1
@@ -30,6 +32,8 @@ class TestThreadPool < Test::Unit::TestCase
 
     assert_equal [1], saw
     assert_equal 1, pool.spawned
+    # Thread name is new in Ruby 2.3
+    assert_equal('puma 001', thread_name) if Thread.current.respond_to?(:name)
   end
 
   def test_converts_pool_sizes


### PR DESCRIPTION
Supports multithreaded logging and problem diagnosis.