### PR TITLE
Remove environment from parse_error

### DIFF
--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -91,8 +91,7 @@ module Puma
     # parsing exception.
     #
     def parse_error(server, env, error)
-      @stderr.puts "#{Time.now}: HTTP parse error, malformed request (#{env[HTTP_X_FORWARDED_FOR] || env[REMOTE_ADDR]}): #{error.inspect}"
-      @stderr.puts "#{Time.now}: ENV: #{env.inspect}\n---\n"
+      @stderr.puts "#{Time.now}: HTTP parse error, malformed request (#{env[HTTP_X_FORWARDED_FOR] || env[REMOTE_ADDR]}): #{error.inspect}\n---\n"
     end
 
     # An SSL error has occurred.


### PR DESCRIPTION
Environment hash can contain headers, parameters, and much more about the request
This unfortunately means that we may be logging authentication credentials, such as basic auth
And a lot more without the users' knowledge.

This only happens during a log to stderr, but it is still worth noting.

