### PR TITLE
Enable log_requests for integration tests

### DIFF
--- a/test/shell/t1_conf.rb
+++ b/test/shell/t1_conf.rb
@@ -1,2 +1,3 @@
+log_requests
 stdout_redirect "t1-stdout"
 pidfile "t1-pid"

--- a/test/shell/t2_conf.rb
+++ b/test/shell/t2_conf.rb
@@ -1,3 +1,4 @@
+log_requests
 stdout_redirect "t2-stdout"
 pidfile "t2-pid"
 bind "tcp://0.0.0.0:10103"


### PR DESCRIPTION
These tests depend on log_requests being enabled, but this was turned
off by default in 03ed48ca903879f3b9a649f5df1cf9d6577ef3d2