### PR TITLE
[wip] Travis: use newer GCC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,14 @@ matrix:
     - rvm: jruby-head
     - rvm: rbx-3
     - rvm: ruby-head
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-6
+env:
+  global:
+    - CC=gcc-6
+    - GCC=g++-6
+


### PR DESCRIPTION
This PR installs a newer GCC, which is suited to the code being shipped with the extension.

Very small goal: Get rid of warnings output like

> ../../../../ext/puma_http11/mini_ssl.c:153:3: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]

Things that get done:

- [ ] Avoid the warning

Trade-off:

- This adds ~30s to each CI job

