### PR TITLE
[close #1238] Don't call non-existent method

### DIFF
--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -97,6 +97,7 @@ module Puma
 
     rescue => e
       @stdout.puts e.message
+      @stdout.puts e.backtrace
       exit 1
     end
 
@@ -230,6 +231,7 @@ module Puma
 
     rescue => e
       message e.message
+      message e.backtrace
       exit 1
     end
 

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -78,11 +78,12 @@ module Puma
         end
 
         if @config_file
-          config = Puma::Configuration.from_file @config_file
-          @state ||= config.options[:state]
-          @control_url ||= config.options[:control_url]
+          config = Puma::Configuration.new({ config_files: [@config_file] }, {})
+          config.load
+          @state              ||= config.options[:state]
+          @control_url        ||= config.options[:control_url]
           @control_auth_token ||= config.options[:control_auth_token]
-          @pidfile ||= config.options[:pidfile]
+          @pidfile            ||= config.options[:pidfile]
         end
       end
 

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -4,6 +4,7 @@ require 'puma/control_cli'
 
 class TestPumaControlCli < Minitest::Test
   def test_config_file
-    Puma::ControlCLI.new ["halt", "--config-file", 'test/config/settings.rb']
+    control_cli = Puma::ControlCLI.new ["--config-file", "test/config/state_file_testing_config.rb", "halt"]
+    assert_equal "t3-pid", control_cli.instance_variable_get("@pidfile")
   end
 end

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+require 'puma/control_cli'
+
+class TestPumaControlCli < Minitest::Test
+  def test_config_file
+    Puma::ControlCLI.new ["halt", "--config-file", 'test/config/settings.rb']
+  end
+end


### PR DESCRIPTION
`Puma::Configuration._from_file` was removed in https://github.com/puma/puma/commit/89f37432deb499ce6cb72a7e7cba5a55430efacd. It was still being used by the `Puma::ControlCLI` class which was previously not being tested while being called with a `--config-file` option.

This PR reintroduces the previous behavior of loading a config file when specified via `pumactl` command.

cc/ @nateberkopec 
