### PR TITLE
Freebsd rc.d jungle for puma

### DIFF
--- a/tools/jungle/README.md
+++ b/tools/jungle/README.md
@@ -11,3 +11,7 @@ See `/tools/jungle/upstart` for Ubuntu's upstart scripts.
 ## Systemd
 
 See [/docs/systemd](https://github.com/puma/puma/blob/master/docs/systemd.md).
+
+## rc.d
+
+See `/tools/jungle/rc.d` for FreeBSD's rc.d scripts

--- a/tools/jungle/rc.d/README.md
+++ b/tools/jungle/rc.d/README.md
@@ -25,15 +25,17 @@ Start the jungle running:
 
 `service puma start`
 
+This script will run at boot time.
+
+
 You can also stop the jungle (stops ALL puma instances) by running:
 
 `service puma stop`
 
+
 To restart the jungle:
 
 `service puma restart`
-
-This script will run at boot time.
 
 ## Conventions
 

--- a/tools/jungle/rc.d/README.md
+++ b/tools/jungle/rc.d/README.md
@@ -2,6 +2,10 @@
 
 Manage one (currently) Puma server as a service on one box using FreeBSD's rc.d service.
 
+## Dependencies
+
+* `jq` - a command-line json parser is needed to parse the json in the config file
+
 ## Installation
 
     # Copy the puma script to the rc.d directory (make sure everyone has read/execute perms)
@@ -21,6 +25,14 @@ Start the jungle running:
 
 `service puma start`
 
+You can also stop the jungle (stops ALL puma instances) by running:
+
+`service puma stop`
+
+To restart the jungle:
+
+`service puma restart`
+
 This script will run at boot time.
 
 ## Conventions
@@ -33,10 +45,16 @@ You can always change those defaults by editing the scripts.
 ## Here's what a minimal app's config file should have
 
 ```
-dir="/path/to/rails/project"
-user="user-to-run-puma"
-ruby_version="version.to.run"
-ruby_env="rbenv"
+{
+	"servers" : [
+		{
+			"dir": "/path/to/rails/project",
+			"user": "deploy-user",
+			"ruby_version": "ruby.version",
+			"ruby_env": "rbenv"
+		}
+	]
+}
 ```
 
 ## Before starting...
@@ -47,7 +65,8 @@ You need to customise `puma.conf` to:
 * Set the directory of the app
 * Set the ruby version to execute
 * Set the ruby environment (currently set to rbenv, since that is the only ruby environment currently supported)
+* Add additional server instances following the scheme in the example
 
 ## Notes:
 
-Only rbenv is currently supported because that's what I've been working with. I might try other implementation and/or manage multiple instances
+Only rbenv is currently supported.

--- a/tools/jungle/rc.d/README.md
+++ b/tools/jungle/rc.d/README.md
@@ -1,6 +1,6 @@
 # Puma as a service using rc.d
 
-Manage one (currently) Puma server as a service on one box using FreeBSD's rc.d service.
+Manage multilpe Puma servers as services on one box using FreeBSD's rc.d service.
 
 ## Dependencies
 

--- a/tools/jungle/rc.d/README.md
+++ b/tools/jungle/rc.d/README.md
@@ -1,0 +1,53 @@
+# Puma as a service using rc.d
+
+Manage one (currently) Puma server as a service on one box using FreeBSD's rc.d service.
+
+## Installation
+
+    # Copy the puma script to the rc.d directory (make sure everyone has read/execute perms)
+    sudo cp puma /usr/local/etc/rc.d/
+
+    # Create an empty configuration file
+    sudo touch /usr/local/etc/puma.conf
+
+    # Enable the puma service
+    sudo echo 'puma_enable="YES"' >> /etc/rc.conf
+
+## Managing the jungle
+
+Puma apps are referenced in /usr/local/etc/puma.conf by default.
+
+Start the jungle running:
+
+`service puma start`
+
+This script will run at boot time.
+
+## Conventions
+
+* The script expects:
+  * a config file to exist under `config/puma.rb` in your app. E.g.: `/home/apps/my-app/config/puma.rb`.
+
+You can always change those defaults by editing the scripts.
+
+## Here's what a minimal app's config file should have
+
+```
+dir="/path/to/rails/project"
+user="user-to-run-puma"
+ruby_version="version.to.run"
+ruby_env="rbenv"
+```
+
+## Before starting...
+
+You need to customise `puma.conf` to:
+
+* Set the right user your app should be running on unless you want root to execute it!
+* Set the directory of the app
+* Set the ruby version to execute
+* Set the ruby environment (currently set to rbenv, since that is the only ruby environment currently supported)
+
+## Notes:
+
+Only rbenv is currently supported because that's what I've been working with. I might try other implementation and/or manage multiple instances

--- a/tools/jungle/rc.d/puma
+++ b/tools/jungle/rc.d/puma
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+
+# PROVIDE: foo
+# REQUIRE: bar_service_required_to_precede_foo
+
+. /etc/rc.subr
+
+name="puma"
+start_cmd="${name}_start"
+stop_cmd="${name}_stop"
+restart_cmd="${name}_restart"
+rcvar=puma_enable
+required_files=/usr/local/etc/puma.conf
+
+# load the config file
+. ${required_files}
+
+puma_start()
+{
+    if [ $ruby_env == "rbenv" ]; then
+        su - $user -c "cd $dir && rbenv shell $ruby_version && bundle exec puma -C $dir/config/puma.rb -d"
+    fi
+}
+
+puma_stop()
+{
+    pkill ruby
+}
+
+puma_restart()
+{
+    if [ $ruby_env == "rbenv" ]; then
+        su - $user -c "cd $dir && pkill ruby && rbenv shell $ruby_version && bundle exec puma -C $dir/config/puma.rb -d"
+    fi
+}
+
+load_rc_config $name
+run_rc_command "$1"
+

--- a/tools/jungle/rc.d/puma
+++ b/tools/jungle/rc.d/puma
@@ -1,26 +1,35 @@
 #!/bin/sh
 #
 
-# PROVIDE: foo
-# REQUIRE: bar_service_required_to_precede_foo
+# PROVIDE: puma
 
 . /etc/rc.subr
 
 name="puma"
-start_cmd="${name}_start"
-stop_cmd="${name}_stop"
-restart_cmd="${name}_restart"
+start_cmd="puma_start"
+stop_cmd="puma_stop"
+restart_cmd="puma_restart"
 rcvar=puma_enable
 required_files=/usr/local/etc/puma.conf
 
-# load the config file
-. ${required_files}
-
 puma_start()
 {
-    if [ $ruby_env == "rbenv" ]; then
-        su - $user -c "cd $dir && rbenv shell $ruby_version && bundle exec puma -C $dir/config/puma.rb -d"
-    fi
+	server_count=$(/usr/local/bin/jq ".servers[] .ruby_env" /usr/local/etc/puma.conf | wc -l)
+	i=0	
+	while [ "$i" -lt "$server_count" ]; do
+		rb_env=$(/usr/local/bin/jq -r ".servers[$i].ruby_env" /usr/local/etc/puma.conf)
+		dir=$(/usr/local/bin/jq -r ".servers[$i].dir" /usr/local/etc/puma.conf)
+		user=$(/usr/local/bin/jq -r ".servers[$i].user" /usr/local/etc/puma.conf)
+		rb_ver=$(/usr/local/bin/jq -r ".servers[$i].ruby_version" /usr/local/etc/puma.conf)
+		case $rb_env in
+			"rbenv")
+				su - $user -c "cd $dir && rbenv shell $rb_ver && bundle exec puma -C $dir/config/puma.rb -d"
+				;;
+			*)
+				;;
+		esac
+		i=$(( i + 1 ))
+	done
 }
 
 puma_stop()
@@ -30,11 +39,23 @@ puma_stop()
 
 puma_restart()
 {
-    if [ $ruby_env == "rbenv" ]; then
-        su - $user -c "cd $dir && pkill ruby && rbenv shell $ruby_version && bundle exec puma -C $dir/config/puma.rb -d"
-    fi
+	server_count=$(/usr/local/bin/jq ".servers[] .ruby_env" /usr/local/etc/puma.conf | wc -l)
+	i=0	
+	while [ "$i" -lt "$server_count" ]; do
+		rb_env=$(/usr/local/bin/jq -r ".servers[$i].ruby_env" /usr/local/etc/puma.conf)
+		dir=$(/usr/local/bin/jq -r ".servers[$i].dir" /usr/local/etc/puma.conf)
+		user=$(/usr/local/bin/jq -r ".servers[$i].user" /usr/local/etc/puma.conf)
+		rb_ver=$(/usr/local/bin/jq -r ".servers[$i].ruby_version" /usr/local/etc/puma.conf)
+		case $rb_env in
+			"rbenv")
+				su - $user -c "cd $dir && pkill ruby && rbenv shell $ruby_version && bundle exec puma -C $dir/config/puma.rb -d"
+				;;
+			*)
+				;;
+		esac
+		i=$(( i + 1 ))
+	done
 }
 
 load_rc_config $name
 run_rc_command "$1"
-

--- a/tools/jungle/rc.d/puma.conf
+++ b/tools/jungle/rc.d/puma.conf
@@ -1,0 +1,4 @@
+dir="/path/to/rails/project"
+user="user-for-project"
+ruby_version="ruby.version"
+ruby_env="rbenv"

--- a/tools/jungle/rc.d/puma.conf
+++ b/tools/jungle/rc.d/puma.conf
@@ -1,4 +1,10 @@
-dir="/path/to/rails/project"
-user="user-for-project"
-ruby_version="ruby.version"
-ruby_env="rbenv"
+{
+	"servers" : [
+		{
+			"dir": "/path/to/rails/project",
+			"user": "deploy-user",
+			"ruby_version": "ruby.version",
+			"ruby_env": "rbenv"
+		}
+	]
+}


### PR DESCRIPTION
I'm a FreeBSD Rails user, and ran into the issue of not having the service start at (re)boot. I only have recent experience with rbenv, but someone else should be able to make sense and add other environment systems like rvm.

It kind of takes a different approach in the config file by using json, but I felt it would be a little less cumbersome to process that instead of writing overly complex shell logic to parse configs.