### PR TITLE
restore environment to original state before restarting

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -163,6 +163,8 @@ module Puma
 
     # Run the server. This blocks until the server is stopped
     def run
+      env = ENV.to_h
+
       @config.clamp
 
       @config.plugins.fire_starts self
@@ -178,6 +180,7 @@ module Puma
         graceful_stop
       when :restart
         log "* Restarting..."
+        ENV.replace(env)
         @runner.before_restart
         restart!
       when :exit

--- a/test/hello-env.ru
+++ b/test/hello-env.ru
@@ -1,0 +1,2 @@
+ENV["RAND"] ||= rand.to_s
+run lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Hello RAND #{ENV["RAND"]}"]] }


### PR DESCRIPTION
 - prevents apps from forever poisoning the ENV by doing bad things (something overrides PATH/HOME etc)
 - allows use of Dotenv to load new ENV settings from disk (they do not override)

Test:

```
puts "THIS SHOULD CHANGE #{ENV["TEST"] ||= rand.to_s}"
```

then restart the server

fixes https://github.com/puma/puma/issues/1258