### PR TITLE
Return proper exit code for TERM signal

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -375,7 +375,10 @@ module Puma
           log "Early termination of worker"
           exit! 0
         else
+          stop_workers
           stop
+
+          raise SignalException, "SIGTERM"
         end
       end
     end

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -392,7 +392,9 @@ module Puma
 
       begin
         Signal.trap "SIGTERM" do
-          stop
+          graceful_stop
+
+          raise SignalException, "SIGTERM"
         end
       rescue Exception
         log "*** SIGTERM not implemented, signal based gracefully stopping unavailable!"


### PR DESCRIPTION
Attempt at returning the proper exit code (128+15) when TERM signal
is sent to the server, for both single and clustered mode.

The changes are achieved by restoring signal from within the trap
and accordingly killing the process using TERM event.

Added plus, stopping single mode gracefully now.

Potential fix for : https://github.com/puma/puma/issues/1183