### PR TITLE
Fix failed tests for "rake test:integration"

### DIFF
--- a/test/shell/t1.rb
+++ b/test/shell/t1.rb
@@ -1,4 +1,4 @@
-system "ruby -rubygems -I../../lib ../../bin/puma -p 10102 -C t1_conf.rb ../hello.ru &"
+system "ruby -rubygems -I../../lib ../../bin/puma -p 10102 -C t1_conf.rb ../rackup/hello.ru &"
 sleep 5
 system "curl http://localhost:10102/"
 

--- a/test/shell/t2_conf.rb
+++ b/test/shell/t2_conf.rb
@@ -2,5 +2,5 @@ log_requests
 stdout_redirect "t2-stdout"
 pidfile "t2-pid"
 bind "tcp://0.0.0.0:10103"
-rackup File.expand_path('../hello.ru', File.dirname(__FILE__))
+rackup File.expand_path('../rackup/hello.ru', File.dirname(__FILE__))
 daemonize

--- a/test/shell/t3.rb
+++ b/test/shell/t3.rb
@@ -1,4 +1,4 @@
-system "ruby -rubygems -I../../lib ../../bin/puma -p 10102 -C t3_conf.rb ../hello.ru &"
+system "ruby -rubygems -I../../lib ../../bin/puma -p 10102 -C t3_conf.rb ../rackup/hello.ru &"
 sleep 5
 
 worker_pid_was_present = File.file? "t3-worker-2-pid"


### PR DESCRIPTION
I fixed below failed tests for "rake test:integration".

```
$ bundle exec rake test:integration
cd test/shell; sh run.sh
t1 FAIL
t2 FAIL
t3 FAIL
rake aborted!
Command failed with status (3): [cd test/shell; sh run.sh...]
/home/jaruga/git/puma/Rakefile:160:in `block (2 levels) in <top (required)>'
/home/jaruga/git/puma/vendor/bundle/ruby/2.4.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/usr/local/ruby-2.4.1/bin/bundle:22:in `load'
/usr/local/ruby-2.4.1/bin/bundle:22:in `<main>'
Tasks: TOP => test:integration
(See full trace by running task with --trace)
```

It works after this modification.

```
$ bundle exec rake test:integration
cd test/shell; sh run.sh
t1 OK
t2 OK
t3 OK
```

But why is this "test:integration" test not included in Travis and Appveyor CI test?
