### PR TITLE
Prune bundler should inherit fds

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -255,6 +255,8 @@ module Puma
         ENV['PUMA_BUNDLER_PRUNED'] = '1'
         wild = File.expand_path(File.join(puma_lib_dir, "../bin/puma-wild"))
         args = [Gem.ruby, wild, '-I', dirs.join(':'), deps.join(',')] + @original_argv
+        # Ruby 2.0+ defaults to true which breaks socket activation
+        argv += [{:close_others => false}] if RUBY_VERSION >= '2.0'
         Kernel.exec(*args)
       end
     end


### PR DESCRIPTION
Ruby 2.0 changed this behaviour so fds are closed by default during an exec. If using socket activation from systemd however this closes the fds before they can be activated (with some extra debug output added into `Puma::Binder#import_from_env`):

```
systemd[1]: Started puma.
puma[11696]: {"LISTEN_FDS"=>"1", "LISTEN_PID"=>"11696"}
puma[11696]: fd=3 sock=#<TCPServer:fd 3>
puma[11696]: % Registered unix:/app/tmp/sockets/puma.sock for activation from LISTEN_FDS
puma[11696]: * Pruning Bundler environment
puma[11696]: {"LISTEN_FDS"=>"1", "LISTEN_PID"=>"11696"}
puma[11696]: /app/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/binder.rb:64:in `for_fd': Bad file descriptor - not a socket file descriptor (Errno::EBADF)
puma[11696]:         from /app/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/binder.rb:64:in `block (2 levels) in import_from_env'
puma[11696]:         from /app/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/binder.rb:62:in `times'
puma[11696]:         from /app/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/binder.rb:62:in `block in import_from_env'
puma[11696]:         from /app/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/binder.rb:56:in `each'
puma[11696]:         from /app/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/binder.rb:56:in `import_from_env'
puma[11696]:         from /app/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/launcher.rb:55:in `initialize'
puma[11696]:         from /app/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cli.rb:65:in `new'
puma[11696]:         from /app/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cli.rb:65:in `initialize'
puma[11696]:         from /app/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/bin/puma-wild:29:in `new'
puma[11696]:         from /app/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/bin/puma-wild:29:in `<main>'
systemd[1]: puma.service: Main process exited, code=exited, status=1/FAILURE
```

Adding `close_others: false` to the exec seems to fix things.
