### PR TITLE
Only write if file doesn't exist

### DIFF
--- a/lib/puma/plugin/tmp_restart.rb
+++ b/lib/puma/plugin/tmp_restart.rb
@@ -8,7 +8,7 @@ Puma::Plugin.create do
 
     # If we can't write to the path, then just don't bother with this plugin
     begin
-      File.write path, ""
+      File.write(path, "") unless File.exist?(path)
       orig = File.stat(path).mtime
     rescue SystemCallError
       return


### PR DESCRIPTION
Before this fix if you have an application that uses Puma and this
plugin it is impossible to start 2 servers at once even if they are
using separate pidfiles and ports. The reason is because this plugin
will overwrite the pidfiles no matter.

To reproduce:

Start a regular Rails server which points to the pidfile in
`tmp/pids/server.pid`

```
rails s
```

Start a second Rails server which points to a new pidfile and port

```
rails s -p 4000 -P tmp/pids/new_server.pid
```

The first server will be stopped and claim that the pid is being used by
another process.

What really is happening is the restart plugin is writing over the
original pidfile which stops the server.

If we check the file exists first this will prevent the problem from
occuring. Touching tmp/restart.txt will still work but starting a
separate process with it's own pidfile should not interfere with other
running servers in the same app.

---

I really want to write a test for this but I for the life of me cannot figure how to do that. It doesn't look like this plugin has tests and I'm happy to add tests with a little guidance. 