### PR TITLE
Specified parameters should overwrite loaded config files

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -30,6 +30,11 @@ module Puma
       @set << @cur
     end
 
+    def reverse_shift
+      @cur = {}
+      @set.unshift(@cur)
+    end
+
     def [](key)
       @set.reverse_each do |o|
         if o.key? key
@@ -201,10 +206,11 @@ module Puma
       end
 
       files.each do |f|
-        @options.shift
+        @options.reverse_shift
 
         DSL.load @options, self, f
       end
+      @options.shift
     end
 
     # Call once all configuration (included from rackup files)

--- a/test/config/settings.rb
+++ b/test/config/settings.rb
@@ -1,0 +1,2 @@
+port 3000
+threads 3, 5

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -67,6 +67,17 @@ class TestConfigFile < Minitest::Test
     assert_equal conf.options[:workers], 4
   end
 
+  def test_parameters_overwrite_files
+    conf = Puma::Configuration.new(config_files: ['test/config/settings.rb']) do |c|
+      c.port 3030
+    end
+    conf.load
+
+    assert_match(/:3030$/, conf.options[:binds].first)
+    assert_equal 3, conf.options[:min_threads]
+    assert_equal 5, conf.options[:max_threads]
+  end
+
   private
 
     def with_env(env = {})


### PR DESCRIPTION
Fix issue #1199, #1200, #1201 by allowing specified parameters to overwrite those loaded from config files.