### PR TITLE
Allow extra runtime deps to be defined when using prune_bundler

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -161,6 +161,10 @@ module Puma
             user_config.prune_bundler
           end
 
+          o.on "--extra-runtime-dependencies GEM1,GEM2", "Defines any extra needed gems when using --prune-bundler" do |arg|
+            c.extra_runtime_dependencies arg.split(',')
+          end
+
           o.on "-q", "--quiet", "Do not log requests internally (default true)" do
             user_config.quiet
           end

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -604,8 +604,8 @@ module Puma
     # When using prune_bundler, if extra runtime dependencies need to be loaded to
     # initialize your app, then this setting can be used.
     #
-    # For each gem's name passed, that gem will be loaded when the environment
-    # is pruned.
+    # Before bundler is pruned, the gem names supplied will be looked up in the bundler
+    # context and then loaded again after bundler is pruned.
     # Only applies if prune_bundler is used.
     #
     # @example

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -601,6 +601,21 @@ module Puma
       @options[:raise_exception_on_sigterm] = answer
     end
 
+    # When using prune_bundler, if extra runtime dependencies need to be loaded to
+    # initialize your app, then this setting can be used.
+    #
+    # For each gem's name passed, that gem will be loaded when the environment
+    # is pruned.
+    # Only applies if prune_bundler is used.
+    #
+    # @example
+    #   extra_runtime_dependencies ['gem_name_1', 'gem_name_2']
+    # @example
+    #   extra_runtime_dependencies ['puma_worker_killer']
+    def extra_runtime_dependencies(answer = [])
+      @options[:extra_runtime_dependencies] = Array(answer)
+    end
+
     # Additional text to display in process listing.
     #
     # If you do not specify a tag, Puma will infer it. If you do not want Puma

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -584,6 +584,7 @@ module Puma
     # dictates.
     #
     # @note This is incompatible with +preload_app!+.
+    # @note This is only supported for RubyGems 2.2+
     def prune_bundler(answer=true)
       @options[:prune_bundler] = answer
     end

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -275,14 +275,12 @@ module Puma
         "#{d.name}:#{spec.version.to_s}"
       end
 
-      if @options[:extra_runtime_dependencies]
-        @options[:extra_runtime_dependencies].each do |d_name|
-          spec = Bundler.rubygems.loaded_specs(d_name) rescue nil
-          if spec
-            dirs += spec.require_paths.map { |x| File.join(spec.full_gem_path, x) }
-          else
-            log "* Couldn't to load extra dependency: #{d_name}"
-          end
+      @options[:extra_runtime_dependencies].each do |d_name|
+        spec = Bundler.rubygems.loaded_specs(d_name)
+        if spec
+          dirs += spec.require_paths.map { |x| File.join(spec.full_gem_path, x) }
+        else
+          log "* Could not load extra dependency: #{d_name}"
         end
       end
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -280,6 +280,7 @@ module Puma
           spec = Bundler.rubygems.loaded_specs(d_name) rescue nil
           if spec
             deps << "#{d_name}:#{spec.version.to_s}"
+            dirs += spec.require_paths.map { |x| File.join(spec.full_gem_path, x) }
           else
             log "* Couldn't to load extra dependency: #{d_name}"
           end

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -279,7 +279,6 @@ module Puma
         @options[:extra_runtime_dependencies].each do |d_name|
           spec = Bundler.rubygems.loaded_specs(d_name) rescue nil
           if spec
-            deps << "#{d_name}:#{spec.version.to_s}"
             dirs += spec.require_paths.map { |x| File.join(spec.full_gem_path, x) }
           else
             log "* Couldn't to load extra dependency: #{d_name}"

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -275,6 +275,15 @@ module Puma
         "#{d.name}:#{spec.version.to_s}"
       end
 
+      @options[:extra_runtime_dependencies].each do |d_name|
+        spec = Bundler.rubygems.loaded_specs(d_name) rescue nil
+        if spec
+          deps << "#{d_name}:#{spec.version.to_s}"
+        else
+          log "* Couldn't to load extra dependency: #{d_name}"
+        end
+      end
+
       log '* Pruning Bundler environment'
       home = ENV['GEM_HOME']
       Bundler.with_clean_env do

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -259,40 +259,50 @@ module Puma
       end
     end
 
-    def prune_bundler
-      return unless defined?(Bundler)
-
-      require_rubygems_min_version!(Gem::Version.new("2.2"), "prune_bundler")
-
+    def dependencies_and_files_to_require_after_prune
       puma = spec_for_gem("puma")
-      dirs = require_paths_for_gem(puma)
-      puma_lib_dir = dirs.detect { |x| File.exist? File.join(x, '../bin/puma-wild') }
-
-      unless puma_lib_dir
-        log "! Unable to prune Bundler environment, continuing"
-        return
-      end
 
       deps = puma.runtime_dependencies.map do |d|
         "#{d.name}:#{spec_for_gem(d.name).version}"
       end
 
-      Array(@options[:extra_runtime_dependencies]).each do |d_name|
-        spec = spec_for_gem(d_name)
-        if spec
-          dirs += require_paths_for_gem(spec)
+      [deps, require_paths_for_gem(puma) + extra_runtime_deps_directories]
+    end
+
+    def extra_runtime_deps_directories
+      Array(@options[:extra_runtime_dependencies]).map do |d_name|
+        if (spec = spec_for_gem(d_name))
+          require_paths_for_gem(spec)
         else
           log "* Could not load extra dependency: #{d_name}"
+          nil
         end
+      end.flatten.compact
+    end
+
+    def puma_wild_location
+      puma = spec_for_gem("puma")
+      dirs = require_paths_for_gem(puma)
+      puma_lib_dir = dirs.detect { |x| File.exist? File.join(x, '../bin/puma-wild') }
+      File.expand_path(File.join(puma_lib_dir, "../bin/puma-wild"))
+    end
+
+    def prune_bundler
+      return unless defined?(Bundler)
+      require_rubygems_min_version!(Gem::Version.new("2.2"), "prune_bundler")
+      unless puma_wild_location
+        log "! Unable to prune Bundler environment, continuing"
+        return
       end
+
+      deps, dirs = dependencies_and_files_to_require_after_prune
 
       log '* Pruning Bundler environment'
       home = ENV['GEM_HOME']
       Bundler.with_clean_env do
         ENV['GEM_HOME'] = home
         ENV['PUMA_BUNDLER_PRUNED'] = '1'
-        wild = File.expand_path(File.join(puma_lib_dir, "../bin/puma-wild"))
-        args = [Gem.ruby, wild, '-I', dirs.join(':'), deps.join(',')] + @original_argv
+        args = [Gem.ruby, puma_wild_location, '-I', dirs.join(':'), deps.join(',')] + @original_argv
         # Ruby 2.0+ defaults to true which breaks socket activation
         args += [{:close_others => false}]
         Kernel.exec(*args)

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -275,12 +275,14 @@ module Puma
         "#{d.name}:#{spec.version.to_s}"
       end
 
-      @options[:extra_runtime_dependencies].each do |d_name|
-        spec = Bundler.rubygems.loaded_specs(d_name) rescue nil
-        if spec
-          deps << "#{d_name}:#{spec.version.to_s}"
-        else
-          log "* Couldn't to load extra dependency: #{d_name}"
+      if @options[:extra_runtime_dependencies]
+        @options[:extra_runtime_dependencies].each do |d_name|
+          spec = Bundler.rubygems.loaded_specs(d_name) rescue nil
+          if spec
+            deps << "#{d_name}:#{spec.version.to_s}"
+          else
+            log "* Couldn't to load extra dependency: #{d_name}"
+          end
         end
       end
 

--- a/test/config/prune_bundler_with_deps.rb
+++ b/test/config/prune_bundler_with_deps.rb
@@ -1,0 +1,2 @@
+prune_bundler true
+extra_runtime_dependencies ["rdoc"]

--- a/test/rackup/hello-last-load-path.ru
+++ b/test/rackup/hello-last-load-path.ru
@@ -1,0 +1,3 @@
+run lambda { |env|
+  [200, {}, [$LOAD_PATH[-1]]]
+}

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -348,6 +348,15 @@ class TestIntegration < Minitest::Test
     @server = nil # prevent `#teardown` from killing already killed server
   end
 
+  def test_load_path_includes_extra_deps
+    skip NO_FORK_MSG unless HAS_FORK
+
+    server("-w 2 -C test/config/prune_bundler_with_deps.rb test/rackup/hello-last-load-path.ru")
+
+    last_load_path = read_body(connect)
+    assert_match(%r{gems/rdoc-[\d.]+/lib$}, last_load_path)
+  end
+
   def test_not_accepts_new_connections_after_term_signal
     skip_on :jruby, :windows
 

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -1,0 +1,63 @@
+require_relative "helper"
+
+require "puma/configuration"
+require "puma/const"
+require "puma/launcher"
+
+class TestLauncher < Minitest::Test
+  def test_dependencies_and_files_to_require_after_prune_is_correctly_built_for_no_extra_deps
+    skip_on :appveyor, suffix: " - bundler not used in appveyor so prune bundler logic tests unavailable"
+
+    l = Puma::Launcher.new Puma::Configuration.new
+    deps, dirs = l.send(:dependencies_and_files_to_require_after_prune)
+
+    assert_equal(1, deps.length)
+    assert_match(%r{^nio4r:[\d.]+$}, deps.first)
+    assert_equal(2, dirs.length)
+    assert_match(%r{puma/lib$}, dirs[0]) # lib dir
+    assert_match(%r{puma-#{Puma::Const::PUMA_VERSION}$}, dirs[1]) # native extension dir
+  end
+
+  def test_dependencies_and_files_to_require_after_prune_is_correctly_built_with_extra_deps
+    skip_on :appveyor, suffix: " - bundler not used in appveyor so prune bundler logic tests unavailable"
+
+    conf = Puma::Configuration.new do |c|
+      c.extra_runtime_dependencies ['rdoc']
+    end
+    l = Puma::Launcher.new conf
+    deps, dirs = l.send(:dependencies_and_files_to_require_after_prune)
+
+    assert_equal(1, deps.length)
+    assert_match(%r{^nio4r:[\d.]+$}, deps.first)
+    assert_equal(3, dirs.length)
+    assert_match(%r{puma/lib$}, dirs[0]) # lib dir
+    assert_match(%r{puma-#{Puma::Const::PUMA_VERSION}$}, dirs[1]) # native extension dir
+    assert_match(%r{gems/rdoc-[\d.]+/lib$}, dirs[2]) # rdoc dir
+  end
+
+  def test_extra_runtime_deps_directories_is_empty_for_no_config
+    l = Puma::Launcher.new Puma::Configuration.new
+    assert_equal([], l.send(:extra_runtime_deps_directories))
+  end
+
+  def test_extra_runtime_deps_directories_is_correctly_built
+    skip_on :appveyor, suffix: " - bundler not used in appveyor so prune bundler logic tests unavailable"
+    conf = Puma::Configuration.new do |c|
+      c.extra_runtime_dependencies ['rdoc']
+    end
+    l = Puma::Launcher.new conf
+    dep_dirs = l.send(:extra_runtime_deps_directories)
+
+    assert_equal(1, dep_dirs.length)
+    assert_match(%r{gems/rdoc-[\d.]+/lib$}, dep_dirs.first)
+  end
+
+  def test_puma_wild_location_is_an_absolute_path
+    skip_on :appveyor, suffix: " - bundler not used in appveyor so prune bundler logic tests unavailable"
+    l = Puma::Launcher.new Puma::Configuration.new
+    puma_wild_location = l.send(:puma_wild_location)
+    assert_match(%r{bin/puma-wild$}, puma_wild_location)
+    # assert no "/../" in path
+    refute_match(%r{/\.\./}, puma_wild_location)
+  end
+end


### PR DESCRIPTION
Extra gems are sometimes needed in the `before_fork` block or before Bundler gets loaded on the workers. This PR adds the ability to define any extra bundler gems to load when pruning bundler.

As an example, when using https://github.com/schneems/puma_worker_killer, it should be loaded in the before_fork of the `config/puma.rb` file like so:

``` ruby
before_fork do
  require 'puma_worker_killer'

  PumaWorkerKiller.config do |config|
    config.ram           = 1024
    config.frequency     = 5
    config.percent_usage = 0.98
    config.reaper_status_logs = false
  end
  PumaWorkerKiller.start
end
```

If you have installed the gem from the github repo, and are using the `prune_bundler` option, the `require 'puma_worker_killer'` will fail. The only way to get it to run is to require bundler, and then require the gem in the context of bundler. Which, if you're also attempting to prune bundler, completely defeats the purpose and means gems aren't reloaded across phased restarts.
