### PR TITLE
Fix test error

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,9 +4,10 @@
 begin
   require "bundler/setup"
 rescue LoadError
-  require "net/http"
-  require "timeout"
 end
+
+require "net/http"
+require "timeout"
 require "minitest/autorun"
 require "minitest/pride"
 require "puma"
@@ -34,7 +35,6 @@ def hit(uris)
   return results
 end
 
-require 'timeout'
 module TimeoutEveryTestCase
   def run(*)
     if !!ENV['CI']


### PR DESCRIPTION
We got following error on travis now:

https://travis-ci.org/puma/puma/jobs/207434226

```
1) Error:
WebServerTest#test_simple_server:
NameError: uninitialized constant Net
    /home/travis/build/puma/puma/test/test_helper.rb:24:in `block in hit'
    /home/travis/build/puma/puma/test/test_helper.rb:20:in `each'
    /home/travis/build/puma/puma/test/test_helper.rb:20:in `hit'
    /home/travis/build/puma/puma/test/test_web_server.rb:36:in `test_simple_server'
```

I confirmed test passed with bundler 1.14.4 but errored with 1.14.5.

https://github.com/bundler/bundler/compare/v1.14.4...v1.14.5

The cause is https://github.com/bundler/bundler/commit/984f64d8a5771b214136b1bc5ffdfa83d4503252
because `rubygems/spec_fetcher` requires `net/http` internally but is deferred now.

I think we should require stdlibs explicitly.