### PR TITLE
Remove Bundler dependency from tests.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,12 @@
 # Copyright (c) 2011 Evan Phoenix
 # Copyright (c) 2005 Zed A. Shaw
 
-require "bundler/setup"
+begin
+  require "bundler/setup"
+rescue LoadError
+  require "net/http"
+  require "timeout"
+end
 require "minitest/autorun"
 require "minitest/pride"
 require "puma"


### PR DESCRIPTION
Hello,

Is it possible not to use "bundler/setup" in tests?

Because I am managing `puma`'s RPM package in Fedora project.
https://admin.fedoraproject.org/pkgdb/package/rpms/rubygem-puma/

And we are running the `puma` unit tests without Bundler like this.
Though not using `bundler` is kind of our Fedora project's custom.

```
ruby \
  -r 'minitest/autorun' \
  -e 'Dir.glob "./test/**/test_*.rb", &method(:require)' \
  -- -v
```

I know Bundler is useful for travis or local environment.
However I am happy that the tests do not depends on Bundler.

Thanks!