### PR TITLE
Stop travis double-builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ before_install:
   # https://github.com/travis-ci/travis-ci/issues/5861
   - gem install bundler
 script: "TESTOPTS=-v bundle exec rake test"
+branches:
+  only: [master]
 rvm:
   - 2.2.6
   - 2.3.2


### PR DESCRIPTION
Travis builds on PR and push, this changes it so it will only trigger the "PUSH" event on the master branch.