### PR TITLE
Add warning about init.d being replaced by systemd

### DIFF
--- a/tools/jungle/README.md
+++ b/tools/jungle/README.md
@@ -1,9 +1,5 @@
 # Puma as a service
 
-## Init.d
-
-See `/tools/jungle/init.d` for tools to use with init.d and start-stop-daemon.
-
 ## Upstart
 
 See `/tools/jungle/upstart` for Ubuntu's upstart scripts.
@@ -11,3 +7,9 @@ See `/tools/jungle/upstart` for Ubuntu's upstart scripts.
 ## Systemd
 
 See [/docs/systemd](https://github.com/puma/puma/blob/master/docs/systemd.md).
+
+## Init.d
+
+Deprecatation Warning : `init.d` was replaced by `systemd` since Debian 8 and Ubuntu 16.04, you should look into [/docs/systemd](https://github.com/puma/puma/blob/master/docs/systemd.md) unless you are on an older OS.
+
+See `/tools/jungle/init.d` for tools to use with init.d and start-stop-daemon.

--- a/tools/jungle/init.d/README.md
+++ b/tools/jungle/init.d/README.md
@@ -1,5 +1,7 @@
 # Puma daemon service
 
+Deprecatation Warning : `init.d` was replaced by `systemd` since Debian 8 and Ubuntu 16.04, you should look into [/docs/systemd](https://github.com/puma/puma/blob/master/docs/systemd.md) unless you are on an older OS. 
+
 Init script to manage multiple Puma servers on the same box using start-stop-daemon.
 
 ## Installation 


### PR DESCRIPTION
Using init.d script in a systemd environment will work for jobs start/stop, but restart will not be managed as expected with old init.d system. This may cause confusion, pain and a lot of systemd search time.

Also move `init.d` last in the jungle documentation.