### PR TITLE
Add early hints feature

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -181,6 +181,10 @@ module Puma
             user_config.tcp_mode!
           end
 
+          o.on "--early-hints", "Enable early hints support" do
+            user_config.early_hints
+          end
+
           o.on "-V", "--version", "Print the version information" do
             puts "puma version #{Puma::Const::VERSION}"
             exit 0

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -221,5 +221,7 @@ module Puma
     HIJACK_P = "rack.hijack?".freeze
     HIJACK = "rack.hijack".freeze
     HIJACK_IO = "rack.hijack_io".freeze
+
+    EARLY_HINTS = "rack.early_hints".freeze
   end
 end

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -241,6 +241,10 @@ module Puma
       @options[:mode] = :tcp
     end
 
+    def early_hints(answer=true)
+      @options[:early_hints] = answer
+    end
+
     # Redirect STDOUT and STDERR to files specified.
     def stdout_redirect(stdout=nil, stderr=nil, append=false)
       @options[:redirect_stdout] = stdout

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -161,6 +161,10 @@ module Puma
         server.tcp_mode!
       end
 
+      if @options[:early_hints]
+        server.early_hints = true
+      end
+
       unless development?
         server.leak_stack_on_error = false
       end


### PR DESCRIPTION
Worked with @tenderlove on adding early hints. This is still a work in progress as there are a few things we need to address, but this PR is to start the conversation.

This commit adds the early hints lambda to the headers hash. Users can
call it to emit the early hints headers. For example:

```
class Server
  def call env
    if env["REQUEST_PATH"] == "/"
      env['rack.early_hints'].call([{ link: "/style.css", as: "style" }, { link: "/script.js" }])
      [200, { "X-Hello" => "World" }, ["Hello world!"]]
    else
      [200, { "X-Hello" => "World" }, ["NEAT!"]]
    end
  end
end

run Server.new
```

In this example, the server sends stylesheet and javascript early hints
if the proxy supports it, it will send H2 pushes to the client.

Of course not every proxy server supports early hints, so to enable the
early hints feature with puma you have to pass the configuration variable,
`--early-hints`.