### PR TITLE
Fix #1265: Load environment-specific config file

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -191,11 +191,8 @@ module Puma
       files = @options.all_of(:config_files)
 
       if files.empty?
-        imp = %W(config/puma/#{@options[:environment]}.rb config/puma.rb).find { |f|
-          File.exist?(f)
-        }
-
-        files << imp
+        names = %W(config/puma/#{@options[:environment].call}.rb config/puma.rb)
+        files << names.find { |f| File.exist?(f) }
       elsif files == ["-"]
         files = []
       end


### PR DESCRIPTION
`@options[:environment]` is a lambda literal.

`@options[:environment].call` returns the environment string, eg, `"development"`.