### PR TITLE
[ci skip]Update default number of threads

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -27,7 +27,7 @@ Here are some rules of thumb:
 * Use cluster mode and set the number of workers to 1.5x the number of cpu cores
   in the machine, minimum 2.
 * Set the number of threads to desired concurrent requests / number of workers.
-  Puma defaults to 8 and that's a decent number.
+  Puma defaults to 16 and that's a decent number.
 
 #### Migrating from Unicorn
 


### PR DESCRIPTION
Default number of threads is 16 in puma. So I think DEPLOYMENT.md needs to be fixed.

(English is not my native language, so I'm sorry if I misunderstood.)