### PR TITLE
Travis fix 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 cache: bundler
 script: "TESTOPTS=-v bundle exec rake test"
 rvm:
-  - 2.1.9
   - 2.2.5
   - 2.3.1
   - ruby-head
@@ -11,6 +10,9 @@ rvm:
   - jruby-head
   - rbx
 matrix:
+  include:
+    - rvm: 2.1
+      gemfile: gemfiles/2.1-Gemfile
   fast_finish: true
   allow_failures:
     - rvm: jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem "hoe"
 gem "hoe-git"

--- a/gemfiles/2.1-Gemfile
+++ b/gemfiles/2.1-Gemfile
@@ -1,0 +1,13 @@
+source "https://rubygems.org"
+
+gem "hoe"
+gem "hoe-git"
+gem "hoe-ignore"
+gem "rdoc"
+gem "rake-compiler"
+gem "test-unit", "~> 3.0"
+
+gem "rack", "~> 1.6"
+gem 'minitest', '~> 5.8'
+
+gem "jruby-openssl", :platform => "jruby"


### PR DESCRIPTION
CI build is failing due to https://github.com/puma/puma/pull/1068
This add a gemfile for Ruby 2.1 fixing rack to ~1.6 release
Cheers