### PR TITLE
Revert "fix access priorities of each level in LeveledOptions"

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -36,7 +36,7 @@ module Puma
     end
 
     def [](key)
-      @set.reverse_each do |o|
+      @set.each do |o|
         if o.key? key
           return o[key]
         end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -56,17 +56,6 @@ class TestConfigFile < Minitest::Test
     assert_equal 'bin/rails server', conf.options[:restart_cmd]
   end
 
-  def test_overwrite_options
-    conf = Puma::Configuration.new do |c|
-      c.workers 3
-    end
-    conf.load
-
-    assert_equal conf.options[:workers], 3
-    conf.options[:workers] += 1
-    assert_equal conf.options[:workers], 4
-  end
-
   def test_parameters_overwrite_files
     conf = Puma::Configuration.new(config_files: ['test/config/settings.rb']) do |c|
       c.port 3030


### PR DESCRIPTION
This reverts commit 15f0847.
See #1154, this commit unintentionally changed behavior regarding the
importance of command line options.

Similar to 6d1c157, Seems that 3.7.0 missed this revert

cc @nateberkopec 