### PR TITLE
CI against JRuby 9.1.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ rvm:
   - 2.3.5
   - 2.4.2
   - ruby-head
-  - jruby-9.1.13.0
+  - jruby-9.1.14.0
   - jruby-head
   - rbx-3
 matrix:


### PR DESCRIPTION
JRuby 9.1.14.0 has been released
http://jruby.org/2017/11/08/jruby-9-1-14-0