### PR TITLE
Add support for --control-url in cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ $ puma -b 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert'
 Puma has a built-in status/control app that can be used to query and control Puma itself.
 
 ```
-$ puma --control tcp://127.0.0.1:9293 --control-token foo
+$ puma --control-url tcp://127.0.0.1:9293 --control-token foo
 ```
 
 Puma will start the control server on localhost port 9293. All requests to the control server will need to include `token=foo` as a query parameter. This allows for simple authentication. Check out [status.rb](https://github.com/puma/puma/blob/master/lib/puma/app/status.rb) to see what the app has available.
@@ -175,7 +175,7 @@ Puma will start the control server on localhost port 9293. All requests to the c
 You can also interact with the control server via `pumactl`. This command will restart Puma:
 
 ```
-$ pumactl -C 'tcp://127.0.0.1:9293' --control-token foo restart
+$ pumactl --control-url 'tcp://127.0.0.1:9293' --control-token foo restart
 ```
 
 To see a list of `pumactl` options, use `pumactl --help`.

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -84,6 +84,14 @@ module Puma
       raise UnsupportedOption
     end
 
+    def configure_control_url(command_line_arg)
+      if command_line_arg
+        @control_url = command_line_arg
+      elsif Puma.jruby?
+        unsupported "No default url available on JRuby"
+      end
+    end
+
     # Build the OptionParser object to handle the available options.
     #
 
@@ -98,13 +106,13 @@ module Puma
             file_config.load arg
           end
 
-          o.on "--control URL", "The bind url to use for the control server",
-            "Use 'auto' to use temp unix server" do |arg|
-            if arg
-              @control_url = arg
-            elsif Puma.jruby?
-              unsupported "No default url available on JRuby"
-            end
+          o.on "--control-url URL", "The bind url to use for the control server. Use 'auto' to use temp unix server" do |arg|
+            configure_control_url(arg)
+          end
+
+          # alias --control-url for backwards-compatibility
+          o.on "--control URL", "DEPRECATED alias for --control-url" do |arg|
+            configure_control_url(arg)
           end
 
           o.on "--control-token TOKEN",

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -220,7 +220,7 @@ module Puma
     end
 
     def run
-      start if @command == "start"
+      return start if @command == "start"
 
       prepare_configuration
 

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -3,8 +3,66 @@ require_relative "helper"
 require 'puma/control_cli'
 
 class TestPumaControlCli < Minitest::Test
+  def setup
+    # use a pipe to get info across thread boundary
+    @wait, @ready = IO.pipe
+  end
+
+  def wait_booted
+    line = @wait.gets until line =~ /Listening on/
+  end
+
+  def teardown
+    @wait.close
+    @ready.close
+  end
+
+  def find_open_port
+    begin
+      server = TCPServer.new("127.0.0.1", 0)
+      server.addr[1]
+    ensure
+      server.close
+    end
+  end
+
   def test_config_file
     control_cli = Puma::ControlCLI.new ["--config-file", "test/config/state_file_testing_config.rb", "halt"]
     assert_equal "t3-pid", control_cli.instance_variable_get("@pidfile")
+  end
+
+  def test_control_url
+    skip if Puma.jruby? || Puma.windows?
+
+    host = "127.0.0.1"
+    port = find_open_port
+    url = "tcp://#{host}:#{port}/"
+
+    opts = [
+      "--control-url", url,
+      "--control-token", "ctrl",
+      "--config-file", "test/config/app.rb",
+    ]
+
+    control_cli = Puma::ControlCLI.new (opts + ["start"]), @ready, @ready
+    t = Thread.new do
+      Thread.current.abort_on_exception = true
+      control_cli.run
+    end
+
+    wait_booted
+
+    s = TCPSocket.new host, 9292
+    s << "GET / HTTP/1.0\r\n\r\n"
+    body = s.read
+    assert_match "200 OK", body
+    assert_match "embedded app", body
+
+    shutdown_cmd = Puma::ControlCLI.new(opts + ["halt"])
+    shutdown_cmd.run
+
+    # TODO: assert something about the stop command
+
+    t.join
   end
 end


### PR DESCRIPTION
# Add support for --control-url

- deprecate `--control`
- add new option `--control-url`
- https://github.com/puma/puma/pull/1416 introduced a bug in pumactl the puma cli does not respond to `control-cli` option. On puma it is called `control`
- this commit https://github.com/puma/puma/commit/a8f54f74cde910b2bf93260a113b057ba6ec40b5 was correct, but it looked like a typo since the names of the options are not consistent across versions
- the best option for fixing this seems to be to support both options in the cli
- we don't want to stop supporting `control` in the cli for backwards-compatibility
