### PR TITLE
Make write_nonblock available under SSL

### DIFF
--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -84,7 +84,7 @@ module Puma
       # is that it means we'd have to have the ability to rewind
       # an engine because after we write+extract, the socket
       # write_nonblock call might raise an exception and later
-      # code would pass the same data in, but the engine would thing
+      # code would pass the same data in, but the engine would think
       # it had already written the data in. So for the time being
       # (and since write blocking is quite rare), go ahead and actually
       # block in write_nonblock.

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -86,7 +86,9 @@ module Puma
       # it had already written the data in. So for the time being
       # (and since write blocking is quite rare), go ahead and actually
       # block in write_nonblock.
-      alias_method :write_nonblock, :write
+      def write_nonblock(data, *_)
+        write data
+      end
 
       def flush
         @socket.flush

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -36,7 +36,9 @@ module Puma
         output
       end
 
-      def read_nonblock(size)
+      def read_nonblock(size, *_)
+        # *_ is to deal with keyword args that were added
+        # at some point (and being used in the wild)
         while true
           output = engine_read_all
           return output if output

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -77,6 +77,17 @@ module Puma
       alias_method :syswrite, :write
       alias_method :<<, :write
 
+      # This is a temporary fix to deal with websockets code using
+      # write_nonblock. The problem with implementing it properly
+      # is that it means we'd have to have the ability to rewind
+      # an engine because after we write+extract, the socket
+      # write_nonblock call might raise an exception and later
+      # code would pass the same data in, but the engine would thing
+      # it had already written the data in. So for the time being
+      # (and since write blocking is quite rare), go ahead and actually
+      # block in write_nonblock.
+      alias_method :write_nonblock, :write
+
       def flush
         @socket.flush
       end


### PR DESCRIPTION
This implementation of `write_nonblock` is not technically correct because it can block, but at least it gets past #1189 for the time being. 

The situation is that implementing it properly means having to be able to rewind the state of OpenSSL, which is hardly trivial.