### PR TITLE
Require puma/events in test helper

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -21,6 +21,7 @@ $LOAD_PATH << File.expand_path("../../lib", __FILE__)
 Thread.abort_on_exception = true
 
 require "puma"
+require "puma/events"
 require "puma/detect"
 
 # Either takes a string to do a get request against, or a tuple of [URI, HTTP] where

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -1,7 +1,6 @@
 require_relative "helper"
 
 require "puma/binder"
-require "puma/events"
 require "puma/puma_http11"
 
 class TestBinder < Minitest::Test

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -1,7 +1,5 @@
 require_relative "helper"
 
-require "puma/events"
-
 class TestEvents < Minitest::Test
   def test_null
     events = Puma::Events.null

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -1,7 +1,5 @@
 require_relative "helper"
 
-require "puma/events"
-
 class SSLEventsHelper < ::Puma::Events
   attr_accessor :addr, :cert, :error
 

--- a/test/test_tcp_logger.rb
+++ b/test/test_tcp_logger.rb
@@ -1,6 +1,5 @@
 require_relative "helper"
 
-require "puma/events"
 require "puma/tcp_logger"
 
 class TestTCPLogger < Minitest::Test

--- a/test/test_tcp_rack.rb
+++ b/test/test_tcp_rack.rb
@@ -1,7 +1,5 @@
 require_relative "helper"
 
-require "puma/events"
-
 class TestTCPRack < Minitest::Test
 
   def setup


### PR DESCRIPTION
Moves the require for puma/events from the individual test files and
into the main test helper.

The reason for this was while I was debugging the `test_puma_server.rb`
tests I was getting an error for an uninitialized constant for
`Puma::Event`.

Moving the require from the individual files to the test help means the
`puma/events` will always be included instead of having to remember to
do that. It makes debugging individual tests locally easier.