### PR TITLE
do not blow up when RUBYOPT is not defined

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -165,10 +165,10 @@ module Puma
     def run
       previous_env =
         if defined?(Bundler)
-          env = Bundler::ORIGINAL_ENV
+          env = Bundler::ORIGINAL_ENV.dup
           # add -rbundler/setup so we load from Gemfile when restarting
           bundle = "-rbundler/setup"
-          env["RUBYOPT"] = [env["RUBYOPT"], bundle].join(" ") unless env["RUBYOPT"].include?(bundle)
+          env["RUBYOPT"] = [env["RUBYOPT"], bundle].join(" ") unless env["RUBYOPT"].to_s.include?(bundle)
           env
         else
           ENV.to_h


### PR DESCRIPTION
tried to run from master ... kaboom :D

```
NoMethodError: undefined method `include?' for nil:NilClass
  puma-0d7a8bb5f377/lib/puma/launcher.rb:171:in `run'
```