### PR TITLE
Dev/ssl cipher support

### DIFF
--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -161,6 +161,11 @@ VALUE engine_init_server(VALUE self, VALUE mini_ssl_ctx) {
   ID sym_verify_mode = rb_intern("verify_mode");
   VALUE verify_mode = rb_funcall(mini_ssl_ctx, sym_verify_mode, 0);
 
+  ID sym_ssl_cipher_filter = rb_intern("ssl_cipher_filter");
+  VALUE ssl_cipher_filter = rb_funcall(mini_ssl_ctx, sym_ssl_cipher_filter, 0);
+  StringValue(ssl_cipher_filter);
+
+
   ctx = SSL_CTX_new(SSLv23_server_method());
   conn->ctx = ctx;
 
@@ -175,7 +180,12 @@ VALUE engine_init_server(VALUE self, VALUE mini_ssl_ctx) {
   SSL_CTX_set_options(ctx, SSL_OP_CIPHER_SERVER_PREFERENCE | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_SINGLE_DH_USE | SSL_OP_SINGLE_ECDH_USE | SSL_OP_NO_COMPRESSION);
   SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF);
 
-  SSL_CTX_set_cipher_list(ctx, "HIGH:!aNULL@STRENGTH");
+  if (!NIL_P(ssl_cipher_filter)) {
+    SSL_CTX_set_cipher_list(ctx, RSTRING_PTR(ssl_cipher_filter));
+  }
+  else {
+    SSL_CTX_set_cipher_list(ctx, "HIGH:!aNULL@STRENGTH");
+  }
 
   DH *dh = get_dh1024();
   SSL_CTX_set_tmp_dh(ctx, dh);

--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -170,6 +170,12 @@ public class MiniSSL extends RubyObject {
         engine.setNeedClientAuth(true);
     }
 
+    IRubyObject sslCipherListObject = miniSSLContext.callMethod(threadContext, "ssl_cipher_list");
+    if (!sslCipherListObject.isNil()) {
+      String[] sslCipherList = sslCipherListObject.convertToString.asJavaString().split(",");
+      engine.setEnabledCipherSuites(sslCipherList);
+    }
+
     SSLSession session = engine.getSession();
     inboundNetData = new MiniSSLBuffer(session.getPacketBufferSize());
     outboundAppData = new MiniSSLBuffer(session.getApplicationBufferSize());

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -120,7 +120,7 @@ module Puma
 
             umask = nil
             mode = nil
-            backlog = nil
+            backlog = 1024
 
             if uri.query
               params = Util.parse_query uri.query
@@ -344,7 +344,7 @@ module Puma
 
     # Tell the server to listen on +path+ as a UNIX domain socket.
     #
-    def add_unix_listener(path, umask=nil, mode=nil, backlog=nil)
+    def add_unix_listener(path, umask=nil, mode=nil, backlog=1024)
       @unix_paths << path
 
       # Let anyone connect by default
@@ -365,7 +365,7 @@ module Puma
         end
 
         s = UNIXServer.new(path)
-        s.listen backlog if backlog
+        s.listen backlog
         @ios << s
       ensure
         File.umask old_mask

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -162,6 +162,7 @@ module Puma
             end
 
             ctx.keystore_pass = params['keystore-pass']
+            ctx.ssl_cipher_list = params['ssl_cipher_list'] if params['ssl_cipher_list']
           else
             unless params['key']
               @events.error "Please specify the SSL key via 'key='"
@@ -182,6 +183,7 @@ module Puma
             end
 
             ctx.ca = params['ca'] if params['ca']
+            ctx.ssl_cipher_filter = params['ssl_cipher_filter'] if params['ssl_cipher_filter']
           end
 
           if params['verify_mode']

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -110,9 +110,22 @@ module Puma
       @options[:config_files] << file
     end
 
-    # Bind the server to +url+. tcp:// and unix:// are the only accepted
-    # protocols.
+    # Adds a binding for the server to +url+. tcp://, unix://, and ssl:// are the only accepted
+    # protocols. Use query parameters within the url to specify options.
     #
+    # @note multiple urls can be bound to, calling `bind` does not overwrite previous bindings.
+    #
+    # @example Explicitly the socket backlog depth (default is 1024)
+    #   bind('unix:///var/run/puma.sock?backlog=2048')
+    #
+    # @example Set up ssl cert
+    #   bind('ssl://127.0.0.1:9292?key=key.key&cert=cert.pem')
+    #
+    # @example Prefer low-latency over higher throughput (via `Socket::TCP_NODELAY`)
+    #   bind('tcp://0.0.0.0:9292?low_latency=true')
+    #
+    # @example Set socket permissions
+    #   bind('unix:///var/run/puma.sock?umask=0111')
     def bind(url)
       @options[:binds] ||= []
       @options[:binds] << url

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -172,6 +172,7 @@ module Puma
         # jruby-specific Context properties: java uses a keystore and password pair rather than a cert/key pair
         attr_reader :keystore
         attr_accessor :keystore_pass
+        attr_accessor :ssl_cipher_list
 
         def keystore=(keystore)
           raise ArgumentError, "No such keystore file '#{keystore}'" unless File.exist? keystore
@@ -187,6 +188,7 @@ module Puma
         attr_reader :key
         attr_reader :cert
         attr_reader :ca
+        attr_accessor :ssl_cipher_filter
 
         def key=(key)
           raise ArgumentError, "No such key file '#{key}'" unless File.exist? key

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -23,8 +23,9 @@ class TestBinder < Minitest::Test
 
     key =  File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
     cert = File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
+    ssl_cipher_filter = "!aNULL:@STRENGTH"
 
-    @binder.parse(["ssl://localhost:10002?key=#{key}&cert=#{cert}"], @events)
+    @binder.parse(["ssl://localhost:10002?key=#{key}&cert=#{cert}&ssl_cipher_filter=#{ssl_cipher_filter}"], @events)
 
     assert_equal [], @binder.listeners
   end


### PR DESCRIPTION
https://github.com/puma/puma/issues/996

Support specifying which ssl cipher suites the server should support. Default behavior is unchanged.