### PR TITLE
Allow persistent_timeout to be configured via the dsl.

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -181,7 +181,8 @@ module Puma
         :tag => method(:infer_tag),
         :environment => lambda { ENV['RACK_ENV'] || "development" },
         :rackup => DefaultRackup,
-        :logger => STDOUT
+        :logger => STDOUT,
+        :persistent_timeout => Const::PERSISTENT_TIMEOUT
       }
     end
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -133,6 +133,13 @@ module Puma
       bind "tcp://#{host}:#{port}"
     end
 
+    # Define how long persistent connections can be idle before puma closes
+    # them
+    #
+    def persistent_timeout(seconds)
+      @options[:persistent_timeout] = seconds
+    end
+
     # Work around leaky apps that leave garbage in Thread locals
     # across requests
     #

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -63,7 +63,7 @@ module Puma
       @thread = nil
       @thread_pool = nil
 
-      @persistent_timeout = PERSISTENT_TIMEOUT
+      @persistent_timeout = options[:persistent_timeout]
 
       @binder = Binder.new(events)
       @own_binder = true


### PR DESCRIPTION
@evanphx This is in response to #957. When using puma directly behind an Amazon ELB, ELB will issue a 504 if the server closes a connection sooner than the "idle timeout". This PR let's you configure puma's timeout for persistent connections.