### PR TITLE
Launcher: Typo: argv should be args here

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -256,7 +256,7 @@ module Puma
         wild = File.expand_path(File.join(puma_lib_dir, "../bin/puma-wild"))
         args = [Gem.ruby, wild, '-I', dirs.join(':'), deps.join(',')] + @original_argv
         # Ruby 2.0+ defaults to true which breaks socket activation
-        argv += [{:close_others => false}] if RUBY_VERSION >= '2.0'
+        args += [{:close_others => false}] if RUBY_VERSION >= '2.0'
         Kernel.exec(*args)
       end
     end


### PR DESCRIPTION
This PR amends a "probable typo". 

Everywhere ELSE in the file, it's `argv` but on the next line, we use `args`.

**Credit**: @parhs

   - see #1114