### PR TITLE
Transfer encoding header should be downcased before comparison

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -223,7 +223,7 @@ module Puma
 
       te = @env[TRANSFER_ENCODING2]
 
-      if te == CHUNKED
+      if te && te.downcase == CHUNKED
         return setup_chunked_body(body)
       end
 

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -223,7 +223,7 @@ module Puma
 
       te = @env[TRANSFER_ENCODING2]
 
-      if te && te.downcase == CHUNKED
+      if te && CHUNKED.casecmp(te) == 0
         return setup_chunked_body(body)
       end
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -610,4 +610,23 @@ class TestPumaServer < Test::Unit::TestCase
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
   end
+
+  def test_chunked_request_header_case
+    body = nil
+    @server.app = proc { |env|
+      body = env['rack.input'].read
+      [200, {}, [""]]
+    }
+
+    @server.add_tcp_listener @host, @port
+    @server.run
+
+    sock = TCPSocket.new @host, @server.connected_port
+    sock << "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: Chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n"
+
+    data = sock.read
+
+    assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
+    assert_equal "hello", body
+  end
 end


### PR DESCRIPTION
- OSX Finder sends 'Chunked' which resulted in failed WebDAV uploads due to
  matching against 'chunked'