### PR TITLE
Modify a require path for testhelp to pass the test.

### DIFF
--- a/test/test_http11.rb
+++ b/test/test_http11.rb
@@ -1,7 +1,7 @@
 # Copyright (c) 2011 Evan Phoenix
 # Copyright (c) 2005 Zed A. Shaw
 
-require 'testhelp'
+require 'test/testhelp'
 
 include Puma
 


### PR DESCRIPTION
This fixes isolated test.

For example.
```
$ bundle exec ruby -Ilib:. \
  -r 'rubygems' -r 'minitest/autorun' \
  -e 'Dir.glob "./test/test_http10.rb", &method(:require)'
...
1 tests, 11 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

```
$ bundle exec ruby -Ilib:. \
  -r 'rubygems' -r 'minitest/autorun' \
  -e 'Dir.glob "./test/test_http11.rb", &method(:require)'
/home/jaruga/git/puma/test/test_http11.rb:4:in `require': cannot load such file -- testhelp (LoadError)
  from /home/jaruga/git/puma/test/test_http11.rb:4:in `<top (required)>'
  from -e:1:in `require'
  from -e:1:in `glob'
  from -e:1:in `<main>'
```

Check testhelp paths in the tests.
```
$ grep -r testhelp test/
test/test_rack_server.rb:require 'test/testhelp'
test/test_http10.rb:require 'test/testhelp'
test/test_rack_handler.rb:require 'test/testhelp'
test/test_ws.rb:require 'test/testhelp'
test/test_http11.rb:require 'testhelp' <= it is wrong.
```

Could you merge this?
Thanks.
