### PR TITLE
Implement user_supplied_options behavior.

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -47,21 +47,21 @@ module Puma
         @parser.parse! @argv
 
         if file = @argv.shift
-          @conf.configure do |c|
-            c.rackup file
+          @conf.configure do |user_config, file_config|
+            file_config.rackup file
           end
         end
       rescue UnsupportedOption
         exit 1
       end
 
-      @conf.configure do |c|
+      @conf.configure do |user_config, file_config|
         if @stdout || @stderr
-          c.stdout_redirect @stdout, @stderr, @append
+          user_config.stdout_redirect @stdout, @stderr, @append
         end
 
         if @control_url
-          c.activate_control_app @control_url, @control_options
+          user_config.activate_control_app @control_url, @control_options
         end
       end
 
@@ -87,14 +87,14 @@ module Puma
     #
 
     def setup_options
-      @conf = Configuration.new do |c|
+      @conf = Configuration.new do |user_config, file_config|
         @parser = OptionParser.new do |o|
           o.on "-b", "--bind URI", "URI to bind to (tcp://, unix://, ssl://)" do |arg|
-            c.bind arg
+            user_config.bind arg
           end
 
           o.on "-C", "--config PATH", "Load PATH as a config file" do |arg|
-            c.load arg
+            file_config.load arg
           end
 
           o.on "--control URL", "The bind url to use for the control server",
@@ -112,21 +112,21 @@ module Puma
           end
 
           o.on "-d", "--daemon", "Daemonize the server into the background" do
-            c.daemonize
-            c.quiet
+            user_config.daemonize
+            user_config.quiet
           end
 
           o.on "--debug", "Log lowlevel debugging information" do
-            c.debug
+            user_config.debug
           end
 
           o.on "--dir DIR", "Change to DIR before starting" do |d|
-            c.directory d
+            user_config.directory d
           end
 
           o.on "-e", "--environment ENVIRONMENT",
             "The environment to run the Rack app on (default development)" do |arg|
-            c.environment arg
+            user_config.environment arg
           end
 
           o.on "-I", "--include PATH", "Specify $LOAD_PATH directories" do |arg|
@@ -135,50 +135,50 @@ module Puma
 
           o.on "-p", "--port PORT", "Define the TCP port to bind to",
             "Use -b for more advanced options" do |arg|
-            c.bind "tcp://#{Configuration::DefaultTCPHost}:#{arg}"
+            user_config.bind "tcp://#{Configuration::DefaultTCPHost}:#{arg}"
           end
 
           o.on "--pidfile PATH", "Use PATH as a pidfile" do |arg|
-            c.pidfile arg
+            user_config.pidfile arg
           end
 
           o.on "--preload", "Preload the app. Cluster mode only" do
-            c.preload_app!
+            user_config.preload_app!
           end
 
           o.on "--prune-bundler", "Prune out the bundler env if possible" do
-            c.prune_bundler
+            user_config.prune_bundler
           end
 
           o.on "-q", "--quiet", "Do not log requests internally (default true)" do
-            c.quiet
+            user_config.quiet
           end
 
           o.on "-v", "--log-requests", "Log requests as they occur" do
-            c.log_requests
+            user_config.log_requests
           end
 
           o.on "-R", "--restart-cmd CMD",
             "The puma command to run during a hot restart",
             "Default: inferred" do |cmd|
-            c.restart_command cmd
+            user_config.restart_command cmd
           end
 
           o.on "-S", "--state PATH", "Where to store the state details" do |arg|
-            c.state_path arg
+            user_config.state_path arg
           end
 
           o.on '-t', '--threads INT', "min:max threads to use (default 0:16)" do |arg|
             min, max = arg.split(":")
             if max
-              c.threads min, max
+              user_config.threads min, max
             else
-              c.threads min, min
+              user_config.threads min, min
             end
           end
 
           o.on "--tcp-mode", "Run the app in raw TCP mode instead of HTTP mode" do
-            c.tcp_mode!
+            user_config.tcp_mode!
           end
 
           o.on "-V", "--version", "Print the version information" do
@@ -188,11 +188,11 @@ module Puma
 
           o.on "-w", "--workers COUNT",
             "Activate cluster mode: How many worker processes to create" do |arg|
-            c.workers arg
+            user_config.workers arg
           end
 
           o.on "--tag NAME", "Additional text to display in process listing" do |arg|
-            c.tag arg
+            user_config.tag arg
           end
 
           o.on "--redirect-stdout FILE", "Redirect STDOUT to a specific file" do |arg|

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -80,8 +80,8 @@ module Puma
     def initialize(options={}, default_options = {}, &blk)
       default_options = self.puma_default_options.merge(default_options)
 
-      @options  = UserFileDefaultOptions.new(options, default_options)
-      @plugins  = PluginLoader.new
+      @options     = UserFileDefaultOptions.new(options, default_options)
+      @plugins     = PluginLoader.new
       @user_dsl    = DSL.new(@options.user_options, self)
       @file_dsl    = DSL.new(@options.file_options, self)
       @default_dsl = DSL.new(@options.default_options, self)

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -77,9 +77,10 @@ module Puma
       return cfg
     end
 
-    def initialize(options={}, &blk)
+    def initialize(options={}, default_options = {}, &blk)
+      default_options = self.puma_default_options.merge(default_options)
 
-      @options  = UserFileDefaultOptions.new(options, self.default_options)
+      @options  = UserFileDefaultOptions.new(options, default_options)
       @plugins  = PluginLoader.new
       @user_dsl    = DSL.new(@options.user_options, self)
       @file_dsl    = DSL.new(@options.file_options, self)
@@ -115,7 +116,7 @@ module Puma
       self
     end
 
-    def default_options
+    def puma_default_options
       {
         :min_threads => 0,
         :max_threads => 16,

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -126,7 +126,7 @@ module Puma
   class Configuration
     include ConfigDefault
 
-    def initialize(user_options={}, default_options = {}, &blk)
+    def initialize(user_options={}, default_options = {}, &block)
       default_options = self.puma_default_options.merge(default_options)
 
       @options     = UserFileDefaultOptions.new(user_options, default_options)
@@ -135,15 +135,15 @@ module Puma
       @file_dsl    = DSL.new(@options.file_options, self)
       @default_dsl = DSL.new(@options.default_options, self)
 
-      if blk
-        configure(&blk)
+      if block
+        configure(&block)
       end
     end
 
     attr_reader :options, :plugins
 
-    def configure(&blk)
-      blk.call(@user_dsl, @file_dsl, @default_dsl)
+    def configure
+      yield @user_dsl, @file_dsl, @default_dsl
     ensure
       @user_dsl._offer_plugins
       @file_dsl._offer_plugins

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -69,14 +69,6 @@ module Puma
   class Configuration
     include ConfigDefault
 
-    def self.from_file(path)
-      cfg = new
-
-      @file_dsl._load_from(path)
-
-      return cfg
-    end
-
     def initialize(options={}, default_options = {}, &blk)
       default_options = self.puma_default_options.merge(default_options)
 

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -152,7 +152,7 @@ module Puma
       end
 
       files.each do |f|
-        @file_dsl.load(f)
+        @file_dsl._load_from(f)
       end
       @options
     end

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -69,10 +69,10 @@ module Puma
   class Configuration
     include ConfigDefault
 
-    def initialize(options={}, default_options = {}, &blk)
+    def initialize(user_options={}, default_options = {}, &blk)
       default_options = self.puma_default_options.merge(default_options)
 
-      @options     = UserFileDefaultOptions.new(options, default_options)
+      @options     = UserFileDefaultOptions.new(user_options, default_options)
       @plugins     = PluginLoader.new
       @user_dsl    = DSL.new(@options.user_options, self)
       @file_dsl    = DSL.new(@options.file_options, self)

--- a/lib/puma/convenient.rb
+++ b/lib/puma/convenient.rb
@@ -3,12 +3,12 @@ require 'puma/configuration'
 
 module Puma
   def self.run(opts={})
-    cfg = Puma::Configuration.new do |c|
+    cfg = Puma::Configuration.new do |user_config|
       if port = opts[:port]
-        c.port port
+        user_config.port port
       end
 
-      c.quiet
+      user_config.quiet
 
       yield c
     end

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -35,26 +35,6 @@ module Puma
       instance_eval(&blk)
     end
 
-    # Load configuration from another named file. If the file name is absolute,
-    # load the file as an absolute path. Otherwise load it relative to the
-    # current config file.
-    #
-    def import(file)
-      if File.extname(file) == ""
-        file += ".rb"
-      end
-
-      if file[0,1] == "/"
-        path = file
-      elsif @path
-        path = File.join File.dirname(@path), file
-      else
-        raise "No original configuration path to import relative to"
-      end
-
-      DSL.new(@options, @config)._load_from(path)
-    end
-
     def get(key,default=nil)
       @options[key.to_sym] || default
     end

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -4,17 +4,6 @@ module Puma
   class DSL
     include ConfigDefault
 
-    # _run
-    # _load
-    def self.load(options, cfg, path)
-      d = new(options, cfg)
-      d._load_from(path)
-
-      options
-    ensure
-      d._offer_plugins
-    end
-
     def initialize(options, config)
       @config  = config
       @options = options

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -16,7 +16,7 @@ module Puma
     end
 
     def initialize(options, config)
-      @config = config
+      @config  = config
       @options = options
 
       @plugins = []
@@ -40,12 +40,6 @@ module Puma
       end
 
       @plugins.clear
-    end
-
-    def _run(&blk)
-      blk.call self
-    ensure
-      _offer_plugins
     end
 
     def inject(&blk)

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -100,10 +100,10 @@ module Puma
     end
 
     # Load additional configuration from a file
+    # Files get loaded later via Configuration#load
     def load(file)
       @options[:config_files] ||= []
       @options[:config_files] << file
-      _load_from(file)
     end
 
     # Bind the server to +url+. tcp:// and unix:// are the only accepted

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -4,6 +4,8 @@ module Puma
   class DSL
     include ConfigDefault
 
+    # _run
+    # _load
     def self.load(options, cfg, path)
       d = new(options, cfg)
       d._load_from(path)
@@ -116,14 +118,17 @@ module Puma
 
     # Load additional configuration from a file
     def load(file)
-      _ary(:config_files) << file
+      @options[:config_files] ||= []
+      @options[:config_files] << file
+      _load_from(file)
     end
 
     # Bind the server to +url+. tcp:// and unix:// are the only accepted
     # protocols.
     #
     def bind(url)
-      _ary(:binds) << url
+      @options[:binds] ||= []
+      @options[:binds] << url
     end
 
     # Define the TCP port to bind to. Use +bind+ for more advanced options.
@@ -192,7 +197,8 @@ module Puma
     # This can be called multiple times to add code each time.
     #
     def on_restart(&block)
-      _ary(:on_restart) << block
+      @options[:on_restart] ||= []
+      @options[:on_restart] << block
     end
 
     # Command to use to restart puma. This should be just how to
@@ -297,7 +303,8 @@ module Puma
     # This can be called multiple times to add hooks.
     #
     def before_fork(&block)
-      _ary(:before_fork) << block
+      @options[:before_fork] ||= []
+      @options[:before_fork] << block
     end
 
     # *Cluster mode only* Code to run in a worker when it boots to setup
@@ -306,7 +313,8 @@ module Puma
     # This can be called multiple times to add hooks.
     #
     def on_worker_boot(&block)
-      _ary(:before_worker_boot) << block
+      @options[:before_worker_boot] ||= []
+      @options[:before_worker_boot] << block
     end
 
     # *Cluster mode only* Code to run immediately before a worker shuts
@@ -317,7 +325,8 @@ module Puma
     # This can be called multiple times to add hooks.
     #
     def on_worker_shutdown(&block)
-      _ary(:before_worker_shutdown) << block
+      @options[:before_worker_shutdown] ||= []
+      @options[:before_worker_shutdown] << block
     end
 
     # *Cluster mode only* Code to run in the master when it is
@@ -326,7 +335,8 @@ module Puma
     # This can be called multiple times to add hooks.
     #
     def on_worker_fork(&block)
-      _ary(:before_worker_fork) << block
+      @options[:before_worker_fork] ||= []
+      @options[:before_worker_fork] << block
     end
 
     # *Cluster mode only* Code to run in the master after it starts
@@ -335,7 +345,8 @@ module Puma
     # This can be called multiple times to add hooks.
     #
     def after_worker_fork(&block)
-      _ary(:after_worker_fork) << block
+      @options[:after_worker_fork] ||= []
+      @options[:after_worker_fork] = block
     end
 
     alias_method :after_worker_boot, :after_worker_fork
@@ -477,10 +488,5 @@ module Puma
       end
     end
 
-    private
-
-    def _ary(key)
-      (@options.cur[key] ||= [])
-    end
   end
 end

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1,6 +1,30 @@
 module Puma
   # The methods that are available for use inside the config file.
+  # These same methods are used in Puma cli and the rack handler
+  # internally.
   #
+  # Used manually (via CLI class):
+  #
+  #   config = Configuration.new({}) do |user_config|
+  #     user_config.port 3001
+  #   end
+  #   config.load
+  #
+  #   puts config.options[:binds]
+  #   "tcp://127.0.0.1:3001"
+  #
+  # Used to load file:
+  #
+  #   $ cat puma_config.rb
+  #     port 3002
+  #
+  #   config = Configuration.new(config_file: "puma_config.rb")
+  #   config.load
+  #
+  #   puts config.options[:binds]
+  #   # => "tcp://127.0.0.1:3002"
+  #
+  # Detailed docs can be found in `examples/config.rb`
   class DSL
     include ConfigDefault
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -59,6 +59,7 @@ module Puma
       @config.load
 
       @options = @config.options
+      @config.clamp
 
       generate_restart_data
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -34,9 +34,9 @@ module Puma
     #
     # Examples:
     #
-    #   conf = Puma::Configuration.new do |c|
-    #     c.threads 1, 10
-    #     c.app do |env|
+    #   conf = Puma::Configuration.new do |user_config|
+    #     user_config.threads 1, 10
+    #     user_config.app do |env|
     #       [200, {}, ["hello world"]]
     #     end
     #   end

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -40,10 +40,14 @@ module Rack
             uri.port ||= options[:Port] || ::Puma::Configuration::DefaultTCPPort
             user_config.bind uri.to_s
           else
-            host ||= ::Puma::Configuration::DefaultTCPHost
-            port = options[:Port] || ::Puma::Configuration::DefaultTCPPort
+            if host
+              options[:Port] ||= ::Puma::Configuration::DefaultTCPPort
+            end
 
-            user_config.port port, host
+            if port = options[:Port]
+              host ||= ::Puma::Configuration::DefaultTCPHost
+              user_config.port port, host
+            end
           end
 
           user_config.app app

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -8,7 +8,7 @@ module Rack
         :Silent  => false
       }
 
-      def self.run(app, options = {})
+      def self.config(app, options = {})
         require 'puma/configuration'
         require 'puma/events'
         require 'puma/launcher'
@@ -48,6 +48,11 @@ module Rack
 
           c.app app
         end
+        conf
+      end
+
+      def self.run(app, options = {})
+        conf   = self.config(app, options)
 
         events = options.delete(:Silent) ? ::Puma::Events.strings : ::Puma::Events.stdio
 

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -15,38 +15,38 @@ module Rack
 
         options = DEFAULT_OPTIONS.merge(options)
 
-        conf = ::Puma::Configuration.new(options) do |c|
-          c.quiet
+        conf = ::Puma::Configuration.new(options) do |user_config, file_config, default_config|
+          user_config.quiet
 
           if options.delete(:Verbose)
             app = Rack::CommonLogger.new(app, STDOUT)
           end
 
           if options[:environment]
-            c.environment options[:environment]
+            user_config.environment options[:environment]
           end
 
           if options[:Threads]
             min, max = options.delete(:Threads).split(':', 2)
-            c.threads min, max
+            user_config.threads min, max
           end
 
           host = options[:Host]
 
           if host && (host[0,1] == '.' || host[0,1] == '/')
-            c.bind "unix://#{host}"
+            user_config.bind "unix://#{host}"
           elsif host && host =~ /^ssl:\/\//
             uri = URI.parse(host)
             uri.port ||= options[:Port] || ::Puma::Configuration::DefaultTCPPort
-            c.bind uri.to_s
+            user_config.bind uri.to_s
           else
             host ||= ::Puma::Configuration::DefaultTCPHost
             port = options[:Port] || ::Puma::Configuration::DefaultTCPPort
 
-            c.port port, host
+            user_config.port port, host
           end
 
-          c.app app
+          user_config.app app
         end
         conf
       end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -28,13 +28,12 @@ class TestConfigFile < Minitest::Test
   def test_double_bind_port
     port = (rand(10_000) + 30_000).to_s
     with_env("PORT" => port) do
-      conf = Puma::Configuration.new do |c|
-        c.bind "tcp://#{Puma::Configuration::DefaultTCPHost}:#{port}"
-        c.load "test/config/app.rb"
+      conf = Puma::Configuration.new do |user_config, file_config, default_config|
+        user_config.bind "tcp://#{Puma::Configuration::DefaultTCPHost}:#{port}"
+        file_config.load "test/config/app.rb"
       end
 
       conf.load
-
       assert_equal ["tcp://0.0.0.0:#{port}"], conf.options[:binds]
     end
   end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -66,6 +66,13 @@ class TestConfigFile < Minitest::Test
     assert_equal conf.options[:workers], 4
   end
 
+  def test_explicit_config_files
+    conf = Puma::Configuration.new(config_files: ['test/config/settings.rb']) do |c|
+    end
+    conf.load
+    assert_match(/:3000$/, conf.options[:binds].first)
+  end
+
   def test_parameters_overwrite_files
     conf = Puma::Configuration.new(config_files: ['test/config/settings.rb']) do |c|
       c.port 3030

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,8 @@ require "minitest/pride"
 require "puma"
 require "puma/detect"
 
+$LOAD_PATH << File.expand_path("../../lib", __FILE__)
+
 # Either takes a string to do a get request against, or a tuple of [URI, HTTP] where
 # HTTP is some kind of Net::HTTP request object (POST, HEAD, etc.)
 def hit(uris)

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -54,4 +54,42 @@ class TestPathHandler < Minitest::Test
     end
   end
 
+  def test_user_supplied_port_wins_over_config_file
+    user_port = 5001
+    file_port = 6001
+    options = {}
+
+    Tempfile.open("puma.rb") do |f|
+      f.puts "port #{file_port}"
+      f.close
+
+      options[:config_files]          = [f.path]
+      options[:user_supplied_options] = [:Port]
+      options[:Port]                  = user_port
+
+      conf = Rack::Handler::Puma.config(app, options)
+      conf.load
+      assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+    end
+  end
+
+  def test_default_port_loses_to_config_file
+    user_port = 5001
+    file_port = 6001
+    options = {}
+
+    Tempfile.open("puma.rb") do |f|
+      f.puts "port #{file_port}"
+      f.close
+
+      options[:config_files]          = [f.path]
+      options[:user_supplied_options] = []
+      options[:Port]                  = user_port
+
+      conf = Rack::Handler::Puma.config(app, options)
+      conf.load
+      puts conf.options[:binds]
+      assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
+    end
+  end
 end

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -54,42 +54,42 @@ class TestPathHandler < Minitest::Test
     end
   end
 
-  def test_user_supplied_port_wins_over_config_file
-    user_port = 5001
-    file_port = 6001
-    options = {}
+  # def test_user_supplied_port_wins_over_config_file
+  #   user_port = 5001
+  #   file_port = 6001
+  #   options = {}
 
-    Tempfile.open("puma.rb") do |f|
-      f.puts "port #{file_port}"
-      f.close
+  #   Tempfile.open("puma.rb") do |f|
+  #     f.puts "port #{file_port}"
+  #     f.close
 
-      options[:config_files]          = [f.path]
-      options[:user_supplied_options] = [:Port]
-      options[:Port]                  = user_port
+  #     options[:config_files]          = [f.path]
+  #     options[:user_supplied_options] = [:Port]
+  #     options[:Port]                  = user_port
 
-      conf = Rack::Handler::Puma.config(app, options)
-      conf.load
-      assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
-    end
-  end
+  #     conf = Rack::Handler::Puma.config(app, options)
+  #     conf.load
+  #     assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+  #   end
+  # end
 
-  def test_default_port_loses_to_config_file
-    user_port = 5001
-    file_port = 6001
-    options = {}
+  # def test_default_port_loses_to_config_file
+  #   user_port = 5001
+  #   file_port = 6001
+  #   options = {}
 
-    Tempfile.open("puma.rb") do |f|
-      f.puts "port #{file_port}"
-      f.close
+  #   Tempfile.open("puma.rb") do |f|
+  #     f.puts "port #{file_port}"
+  #     f.close
 
-      options[:config_files]          = [f.path]
-      options[:user_supplied_options] = []
-      options[:Port]                  = user_port
+  #     options[:config_files]          = [f.path]
+  #     options[:user_supplied_options] = []
+  #     options[:Port]                  = user_port
 
-      conf = Rack::Handler::Puma.config(app, options)
-      conf.load
-      puts conf.options[:binds]
-      assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
-    end
-  end
+  #     conf = Rack::Handler::Puma.config(app, options)
+  #     conf.load
+  #     puts conf.options[:binds]
+  #     assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
+  #   end
+  # end
 end

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -73,23 +73,21 @@ class TestPathHandler < Minitest::Test
   #   end
   # end
 
-  # def test_default_port_loses_to_config_file
-  #   user_port = 5001
-  #   file_port = 6001
-  #   options = {}
+  def test_default_port_loses_to_config_file
+    user_port = 5001
+    file_port = 6001
+    options = {}
 
-  #   Tempfile.open("puma.rb") do |f|
-  #     f.puts "port #{file_port}"
-  #     f.close
+    Dir.mktmpdir do |d|
+      Dir.chdir(d) do
+        FileUtils.mkdir("config")
+        File.open("config/puma.rb", "w") { |f| f << "port #{6001}" }
 
-  #     options[:config_files]          = [f.path]
-  #     options[:user_supplied_options] = []
-  #     options[:Port]                  = user_port
+        conf = Rack::Handler::Puma.config(app, options)
+        conf.load
 
-  #     conf = Rack::Handler::Puma.config(app, options)
-  #     conf.load
-  #     puts conf.options[:binds]
-  #     assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
-  #   end
-  # end
+        assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
+      end
+    end
+  end
 end

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -111,8 +111,7 @@ class TestUserSuppliedOptionsIsNotPresent < Minitest::Test
   end
 
   def test_default_port_when_no_config_file
-    options = {}
-    conf = Rack::Handler::Puma.config(->{}, options)
+    conf = Rack::Handler::Puma.config(->{}, @options)
     conf.load
 
     assert_equal ["tcp://0.0.0.0:9292"], conf.options[:binds]
@@ -120,7 +119,6 @@ class TestUserSuppliedOptionsIsNotPresent < Minitest::Test
 
   def test_config_wins_over_default
     file_port = 6001
-    @options = {}
 
     Dir.mktmpdir do |d|
       Dir.chdir(d) do
@@ -147,7 +145,6 @@ class TestUserSuppliedOptionsIsNotPresent < Minitest::Test
   def test_user_port_wins_over_config
     user_port = 5001
     file_port = 6001
-    @options = {}
 
     Dir.mktmpdir do |d|
       Dir.chdir(d) do


### PR DESCRIPTION
This is the Puma side of rails/rails#28137 

When options are passed to the Puma rack handler it is unknown if the options were set via a framework as a default or via a user. Puma currently has 3 different sources of configuration, the user via command line, the config files, and defaults.

Rails 5.1+ will record the values actually specified by the user versus the values specified by the frameworks. It passes these values to the Rack handler and now it's up to Puma to do something with that information.

When only framework defaults are passed it will set

```
options[:user_supplied_options] = []
```

When one or more options are specified by the user such as `:Port` then those keys will be in the array. In that example it will look like this


```
options[:user_supplied_options] = [:Port]
```

This change is 100% backwards compatible. If the framework is older and does not pass this information then the `user_supplied_options` will not be set, in that case we assume all values are user supplied.

Internally we accomplish this separation by replacing `LeveledOptions` which was a generic way of specifying options with different priorities with a more explicit `UserFileDefaultOptions` this assumes only 3 levels of options and it will use them in the order supplied (user config wins over file based config wins over defaults).

Now instead of using 1 dsl to set all values, we use 3. A user dsl, a file dsl and a `Configuration.new` will return all 3 DSLs to the block. It's up to the person using the block to use the correct dsl corresponding to the source of data they are getting.
