### PR TITLE
Puma::Launcher: avoid a leading space character in RUBYOPT

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -168,7 +168,7 @@ module Puma
           env = Bundler::ORIGINAL_ENV.dup
           # add -rbundler/setup so we load from Gemfile when restarting
           bundle = "-rbundler/setup"
-          env["RUBYOPT"] = [env["RUBYOPT"], bundle].join(" ") unless env["RUBYOPT"].to_s.include?(bundle)
+          env["RUBYOPT"] = [env["RUBYOPT"], bundle].join(" ").lstrip unless env["RUBYOPT"].to_s.include?(bundle)
           env
         else
           ENV.to_h


### PR DESCRIPTION
The problem is this:

```
2.4.2 :001 > [nil, 'foo'].join(' ')
 => " foo"
```

Note the leading space character. By `lstrip`:ing the result of the join, we avoid this altogether.

(This is a fix for the underlying problem that triggered https://github.com/jruby/jruby/issues/4849.)