### PR TITLE
Let's use Rubocop!

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,85 @@
+AllCops:
+  DisabledByDefault: true
+  TargetRubyVersion: 1.9.3
+  DisplayCopNames: true
+  StyleGuideCopsOnly: false
+  Exclude:
+    - 'tmp/**/*'
+
+Layout/SpaceAfterColon:
+  Enabled: true
+
+Layout/SpaceAroundKeyword:
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+Layout/Tab:
+  Enabled: true
+
+Layout/TrailingBlankLines:
+  Enabled: true
+
+Layout/TrailingWhitespace:
+  Enabled: true
+
+Lint/Debugger:
+  Enabled: true
+
+Style/MethodDefParentheses:
+  Enabled: true
+
+Style/MethodName:
+  Enabled: true
+  EnforcedStyle: snake_case
+  Exclude:
+    - 'test/**/**'
+
+Style/TrailingCommaInArguments:
+  Enabled: true
+
+Style/VariableName:
+  Enabled: true
+
+Performance/Count:
+  Enabled: true
+
+Performance/Detect:
+  Enabled: true
+
+Performance/EndWith:
+  Enabled: true
+
+Performance/FlatMap:
+  Enabled: true
+
+Performance/HashEachMethods:
+  Enabled: true
+
+Performance/RangeInclude:
+  Enabled: true
+
+Performance/RedundantMerge:
+  Enabled: true
+
+Performance/RedundantSortBy:
+  Enabled: true
+
+Performance/ReverseEach:
+  Enabled: true
+
+Performance/Sample:
+  Enabled: true
+
+Performance/Size:
+  Enabled: true
+
+Performance/StartWith:
+  Enabled: true
+
+Performance/TimesMap:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ AllCops:
   StyleGuideCopsOnly: false
   Exclude:
     - 'tmp/**/*'
+    - 'gemfiles/vendor/**/*'
+    - 'vendor/**/*'
+    - 'Rakefile'
 
 Layout/SpaceAfterColon:
   Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,0 +1,86 @@
+inherit_from: "./.rubocop.yml"
+
+# 29 offenses
+Layout/SpaceAroundOperators:
+  Enabled: true
+
+# 21 offenses
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+
+# 16 offenses
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+  EnforcedStyle: no_space
+
+# 15 offenses
+Layout/SpaceBeforeBlockBraces:
+  Enabled: true
+
+# 15 offenses
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+  EnforcedStyle: no_space
+
+# 8 offenses
+Layout/EmptyLines:
+  Enabled: true
+
+# 4 offenses
+Layout/EmptyLinesAroundClassBody:
+  Enabled: true
+  Exclude:
+    - 'test/**/*'
+
+# 6 offenses
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: true
+
+# 5 offenses
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: true
+
+# 5 offenses
+Layout/IndentationWidth:
+  Enabled: true
+
+# 3 offenses
+Layout/AccessModifierIndentation:
+  EnforcedStyle: indent
+
+# 2 offenses
+Style/WhileUntilModifier:
+  Enabled: true
+
+# 1 offense
+Style/TernaryParentheses:
+  Enabled: true
+
+# >200 offenses for 80
+# 58 offenses for 100
+# 18 offenses for 120
+Metrics/LineLength:
+  Max: 120
+  AllowHeredoc: true
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
+  IgnoreCopDirectives: false
+  IgnoredPatterns: []
+
+# 1 offense
+Metrics/ParameterLists:
+  Max: 5
+
+# 1 offense
+Performance/RedundantMatch:
+  Enabled: true
+
+# 1 offense
+Performance/RedundantBlockCall:
+  Enabled: true
+
+# 1 offense
+Performance/StringReplacement:
+  Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   # bundler installation needed for jruby-head
   # https://github.com/travis-ci/travis-ci/issues/5861
   - gem install bundler -v 1.11.2
-script: "TESTOPTS=-v bundle exec rake test"
+script: "TESTOPTS=-v bundle exec rake"
 branches:
   only: [master]
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,5 @@ gem "rack", "< 3.0"
 gem "minitest", "~> 5.9"
 
 gem "jruby-openssl", :platform => "jruby"
+
+gem "rubocop", "~> 0.49.1"

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,10 @@ require "bundler/setup"
 require "hoe"
 require "rake/extensiontask"
 require "rake/javaextensiontask"
+require "rubocop/rake_task"
+
+# Add rubocop task
+RuboCop::RakeTask.new
 
 IS_JRUBY = defined?(RUBY_ENGINE) ? RUBY_ENGINE == "jruby" : false
 
@@ -163,3 +167,5 @@ namespace :test do
     task :all => [:test, "test:integration"]
   end
 end
+
+task :default => [:rubocop, :test]

--- a/examples/qc_config.rb
+++ b/examples/qc_config.rb
@@ -6,7 +6,7 @@
   CA[:domainname] = domainname
   CA[:CA_dir] = File.join Dir.pwd, "CA"
   CA[:password] = 'puma'
-  
+
   CERTS << {
     :type => 'server',
     :hostname => 'puma'

--- a/gemfiles/2.1-Gemfile
+++ b/gemfiles/2.1-Gemfile
@@ -10,3 +10,5 @@ gem "rack", "~> 1.6"
 gem "minitest", '~> 5.9'
 
 gem "jruby-openssl", :platform => "jruby"
+
+gem "rubocop", "~> 0.49.1"

--- a/lib/puma/jruby_restart.rb
+++ b/lib/puma/jruby_restart.rb
@@ -80,4 +80,3 @@ module Puma
     end
   end
 end
-

--- a/lib/puma/plugin/tmp_restart.rb
+++ b/lib/puma/plugin/tmp_restart.rb
@@ -32,4 +32,3 @@ Puma::Plugin.create do
     end
   end
 end
-

--- a/test/config/state_file_testing_config.rb
+++ b/test/config/state_file_testing_config.rb
@@ -11,4 +11,3 @@ on_worker_fork { 1 }
 on_restart { 1 }
 after_worker_boot { 1 }
 lowlevel_error_handler { 1 }
-

--- a/test/shell/t1.rb
+++ b/test/shell/t1.rb
@@ -16,4 +16,3 @@ if log =~ %r!GET / HTTP/1\.1!
 else
   exit 1
 end
-

--- a/test/shell/t3.rb
+++ b/test/shell/t3.rb
@@ -9,7 +9,7 @@ sleep 2
 
 worker_index_within_number_of_workers = !File.file?("t3-worker-3-pid")
 
-system "kill `cat t3-pid`" 
+system "kill `cat t3-pid`"
 
 File.unlink "t3-pid" if File.file? "t3-pid"
 File.unlink "t3-worker-0-pid" if File.file? "t3-worker-0-pid"
@@ -22,4 +22,3 @@ if worker_pid_was_present and worker_index_within_number_of_workers
 else
   exit 1
 end
-

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -179,4 +179,3 @@ class TestUserSuppliedOptionsIsNotPresent < Minitest::Test
     end
   end
 end
-

--- a/tools/trickletest.rb
+++ b/tools/trickletest.rb
@@ -31,7 +31,7 @@ st = "GET / HTTP/1.1\r\nHost: www.zedshaw.com\r\nContent-Type: text/plain\r\nCon
 puts "length: #{content.length}"
 
 threads = []
-ARGV[1].to_i.times do 
+ARGV[1].to_i.times do
   t = Thread.new do
     size = 100
     puts ">>>> #{size} sized chunks"


### PR DESCRIPTION
Closes #1149.

I've added very basic, all-off-by-default, Rubocop config, which passes. It contains mostly Performance and Layout cops.

Also, I've added a TODO config which contains cops producing a small number of offenses – so, we can easily fix them and make the code style more consistent.

There is the output of the `rubocop -f o -c .rubocop_todo.yml` command:

```
29   Layout/SpaceAroundOperators
21   Layout/SpaceInsideBlockBraces
18   Metrics/LineLength
16   Layout/SpaceAroundEqualsInParameterDefault
15   Layout/SpaceBeforeBlockBraces
15   Layout/SpaceInsideHashLiteralBraces
8    Layout/EmptyLines
6    Layout/EmptyLinesAroundMethodBody
     Layout/EmptyLinesAroundModuleBody
5    Layout/IndentationWidth
4    Layout/EmptyLinesAroundClassBody
3    Layout/AccessModifierIndentation
2    Style/WhileUntilModifier
1    Metrics/ParameterLists
1    Performance/RedundantBlockCall
1    Performance/RedundantMatch
1    Performance/StringReplacement
1    Style/TernaryParentheses
--
152  Total
```