### PR TITLE
Replace use of Process.getpgid which does not behave as intended on all platforms

### DIFF
--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -179,39 +179,39 @@ module Puma
       end
 
       begin
-        Process.getpgid @pid
+
+        case @command
+        when "restart"
+          Process.kill "SIGUSR2", @pid
+
+        when "halt"
+          Process.kill "QUIT", @pid
+
+        when "stop"
+          Process.kill "SIGTERM", @pid
+
+        when "stats"
+          puts "Stats not available via pid only"
+          return
+
+        when "reload-worker-directory"
+          puts "reload-worker-directory not available via pid only"
+          return
+
+        when "phased-restart"
+          Process.kill "SIGUSR1", @pid
+
+        else
+          message "Puma is started"
+          return
+        end
+
       rescue SystemCallError
         if @command == "restart"
           start
         else
           raise "No pid '#{@pid}' found"
         end
-      end
-
-      case @command
-      when "restart"
-        Process.kill "SIGUSR2", @pid
-
-      when "halt"
-        Process.kill "QUIT", @pid
-
-      when "stop"
-        Process.kill "SIGTERM", @pid
-
-      when "stats"
-        puts "Stats not available via pid only"
-        return
-
-      when "reload-worker-directory"
-        puts "reload-worker-directory not available via pid only"
-        return
-
-      when "phased-restart"
-        Process.kill "SIGUSR1", @pid
-
-      else
-        message "Puma is started"
-        return
       end
 
       message "Command #{@command} sent success"


### PR DESCRIPTION
This pull request has two small fixes for issues I experienced with puma 3.6.0
1. Using pumactl (3.6.0) on OSX it was possible to come cross uninitialised constant Puma::StateFile. I have rectified this.
2. On some platforms (specifically encountered on OpenBSD) Process.getpgid which is backed by the POSIX.1 getgpid implementation does not behave in a fashion which the original implementer expected. 

Process.getpgid is being used to confirm the existence of a running process before proceeding on to act upon said process. 

Using this man page as a [reference](http://man.openbsd.org/getpgid.2) one can see that unless getpgid is called from within the same session as the running process a permission error will be returned. Considering the main uses cases; running in the same session will not be the norm. The exception handling block surrounding Porcess.getpgid does not differentiate between an unknown process id and permission denied. Therefore the error "unknown pid" is returned and execution ceases.

Considering that the various kill methods in waiting result in the same exception I decided to simply change the method logic from "asking permission" to "asking forgiveness" and circumventing the need for Process.getpgid all-together.
