### PR TITLE
Don't omit empty header values.

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -687,7 +687,7 @@ module Puma
             next
           end
 
-          if vs.respond_to?(:to_s)
+          if vs.respond_to?(:to_s) && !vs.to_s.empty?
             vs.to_s.split(NEWLINE).each do |v|
               lines.append k, colon, v, line_ending
             end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -623,4 +623,19 @@ class TestPumaServer < Minitest::Test
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
   end
+
+  def test_empty_header_values
+    @server.app = proc { |env| [200, {"X-Empty-Header" => ""}, []] }
+
+    @server.add_tcp_listener @host, @port
+    @server.run
+
+    sock = TCPSocket.new @host, @server.connected_port
+
+    sock << "HEAD / HTTP/1.0\r\n\r\n"
+
+    data = sock.read
+
+    assert_equal "HTTP/1.0 200 OK\r\nX-Empty-Header: \r\n\r\n", data
+  end
 end


### PR DESCRIPTION
Some servers might return empty HTTP header values.  For example:

```
Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS, PATCH
Access-Control-Expose-Headers:
Access-Control-Max-Age: 1728000
```

We are trying to write a test for a Rack proxy server, and in the tests we are using Puma.  Because Puma won't send headers with empty values, [our test is failing](https://github.com/ysbaddaden/prax.cr/blob/0517efd69dc6b67da1772948efb3e92a32bb7b93/test/proxy_test.rb#L67).  Our proxy server may be used with Rack configurations that use other handlers, such as WEBrick, which do send empty header values, so testing this case matters to us.

This change ensures that headers with empty values aren't omitted from the response.