### PR TITLE
Travis: JRuby 9.1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ rvm:
   - 2.3.3
   - 2.4.0
   - ruby-head
-  - jruby-9.1.7.0
+  - jruby-9.1.8.0
   - jruby-head
   - rbx-3
 matrix:


### PR DESCRIPTION
This PR updates Travis' JRuby to latest stable.