### PR TITLE
Updates for frozen string literal compatibility.

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -229,8 +229,8 @@ module Puma
     end
 
     def worker(index, master)
-      title = "puma: cluster worker #{index}: #{master}"
-      title << " [#{@options[:tag]}]" if @options[:tag] && !@options[:tag].empty?
+      title  = "puma: cluster worker #{index}: #{master}"
+      title += " [#{@options[:tag]}]" if @options[:tag] && !@options[:tag].empty?
       $0 = title
 
       Signal.trap "SIGINT", "IGNORE"

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -341,7 +341,7 @@ module Puma
       end
 
       if bytes
-        token = ""
+        token = "".dup
         bytes.each_byte { |b| token << b.to_s(16) }
       else
         token = (0..count).to_a.map { rand(255).to_s(16) }.join

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -298,8 +298,8 @@ module Puma
     end
 
     def title
-      buffer = "puma #{Puma::Const::VERSION} (#{@options[:binds].join(',')})"
-      buffer << " [#{@options[:tag]}]" if @options[:tag] && !@options[:tag].empty?
+      buffer  = "puma #{Puma::Const::VERSION} (#{@options[:binds].join(',')})"
+      buffer += " [#{@options[:tag]}]" if @options[:tag] && !@options[:tag].empty?
       buffer
     end
 

--- a/test/test_http11.rb
+++ b/test/test_http11.rb
@@ -166,8 +166,8 @@ class Http11ParserTest < Minitest::Test
     end
 
     # then large headers are rejected too
-    get = "GET /#{rand_data(10,120)} HTTP/1.1\r\n"
-    get << "X-Test: test\r\n" * (80 * 1024)
+    get  = "GET /#{rand_data(10,120)} HTTP/1.1\r\n"
+    get += "X-Test: test\r\n" * (80 * 1024)
     assert_raises Puma::HttpParserError do
       parser.execute({}, get, 0)
       parser.reset

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -37,7 +37,7 @@ class TestPersistent < Minitest::Test
   end
 
   def lines(count, s=@client)
-    str = ""
+    str = "".dup
     Timeout.timeout(5) do
       count.times { str << s.gets }
     end
@@ -192,7 +192,7 @@ class TestPersistent < Minitest::Test
     @server.persistent_timeout = 3
 
     req = @valid_request.to_s
-    req << "GET /second HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
+    req += "GET /second HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
 
     @client << req
 
@@ -209,7 +209,7 @@ class TestPersistent < Minitest::Test
     @server.persistent_timeout = 3
 
     req = @valid_request.to_s
-    req << "GET /second HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
+    req += "GET /second HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
 
     @client << req
 


### PR DESCRIPTION
These changes allow the tests to run with `RUBYOPT="--enable-frozen-string-literal"` - well, except for the last three tests in `test/test_integration.rb`, which were hanging for me, so I added temporary skip statements in (though this happens without the env variable too - a quirk of my system, I guess).

At the current point in time, Rubocop is not frozen-string-literal friendly, as it depends on parser (which I've got a pending PR submitted for), but parser depends on racc (which has existing PRs from quite some time ago, not yet merged). So, if anyone knows anything about racc, would love your input there, as the maintainer of parser is happy enough with my patch but wants racc patched first. Due to the compiling nature of parser, it can't be used as a git reference in Gemfiles, so this is certainly more of a roadblock than I'd like.

All of that is to say: there's no point setting the `RUBYOPT` flag for MRI 2.4+ in the Travis configuration until these dependencies are sorted, which means there's the possibility of introducing regressions in the meantime.

https://github.com/whitequark/parser/pull/354
https://github.com/tenderlove/racc/pull/80
https://github.com/tenderlove/racc/pull/81