### PR TITLE
Duplicated load path

### DIFF
--- a/test/testhelp.rb
+++ b/test/testhelp.rb
@@ -1,12 +1,6 @@
 # Copyright (c) 2011 Evan Phoenix
 # Copyright (c) 2005 Zed A. Shaw 
 
-
-%w(lib test).each do |d|
-  dir = File.expand_path("../../#{d}", __FILE__)
-  $LOAD_PATH.unshift dir unless $LOAD_PATH.include?(dir)
-end
-
 require 'rubygems'
 require 'test/unit'
 require 'net/http'


### PR DESCRIPTION
When we would run test, the load path "lib:bin:test:." is loaded by Hoe test default settings.

https://github.com/seattlerb/hoe/blob/master/lib/hoe.rb#L106

So, I think we do not need to set load path in test/testhelp.rb again.
How do you think?

```
$ bundle exec rake test
...
/usr/local/ruby-2.3.1/bin/ruby -w -Ilib:bin:test:. -e 'require "rubygems"; require "minitest/autorun"; require "test/test_thread_pool.rb"; require "test/test_puma_server.rb"; require "test/test_app_status.rb"; require "test/test_rack_server.rb"; require "test/test_minissl.rb"; require "test/test_tcp_logger.rb"; require "test/test_unix_socket.rb"; require "test/test_tcp_rack.rb"; require "test/test_null_io.rb"; require "test/test_http10.rb"; require "test/test_rack_handler.rb"; require "test/test_persistent.rb"; require "test/test_ws.rb"; require "test/test_puma_server_ssl.rb"; require "test/test_config.rb"; require "test/test_iobuffer.rb"; require "test/test_integration.rb"; require "test/test_cli.rb"; require "test/test_http11.rb"' --
...
```

Below tests were also passed.
```
$ bundle exec rake test
$ bundle exec rake test:integration
```