### PR TITLE
Require StateFile if needed.

### DIFF
--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -1,7 +1,6 @@
 # Standard libraries
 require 'socket'
 require 'tempfile'
-require 'yaml'
 require 'time'
 require 'etc'
 require 'uri'

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -7,7 +7,6 @@ require 'puma/single'
 require 'puma/const'
 
 require 'puma/binder'
-require 'puma/state_file'
 
 module Puma
   # Puma::Launcher is the single entry point for starting a Puma server based on user
@@ -104,6 +103,8 @@ module Puma
 
       path = @options[:state]
       return unless path
+
+      require 'puma/state_file'
 
       sf = StateFile.new
       sf.pid = Process.pid

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -2,6 +2,7 @@ require "rbconfig"
 require 'test/unit'
 require 'puma/cli'
 require 'tempfile'
+require 'yaml'
 
 class TestCLI < Test::Unit::TestCase
   def setup


### PR DESCRIPTION
I made some benchmarks with derailed_benchmarks:

Before:

```
allocated memory by gem
-----------------------------------
   1572863  rake-11.2.2
   1071797  2.3.1/lib
     74852  bundler-1.12.5
     18833  puma/lib
     12232  rack-2.0.1
        80  derailed_benchmarks-1.3.1
```

```
$ bundle exec derailed bundle:mem
TOP: 1.4336 MiB
  rake: 0.8711 MiB
    rake/rake_module: 0.6094 MiB
      rake/application: 0.5938 MiB (Also required by: rake)
        rake/file_list: 0.4141 MiB (Also required by: rake)
  puma: 0.5195 MiB
    yaml: 0.4883 MiB
      psych: 0.4883 MiB
```

After:

```
$ bundle exec derailed bundle:mem
TOP: 0.9023 MiB
  rake: 0.8477 MiB
    rake/rake_module: 0.5586 MiB
      rake/application: 0.5586 MiB (Also required by: rake)
        rake/file_list: 0.4219 MiB (Also required by: rake)
```

```
allocated memory by gem
-----------------------------------
   1573183  rake-11.2.2
     74852  bundler-1.12.5
     12232  rack-2.0.1
      9807  2.3.1/lib
      1993  puma/lib
        80  derailed_benchmarks-1.3.1
```