### PR TITLE
reinject RUBYOPT that bundler adds since we reset the environment bef…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+gemspec
+
 gem "hoe"
 gem "hoe-git"
 gem "hoe-ignore"

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ IS_JRUBY = defined?(RUBY_ENGINE) ? RUBY_ENGINE == "jruby" : false
 Hoe.plugin :git
 Hoe.plugin :ignore
 
+# Keep in sync with puma/gemspec
 HOE = Hoe.spec "puma" do
   self.readme_file    = "README.md"
   self.urls = %w!http://puma.io https://github.com/puma/puma!
@@ -17,13 +18,9 @@ HOE = Hoe.spec "puma" do
 
   spec_extras[:extensions]  = ["ext/puma_http11/extconf.rb"]
   spec_extras[:executables] = ['puma', 'pumactl']
-  spec_extras[:homepage] = self.urls.first
+  spec_extras[:homepage] = urls.first
 
   require_ruby_version ">= 1.9.3"
-
-  dependency "rack", [">= 1.1", "< 3.0"], :development
-
-  extra_dev_deps << ["rake-compiler", "~> 0.8"]
 end
 
 task :prerelease => [:clobber, :check_manifest, :test]

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -355,6 +355,9 @@ module Puma
       lib = File.expand_path "lib"
       arg0[1,0] = ["-I", lib] if [lib, "lib"].include?($LOAD_PATH[0])
 
+      # Detect and reinject any rubyopt that were set and will be removed by ENV reset
+      arg0[1,0] = ENV["RUBYOPT"] if ENV["RUBYOPT"] && defined?(Bundler)
+
       if defined? Puma::WILD_ARGS
         @restart_argv = arg0 + Puma::WILD_ARGS + @original_argv
       else

--- a/puma.gemspec
+++ b/puma.gemspec
@@ -1,52 +1,20 @@
 # -*- encoding: utf-8 -*-
 
-# This is only used when puma is a git dep from Bundler, so it's a little
-# weird.
+# This is only used when puma is a git dep from Bundler, keep in sync with Rakefile
 
-d = File.read(File.expand_path("../lib/puma/const.rb", __FILE__))
-if d =~ /VERSION = "(\d+\.\d+\.\d+)"/
-  version = $1
-else
-  version = "0.0.1"
-end
+version = File.read(File.expand_path("../lib/puma/const.rb", __FILE__))[/VERSION = "(\d+\.\d+\.\d+)"/, 1] || raise
 
 Gem::Specification.new do |s|
   s.name = "puma"
   s.version = version
-
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Evan Phoenix"]
-  s.date = `git log --pretty="%ai" -n 1`.split(" ").first
   s.description = "Puma is a simple, fast, threaded, and highly concurrent HTTP 1.1 server for Ruby/Rack applications. Puma is intended for use in both development and production environments. It's great for highly concurrent Ruby implementations such as Rubinius and JRuby as well as as providing process worker support to support CRuby well."
+  s.summary = "Puma is a simple, fast, threaded, and highly concurrent HTTP 1.1 server for Ruby/Rack applications"
   s.email = ["evan@phx.io"]
   s.executables = ["puma", "pumactl"]
   s.extensions = ["ext/puma_http11/extconf.rb"]
   s.files = `git ls-files`.split($/)
   s.homepage = "http://puma.io"
   s.license = "BSD-3-Clause"
-  s.rdoc_options = ["--main", "README.md"]
-  s.require_paths = ["lib"]
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
-  s.rubyforge_project = "puma"
-  s.rubygems_version = "1.8.25"
-  s.summary = "Puma is a simple, fast, threaded, and highly concurrent HTTP 1.1 server for Ruby/Rack applications"
-  s.test_files = s.files.grep(/^test/)
-
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
-      s.add_development_dependency(%q<rake-compiler>, ["~> 0.8.0"])
-      s.add_development_dependency(%q<hoe>, ["~> 3.6"])
-    else
-      s.add_dependency(%q<rdoc>, ["~> 4.0"])
-      s.add_dependency(%q<rake-compiler>, ["~> 0.8.0"])
-      s.add_dependency(%q<hoe>, ["~> 3.6"])
-    end
-  else
-    s.add_dependency(%q<rdoc>, ["~> 4.0"])
-    s.add_dependency(%q<rake-compiler>, ["~> 0.8.0"])
-    s.add_dependency(%q<hoe>, ["~> 3.6"])
-  end
 end

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -41,7 +41,11 @@ class TestIntegration < Minitest::Test
   end
 
   def server(argv)
-    cmd = "#{Gem.ruby} -Ilib bin/puma -b tcp://127.0.0.1:#{@tcp_port} #{argv}"
+    # when we were started with bundler all load-paths and bin-paths are setup correctly
+    # this is what 9X% of users run, so it is what we should test
+    # the other case is solely for package builders or testing 1-off cases where the system puma is used
+    base = (defined?(Bundler) ? "bundle exec puma" : "#{Gem.ruby} -Ilib bin/puma")
+    cmd = "#{base} -b tcp://127.0.0.1:#{@tcp_port} #{argv}"
     @server = IO.popen(cmd, "r")
 
     wait_for_server_to_boot


### PR DESCRIPTION
…ore restarting

we remove all bundler ENV state before restating since it includes PATH to gems, Gemfile location, the version of bundler ... all things that should be able to change when an app is redeployed

bundler adds `-rbundler/setup` to RUBYOPT but we remove that when restarting since we restore to pre-bundler ENV ... but we still want to restart with bundler

possible fallout:
 - `bundle _1.14.0_ puma` not being restarted automatically
 - `RUBYOPT` that existed before bundler get applied twice `ruby -rfoo -rbundler/setup puma` would require foo twice ... or whatever other RUBYOPT was given

fixes https://github.com/puma/puma/issues/1308