### PR TITLE
worker_timeout, worker_boot_timeout, worker_shutdown_timeout fix integer convert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: bundler
 before_install:
   # bundler installation needed for jruby-head
   # https://github.com/travis-ci/travis-ci/issues/5861
-  - gem install bundler
+  - gem update --system
 branches:
   only:
     - "master"

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -424,17 +424,17 @@ module Puma
     # that have not checked in within the given +timeout+.
     # This mitigates hung processes. Default value is 60 seconds.
     def worker_timeout(timeout)
-      @options[:worker_timeout] = timeout
+      @options[:worker_timeout] = Integer(timeout)
     end
 
     # *Cluster mode only* Set the timeout for workers to boot
     def worker_boot_timeout(timeout)
-      @options[:worker_boot_timeout] = timeout
+      @options[:worker_boot_timeout] = Integer(timeout)
     end
 
     # *Cluster mode only* Set the timeout for worker shutdown
     def worker_shutdown_timeout(timeout)
-      @options[:worker_shutdown_timeout] = timeout
+      @options[:worker_shutdown_timeout] = Integer(timeout)
     end
 
     # When set to true (the default), workers accept all requests

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -146,13 +146,13 @@ module Puma
     # them
     #
     def persistent_timeout(seconds)
-      @options[:persistent_timeout] = seconds
+      @options[:persistent_timeout] = Integer(seconds)
     end
 
     # Define how long the tcp socket stays open, if no data has been received
     #
     def first_data_timeout(seconds)
-      @options[:first_data_timeout] = seconds
+      @options[:first_data_timeout] = Integer(seconds)
     end
 
     # Work around leaky apps that leave garbage in Thread locals

--- a/test/config/with_integer_convert.rb
+++ b/test/config/with_integer_convert.rb
@@ -1,0 +1,9 @@
+persistent_timeout "6"
+first_data_timeout "3"
+
+workers "2"
+threads "4", "8"
+
+worker_timeout "90"
+worker_boot_timeout "120"
+worker_shutdown_timeout "150"

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -43,7 +43,7 @@ class TestConfigFile < Minitest::Test
     end
   end
 
-  def test_lowleve_error_handler_DSL
+  def test_lowlevel_error_handler_DSL
     conf = Puma::Configuration.new do |c|
       c.load "test/config/app.rb"
     end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -135,6 +135,21 @@ class TestConfigFile < Minitest::Test
     assert_equal ['config/puma/fake-env.rb'], conf.config_files
   end
 
+  def test_config_files_with_integer_convert
+    conf = Puma::Configuration.new(config_files: ['test/config/with_integer_convert.rb']) do
+    end
+    conf.load
+
+    assert_equal 6, conf.options[:persistent_timeout]
+    assert_equal 3, conf.options[:first_data_timeout]
+    assert_equal 2, conf.options[:workers]
+    assert_equal 4, conf.options[:min_threads]
+    assert_equal 8, conf.options[:max_threads]
+    assert_equal 90, conf.options[:worker_timeout]
+    assert_equal 120, conf.options[:worker_boot_timeout]
+    assert_equal 150, conf.options[:worker_shutdown_timeout]
+  end
+
   def teardown
     FileUtils.rm_r("config/puma")
   end


### PR DESCRIPTION
When passing a character string of seconds to worker_timeout etc.,
In order to prevent the occurrence of the following error, we convert it to an integer like other options.

```
/Users/mitto/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.10.0/lib/puma/cluster.rb:89:in `>': comparison of Float with String failed (ArgumentError)
        from /Users/mitto/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.10.0/lib/puma/cluster.rb:89:in `ping_timeout?'
        from /Users/mitto/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.10.0/lib/puma/cluster.rb:179:in `block in check_workers'
        from /Users/mitto/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.10.0/lib/puma/cluster.rb:177:in `each'
        from /Users/mitto/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.10.0/lib/puma/cluster.rb:177:in `check_workers'
        from /Users/mitto/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.10.0/lib/puma/cluster.rb:471:in `run'
        from /Users/mitto/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.10.0/lib/puma/launcher.rb:183:in `run'
        from /Users/mitto/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.10.0/lib/puma/cli.rb:77:in `run'
        from /Users/mitto/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/puma-3.10.0/bin/puma-wild:31:in `<main>'
```