### PR TITLE
Use hooks for on_booted event.

### DIFF
--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -34,8 +34,6 @@ module Puma
 
       @debug = ENV.key? 'PUMA_DEBUG'
 
-      @on_booted = []
-
       @hooks = Hash.new { |h,k| h[k] = [] }
     end
 
@@ -124,12 +122,12 @@ module Puma
       end
     end
 
-    def on_booted(&b)
-      @on_booted << b
+    def on_booted(&block)
+      register(:on_booted, &block)
     end
 
     def fire_on_booted!
-      @on_booted.each { |b| b.call }
+      fire(:on_booted)
     end
 
     DEFAULT = new(STDOUT, STDERR)

--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -46,7 +46,7 @@ module Puma
       @hooks[hook].each { |t| t.call(*args) }
     end
 
-    # Register a callbock for a given hook
+    # Register a callback for a given hook
     #
     def register(hook, obj=nil, &blk)
       if obj and blk


### PR DESCRIPTION
Callbacks were introduced after Puma::Events#on_booted.

https://github.com/puma/puma/commit/b24920d3eda7a7f60da99c006f0d4f082b69d752#diff-af46a0af8a5e391324bbe812613b44a8R25