### PR TITLE
Allow rack handler to accept ssl host

### DIFF
--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -35,6 +35,10 @@ module Rack
 
           if host && (host[0,1] == '.' || host[0,1] == '/')
             c.bind "unix://#{host}"
+          elsif host && host =~ /^ssl:\/\//
+            uri = URI.parse(host)
+            uri.port ||= options[:Port] || ::Puma::Configuration::DefaultTCPPort
+            c.bind uri.to_s
           else
             host ||= ::Puma::Configuration::DefaultTCPHost
             port = options[:Port] || ::Puma::Configuration::DefaultTCPPort


### PR DESCRIPTION
It then allow rails to start puma and pass the TLS/SSL configuration:
~~~
bin/rails server puma -b "ssl://0.0.0.0?key=/path/to/example.key&cert=/path/to/example.crt"
~~~