### PR TITLE
Setup signal to trap SIGINT and gracefully stop server

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -399,6 +399,20 @@ module Puma
       end
 
       begin
+        Signal.trap "SIGINT" do
+          if Puma.jruby?
+            @status = :exit
+            graceful_stop
+            exit
+          end
+
+          stop
+        end
+      rescue Exception
+        log "*** SIGINT not implemented, signal based gracefully stopping unavailable!"
+      end
+
+      begin
         Signal.trap "SIGHUP" do
           if @runner.redirected_io?
             @runner.redirect_io
@@ -408,14 +422,6 @@ module Puma
         end
       rescue Exception
         log "*** SIGHUP not implemented, signal based logs reopening unavailable!"
-      end
-
-      if Puma.jruby?
-        Signal.trap("INT") do
-          @status = :exit
-          graceful_stop
-          exit
-        end
       end
     end
   end


### PR DESCRIPTION
This way, when you send `SIGINT` to a server, when running via
`rails s`, a graceful shutdown/stop will be performed.

Before this, not trapping `SIGINT` would mean that either `Rails::Server#start`
or `::Rack::Server#start` would be trapping `SIGINT` and exiting the process.

Fix for: https://github.com/puma/puma/issues/1362

**References**:
- [`::Rack::Server#start`](https://github.com/rack/rack/blob/5c36acac4d298dcf04c58a10014c849a478da53f/lib/rack/server.rb#L289)'s trapping of`SIGINT`.

**Replication of current/fixed behavior**:

```
rails s
=> Booting Puma
=> Rails 5.1.2 application starting in development on http://localhost:3000
=> Run `rails server -h` for more startup options
Puma starting in single mode...
* Version 3.9.1 (ruby 2.3.3-p222), codename: Private Caller
* Min threads: 5, max threads: 5
* Environment: development
* Listening on tcp://0.0.0.0:3000
Use Ctrl-C to stop
^C- Gracefully stopping, waiting for requests to finish
=== puma shutdown: 2017-07-26 19:53:48 -0700 ===
- Goodbye!
Exiting
```