### PR TITLE
Idempotent close

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -47,8 +47,8 @@ module Puma
     end
 
     def close
-      @ios.each { |i| i.close }
-      @unix_paths.each { |i| File.unlink i }
+      @ios.each { |i| i.close rescue nil }
+      @unix_paths.each { |i| File.unlink(i) if File.exist?(i) }
     end
 
     def import_from_env

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -155,7 +155,6 @@ module Puma
       server = Puma::Server.new app, @launcher.events, @options
       server.min_threads = min_t
       server.max_threads = max_t
-      server.inherit_binder @launcher.binder
 
       if @options[:mode] == :tcp
         server.tcp_mode!

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -66,7 +66,6 @@ module Puma
       @persistent_timeout = options.fetch(:persistent_timeout, PERSISTENT_TIMEOUT)
 
       @binder = Binder.new(events)
-      @own_binder = true
 
       @first_data_timeout = FIRST_DATA_TIMEOUT
 
@@ -88,11 +87,6 @@ module Puma
     forward :add_ssl_listener,  :@binder
     forward :add_unix_listener, :@binder
     forward :connected_port,    :@binder
-
-    def inherit_binder(bind)
-      @binder = bind
-      @own_binder = false
-    end
 
     def tcp_mode!
       @mode = :tcp
@@ -237,7 +231,7 @@ module Puma
         @check.close
         @notify.close
 
-        if @status != :restart and @own_binder
+        if @status != :restart
           @binder.close
         end
       end
@@ -392,7 +386,7 @@ module Puma
         @check.close
         @notify.close
 
-        if @status != :restart and @own_binder
+        if @status != :restart
           @binder.close
         end
       end

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -180,3 +180,56 @@ class TestUserSuppliedOptionsIsNotPresent < Minitest::Test
   end
 end
 
+class TestServerStops < Minitest::Test
+  def app
+    proc { [200, {}, ['hello world']] }
+  end
+
+  def in_handler(app, options = {})
+    options[:Port] ||= 0
+    options[:Silent] = true
+
+    @launcher = nil
+    thread = Thread.new do
+      Rack::Handler::Puma.run(app, options) do |s, p|
+        @launcher = s
+      end
+    end
+    thread.abort_on_exception = true
+
+    # Wait for launcher to boot
+    Timeout.timeout(10) do
+      until @launcher
+        sleep 1
+      end
+    end
+    sleep 1
+
+    yield @launcher
+  ensure
+    thread.join if thread
+  end
+
+  def test_handler_stops
+    in_handler(app) do |launcher|
+      launcher.stop
+      sleep 2
+      assert_equal port_open?(@launcher.connected_port), false
+    end
+  end
+
+  private
+
+  def port_open?(port, ip = '127.0.0.1', seconds = 1)
+    Timeout.timeout(seconds) do
+      begin
+        TCPSocket.new(ip, port).close
+        true
+      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+        false
+      end
+    end
+  rescue Timeout::Error
+    false
+  end
+end


### PR DESCRIPTION
Sometimes the binder doesn't ever get closed. Rather than try to track down where it should have been closed, let's just make closing idempotent.