### PR TITLE
plugins: listen_reaper add_plugin_restart_hook

### DIFF
--- a/lib/puma/plugin/add_plugin_restart_hook.rb
+++ b/lib/puma/plugin/add_plugin_restart_hook.rb
@@ -1,0 +1,38 @@
+# ### Usage
+#
+# This plugin is used indirectly by plugin developers to allow restart-triggered **instances** plugins like below.
+# Normally, a plain `dsl.on_restart` block would be fine.
+#
+#     require 'puma/plugin'
+#
+#     Puma::Plugin.create do
+#       def config(dsl)
+#         dsl.plugin :add_plugin_restart_hook
+#       end
+#
+#       def restart(launcher)
+#         # do something on_restart
+#       end
+#     end
+#
+require 'puma/plugin'
+
+Puma::Plugin.create do
+  def config(dsl)
+    Puma::Launcher.class_eval do
+      def fire_plugins_restart
+        @config.plugins.fire_restarts self
+      end
+    end
+
+    Puma::PluginLoader.class_eval do
+      def fire_restarts(launcher)
+        @instances.each do |i|          
+          i.restart(launcher) if i.respond_to? :restart
+        end
+      end
+    end
+
+    dsl.on_restart { |launcher| launcher.fire_plugins_restart }
+  end
+end

--- a/lib/puma/plugin/listen_reaper.rb
+++ b/lib/puma/plugin/listen_reaper.rb
@@ -1,0 +1,19 @@
+# Usage: add `plugin :listen_reaper` to `config/puma.rb`
+require 'puma/plugin'
+
+# This plugin stops all Listen instances from gem listen upon restart.
+# This prevents too many fsevent_watch (macOS only) processes and
+# cleans up unused system resources between restarts.
+Puma::Plugin.create do
+  def config(dsl)
+    # add :restart hook to plugin 
+    dsl.plugin :add_plugin_restart_hook
+  end
+
+  # call #stop on all FSEvent instances
+  # this should close pipes and make fsevent_watch'es die
+  def restart(_launcher)
+    return unless defined? Listen
+    ObjectSpace.each_object(Listen, &:stop)
+  end
+end


### PR DESCRIPTION
Adds
- `plugin :listen_reaper` - stop all `Listen` instances on restart
- `plugin :add_plugin_restart_hook` - allow plugins to be triggered `on_restart`
