### PR TITLE
Fix rack handler logic

### DIFF
--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -42,10 +42,12 @@ module Rack
             user_config.threads min, max
           end
 
-          host = options[:Host] || default_options[:Host]
-          port = options[:Port] || default_options[:Port]
+          if options[:Host] || options[:Port]
+            host = options[:Host] || default_options[:Host]
+            port = options[:Port] || default_options[:Port]
+            self.set_host_port_to_config(host, port, user_config)
+          end
 
-          self.set_host_port_to_config(host, port, user_config)
           self.set_host_port_to_config(default_options[:Host], default_options[:Port], default_config)
 
           user_config.app app


### PR DESCRIPTION
There was a mistake previously where if both host and port were passed in as "default" they would take precedence of any values from the puma config "file". 

We can fix this by checking to make sure there were values explicitly passed before setting the config.