### PR TITLE
Fix empty :user_supplied_options causing duplicate puma binds

### DIFF
--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -82,7 +82,7 @@ module Rack
           "Verbose"         => "Don't report each request (default: false)"
         }
       end
-    private
+
       def self.set_host_port_to_config(host, port, config)
         if host && (host[0,1] == '.' || host[0,1] == '/')
           config.bind "unix://#{host}"

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -26,6 +26,8 @@ module Rack
           end
         end
 
+        self.set_host_port_to_config(default_options[:Host], default_options[:Port], default_options)
+
         conf = ::Puma::Configuration.new(options, default_options) do |user_config, file_config, default_config|
           user_config.quiet
 
@@ -47,8 +49,6 @@ module Rack
             port = options[:Port] || default_options[:Port]
             self.set_host_port_to_config(host, port, user_config)
           end
-
-          self.set_host_port_to_config(default_options[:Host], default_options[:Port], default_config)
 
           user_config.app app
         end
@@ -85,11 +85,11 @@ module Rack
 
       def self.set_host_port_to_config(host, port, config)
         if host && (host[0,1] == '.' || host[0,1] == '/')
-          config.bind "unix://#{host}"
+          apply_bind_to_config "unix://#{host}", config
         elsif host && host =~ /^ssl:\/\//
           uri = URI.parse(host)
           uri.port ||= port || ::Puma::Configuration::DefaultTCPPort
-          config.bind uri.to_s
+          apply_bind_to_config uri.to_s, config
         else
 
           if host
@@ -98,8 +98,18 @@ module Rack
 
           if port
             host ||= ::Puma::Configuration::DefaultTCPHost
-            config.port port, host
+            apply_bind_to_config "tcp://#{host}:#{port}", config
           end
+        end
+      end
+
+      def self.apply_bind_to_config(val, config)
+        if config.is_a? ::Puma::DSL
+          config.public_send :bind, val
+        else
+          # Respect any existing :binds value that might already exist
+          config[:binds] ||= []
+          config[:binds]  << val
         end
       end
     end

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -123,6 +123,41 @@ class TestUserSuppliedOptionsIsEmpty < Minitest::Test
       end
     end
   end
+
+  def test_empty_config_file_creates_single_bind
+    user_port = 5001
+
+    Dir.mktmpdir do |d|
+      Dir.chdir(d) do
+        FileUtils.mkdir("config")
+        File.write("config/puma.rb", "")
+
+        @options[:Port] = user_port
+        conf = Rack::Handler::Puma.config(->{}, @options)
+        conf.load
+
+        assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+      end
+    end
+  end
+
+  def test_empty_config_file_with_port_and_bind_options_creates_two_binds
+    user_port = 5001
+
+    Dir.mktmpdir do |d|
+      Dir.chdir(d) do
+        FileUtils.mkdir("config")
+        File.write("config/puma.rb", "")
+
+        @options[:Port]  = user_port
+        @options[:binds] = ["ssl://foo.com:12345"]
+        conf = Rack::Handler::Puma.config(->{}, @options)
+        conf.load
+
+        assert_equal ["ssl://foo.com:12345", "tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+      end
+    end
+  end
 end
 
 class TestUserSuppliedOptionsIsNotPresent < Minitest::Test


### PR DESCRIPTION
This aims to work in the spirit of the original code from #1234, but doesn't allow the `default_options` inadvertently apply two different bind addresses.


What this change fixes:
-----------------------

When the `Rack::Handler::Puma` sets the `Puma::Configuration`, it checks to see if any `:user_supplied_options` exist in the options hash, and if that hash exists, it then takes any keys not existing in that hash, and pushes them down as `default_options`, giving them lesser priority when evaluated.

This works fine for most values, except the `:binds`, since that can sometimes be the combination of `:Host`/`:Port`.  When the `Puma::Configuration#configure` block is hit in the Rack handler, the `:binds` option already exists with a default from `Puma::Configuration.puma_default_options`, so the resulting config DSL will now append to that array, instead of creating a new value.

This is most likely not the desired behavior, as this will create two listening ports by default.


What this change does:
----------------------
This change effectively creates a `binds` key in the default_options, based off of the `:Host` and `:Port` values, which will then override the `Puma::Configuration.puma_default_options`'s `binds` key when the `Puma::Configuration` instance is instantiated from the rack handler.

To do this, the `set_host_port_to_config` has been updated to work with either a `Puma::DSL` (previous implementation), or a hash.  This allows us to call it prior to instantiating the `Puma::Configuration`, instead of during the configure block, preventing two listening ports from being defined.