### PR TITLE
Rack handler uses ::Rack::CommonLogger.

### DIFF
--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -10,11 +10,10 @@ module Rack
 
       def self.run(app, options = {})
         require 'puma/configuration'
-        require 'puma/commonlogger'
         require 'puma/events'
         require 'puma/launcher'
 
-        options  = DEFAULT_OPTIONS.merge(options)
+        options = DEFAULT_OPTIONS.merge(options)
 
         conf = ::Puma::Configuration.new(options) do |c|
           c.quiet


### PR DESCRIPTION
No need to require Puma::CommonLogger.