### PR TITLE
Fix incorrect thread name

### DIFF
--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -71,9 +71,9 @@ module Puma
     def spawn_thread
       @spawned += 1
 
-      th = Thread.new do
+      th = Thread.new(@spawned) do |spawned|
         # Thread name is new in Ruby 2.3
-        Thread.current.name = 'puma %03i' % @spawned if Thread.current.respond_to?(:name=)
+        Thread.current.name = 'puma %03i' % spawned if Thread.current.respond_to?(:name=)
         todo  = @todo
         block = @block
         mutex = @mutex


### PR DESCRIPTION
Fix incorrect thread name.

Before:
```shell
$ puma -t 5:5
$ ps -eT | grep puma
148652 148652 pts/0    00:00:00 puma
148652 148681 pts/0    00:00:00 puma 004
148652 148682 pts/0    00:00:00 puma 004
148652 148683 pts/0    00:00:00 puma 004
148652 148684 pts/0    00:00:00 puma 004
148652 148685 pts/0    00:00:00 puma 005
```

After:
```shell
$ puma -t 5:5
$ ps -eT | grep puma
148951 148951 pts/0    00:00:00 puma
148951 148980 pts/0    00:00:00 puma 001
148951 148981 pts/0    00:00:00 puma 002
148951 148982 pts/0    00:00:00 puma 003
148951 148983 pts/0    00:00:00 puma 004
148951 148984 pts/0    00:00:00 puma 005
```