### PR TITLE
if we use a symlinked folder restarting the app needs to pick up the …

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -163,7 +163,12 @@ module Puma
 
     # Run the server. This blocks until the server is stopped
     def run
-      previous_env = (defined?(Bundler) ? Bundler::ORIGINAL_ENV : ENV.to_h)
+      if defined?(Bundler)
+        previous_env = Bundler::ORIGINAL_ENV # forget changed load paths and RUBYOPT
+        previous_env.delete("BUNDLE_GEMFILE") # forget Gemfile location in case we replace a symlinked folder
+      else
+        previous_env = ENV.to_h
+      end
 
       @config.clamp
 


### PR DESCRIPTION
…new Gemfile

... had .clean_env for a reason ... need to bring this back to fix ... will add a test soon, just heads up that we still need 1 more fix

reproduction:
 - create a a folder
 - symlink to new location x
 - boot puma from x
 - swap x with new location y
 - SIGUSR2 puma

expected: puma picks up new Gemfile in y
actual: puma reloads Gemfile from x (possibly even deleted now)

@nateberkopec 