### PR TITLE
Travis: Use latest bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: bundler
 before_install:
   # bundler installation needed for jruby-head
   # https://github.com/travis-ci/travis-ci/issues/5861
-  - gem install bundler -v 1.11.2
+  - gem install bundler
 script: "TESTOPTS=-v bundle exec rake"
 branches:
   only:


### PR DESCRIPTION
This PR updates the `before_install` step to not peg to a specific version of Bundler, but to use latest stable release.