### PR TITLE
[Close #1255] Prefer user supplied defaults

### DIFF
--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -42,7 +42,10 @@ module Rack
             user_config.threads min, max
           end
 
-          self.set_host_port_to_config(options[:Host], options[:Port], user_config)
+          host = options[:Host] || default_options[:Host]
+          port = options[:Port] || default_options[:Port]
+
+          self.set_host_port_to_config(host, port, user_config)
           self.set_host_port_to_config(default_options[:Host], default_options[:Port], default_config)
 
           user_config.app app

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -80,6 +80,25 @@ class TestUserSuppliedOptionsPortIsSet < Minitest::Test
   end
 end
 
+class TestUserSuppliedOptionsHostIsSet < Minitest::Test
+  def setup
+    @options = {}
+    @options[:user_supplied_options] = [:Host]
+  end
+
+  def test_host_uses_supplied_port_default
+    user_port = rand(1000..9999)
+    user_host = "123.456.789"
+
+    @options[:Host] = user_host
+    @options[:Port] = user_port
+    conf = Rack::Handler::Puma.config(->{}, @options)
+    conf.load
+
+    assert_equal ["tcp://#{user_host}:#{user_port}"], conf.options[:binds]
+  end
+end
+
 class TestUserSuppliedOptionsIsEmpty < Minitest::Test
   def setup
     @options = {}


### PR DESCRIPTION
To build a "binds" we need a host IP (via Host) and a port. We were running into a problem where a Host was being explicitly set via user but the Port was being defaulted to by Rails. When this happened the Host was used, but Puma would accidentally use it's own default port 9292 instead of Rail's port of 3000.

The fix was to use the "default" port passed in from a framework (if available) when no explicitly set Port is provided.
