### PR TITLE
Don't let persistent_timeout be nil

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -63,7 +63,7 @@ module Puma
       @thread = nil
       @thread_pool = nil
 
-      @persistent_timeout = options[:persistent_timeout]
+      @persistent_timeout = options.fetch(:persistent_timeout, PERSISTENT_TIMEOUT)
 
       @binder = Binder.new(events)
       @own_binder = true


### PR DESCRIPTION
I got some errors in a project that uses Puma because persistent_timeout doesn't get set, and arithmetic with nil explodes.