### PR TITLE
Fix crash when no_token is set in config file #1193

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -93,7 +93,7 @@ module Puma
       end
 
       if opts[:no_token]
-        auth_token = :none
+        auth_token = ''
       else
         auth_token = opts[:auth_token]
         auth_token ||= Configuration.random_token

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -93,7 +93,7 @@ module Puma
       end
 
       if opts[:no_token]
-        auth_token = ''
+        auth_token = 'none'
       else
         auth_token = opts[:auth_token]
         auth_token ||= Configuration.random_token

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -46,7 +46,7 @@ module Puma
       app = Puma::App::Status.new @launcher
 
       if token = @options[:control_auth_token]
-        app.auth_token = token unless token.empty? or token == :none
+        app.auth_token = token unless token.empty?
       end
 
       control = Puma::Server.new app, @launcher.events

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -46,7 +46,7 @@ module Puma
       app = Puma::App::Status.new @launcher
 
       if token = @options[:control_auth_token]
-        app.auth_token = token unless token.empty?
+        app.auth_token = token unless token.empty? || token == 'none'
       end
 
       control = Puma::Server.new app, @launcher.events


### PR DESCRIPTION
This fixes issue #1193 when puma would crash with `undefined method rindex for :none:Symbol` when `{ no_token: true }` is set as an option for `activate_control_app` in `puma/config.rb`.