### PR TITLE
Minor refactor on Thread pool

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -113,11 +113,6 @@ module Puma
     # sending data back
     WRITE_TIMEOUT = 10
 
-    # How long, after raising the ForceShutdown of a thread during
-    # forced shutdown mode, to wait for the thread to try and finish
-    # up it's work before leaving the thread to die on the vine.
-    SHUTDOWN_GRACE_TIME = 5 # seconds
-
     # The original URI requested by the client.
     REQUEST_URI= 'REQUEST_URI'.freeze
     REQUEST_PATH = 'REQUEST_PATH'.freeze

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -9,7 +9,7 @@ module Puma
 
     # How long, after raising the ForceShutdown of a thread during
     # forced shutdown mode, to wait for the thread to try and finish
-    # up it's work before leaving the thread to die on the vine.
+    # up its work before leaving the thread to die on the vine.
     SHUTDOWN_GRACE_TIME = 5 # seconds
 
     # Maintain a minimum of +min+ and maximum of +max+ threads

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -4,9 +4,13 @@ module Puma
   # A simple thread pool management object.
   #
   class ThreadPool
-
     class ForceShutdown < RuntimeError
     end
+
+    # How long, after raising the ForceShutdown of a thread during
+    # forced shutdown mode, to wait for the thread to try and finish
+    # up it's work before leaving the thread to die on the vine.
+    SHUTDOWN_GRACE_TIME = 5 # seconds
 
     # Maintain a minimum of +min+ and maximum of +max+ threads
     # in the pool.
@@ -268,7 +272,7 @@ module Puma
         end
 
         threads.each do |t|
-          t.join Const::SHUTDOWN_GRACE_TIME
+          t.join SHUTDOWN_GRACE_TIME
         end
       else
         timeout.times do
@@ -288,7 +292,7 @@ module Puma
         end
 
         threads.each do |t|
-          t.join Const::SHUTDOWN_GRACE_TIME
+          t.join SHUTDOWN_GRACE_TIME
         end
       end
 

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -263,18 +263,12 @@ module Puma
         @workers.dup
       end
 
-      case timeout
-      when -1
+      if timeout == -1
+        # Wait for threads to finish without force shutdown.
         threads.each(&:join)
-      when 0
-        threads.each do |t|
-          t.raise ForceShutdown
-        end
-
-        threads.each do |t|
-          t.join SHUTDOWN_GRACE_TIME
-        end
       else
+        # Wait for threads to finish after n attempts (+timeout+).
+        # If threads are still running, it will forcefully kill them.
         timeout.times do
           threads.delete_if do |t|
             t.join 1

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -230,4 +230,21 @@ class TestThreadPool < Test::Unit::TestCase
 
     assert_equal 0, pool.spawned
   end
+
+  def test_force_shutdown_immediately
+    pool = new_pool(1, 1) {
+      begin
+        sleep 1
+      rescue Puma::ThreadPool::ForceShutdown
+      end
+    }
+
+    pool << 1
+
+    sleep 0.1
+
+    pool.shutdown(0)
+
+    assert_equal 0, pool.spawned
+  end
 end


### PR DESCRIPTION
- Puma::Threadpool uses only one constant from the constants file. At the beginning, I was thinking to add the missing require to const.rb to the ThreadPool, but I think it's better to just move the constant to where it's used.
- I removed the check for `timeout == 0` since the `times` block will not be executed if it's zero.
