### PR TITLE
Fix 3 corner cases when request body is chunked

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -147,6 +147,7 @@ module Puma
         if @partial_part_left <= chunk.size
           @body << chunk[0..(@partial_part_left-3)] # skip the \r\n
           chunk = chunk[@partial_part_left..-1]
+          @partial_part_left = 0
         else
           @body << chunk
           @partial_part_left -= chunk.size

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -171,6 +171,7 @@ module Puma
           if len == 0
             @body.rewind
             rest = io.read
+            rest = rest[2..-1] if rest.start_with?("\r\n")
             @buffer = rest.empty? ? nil : rest
             @requests_served += 1
             @ready = true

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -211,7 +211,7 @@ module Puma
       while true
         begin
           chunk = @io.read_nonblock(4096)
-        rescue Errno::EAGAIN
+        rescue IO::WaitReadable
           return false
         rescue SystemCallError, IOError
           raise ConnectionError, "Connection error detected during read"

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -145,7 +145,9 @@ module Puma
     def decode_chunk(chunk)
       if @partial_part_left > 0
         if @partial_part_left <= chunk.size
-          @body << chunk[0..(@partial_part_left-3)] # skip the \r\n
+          if @partial_part_left > 2
+            @body << chunk[0..(@partial_part_left-3)] # skip the \r\n
+          end
           chunk = chunk[@partial_part_left..-1]
           @partial_part_left = 0
         else

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -658,6 +658,38 @@ EOF
     assert_equal "hello", body
   end
 
+  def test_chunked_request_pause_between_cr_lf_after_size_of_second_chunk
+    body = nil
+    @server.app = proc { |env|
+      body = env['rack.input'].read
+      [200, {}, [""]]
+    }
+
+    @server.add_tcp_listener @host, @port
+    @server.run
+
+    part1 = 'a' * 4200
+
+    chunked_body = "#{part1.size.to_s(16)}\r\n#{part1}\r\n1\r\nb\r\n0\r\n\r\n"
+
+    sock = TCPSocket.new @host, @server.connected_port
+    sock << "PUT /path HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n"
+
+    sleep 0.1
+
+    sock << chunked_body[0..-10]
+
+    sleep 0.1
+
+    sock << chunked_body[-9..-1]
+
+    data = sock.read
+
+    assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
+    assert_equal (part1 + 'b'), body
+  end
+
+
   def test_chunked_request_header_case
     body = nil
     @server.app = proc { |env|

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -754,6 +754,55 @@ EOF
     assert_equal "hello", body
   end
 
+  def test_chunked_keep_alive
+    body = nil
+    @server.app = proc { |env|
+      body = env['rack.input'].read
+      [200, {}, [""]]
+    }
+
+    @server.add_tcp_listener @host, @port
+    @server.run
+
+    sock = TCPSocket.new @host, @server.connected_port
+    sock << "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
+
+    h = header(sock)
+
+    assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], h
+    assert_equal "hello", body
+
+    sock.close
+  end
+
+  def test_chunked_keep_alive_two_back_to_back
+    body = nil
+    @server.app = proc { |env|
+      body = env['rack.input'].read
+      [200, {}, [""]]
+    }
+
+    @server.add_tcp_listener @host, @port
+    @server.run
+
+    sock = TCPSocket.new @host, @server.connected_port
+    sock << "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
+
+    h = header(sock)
+    assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], h
+    assert_equal "hello", body
+
+    sock << "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ngood\r\n3\r\nbye\r\n0\r\n\r\n"
+    sleep 0.1
+
+    h = header(sock)
+
+    assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], h
+    assert_equal "goodbye", body
+
+    sock.close
+  end
+
   def test_empty_header_values
     @server.app = proc { |env| [200, {"X-Empty-Header" => ""}, []] }
 


### PR DESCRIPTION
I have found and fixed 3 cases when puma does not read a chunked body correctly.

In the first case it hangs.

In the second and third cases it adds extra bytes to the body.

Please see the individual commit messages for more information.

