### PR TITLE
puma/launcher: Fixed typo

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -40,7 +40,7 @@ module Puma
     #       [200, {}, ["hello world"]]
     #     end
     #   end
-    #   Puma::Launcher.new(conf, argv: Puma::Events.stdio).run
+    #   Puma::Launcher.new(conf, events: Puma::Events.stdio).run
     def initialize(conf, launcher_args={})
       @runner        = nil
       @events        = launcher_args[:events] || Events::DEFAULT


### PR DESCRIPTION
I noted this while trying to apply suggestions from #1363.

The previous example causes exceptions when you try to run it:

```
FATAL [2017-10-05 11:11:17.535] UxFactory::Server: A fatal error occurred. Details below.
FATAL [2017-10-05 11:11:17.535] UxFactory::Server: no implicit conversion of Puma::Events into Array (TypeError)
        /Users/plundberg/.rvm/gems/ruby-2.4.2/gems/puma-3.10.0/lib/puma/launcher.rb:370:in `generate_restart_data'
        /Users/plundberg/.rvm/gems/ruby-2.4.2/gems/puma-3.10.0/lib/puma/launcher.rb:64:in `initialize'
        /Volumes/extra/git/ecraft/ecraft.uxfactory.server-8.x/src/server/lib/server/uxfactory_server.rb:32:in `new'
        /Volumes/extra/git/ecraft/ecraft.uxfactory.server-8.x/src/server/lib/server/uxfactory_server.rb:32:in `start_server'
        /Volumes/extra/git/ecraft/ecraft.uxfactory.server-8.x/src/server/lib/server/uxfactory_server.rb:15:in `start'
        /Volumes/extra/git/ecraft/ecraft.uxfactory.server-8.x/src/uxfactory/server.rb:69:in `block in start!'
```