### PR TITLE
gemspec: correct msys2 metadata typo

### DIFF
--- a/puma.gemspec
+++ b/puma.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = ["evan@phx.io"]
   s.executables = ["puma", "pumactl"]
   s.extensions = ["ext/puma_http11/extconf.rb"]
-  s.metadata["msys5_mingw_dependencies"] = "openssl"
+  s.metadata["msys2_mingw_dependencies"] = "openssl"
   s.files = `git ls-files -- bin docs ext lib tools`.split("\n") +
             %w[History.md LICENSE README.md]
   s.homepage = "http://puma.io"


### PR DESCRIPTION
To help out RubyInstaller2 and provide hints to MSYS2 about required dependencies, `msys2_mingw_dependencies` metadata was added to the gemspec.

This change aims to correct the typo around the new metadata field.

Ref #1434
Ref #1428

Thank you.
:heart: :heart: :heart: 