### PR TITLE
DO NOT MERGE, WILL CLOSE: Add /gc URL to status server. Send GC stats as a result of GC request.

### DIFF
--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -60,7 +60,6 @@ module Puma
           return rack_response(200, OK_STATUS)
 
         when /\/gc-stats$/
-          stats = GC.stat
           json = "{" + GC.stat.map { |k, v| "\"#{k}\": #{v}" }.join(",") + "}"
           return rack_response(200, json)
 

--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -55,14 +55,14 @@ module Puma
             return rack_response(200, OK_STATUS)
           end
 
-	when /\/gc$/
-	  GC.start
-	  return rack_response(200, OK_STATUS)
+        when /\/gc$/
+          GC.start
+          return rack_response(200, OK_STATUS)
 
-	when /\/gc-stats$/
+        when /\/gc-stats$/
           stats = GC.stat
           json = "{" + GC.stat.map { |k, v| "\"#{k}\": #{v}" }.join(",") + "}"
-	  return rack_response(200, json)
+          return rack_response(200, json)
 
         when /\/stats$/
           return rack_response(200, @cli.stats)

--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -55,6 +55,15 @@ module Puma
             return rack_response(200, OK_STATUS)
           end
 
+	when /\/gc$/
+	  GC.start
+	  return rack_response(200, OK_STATUS)
+
+	when /\/gc-stats$/
+          stats = GC.stat
+          json = "{" + GC.stat.map { |k, v| "\"#{k}\": #{v}" }.join(",") + "}"
+	  return rack_response(200, json)
+
         when /\/stats$/
           return rack_response(200, @cli.stats)
         else

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -9,7 +9,7 @@ require 'socket'
 module Puma
   class ControlCLI
 
-    COMMANDS = %w{halt restart phased-restart start stats status stop reload-worker-directory}
+    COMMANDS = %w{halt restart phased-restart start stats status stop reload-worker-directory gc gc-stats}
 
     def initialize(argv, stdout=STDOUT, stderr=STDERR)
       @state = nil
@@ -169,7 +169,7 @@ module Puma
         end
 
         message "Command #{@command} sent success"
-        message response.last if @command == "stats"
+        message response.last if @command == "stats" || @command == "gc-stats"
       end
 
       @server.close

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -170,7 +170,7 @@ class TestCLI < Minitest::Test
       p =~ /\"([^\"]+)\": ([^,]+)/ || raise("Can't parse #{p.inspect}!")
       gc_stats[$1] = $2
     end
-    gc_count_before = gc_stats[count].to_i
+    gc_count_before = gc_stats["count"].to_i
 
     s << "GET /gc HTTP/1.0\r\n\r\n"
     body = s.read # Ignored
@@ -185,7 +185,7 @@ class TestCLI < Minitest::Test
       p =~ /\"([^\"]+)\": ([^,]+)/ || raise("Can't parse #{p.inspect}!")
       gc_stats[$1] = $2
     end
-    gc_count_after = gc_stats[count].to_i
+    gc_count_after = gc_stats["count"].to_i
 
     # Hitting the /gc route should increment the count by 1
     assert_equal gc_count_before + 1, gc_count_after


### PR DESCRIPTION
After talking to Nate, I did some tests to see how much of slow-request Rails performance was due to GC. The blog post should go up next week :-) As part of that, I built a customized Puma whose control server would do a full GC and dump GC stats.

Arguably the GC and the GC stats should be two separate URLs in the control server, but this seems useful enough to me to be worth a PR.
