### PR TITLE
mini_ssl.c: Avoid warning: unused variable 'eng'

### DIFF
--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -447,7 +447,7 @@ VALUE raise_error(VALUE self) {
 }
 
 void Init_mini_ssl(VALUE puma) {
-  VALUE mod, eng;
+  VALUE mod;
 
   mod = rb_define_module_under(puma, "MiniSSL");
   rb_define_class_under(mod, "SSLError", rb_eStandardError);


### PR DESCRIPTION
This warning appeared in AppVeyor output:

https://ci.appveyor.com/project/nateberkopec/puma/build/job/wiq5ep0b2r1oqdj9

This PR heeds the warning, and does not declare an unused variable name.