### PR TITLE
Support rack 2.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "rdoc"
 gem "rake-compiler"
 gem "test-unit", "~> 3.0"
 
-gem "rack", "< 2.0"
+gem "rack", "< 3.0"
 gem 'minitest', '~> 5.8'
 
 gem "jruby-openssl", :platform => "jruby"

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ HOE = Hoe.spec "puma" do
 
   require_ruby_version ">= 1.8.7"
 
-  dependency "rack", [">= 1.1", "< 2.0"], :development
+  dependency "rack", [">= 1.1", "< 3.0"], :development
 
   extra_dev_deps << ["rake-compiler", "~> 0.8"]
 end


### PR DESCRIPTION
Hi,
This patch is to support a rack latest version 2.0.1, as I want to use it.
https://rubygems.org/gems/rack

Could you merge this?
Thanks.
