### PR TITLE
Prevent accumulation of clients being polled forever.

### DIFF
--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -60,19 +60,14 @@ module Puma
                 end
               end
             else
-              # We have to be sure to remove it from the timeout
-              # list or we'll accidentally close the socket when
-              # it's in use!
-              if c.timeout_at
-                @mutex.synchronize do
-                  @timeouts.delete c
-                end
-              end
-
               begin
                 if c.try_to_finish
                   @app_pool << c
                   sockets.delete c
+
+                  @mutex.synchronize do
+                    @timeouts.delete c
+                  end
                 end
 
               # Don't report these to the lowlevel_error handler, otherwise

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -296,8 +296,6 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_timeout_in_data_phase
-    skip("Hangs too often, TODO: fix")
-
     @server.first_data_timeout = 2
     @server.add_tcp_listener @host, @port
     @server.run


### PR DESCRIPTION
When a file descriptor for a client is returned from select, it is removed from the clients currently being monitored for a timeout. This removal happens independently from the code that removes the descriptor from the list of descriptors that are currently being polled, allowing a potential accumulation of descriptors being passed into by select.