### PR TITLE
Raise EOFError if the socket has been closed

### DIFF
--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -59,7 +59,7 @@ module Puma
                 IO.select(nil, [@socket.to_io])
               end
             elsif !data
-              return nil
+              raise EOFError
             else
               break
             end


### PR DESCRIPTION
ref #1502
ref #1507

Fixes errors:
```
Error reached top of thread-pool: EOFError (EOFError)

backtrace:
/Users/july/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/puma-3.11.2/lib/puma/client.rb:296:in `try_to_finish'
/Users/july/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/puma-3.11.2/lib/puma/client.rb:370:in `eagerly_finish'
/Users/july/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/puma-3.11.2/lib/puma/server.rb:280:in `block in run'
/Users/july/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/puma-3.11.2/lib/puma/thread_pool.rb:120:in `block in spawn_thread'
```
and
```
2018-03-05 11:02:07 +0300: Read error: #<EOFError: EOFError>

backtrace:
/Users/july/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/puma-3.11.2/lib/puma/client.rb:297:in `try_to_finish'
/Users/july/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/puma-3.11.2/lib/puma/client.rb:106:in `reset'
/Users/july/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/puma-3.11.2/lib/puma/server.rb:450:in `process_client'
/Users/july/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/puma-3.11.2/lib/puma/server.rb:302:in `block in run'
/Users/july/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/puma-3.11.2/lib/puma/thread_pool.rb:120:in `block in spawn_thread'
```
According to Socket's read_nonblock call nil can be returned only in case of an empty chunk - https://github.com/ruby/ruby/blob/96db72ce38b27799dd8e80ca00696e41234db6ba/io.c#L2905
We currently process it by returning nil from read_nonblock and then checking the chunk and raising `EOFError` (https://github.com/puma/puma/blob/master/lib/puma/client.rb#L292). The problem is that this exception is handled incorrectly but it can be fixed if we treat it as `ConnectionError` while calling read_nonblock.
Since `EOFError` is a subclass of `IOError` the exception will be handled within this block https://github.com/puma/puma/blob/master/lib/puma/client.rb#L283
