### PR TITLE
Really fix `uninitialized constant Puma::StateFile`

### DIFF
--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -1,5 +1,5 @@
 require 'optparse'
-require 'puma'
+require 'puma/state_file'
 require 'puma/const'
 require 'puma/detect'
 require 'puma/configuration'


### PR DESCRIPTION
```
$ bin/bundle exec pumactl -S tmp/puma.state restart
uninitialized constant Puma::StateFile
```

requiring puma doesn't require puma/state_file

Related: #901 