### PR TITLE
Travis: jruby-9.1.6.0 is latest stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ rvm:
   - 2.2.6
   - 2.3.2
   - ruby-head
-  - jruby-9.1.5.0
+  - jruby-9.1.6.0
   - jruby-head
   - rbx-3
 matrix:


### PR DESCRIPTION
This PR changes to use latest stable jruby in Travis.