### PR TITLE
Fixed the issue of @listeners getting nil io

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -105,7 +105,7 @@ module Puma
             io = add_tcp_listener uri.host, uri.port, opt, bak
           end
 
-          @listeners << [str, io]
+          @listeners << [str, io] if io
         when "unix"
           path = "#{uri.host}#{uri.path}".gsub("%20", " ")
 
@@ -209,7 +209,7 @@ module Puma
             io = add_ssl_listener uri.host, uri.port, ctx
           end
 
-          @listeners << [str, io]
+          @listeners << [str, io] if io
         else
           logger.error "Invalid URI: #{str}"
         end

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -1,5 +1,6 @@
 require "rbconfig"
 require 'test/unit'
+require 'testhelp'
 
 require 'puma/binder'
 require 'puma/events'
@@ -12,12 +13,16 @@ class TestBinder < Test::Unit::TestCase
   end
 
   def test_localhost_addresses_dont_alter_listeners_for_tcp_addresses
+    omit_on_jruby
+
     @binder.parse(["tcp://localhost:10001"], @events)
 
     assert_equal [], @binder.listeners
   end
 
   def test_localhost_addresses_dont_alter_listeners_for_ssl_addresses
+    omit_on_jruby
+
     key =  File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
     cert = File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
 

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -1,0 +1,28 @@
+require "rbconfig"
+require 'test/unit'
+
+require 'puma/binder'
+require 'puma/events'
+
+class TestBinder < Test::Unit::TestCase
+
+  def setup
+    @events = Puma::Events.new(STDOUT, STDERR)
+    @binder = Puma::Binder.new(@events)
+  end
+
+  def test_localhost_addresses_dont_alter_listeners_for_tcp_addresses
+    @binder.parse(["tcp://localhost:3000"], @events)
+
+    assert_equal [], @binder.listeners
+  end
+
+  def test_localhost_addresses_dont_alter_listeners_for_ssl_addresses
+    pend
+
+    @binder.parse(["ssl://localhost:3000"], @events)
+
+    assert_equal [], @binder.listeners
+  end
+
+end

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -12,15 +12,16 @@ class TestBinder < Test::Unit::TestCase
   end
 
   def test_localhost_addresses_dont_alter_listeners_for_tcp_addresses
-    @binder.parse(["tcp://localhost:3000"], @events)
+    @binder.parse(["tcp://localhost:10001"], @events)
 
     assert_equal [], @binder.listeners
   end
 
   def test_localhost_addresses_dont_alter_listeners_for_ssl_addresses
-    pend
+    key =  File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
+    cert = File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
 
-    @binder.parse(["ssl://localhost:3000"], @events)
+    @binder.parse(["ssl://localhost:10002?key=#{key}&cert=#{cert}"], @events)
 
     assert_equal [], @binder.listeners
   end

--- a/test/testhelp.rb
+++ b/test/testhelp.rb
@@ -9,6 +9,7 @@ require 'uri'
 require 'stringio'
 
 require 'puma'
+require 'puma/detect'
 
 # Either takes a string to do a get request against, or a tuple of [URI, HTTP] where
 # HTTP is some kind of Net::HTTP request object (POST, HEAD, etc.)
@@ -41,3 +42,10 @@ module TimeoutEveryTestCase
   end
 end
 Test::Unit::TestCase.prepend TimeoutEveryTestCase
+
+module OmitTestsBasedOnRubyEngine
+  def omit_on_jruby
+    omit "Omitted on JRuby" if Puma.jruby?
+  end
+end
+Test::Unit::TestCase.prepend OmitTestsBasedOnRubyEngine


### PR DESCRIPTION
- `add_tcp_listener` and `add_ssl_listener` return `nil` now for
  localhost addresses and it was getting added to the `@listeners`.
- Later on the file descriptor `nil` was getting converted to 0 and
  resulting into `BadFileDescriptor` error as per this gist -
  https://gist.github.com/prathamesh-sonpatki/bc0cac8929dbf17316e8b4b7dda93e20.
- This issue is now fixed and added test case.
- This fixes `rails restart` command on Rails 5 + Puma 3.5 and above.
