### PR TITLE
Bug fix for a race condition on MRI(all versions).

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -875,6 +875,8 @@ module Puma
       rescue IOError
         # The server, in another thread, is shutting down
       rescue RuntimeError => e
+        # The server, in another thread, has been shut down during the system call
+        # https://github.com/puma/puma/pull/1206
         raise e unless e.message.include?('IOError')
       end
     end

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -875,9 +875,10 @@ module Puma
       rescue IOError
         # The server, in another thread, is shutting down
       rescue RuntimeError => e
-        raise e unless e.message.include?('frozen')
+        raise e unless e.message.include?('IOError')
       end
     end
+    private :notify_safely
 
     # Stops the acceptor thread and then causes the worker threads to finish
     # off the request queue before finally exiting.

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -869,35 +869,31 @@ module Puma
       end
     end
 
-    # Stops the acceptor thread and then causes the worker threads to finish
-    # off the request queue before finally exiting.
-    #
-    def stop(sync=false)
+    def notify_safely(message)
       begin
-        @notify << STOP_COMMAND
+        @notify << message
       rescue IOError
         # The server, in another thread, is shutting down
+      rescue RuntimeError => e
+        raise e unless e.message.include?('frozen')
       end
+    end
 
+    # Stops the acceptor thread and then causes the worker threads to finish
+    # off the request queue before finally exiting.
+
+    def stop(sync=false)
+      notify_safely(STOP_COMMAND)
       @thread.join if @thread && sync
     end
 
     def halt(sync=false)
-      begin
-        @notify << HALT_COMMAND
-      rescue IOError
-        # The server, in another thread, is shutting down
-      end
-
+      notify_safely(HALT_COMMAND)
       @thread.join if @thread && sync
     end
 
     def begin_restart
-      begin
-        @notify << RESTART_COMMAND
-      rescue IOError
-        # The server, in another thread, is shutting down
-      end
+      notify_safely(RESTART_COMMAND)
     end
 
     def fast_write(io, str)


### PR DESCRIPTION
I've stumbled into a pretty elusive bug in puma when I was working with it in my project. Most often it happened in the result of Interrupt signal to the process. Shortly, it leads to a possibility for the pipe to be closed here:
https://github.com/puma/puma/blob/482ea5a24abaccf33c49dc9238a22e2a9affe288/lib/puma/server.rb#L369
even before have been finished the write method calls here:
https://github.com/puma/puma/blob/482ea5a24abaccf33c49dc9238a22e2a9affe288/lib/puma/server.rb#L877
or here:
https://github.com/puma/puma/blob/482ea5a24abaccf33c49dc9238a22e2a9affe288/lib/puma/server.rb#L887
After pretty deep investigation I've found out that it becomes possible because of how MRI ruby handles its Global Interpretation lock.
Here what was happening:
1) The `@notify << STOP_COMMAND` is a system call that pauses the thread from where it has been done.
2) This system call get handled fast and successfully, but ruby GIL does not wake the thread yet.
3) After this system call it wakes another thread, the one that with `IO.select` waits for messages in `@check` pipe.
4) It gets it own 100ms chunk to do it's job and closes the pipe.
5) The first thread is woken up right in the middle of `<<` system call and finds out that pipe it used is already closed. Which leads to the bug that looked like this:
```
RuntimeError: can't modify frozen IOError
  /home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/puma-3.6.2/lib/puma/server.rb:877:in `write'
  /home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/puma-3.6.2/lib/puma/server.rb:877:in `<<'
  /home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/puma-3.6.2/lib/puma/server.rb:877:in `stop'
```
As a confirmation for this theory, the time of execution of `<<` method call is always a multiple of 100ms (0, 100, 200, 300, etc) because that is regular GLI time chunk when it changes the current thread: https://github.com/ruby/ruby/blob/trunk/thread_pthread.c#L1252 The more threads - the more likely to encounter it.
So I've made a small fix for that, in the same manner as already existent `rescue IOError` clause do it. The difference only on that IOError is thrown when pipe is already closed, an this case is when it being closed in the middle.
 
Unfortunately, it's very hard to meaningfully reproduce this case in tests, because it's caused by MRI's GIL assignment in presence of several threads(2 not enough). I've run current test suite and nicely tested it manually, but if it's necessary to cover that to make the PR mergeable, I can try to figure it out.