### PR TITLE
Skip SSL tests instead silently passing them.

### DIFF
--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -21,7 +21,7 @@ DISABLE_SSL = begin
 class TestPumaServerSSL < Minitest::Test
 
   def setup
-    return if DISABLE_SSL
+    skip("SSL isn't used.") if DISABLE_SSL
     @port = 3212
     @host = "127.0.0.1"
 
@@ -55,8 +55,6 @@ class TestPumaServerSSL < Minitest::Test
   end
 
   def test_url_scheme_for_https
-    return if DISABLE_SSL
-
     body = nil
     @http.start do
       req = Net::HTTP::Get.new "/", {}
@@ -70,8 +68,6 @@ class TestPumaServerSSL < Minitest::Test
   end
 
   def test_very_large_return
-    return if DISABLE_SSL
-
     giant = "x" * 2056610
 
     @server.app = proc do
@@ -90,8 +86,6 @@ class TestPumaServerSSL < Minitest::Test
   end
 
   def test_form_submit
-    return if DISABLE_SSL
-
     body = nil
     @http.start do
       req = Net::HTTP::Post.new '/'
@@ -107,7 +101,6 @@ class TestPumaServerSSL < Minitest::Test
   end
 
   def test_ssl_v3_rejection
-    return if DISABLE_SSL
     @http.ssl_version='SSLv3'
     assert_raises(OpenSSL::SSL::SSLError) do
       @http.start do


### PR DESCRIPTION
If SSL is not used, the tests might be silently passing, while they are
not executed at all.

Let me explain.

The think is that you might not be testing some functionality of Puma and you might not even notice it, because the behavior of test suite apparently depends on load order.

E.g. the test suite is failing for me when I try to execute the test suite like this:

~~~
$ ruby -e 'Dir.glob "./test/**/test_*.rb", &method(:require)' -- -v

... snip ...

  1) Failure:
TestPumaServerSSL#test_ssl_v3_rejection [/builddir/build/BUILD/puma-3.11.0/usr/share/gems/gems/puma-3.11.0/test/test_puma_server_ssl.rb:119]:
Expected /wrong\ version\ number/ to match # encoding: ASCII-8BIT
"OpenSSL error: error:1417D102:SSL routines:tls_process_client_hello:unsupported protocol - 337105154".

177 runs, 372 assertions, 1 failures, 0 errors, 0 skips
~~~

But if you use the right load order, the test suite pass, although it ignores some tests:

~~~
$ ruby -r./test/test_puma_server_ssl -e 'Dir.glob "./test/**/test_*.rb", &method(:require)' -- -v

... snip ...

177 runs, 351 assertions, 0 failures, 0 errors, 0 skips
~~~

But with the patch applied, you can see that some tests were actually skipped:

~~~
$ ruby -r./test/test_puma_server_ssl -e 'Dir.glob "./test/**/test_*.rb", &method(:require)' -- -v

... snip ...

177 runs, 351 assertions, 0 failures, 0 errors, 4 skips
~~~