### PR TITLE
Fix warning: MiniTest::Unit::TestCase is now Minitest::Test.

### DIFF
--- a/test/test_tcp_logger.rb
+++ b/test/test_tcp_logger.rb
@@ -6,7 +6,7 @@ require 'socket'
 require 'puma/server'
 require 'puma/events'
 
-class TestTCPLogger < Minitest::Unit::TestCase
+class TestTCPLogger < Minitest::Test
 
   def setup
     @events = Puma::Events.new STDOUT, STDERR


### PR DESCRIPTION
Sorry about this. My previous change broke the build. This test file needs Minitest because it's using the `capture_subprocess_io` method. I updated my PR to change `MiniTest::Unit::TestCase` to `Minitest::Test`. This removes the warning.