### PR TITLE
WIP: MiniSSL.java: Implement #init?, #shutdown

### DIFF
--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -335,6 +335,10 @@ public class MiniSSL extends RubyObject {
     }
   }
 
+  /**
+   * Returns true if the SSL connection was able to shutdown correctly.
+   * Or false if there were any problems.
+   */
   @JRubyMethod
   public IRubyObject peercert() throws CertificateEncodingException {
     try {
@@ -345,11 +349,14 @@ public class MiniSSL extends RubyObject {
   }
 
   public IRubyObject shutdown() {
-    return getRuntime().getNil(); // TODO: Implement!
+    return getRuntime().getTrue(); // TODO: Implement!
   }
 
+  /**
+   * Returns true if the SSL connection is still in init phase.
+   */
   @JRubyMethod(name = "init?")
   public IRubyObject init_p() {
-    return getRuntime().getNil(); // TODO: Implement!
+    return getRuntime.getFalse(); // TODO: Implement!
   }
 }

--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -343,4 +343,13 @@ public class MiniSSL extends RubyObject {
       return getRuntime().getNil();
     }
   }
+
+  public IRubyObject shutdown() {
+    return getRuntime().getNil(); // TODO: Implement!
+  }
+
+  @JRubyMethod(name = "init?")
+  public IRubyObject init_p() {
+    return getRuntime().getNil(); // TODO: Implement!
+  }
 }

--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -50,7 +50,7 @@ public class MiniSSL extends RubyObject {
                            runtime.getClass("IOError"),
                            runtime.getClass("IOError").getAllocator());
 
-    RubyClass eng = ssl.defineClassUnder("Engine",runtime.getObject(),ALLOCATOR);
+    RubyClass eng = ssl.defineClassUnder("Engine", runtime.getObject(), ALLOCATOR);
     eng.defineAnnotatedMethods(MiniSSL.class);
   }
 
@@ -357,6 +357,6 @@ public class MiniSSL extends RubyObject {
    */
   @JRubyMethod(name = "init?")
   public IRubyObject init_p() {
-    return getRuntime.getFalse(); // TODO: Implement!
+    return getRuntime().getFalse(); // TODO: Implement!
   }
 }


### PR DESCRIPTION
This PR stubs out `MiniSSL#init?` and `MiniSSL#shutdown` in the Java extension with methods with fixed return values.

### What it does

- `#init?` only returns  a Ruby `false` (The equivalent of [SSL_in_init(a)](http://osxr.org:8080/openssl/source/include/openssl/ssl.h#1421))
- `#shutdown` - only returns  a Ruby ~`true`~ `nil`

### What it needs:

- [ ] It needs to pass the https://github.com/mattyb/puma-socket-test.

That test currently outputs a lot of failed handshake errors that look like this:

```
SSL handshake failed (1).
140735159976016:error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol:/Library/Caches/com.apple.xbs/Sources/libressl/libressl-1.60.1/libressl/ssl/s23_clnt.c:565:
```



Fixes #1125 