### PR TITLE
Appveyor CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ gem "jruby-openssl", :platform => "jruby"
 gem "rubocop", "~> 0.49.1"
 
 if %w(2.2.7 2.3.4 2.4.1).include? RUBY_VERSION
-  gem "stopgap_13632", "~> 1.0", :platform => "mri"
+  gem "stopgap_13632", "~> 1.0", :platforms => ["mri", "mingw", "x64_mingw"]
 end

--- a/README.md
+++ b/README.md
@@ -311,6 +311,29 @@ reliability in production environments:
 * [tools/jungle](https://github.com/puma/puma/tree/master/tools/jungle) for sysvinit (init.d) and upstart
 * [docs/systemd](https://github.com/puma/puma/blob/master/docs/systemd.md)
 
+## Known bugs
+For MRI versions 2.2.7, 2.3.4 and 2.4.1 you may start erratically get the following exception in places where it should not happen:
+```ruby
+stream closed in another thread (IOError)
+```
+If that's the case then it might be caused by ruby bug https://bugs.ruby-lang.org/issues/13632 and it could be temporary fixed with the gem https://rubygems.org/gems/stopgap_13632.
+Add to gemfile:
+```
+if %w(2.2.7 2.3.4 2.4.1).include? RUBY_VERSION
+  gem "stopgap_13632", "~> 1.0", :platforms => ["mri", "mingw", "x64_mingw"]
+end
+```
+Don't forget to require it:
+```
+require 'stopgap_13632'
+```
+And when an "IOError: stream closed" happens in a thread, accessing a busy IO, catch it and call the following method:
+```
+rescue IOError
+  Thread.current.purge_interrupt_queue
+end
+```
+
 ## Capistrano deployment
 
 Puma has support for Capistrano3 with an [external gem](https://github.com/seuros/capistrano-puma), you just need require that in Gemfile:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+install:
+  - set PATH=C:\MinGW\bin;C:\Ruby%ruby_version%\bin;%PATH%
+  - set RAKEOPT=-rdevkit
+  - set DISABLE_SSL=true
+  - set APPVEYOR=true
+  - ruby --version
+  - gem --version
+  - bundle --version
+  - bundle install
+
+before_deploy:
+  - PowerShell .\InstallSelfSignedCert.ps1
+
+test_script:
+  - bundle exec rake
+
+environment:
+  matrix:
+    - ruby_version: "24"
+    - ruby_version: "24-x64"
+    - ruby_version: "23"
+    - ruby_version: "23-x64"
+    - ruby_version: "22"
+    - ruby_version: "22-x64"
+    - ruby_version: "21"
+    - ruby_version: "21-x64"
+
+branches:
+  only:
+    - master
+
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,6 @@ install:
   - bundle --version
   - bundle install
 
-before_deploy:
-  - PowerShell .\InstallSelfSignedCert.ps1
-
 test_script:
   - bundle exec rake
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -59,7 +59,7 @@ module SkipTestsBasedOnRubyEngine
   end
 
   def skip_on_appveyor
-    skip "Skipped on JRuby" if ENV["APPVEYOR"]
+    skip "Skipped on Appveyor" if ENV["APPVEYOR"]
   end
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -57,6 +57,10 @@ module SkipTestsBasedOnRubyEngine
   def skip_on_jruby
     skip "Skipped on JRuby" if Puma.jruby?
   end
+
+  def skip_on_appveyor
+    skip "Skipped on JRuby" if ENV["APPVEYOR"]
+  end
 end
 
 Minitest::Test.include SkipTestsBasedOnRubyEngine

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -19,6 +19,7 @@ class TestBinder < Minitest::Test
   end
 
   def test_localhost_addresses_dont_alter_listeners_for_ssl_addresses
+    skip_on_appveyor
     skip_on_jruby
 
     key =  File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -194,9 +194,8 @@ class TestIntegration < Minitest::Test
     assert_match(/No pid '\d+' found/, sout.readlines.join(""))
     assert_equal(1, e.status)
   end
-
-
-  def test_restart_closes_keepalive_sockets ####??
+  
+  def test_restart_closes_keepalive_sockets
     _, new_reply = restart_server_and_listen("-q test/rackup/hello.ru")
     assert_equal "Hello World", new_reply
   end
@@ -207,7 +206,7 @@ class TestIntegration < Minitest::Test
     assert_equal "Hello World", new_reply
   end
 
-      # It does not share environments between multiple generations, which would break Dotenv
+  # It does not share environments between multiple generations, which would break Dotenv
   def test_restart_restores_environment
     # jruby has a bug where setting `nil` into the ENV or `delete` do not change the
     # next workers ENV

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -54,6 +54,7 @@ class TestIntegration < Minitest::Test
   end
 
   def restart_server_and_listen(argv)
+    skip_on_appveyor
     server(argv)
     s = connect
     initial_reply = read_body(s)
@@ -194,7 +195,8 @@ class TestIntegration < Minitest::Test
     assert_equal(1, e.status)
   end
 
-  def test_restart_closes_keepalive_sockets
+
+  def test_restart_closes_keepalive_sockets ####??
     _, new_reply = restart_server_and_listen("-q test/rackup/hello.ru")
     assert_equal "Hello World", new_reply
   end
@@ -205,7 +207,7 @@ class TestIntegration < Minitest::Test
     assert_equal "Hello World", new_reply
   end
 
-  # It does not share environments between multiple generations, which would break Dotenv
+      # It does not share environments between multiple generations, which would break Dotenv
   def test_restart_restores_environment
     # jruby has a bug where setting `nil` into the ENV or `delete` do not change the
     # next workers ENV

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -194,7 +194,7 @@ class TestIntegration < Minitest::Test
     assert_match(/No pid '\d+' found/, sout.readlines.join(""))
     assert_equal(1, e.status)
   end
-  
+
   def test_restart_closes_keepalive_sockets
     _, new_reply = restart_server_and_listen("-q test/rackup/hello.ru")
     assert_equal "Hello World", new_reply

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -48,6 +48,7 @@ class TestPathHandler < Minitest::Test
 
 
   def test_handler_boots
+    skip_on_appveyor
     in_handler(app) do |launcher|
       hit(["http://0.0.0.0:#{ launcher.connected_port }/test"])
       assert_equal("/test", @input["PATH_INFO"])


### PR DESCRIPTION
@nateberkopec @evanphx @stereobooster 
I've made it work, except for the tests with SSL or restarting functionality. The configuration of the environment in Appveyor does not allow to use that straightforwardly, but with some effort, it can be fixed, in case we deem it necessary.

Below is the precise list of problematic tests, if some one will need to get back to them. I've disabled them for Appveyor so far.
Tests that try unhappy path with SSL get uncaught exceptions:
```
TestPumaServerSSLClient#test_verify_fail_if_client_expired_cert = Error reached top of thread-pool: OpenSSL certificate verification error: certificate has expired - 10 (Puma::MiniSSL::SSLError)
1.87 s = E
TestPumaServerSSLClient#test_verify_client_cert = 0.16 s = E
TestPumaServerSSLClient#test_verify_fail_if_client_unknown_ca = Error reached top of thread-pool: OpenSSL certificate verification error: self signed certificate in certificate chain - 19 (Puma::MiniSSL::SSLError)
0.09 s = E
TestPumaServerSSLClient#test_verify_fail_if_no_client_cert = Error reached top of thread-pool: OpenSSL error: error:140890C7:SSL routines:ssl3_get_client_certificate:peer did not return a certificate - 336105671 (Puma::MiniSSL::SSLError)
```
Other SSL tests, seem to be configuration-related:
```
TestPumaServerSSL#test_form_submit:
Errno::ECONNABORTED: An established connection was aborted by the software in your host machine.
TestPumaServerSSL#test_url_scheme_for_https:
Errno::ECONNABORTED: An established connection was aborted by the software in your host machine.
TestPumaServerSSL#test_very_large_return:
Errno::ECONNABORTED: An established connection was aborted by the software in your host machine.
TestPumaServerSSLClient#test_verify_client_cert:
Errno::ECONNABORTED: An established connection was aborted by the software in your host machine.
TestPathHandler#test_handler_boots:
Errno::EADDRNOTAVAIL: Failed to open TCP connection to 0.0.0.0:1206 (The requested address is not valid in its context. - connect(2) for "0.0.0.0" port 1206)
```
And three tests that recieve interrupt that Appveyor could not handle:
```
  TestIntegration#test_restart_closes_keepalive_sockets
  TestIntegration#test_restart_closes_keepalive_sockets_workers
  TestIntegration#test_restart_restores_environment
```
