### PR TITLE
Fix typos in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -149,7 +149,7 @@ task :ensure_no_puma_gem do
   Bundler.with_clean_env do
     out = `gem list puma`.strip
     if !$?.success? || out != ""
-      abort "No other puma version should be install to avoid false positives or lading it by accident but found #{out}"
+      abort "No other puma version should be installed to avoid false positives or loading it by accident but found #{out}"
     end
   end
 end


### PR DESCRIPTION
I noticed some typos when running `bundle exec rake`.