### PR TITLE
Ensure env[QUERY_STRING] is not set to nil when there is no query.

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -522,7 +522,7 @@ module Puma
 
         raise "No REQUEST PATH" unless env[REQUEST_PATH]
 
-        env[QUERY_STRING] = uri.query
+        env[QUERY_STRING] = uri.query if uri.query
       end
 
       env[PATH_INFO] = env[REQUEST_PATH]

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -522,6 +522,8 @@ module Puma
 
         raise "No REQUEST PATH" unless env[REQUEST_PATH]
 
+        # A nil env value will cause a LintError (and fatal errors elsewhere),
+        # so only set the env value if there actually is a value.
         env[QUERY_STRING] = uri.query if uri.query
       end
 


### PR DESCRIPTION
In [this unit test](https://github.com/ysbaddaden/prax.cr/blob/52242e6e4fd8026693c87c8b97185cd86e1c3d21/test/failures_test.rb#L24), sending a request like "GET http://example.dev:20557/ HTTP/1.1" would cause "Rack::Lint::LintError: env variable QUERY_STRING has non-string value nil" and eventually "Read error: #<NoMethodError: undefined method `empty?' for nil:NilClass>", due to there being no query string in the "dumbass full host request header."