### PR TITLE
Travis: Test on JRuby 9.1.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,17 @@ rvm:
   - 2.2.5
   - 2.3.1
   - ruby-head
-  - jruby-9.0.5.0
+  - jruby-9.1.5.0
   - jruby-head
   - rbx
 matrix:
   include:
     - rvm: 2.1
       gemfile: gemfiles/2.1-Gemfile
+    - rvm: jruby-9.1.5.0
+      env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"      
+    - rvm: jruby-head
+      env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"      
   fast_finish: true
   allow_failures:
     - rvm: jruby-head


### PR DESCRIPTION
This PR changes the Travis setup to test on latest stable JRuby.

---

Noting that [MiniSSL::Engine#init?](https://github.com/puma/puma/blob/master/lib/puma/minissl.rb#L88) is NoMethodError on this platform.