### PR TITLE
Improve required testhelp.rb path.

### DIFF
--- a/test/test_http10.rb
+++ b/test/test_http10.rb
@@ -1,4 +1,4 @@
-require 'test/testhelp'
+require 'testhelp'
 
 class Http10ParserTest < Test::Unit::TestCase
   include Puma

--- a/test/test_http11.rb
+++ b/test/test_http11.rb
@@ -1,7 +1,7 @@
 # Copyright (c) 2011 Evan Phoenix
 # Copyright (c) 2005 Zed A. Shaw
 
-require 'test/testhelp'
+require 'testhelp'
 
 include Puma
 

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -1,5 +1,5 @@
 require 'test/unit'
-require 'test/testhelp'
+require 'testhelp'
 require 'puma'
 require 'rack/handler/puma'
 

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -1,7 +1,7 @@
 require 'test/unit'
 require 'puma'
 require 'rack/lint'
-require 'test/testhelp'
+require 'testhelp'
 require 'puma/commonlogger'
 
 class TestRackServer < Test::Unit::TestCase

--- a/test/test_ws.rb
+++ b/test/test_ws.rb
@@ -1,7 +1,7 @@
 # Copyright (c) 2011 Evan Phoenix
 # Copyright (c) 2005 Zed A. Shaw
 
-require 'test/testhelp'
+require 'testhelp'
 
 include Puma
 


### PR DESCRIPTION
Last time I sent pull-request to change testhelp.rb path, and it was merged. (https://github.com/puma/puma/commit/73bf56cf8b375f1b9abc1ec30ae64561cebedfd5).
I think it might be my mistake.

Because it looks usual to set "lib" and "test" as a ruby path than "lib" and ".".

Though it may be small thing.

For example, below Rake TestTask is using both "lib" and "test" below page.
http://rake.rubyforge.org/classes/Rake/TestTask.html
`t.libs << "test"`


Maybe hoe that is used in our Rakefile, its test way is kind of special, because of "lib:bin:test:.". "." is set as a Ruby load path.

```
bundle exec rake test
...
/usr/local/ruby-2.3.1/bin/ruby -w -Ilib:bin:test:. -e 'require "rubygems"; require "minitest/autorun"; require "test/test_thread_pool.rb"; require "test/test_puma_server.rb"; require "test/test_app_status.rb"; require "test/test_rack_server.rb"; require "test/test_minissl.rb"; require "test/test_tcp_logger.rb"; require "test/test_unix_socket.rb"; require "test/test_tcp_rack.rb"; require "test/test_null_io.rb"; require "test/test_http10.rb"; require "test/test_rack_handler.rb"; require "test/test_persistent.rb"; require "test/test_ws.rb"; require "test/test_puma_server_ssl.rb"; require "test/test_config.rb"; require "test/test_iobuffer.rb"; require "test/test_integration.rb"; require "test/test_cli.rb"; require "test/test_http11.rb"' --
```

I think that Including "." causes a duplicated path situation. 
I am asking hoe community for this point now. (https://github.com/seattlerb/hoe/issues/74)


So, this pull-request's modification looks better than before right now.

Below tests are passed.

```
$ bundle exec ruby -Ilib:test \
  -r 'rubygems' \
  -r 'minitest/autorun' \
  -e 'Dir.glob "./test/**/test_*.rb", &method(:require)' \
  -- -v
$ bundle exec rake test
$ bundle exec rake test:integration
```

How do you think?

Thank you.
