### PR TITLE
Avoid waiting on idle connections when we have only 1 worker thread

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -81,7 +81,7 @@ module Puma
       @timeout_at = Time.now + val
     end
 
-    def reset(fast_check=true)
+    def reset(fast_track_ka_timeout)
       @parser.reset
       @read_header = true
       @env = @proto_env.dup
@@ -101,8 +101,8 @@ module Puma
         end
 
         return false
-      elsif fast_check &&
-            IO.select([@to_io], nil, nil, FAST_TRACK_KA_TIMEOUT)
+      elsif fast_track_ka_timeout &&
+            IO.select([@to_io], nil, nil, fast_track_ka_timeout)
         return try_to_finish
       end
     end


### PR DESCRIPTION
When serving non multithread safe applications, a single worker thread is used, possibly with quite a few worker processes.

When a keep-alive request is dispatched, Puma checks for a new request coming in. This check makes any one worker thread stall if no data is available, up to `FAST_TRACK_KA_TIMEOUT` seconds (set to 200ms currently).

This has the effect of neglecting other requests that are ready, waiting to be picked up for processing.

This patch fixes the case for max_threads == 1, where waiting 200ms can greatly affect performance. It probably affects it too with more threads, but further benchmarks are needed to consider when it pays to wait up to 200ms.

Reproducing this is easy when running Puma with 1 thread. I used a fast application that responds in a few ms. Even when the 99 perc of the response times was like 5ms, there were peaks of several seconds.