### PR TITLE
Make `get_dh1024` compatible with OpenSSL v1.1.0

### DIFF
--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -87,6 +87,8 @@ DH *get_dh1024() {
 
   DH *dh;
   dh = DH_new();
+
+#if OPENSSL_VERSION_NUMBER < 0x10100005L
   dh->p = BN_bin2bn(dh1024_p, sizeof(dh1024_p), NULL);
   dh->g = BN_bin2bn(dh1024_g, sizeof(dh1024_g), NULL);
 
@@ -94,6 +96,18 @@ DH *get_dh1024() {
     DH_free(dh);
     return NULL;
   }
+#else
+  BIGNUM *p, *g;
+  p = BN_bin2bn(dh1024_p, sizeof(dh1024_p), NULL);
+  g = BN_bin2bn(dh1024_g, sizeof(dh1024_g), NULL);
+
+  if (p == NULL || g == NULL || !DH_set0_pqg(dh, p, NULL, g)) {
+    DH_free(dh);
+    BN_free(p);
+    BN_free(g);
+    return NULL;
+  }
+#endif
 
   return dh;
 }


### PR DESCRIPTION
Fixes the following error:

```
../../../../ext/puma_http11/mini_ssl.c: In function ‘get_dh1024’:
../../../../ext/puma_http11/mini_ssl.c:90:5: error: dereferencing pointer to incomplete type ‘DH {aka struct dh_st}’
   dh->p = BN_bin2bn(dh1024_p, sizeof(dh1024_p), NULL);
     ^~
```

These changes are based on the following patch to nginx:
<https://github.com/nginx/nginx/commit/789abf2b8cfd184555a09f7001b59e82c003c43c>
("SSL: default DH parameters compatible with OpenSSL 1.1.0").

Relevant parts of the nginx source code in their full context can be
found here:
<https://github.com/nginx/nginx/blob/release-1.10.2/src/event/ngx_event_openssl.c#L954-L980>.

For reference:

> *) Made DH and DH_METHOD opaque. The structures for managing DH objects
>    have been moved out of the public header files. New functions for managing
>    these have been added.
>    [Matt Caswell]

<https://www.openssl.org/news/cl110.txt>

Fixes #1136.