### PR TITLE
Parse command-line options for pumactl

### DIFF
--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -205,7 +205,6 @@ module Puma
           Process.kill "SIGUSR1", @pid
 
         else
-          message "Puma is started"
           return
         end
 

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -69,6 +69,7 @@ module Puma
       end
 
       opts.order!(argv) { |a| opts.terminate a }
+      opts.parse!
 
       @command = argv.shift
 


### PR DESCRIPTION
- Before, we would remove any non-yielding
args, but missed to actually parse them.
Resulting in issues like, `--pidfile` or
similar args not taking any effect.


**Before**

```
pumactl start -P ~/puma.pid

...

cat ~/puma.pid
=> No such file or directory
```


**Now**

```
pumactl start -P ~/puma.pid

...

cat ~/puma.pid
=> 131232
```

-----

- Remove misleading message of puma starting on pumactl exit: This way, when puma shuts down (running from pumactl), it does not end
with "Puma is started" message. Because, the copy is dependent
on the value of `@command`, the same will always point
to `start`, if pumactl was issued a `start`, hence during
exit, this message appeared as misleading.

**Before**

```
Puma starting in single mode...
* Version 3.10.0 (ruby 2.3.3-p222), codename: Russell's Teapot
* Min threads: 5, max threads: 5
* Environment: development
* Listening on tcp://0.0.0.0:3000
Use Ctrl-C to stop
^C- Gracefully stopping, waiting for requests to finish
=== puma shutdown: 2017-12-06 23:26:45 -0800 ===
- Goodbye!
Puma is started <===== Removing this message =====>
```

**Now**

```
Puma starting in single mode...
* Version 3.10.0 (ruby 2.3.3-p222), codename: Russell's Teapot
* Min threads: 5, max threads: 5
* Environment: development
* Listening on tcp://0.0.0.0:3000
Use Ctrl-C to stop
^C- Gracefully stopping, waiting for requests to finish
=== puma shutdown: 2017-12-06 23:26:45 -0800 ===
- Goodbye!
```