### PR TITLE
Failing tests for Port decision logic

### DIFF
--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -8,7 +8,7 @@ module Rack
         :Silent  => false
       }
 
-      def self.run(app, options = {})
+      def self.config(app, options = {})
         require 'puma/configuration'
         require 'puma/events'
         require 'puma/launcher'
@@ -48,6 +48,11 @@ module Rack
 
           c.app app
         end
+        conf
+      end
+
+      def self.run(app, options = {})
+        conf   = self.config(app, options)
 
         events = options.delete(:Silent) ? ::Puma::Events.strings : ::Puma::Events.stdio
 

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -54,4 +54,42 @@ class TestPathHandler < Minitest::Test
     end
   end
 
+  def test_user_supplied_port_wins_over_config_file
+    user_port = 5001
+    file_port = 6001
+    options = {}
+
+    Tempfile.open("puma.rb") do |f|
+      f.puts "port #{file_port}"
+      f.close
+
+      options[:config_files]          = [f.path]
+      options[:user_supplied_options] = [:Port]
+      options[:Port]                  = user_port
+
+      conf = Rack::Handler::Puma.config(app, options)
+      conf.load
+      assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+    end
+  end
+
+  def test_default_port_loses_to_config_file
+    user_port = 5001
+    file_port = 6001
+    options = {}
+
+    Tempfile.open("puma.rb") do |f|
+      f.puts "port #{file_port}"
+      f.close
+
+      options[:config_files]          = [f.path]
+      options[:user_supplied_options] = []
+      options[:Port]                  = user_port
+
+      conf = Rack::Handler::Puma.config(app, options)
+      conf.load
+      puts conf.options[:binds]
+      assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
+    end
+  end
 end


### PR DESCRIPTION
As a follow up to https://github.com/rails/rails/pull/28137 I started hacking on the puma part. 

It is tough because externally we only care about "host" or "port" however internally puma only cares about "binds". Puma will set this value to the default binds value and then puma doesn't know that it's the default so the config file still does not take priority.

I'm open to suggestions here.
