### PR TITLE
also forget about BUNDLE_GEMFILE etc settings bundler sets up before …

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -163,7 +163,7 @@ module Puma
 
     # Run the server. This blocks until the server is stopped
     def run
-      env = ENV.to_h
+      previous_env = (defined?(Bundler) ? Bundler.clean_env : ENV.to_h)
 
       @config.clamp
 
@@ -180,7 +180,7 @@ module Puma
         graceful_stop
       when :restart
         log "* Restarting..."
-        ENV.replace(env)
+        ENV.replace(previous_env)
         @runner.before_restart
         restart!
       when :exit


### PR DESCRIPTION
…loading puma

when restarting a symlinked server the BUNDLE_GEMFILE env var
will point to the old releases Gemfile ... which results in running gems that
do not belong to the current release

followup to https://github.com/puma/puma/pull/1260

monkey-patch:

```
# make puma restart reset ENV vars and especially BUNDLE_GEMFILE
# can be removed if https://github.com/puma/puma/pull/1282 is released
# test puma restart works: `puts ENV['TEST']` in application.rb, change TEST in .env and then kill -SIGUSR1 the app
Puma::Runner.prepend(Module.new do
  def before_restart
    ENV.replace(Bundler. clean_env)
    super
  end
end)
```

@schneems @nateberkopec 