### PR TITLE
Travis: jruby-9.1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ rvm:
   - 2.3.5
   - 2.4.2
   - ruby-head
-  - jruby-9.1.14.0
+  - jruby-9.1.15.0
   - jruby-head
   - rbx-3
 matrix:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/12/07/jruby-9-1-15-0.html