### PR TITLE
Appropriately wait for worker child process when shutting down via SIGTERM

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -24,7 +24,9 @@ module Puma
       @workers.each { |x| x.term }
 
       begin
-        Process.waitall
+        @workers.each do |w|
+          Process.waitpid(w.pid)
+        end
       rescue Interrupt
         log "! Cancelled waiting for workers"
       end


### PR DESCRIPTION
This way when a SIGTERM is issued to a puma cluster (master process)
the shutting down of workers/child processes successfully completes.

Before this, it meant the master process will wait for every child process, not just
puma specific child process. Which meant even though the workers were to
successfully terminate, the server never exits as intended.

Issue: https://github.com/puma/puma/issues/1386