### PR TITLE
Additional docs/systemd refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,11 @@ $ bundle exec cap puma:stop
 $ bundle exec cap puma:phased-restart
 ```
 
+See
+[docs/systemd](https://github.com/puma/puma/blob/master/docs/systemd.md),
+including the last section, if using this in conjunction with systemd
+(all recent, major distributions of Linux).
+
 ## Contributing
 
 To run the test suite:

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -186,8 +186,10 @@ Apr 07 08:40:19 hx puma[28320]: Use Ctrl-C to stop
 Other systems/tools might expect or need puma to be run as a
 "traditional" forking server, for example so that the `pumactl`
 command can be used directly and outside of systemd for
-stop/start/restart. This use case is incompatible with systemd
-socket activation, so it should not be configured.
+stop/start/restart. This use case is incompatible with systemd socket
+activation, so it should not be configured. Below is an alternative
+puma.service config sample, using `Type=forking` and the `--daemon`
+flag in `ExecStart`.
 
 ~~~~ ini
 [Unit]

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -192,7 +192,7 @@ puma.service config sample, using `Type=forking` and the `--daemon`
 flag in `ExecStart`. Here systemd is playing a role more equivalent to
 SysV init.d, where it is responsible for starting Puma on boot
 (multi-user.target) and stopping it on shutdown, but is not performing
-continuous restarts. Therfore running Puma in cluster mode, where the
+continuous restarts. Therefore running Puma in cluster mode, where the
 master can restart workers, is highly recommended. See the systemd
 [Restart] directive for details.
 

--- a/tools/jungle/README.md
+++ b/tools/jungle/README.md
@@ -7,3 +7,7 @@ See `/tools/jungle/init.d` for tools to use with init.d and start-stop-daemon.
 ## Upstart
 
 See `/tools/jungle/upstart` for Ubuntu's upstart scripts.
+
+## Systemd
+
+See [/docs/systemd](https://github.com/puma/puma/blob/master/docs/systemd.md).


### PR DESCRIPTION
 * Section renamed Alternative Forking Configuration with explanation given for when to use this.
 * capistrano3-puma in sub-section with consolidated dry-run shell commands
 * Section Service Configuration contrasts and references Forking section
 * Streamline config samples and highlight configs using ini format

Cc: @mdesantis, @nateberkopec as a courtesy and in the hope you might cross-review my edits to the forking config. section you added.  Any errors here?
