### PR TITLE
Add option to reject connections when shutting down.

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -161,6 +161,13 @@ module Puma
       @options[:drain_on_shutdown] = which
     end
 
+    # Immediately close connections when in graceful shutdown mode rather than
+    # not accepting them. This signals to downstream proxies that requests for
+    # the server should go somewhere else.
+    def reject_when_shutting_down(which=true)
+      @options[:reject_when_shutting_down] = which
+    end
+
     # Set the environment in which the Rack's app will run.
     def environment(environment)
       @options[:environment] = environment


### PR DESCRIPTION
Heya,

This is a change we recently made to make Puma more compatible with the way we're using nginx.

When nginx receives a connection error from an upstream proxy server, it temporarily removes the proxy server from the rotation and resends traffic to a different upstream. With the usual Puma behavior, requests to Puma while it's in shutdown mode hang until all threads are finished, at which point Puma shuts down. Only then does nginx send its requests to the next upstream. With this flag on, Puma actively rejects all connections so that nginx will immediately begin redirecting requests.

In other words, this change immediately cuts off clients that attempt to connect while Puma is shutting down rather than hanging until Puma finishes shutting down.

I'm all ears on feedback or if there's a better way to do this :)