### PR TITLE
Add eof? method to NullIO?

### DIFF
--- a/lib/puma/null_io.rb
+++ b/lib/puma/null_io.rb
@@ -26,6 +26,10 @@ module Puma
       0
     end
 
+    def eof?
+      true
+    end
+
     def sync=(v)
     end
 

--- a/test/test_null_io.rb
+++ b/test/test_null_io.rb
@@ -9,6 +9,10 @@ class TestNullIO < Minitest::Test
     self.nio = Puma::NullIO.new
   end
 
+  def test_eof_returns_true
+    assert nio.eof?
+  end
+
   def test_gets_returns_nil
     assert_nil nio.gets
   end


### PR DESCRIPTION
Rack appears to be counting on eof? being defined on objects passed into its multipart parser, e.g. https://github.com/rack/rack/blob/master/lib/rack/multipart/parser.rb#L68 , but this method is not defined on Puma::NullIO.  This created a problem for rack-2.0.1 and puma-3.6.0.

Perhaps, I am missing the full context, but it seems that it should simply return true.