### PR TITLE
Allow user supplied procline tags to be dynamic

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -229,7 +229,12 @@ module Puma
 
     def worker(index, master)
       title = "puma: cluster worker #{index}: #{master}"
-      title << " [#{@options[:tag]}]" if @options[:tag] && !@options[:tag].empty?
+      if @options[:tag] && @options[:tag].respond_to?(:call)
+        title << " [#{@options[:tag].call}]"
+      elsif @options[:tag] && !@options[:tag].empty?
+        title << " [#{@options[:tag]}]"
+      end
+
       $0 = title
 
       Signal.trap "SIGINT", "IGNORE"

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -391,7 +391,7 @@ module Puma
 
     # Additional text to display in process listing
     def tag(string)
-      @options[:tag] = string.to_s
+      @options[:tag] = string
     end
 
     # *Cluster mode only* Set the timeout for workers in seconds

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -286,7 +286,11 @@ module Puma
 
     def title
       buffer = "puma #{Puma::Const::VERSION} (#{@options[:binds].join(',')})"
-      buffer << " [#{@options[:tag]}]" if @options[:tag] && !@options[:tag].empty?
+      if @options[:tag] && @options[:tag].respond_to?(:call)
+        buffer << " [#{@options[:tag].call}]"
+      elsif @options[:tag] && !@options[:tag].empty?
+        buffer << " [#{@options[:tag]}]"
+      end
       buffer
     end
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -78,6 +78,12 @@ class TestConfigFile < Minitest::Test
     assert_equal 5, conf.options[:max_threads]
   end
 
+  def test_proc_allowed_in_tag
+    conf = Puma::Configuration.new(tag: -> {"a" + "b"})
+
+    assert_equal 'ab', conf.options[:tag].call
+  end
+
   private
 
     def with_env(env = {})


### PR DESCRIPTION
The current behavior of the `tag` config option allows the default value to be a callable (defaults to part of the master's working path), but doesn't allow user supplied tags to be dynamic. This patch allows tags to be a callable, making both default and user supplied behaviors the same.

The specific use case here is that I'd like to include the current SHA in the procline, specifically the procline of worker processes. This is helpful when monitoring phased restarts to tell which processes have rolled, which haven't, and what point in time they're from.