### PR TITLE
remove check for clustered when attempting to prune_bundler

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -313,7 +313,7 @@ module Puma
     end
 
     def prune_bundler?
-      @options[:prune_bundler] && clustered? && !@options[:preload_app]
+      @options[:prune_bundler] && !@options[:preload_app]
     end
 
     def close_binder_listeners


### PR DESCRIPTION
I've removed this check for clustered? in prune_bundler? 

I could see no reason for it to be there and it was preventing a clean restart when workers = 0. Issuing a restart when workers = 0 would result in errors like the following observable in the puma_errors.log 

```
=== puma startup: 2017-06-22 07:00:28 +0000 ===
/home/deploy/.rbenv/versions/2.2.7/lib/ruby/2.2.0/rubygems/dependency.rb:315:in `to_specs': Could not find 'puma' (>= 0) among 10 total gem(s) (Gem::LoadError)
Checked in 'GEM_PATH=/home/deploy/.gem/ruby/2.2.0:/home/deploy/.rbenv/versions/2.2.7/lib/ruby/gems/2.2.0', execute `gem env` for more information
	from /home/deploy/.rbenv/versions/2.2.7/lib/ruby/2.2.0/rubygems/dependency.rb:324:in `to_spec'
	from /home/deploy/.rbenv/versions/2.2.7/lib/ruby/2.2.0/rubygems/core_ext/kernel_gem.rb:64:in `gem'
	from /var/www/pin-site/shared/bundle/ruby/2.2.0/bin/puma:22:in `<main>'
```

Naturally, this means the puma restart failed and puma is down. Undesirable. I've tested this with workers = 0 and it appears to work as expected. 