### PR TITLE
run tests with bundler since that is what our users run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tmp
 t/
 .rbx/
 Gemfile.lock
+gemfiles/2.1-Gemfile.lock
 .idea/
 /test/test_puma.state
 /test/test_server.sock

--- a/gemfiles/2.1-Gemfile
+++ b/gemfiles/2.1-Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+gemspec path: ".."
+
 gem "hoe"
 gem "hoe-git"
 gem "hoe-ignore"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -36,9 +36,13 @@ def hit(uris)
 end
 
 module TimeoutEveryTestCase
+  # our own subclass so we never confused different timeouts
+  class TestTookTooLong < Timeout::Error
+  end
+
   def run(*)
     if ENV['CI']
-      ::Timeout.timeout(Puma.jruby? ? 120 : 30) { super }
+      ::Timeout.timeout(Puma.jruby? ? 120 : 30, TestTookTooLong) { super }
     else
       super # we want to be able to use debugger
     end

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -41,7 +41,11 @@ class TestIntegration < Minitest::Test
   end
 
   def server(argv)
-    cmd = "#{Gem.ruby} -Ilib bin/puma -b tcp://127.0.0.1:#{@tcp_port} #{argv}"
+    # when we were started with bundler all load-paths and bin-paths are setup correctly
+    # this is what 9X% of users run, so it is what we should test
+    # the other case is solely for package builders or testing 1-off cases where the system puma is used
+    base = (defined?(Bundler) ? "bundle exec puma" : "#{Gem.ruby} -Ilib bin/puma")
+    cmd = "#{base} -b tcp://127.0.0.1:#{@tcp_port} #{argv}"
     @server = IO.popen(cmd, "r")
 
     wait_for_server_to_boot


### PR DESCRIPTION
@nateberkopec would have caught https://github.com/puma/puma/issues/1308 early

does not change a lot since we previously ran the test with `bundle exec` and so already had all the load-paths etc setup with bundler