### PR TITLE
Travis: Use default script step; latest versions in matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
   # bundler installation needed for jruby-head
   # https://github.com/travis-ci/travis-ci/issues/5861
   - gem install bundler
-script: "TESTOPTS=-v bundle exec rake"
 branches:
   only:
     - "master"
@@ -28,3 +27,6 @@ matrix:
     - rvm: jruby-head
     - rvm: rbx-3
     - rvm: ruby-head
+env:
+  global:
+    - TESTOPTS="-v"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ branches:
   only:
     - "master"
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
   - ruby-head
   - jruby-9.1.13.0
   - jruby-head


### PR DESCRIPTION
This PR tries once more to make the Travis CI configuration smaller and more defaults-based.

 - The default script step is `bundle exec rake` for `language: ruby`.
 - This PR moves `TESTOPTS=-v` to a matrix-global env instead
 - Use latest versions of Ruby from `rvm` in the matrix 