### PR TITLE
allow app to also handle sighup and call super

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -414,16 +414,14 @@ module Puma
         log "*** SIGINT not implemented, signal based gracefully stopping unavailable!"
       end
 
-      begin
-        Signal.trap "SIGHUP" do
-          if @runner.redirected_io?
+      if @runner.redirected_io?
+        begin
+          Signal.trap "SIGHUP" do
             @runner.redirect_io
-          else
-            stop
           end
+        rescue Exception
+          log "*** SIGHUP not implemented, signal based logs reopening unavailable!"
         end
-      rescue Exception
-        log "*** SIGHUP not implemented, signal based logs reopening unavailable!"
       end
     end
   end


### PR DESCRIPTION
our app wants to reopen rails logs on sighup
to do that it needs to trap sighup too
but calling pumas trap after does not work since it crashes the server if redirect_io was not used

with this change there is 1 less trap used and our app can only call pumas trap if it was set

see https://github.com/zendesk/samson/pull/2637

/cc @ragurney @jonmoter