### PR TITLE
Move TTOU processing

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -115,6 +115,7 @@ module Puma
 
     def spawn_workers
       diff = @options[:workers] - @workers.size
+      return if diff < 1
 
       master = Process.pid
 

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -144,10 +144,12 @@ module Puma
     def cull_workers
       diff = @workers.size - @options[:workers]
       return if diff < 1
-      log "Culling #{diff.inspect} workers"
+
+      debug "Culling #{diff.inspect} workers"
 
       workers_to_cull = @workers[-diff,diff]
-      log "Workers to cull: #{workers_to_cull.inspect}"
+      debug "Workers to cull: #{workers_to_cull.inspect}"
+
       workers_to_cull.each do |worker|
         log "- Worker #{worker.index} (pid: #{worker.pid}) terminating"
         worker.term

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -6,6 +6,8 @@ require 'time'
 
 module Puma
   class Cluster < Runner
+    WORKER_CHECK_INTERVAL = 5
+
     def initialize(cli, events)
       super cli, events
 
@@ -152,7 +154,7 @@ module Puma
     def check_workers(force=false)
       return if !force && @next_check && @next_check >= Time.now
 
-      @next_check = Time.now + 5
+      @next_check = Time.now + WORKER_CHECK_INTERVAL
 
       any = false
 
@@ -256,7 +258,7 @@ module Puma
         base_payload = "p#{Process.pid}"
 
         while true
-          sleep 5
+          sleep WORKER_CHECK_INTERVAL
           begin
             b = server.backlog
             r = server.running
@@ -448,7 +450,7 @@ module Puma
 
             force_check = false
 
-            res = IO.select([read], nil, nil, 5)
+            res = IO.select([read], nil, nil, WORKER_CHECK_INTERVAL)
 
             if res
               req = read.read_nonblock(1)


### PR DESCRIPTION
This pull request changes a few things in the cluster:
- Move the check worker interval into a constant (please check to see if all occurrences of 5 were indeed meant to indicate the same interval)
- Move the killing of workers out of the signal handler into a #cull_workers method called from the #check_workers method
- Skip processing of #spawn_workers and #cull_workers if there is no difference in the number of workers to the expected number of workers (to deal with diff now being able to be < 0 in #spawn_workers)
- When a worker is culled, it is logged (takes care of #1147)

This of course changes the behaviour of puma in dealing with TTOU signals, as they are no longer processed immediately, but there is a delay until the next WORKER_CHECK_INTERVAL expires. On the upside, multiple TTOU signals can be handled at once and the signal handler is leaner and more symmetric to the TTIN signal handler.

Unfortunately I did not come up with a way to add tests for the changes (or the signal handlers themselves) without changing the internal structure of Puma::Launcher and Puma::Cluster. If you can give me pointers to how you'd like to have this tested, I'd be happy to add the tests.