### PR TITLE
Use Socket.ip_address_list to get loopback addresses

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -245,9 +245,10 @@ module Puma
       end
     end
 
-    def localhost_addresses
-      addrs = TCPSocket.gethostbyname "localhost"
-      addrs[3..-1].uniq
+    def loopback_addresses
+      Socket.ip_address_list.select do |addrinfo|
+        addrinfo.ipv6_loopback? || addrinfo.ipv4_loopback?
+      end.map { |addrinfo| addrinfo.ip_address }.uniq
     end
 
     # Tell the server to listen on host +host+, port +port+.
@@ -259,7 +260,7 @@ module Puma
     #
     def add_tcp_listener(host, port, optimize_for_latency=true, backlog=1024)
       if host == "localhost"
-        localhost_addresses.each do |addr|
+        loopback_addresses.each do |addr|
           add_tcp_listener addr, port, optimize_for_latency, backlog
         end
         return
@@ -298,7 +299,7 @@ module Puma
       MiniSSL.check
 
       if host == "localhost"
-        localhost_addresses.each do |addr|
+        loopback_addresses.each do |addr|
           add_ssl_listener addr, port, ctx, optimize_for_latency, backlog
         end
         return


### PR DESCRIPTION
This will fix #1167 

[See JRuby bug](https://github.com/jruby/jruby/issues/4333)

Need some guidance from @evanphx here: is binder supposed to bind to *only loopback* interfaces by default (as I've done in this PR) or is it supposed to bind to *linklocal addresses* as well?

Here's what this method returned before (my machine, CRuby):

```
["::1", "fe80::1%lo0", "127.0.0.1"]
```

Now:

```
["127.0.0.1", "::1"]
```

Note the omission of an ipv6 link-local interface. The reason I removed it was that there are several other link-local interfaces on my machine which I don't think puma should bind to: 

```
irb(main):013:0> Socket.ip_address_list.select do |addrinfo|
irb(main):014:1* addrinfo.ipv6_linklocal?
irb(main):015:1> end
=> [#<Addrinfo: fe80::1%lo0>, #<Addrinfo: fe80::4b:c017:51b5:cd33%en0>, #<Addrinfo: fe80::989b:30ff:fe14:9e01%awdl0>, #<Addrinfo: fe80::f16e:6368:16b5:ff60%utun0>]
```

@evanphx if you can clarify the intent here, I'll add a test.