### PR TITLE
Use Rubocop 0.50

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,10 @@ Layout/SpaceAfterColon:
 Layout/SpaceAroundKeyword:
   Enabled: true
 
+Layout/SpaceBeforeBlockBraces:
+  EnforcedStyleForEmptyBraces: no_space
+  Enabled: true
+
 Layout/SpaceBeforeFirstArg:
   Enabled: true
 
@@ -33,19 +37,19 @@ Layout/TrailingWhitespace:
 Lint/Debugger:
   Enabled: true
 
-Style/MethodDefParentheses:
-  Enabled: true
-
-Style/MethodName:
+Naming/MethodName:
   Enabled: true
   EnforcedStyle: snake_case
   Exclude:
     - 'test/**/**'
 
-Style/TrailingCommaInArguments:
+Naming/VariableName:
   Enabled: true
 
-Style/VariableName:
+Style/MethodDefParentheses:
+  Enabled: true
+
+Style/TrailingCommaInArguments:
   Enabled: true
 
 Performance/Count:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,10 +14,6 @@ Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
 
 # 15 offenses
-Layout/SpaceBeforeBlockBraces:
-  Enabled: true
-
-# 15 offenses
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: true
   EnforcedStyle: no_space

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "minitest-retry"
 
 gem "jruby-openssl", :platform => "jruby"
 
-gem "rubocop", "~> 0.49.1"
+gem "rubocop", "~> 0.50.0"
 
 if %w(2.2.7 2.2.8 2.3.4 2.4.1).include? RUBY_VERSION
   gem "stopgap_13632", "~> 1.0", :platforms => ["mri", "mingw", "x64_mingw"]

--- a/examples/puma/client-certs/generate.rb
+++ b/examples/puma/client-certs/generate.rb
@@ -43,7 +43,7 @@ when "g"
     ef = OpenSSL::X509::ExtensionFactory.new
     ef.subject_certificate = cert
     ef.issuer_certificate = issuer
-    extensions.each{|oid, value, critical|
+    extensions.each {|oid, value, critical|
       cert.add_extension(ef.create_extension(oid, value, critical))
     }
     cert.sign(issuer_key, digest)
@@ -69,10 +69,10 @@ when "g"
   @svr_cert = issue_cert(@svr, @svr_key, 2, now, now+1800_000, ee_exts, @ca_cert, @ca_key, OpenSSL::Digest::SHA1.new)
   @cli_cert = issue_cert(@cli, @cli_key, 3, now, now+1800_000, ee_exts, @ca_cert, @ca_key, OpenSSL::Digest::SHA1.new)
 
-  File.open("ca.crt","wb"){|f| f.print @ca_cert.to_pem }
-  File.open("ca.key","wb"){|f| f.print @ca_key.to_pem }
-  File.open("server.crt","wb"){|f| f.print @svr_cert.to_pem }
-  File.open("server.key","wb"){|f| f.print @svr_key.to_pem }
-  File.open("client1.crt","wb"){|f| f.print @cli_cert.to_pem }
-  File.open("client1.key","wb"){|f| f.print @cli_key.to_pem }
+  File.open("ca.crt","wb") {|f| f.print @ca_cert.to_pem }
+  File.open("ca.key","wb") {|f| f.print @ca_key.to_pem }
+  File.open("server.crt","wb") {|f| f.print @svr_cert.to_pem }
+  File.open("server.key","wb") {|f| f.print @svr_key.to_pem }
+  File.open("client1.crt","wb") {|f| f.print @cli_cert.to_pem }
+  File.open("client1.key","wb") {|f| f.print @cli_key.to_pem }
 end

--- a/gemfiles/2.1-Gemfile
+++ b/gemfiles/2.1-Gemfile
@@ -11,4 +11,4 @@ gem "minitest-retry"
 
 gem "jruby-openssl", :platform => "jruby"
 
-gem "rubocop", "~> 0.49.1"
+gem "rubocop", "~> 0.50.0"

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -340,7 +340,7 @@ module Puma
     def stats
       old_worker_count = @workers.count { |w| w.phase != @phase }
       booted_worker_count = @workers.count { |w| w.booted? }
-      worker_status = '[' + @workers.map{ |w| %Q!{ "pid": #{w.pid}, "index": #{w.index}, "phase": #{w.phase}, "booted": #{w.booted?}, "last_checkin": "#{w.last_checkin.utc.iso8601}", "last_status": #{w.last_status} }!}.join(",") + ']'
+      worker_status = '[' + @workers.map { |w| %Q!{ "pid": #{w.pid}, "index": #{w.index}, "phase": #{w.phase}, "booted": #{w.booted?}, "last_checkin": "#{w.last_checkin.utc.iso8601}", "last_status": #{w.last_status} }!}.join(",") + ']'
       %Q!{ "workers": #{@workers.size}, "phase": #{@phase}, "booted_workers": #{booted_worker_count}, "old_workers": #{old_worker_count}, "worker_status": #{worker_status} }!
     end
 

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -180,7 +180,7 @@ module Puma
         :worker_shutdown_timeout => DefaultWorkerShutdownTimeout,
         :remote_address => :socket,
         :tag => method(:infer_tag),
-        :environment => ->{ ENV['RACK_ENV'] || "development" },
+        :environment => -> { ENV['RACK_ENV'] || "development" },
         :rackup => DefaultRackup,
         :logger => STDOUT,
         :persistent_timeout => Const::PERSISTENT_TIMEOUT,

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -53,7 +53,7 @@ module Puma
     attr_accessor :clean_thread_locals
 
     def self.clean_thread_locals
-      Thread.current.keys.each do |key|
+      Thread.current.keys.each do |key| # rubocop: disable Performance/HashEachMethods
         Thread.current[key] = nil unless key == :__recursive_key__
       end
     end

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -21,7 +21,7 @@ module Rack
         # contains an array of all explicitly defined user options. We then
         # know that all other values are defaults
         if user_supplied_options = options.delete(:user_supplied_options)
-          (options.keys - user_supplied_options).each do |k, v|
+          (options.keys - user_supplied_options).each do |k|
             default_options[k] = options.delete(k)
           end
         end

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -145,7 +145,7 @@ class TestUserSuppliedOptionsIsNotPresent < Minitest::Test
         FileUtils.mkdir("config")
         File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
-        conf = Rack::Handler::Puma.config(-> {}, @options)
+        conf = Rack::Handler::Puma.config(->{}, @options)
         conf.load
 
         assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]


### PR DESCRIPTION
That's the small follow-up for #1325.

Initially I decided not to correct `SpaceBeforeBlockBraces` cop offences but update the cop itself to comply with Puma style (more precisely this syntax `->{}` for no-op lambdas).

The patch has been released in 0.50.0.

There is also new cop `Performance/HashEachMethods`, which detected one typo (?) and one false negative)

By the way, that's the last version of Rubocop which supports 1.9.3.

@nateberkopec Maybe it make sense to reduce the number of TODO items within along with Rubocop upgrade? (I.e. within this PR)