### PR TITLE
Appveyor fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
+# cache cleanup 2018-03-16
+
 init:
   - set PATH=C:\ruby%ruby_version%\bin;C:\Program Files\7-Zip;C:\Program Files\AppVeyor\BuildAgent;C:\Program Files\Git\cmd;C:\Windows\system32
+  # Download current trunk, install OpenSSL via trunk_pkgs.cmd file
   - if %ruby_version%==_trunk (
       appveyor DownloadFile https://ci.appveyor.com/api/projects/MSP-Greg/ruby-loco/artifacts/ruby_trunk.7z -FileName C:\ruby_trunk.7z &
       7z x C:\ruby_trunk.7z -oC:\ruby_trunk &
@@ -7,7 +10,11 @@ init:
     )
 
 install:
-  # Download RI OpenSSL Knapsack package
+  # Install ragel
+  - if "%ri_file%"=="x64_2" ( C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-x86_64-ragel )
+  - if "%ri_file%"=="x86_2" ( C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-i686-ragel   )
+  
+  # Install ragel & download RI OpenSSL Knapsack package
   # RI DevKit is only installed in Ruby23 and Ruby23-x64 folders
   # RI2 MSYS2/MinGW OpenSSL package is standard Appveyor item
   - if "%ri_file%"=="x86" (
@@ -15,21 +22,36 @@ install:
       7z e openssl-1.0.2j-x86-windows.tar.lzma &
       7z x -y openssl-1.0.2j-x86-windows.tar -oC:\ruby23\DevKit\mingw &
       set b_config="--with-ssl-dir=C:/ruby23/DevKit/mingw --with-opt-include=C:/ruby23/DevKit/mingw/include" &
-      set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem
+      set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem &
+      C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-x86_64-ragel &
+      set PATH=%PATH%;C:\msys64\ming32\bin
     )
   - if "%ri_file%"=="x64" (
       appveyor DownloadFile https://dl.bintray.com/oneclick/OpenKnapsack/x64/openssl-1.0.2j-x64-windows.tar.lzma &
       7z e openssl-1.0.2j-x64-windows.tar.lzma &
       7z x -y openssl-1.0.2j-x64-windows.tar -oC:\ruby23-x64\DevKit\mingw &
       set b_config="--with-ssl-dir=C:/ruby23-x64/DevKit/mingw --with-opt-include=C:/ruby23-x64/DevKit/mingw/include" &
-      set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem
+      set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem &
+      C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-i686-ragel &
+      set PATH=%PATH%;C:\msys64\ming64\bin
     )
   - RAKEOPT: 
   - APPVEYOR: true
   - ruby --version
   - gem --version
   - bundle --version
-  - bundle install --without documentation --path av_bundle/%ruby_version%
+  - bundle install --without documentation --path C:/av_bundle
+
+  # Download & install current OpenSSL package for later RubyInstaller2 version(s)
+  - set openssl=mingw-w64-x86_64-openssl-1.1.0.g-1-any.pkg.tar.xz
+  - set  dl_uri=https://dl.bintray.com/msp-greg/ruby_trunk
+  - if %ruby_version%==25-x64 (
+      C:\msys64\usr\bin\bash -lc "pacman-key -r 77D8FA18 --keyserver na.pool.sks-keyservers.net && pacman-key -f 77D8FA18 && pacman-key --lsign-key 77D8FA18" &
+      appveyor DownloadFile %dl_uri%/%openssl%     -FileName C:\%openssl%      &
+      appveyor DownloadFile %dl_uri%/%openssl%.sig -FileName C:\%openssl%.sig  &
+      C:\msys64\usr\bin\pacman -Rdd --noconfirm mingw-w64-x86_64-openssl &
+      C:\msys64\usr\bin\pacman -Udd --noconfirm --force C:\%openssl%
+    )
 
 build_script:
   - bundle exec rake -rdevkit compile -- %b_config%
@@ -45,10 +67,16 @@ environment:
   matrix:
     - ruby_version: _trunk
       b_config: "--use-system-libraries"
+      ri_file: x64_2
+    - ruby_version: 25-x64
+      b_config: "--use-system-libraries"
+      ri_file: x64_2
     - ruby_version: 24
       b_config: "--use-system-libraries"
+      ri_file: x86_2
     - ruby_version: 24-x64
       b_config: "--use-system-libraries"
+      ri_file: x64_2
     - ruby_version: 23
       ri_file: x86
     - ruby_version: 23-x64
@@ -57,13 +85,9 @@ environment:
       ri_file: x86
     - ruby_version: 22-x64
       ri_file: x64
-    - ruby_version: 21
-      DISABLE_SSL: true
-    - ruby_version: 21-x64
-      DISABLE_SSL: true
 
 cache:
-  - av_bundle
+  - C:\av_bundle
 
 branches:
   only:

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -249,7 +249,7 @@ module Puma
       end
 
       def close
-        @socket.close
+        @socket.close unless @socket.closed?       # closed? call is for Windows
       end
     end
   end

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -22,36 +22,43 @@ class TestPumaServerSSL < Minitest::Test
 
   def setup
     return if DISABLE_SSL
-    @port = 3212
-    @host = "127.0.0.1"
+    port = 3212
+    host = "127.0.0.1"
 
-    @app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
+    app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
 
-    @ctx = Puma::MiniSSL::Context.new
+    ctx = Puma::MiniSSL::Context.new
 
     if Puma.jruby?
-      @ctx.keystore =  File.expand_path "../../examples/puma/keystore.jks", __FILE__
-      @ctx.keystore_pass = 'blahblah'
+      ctx.keystore =  File.expand_path "../../examples/puma/keystore.jks", __FILE__
+      ctx.keystore_pass = 'blahblah'
     else
-      @ctx.key =  File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
-      @ctx.cert = File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
+      ctx.key  =  File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
+      ctx.cert = File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
     end
 
-    @ctx.verify_mode = Puma::MiniSSL::VERIFY_NONE
+    ctx.verify_mode = Puma::MiniSSL::VERIFY_NONE
 
     @events = SSLEventsHelper.new STDOUT, STDERR
-    @server = Puma::Server.new @app, @events
-    @server.add_ssl_listener @host, @port, @ctx
+    @server = Puma::Server.new app, @events
+    @ssl_listener = @server.add_ssl_listener host, port, ctx
     @server.run
 
-    @http = Net::HTTP.new @host, @port
+    @http = Net::HTTP.new host, port
     @http.use_ssl = true
     @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    @no_teardown = false
   end
 
   def teardown
-    return if DISABLE_SSL
+    return if DISABLE_SSL || @no_teardown
+    @http.finish if @http.started?
     @server.stop(true)
+  ensure
+    if windows? && @ssl_listener && !@ssl_listener.closed?
+      @ssl_listener.close
+      @ssl_listener = nil
+    end
   end
 
   def test_url_scheme_for_https
@@ -115,7 +122,14 @@ class TestPumaServerSSL < Minitest::Test
       end
     end
     unless Puma.jruby?
-      assert_match("wrong version number", @events.error.message) if @events.error
+      assert_match(/wrong version number|no protocols available/, @events.error.message) if @events.error
+    end
+    if windows?
+      @http.finish if @http.started?
+      @http = nil
+      @server.thread.kill
+      @server = nil
+      @no_teardown = true
     end
   end
 
@@ -125,38 +139,38 @@ end
 class TestPumaServerSSLClient < Minitest::Test
 
   def assert_ssl_client_error_match(error, subject=nil, &blk)
-    @port = 3212
-    @host = "127.0.0.1"
+    port = 3212
+    host = "127.0.0.1"
 
-    @app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
+    app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
 
-    @ctx = Puma::MiniSSL::Context.new
+    ctx = Puma::MiniSSL::Context.new
     if Puma.jruby?
-      @ctx.keystore =  File.expand_path "../../examples/puma/client-certs/keystore.jks", __FILE__
-      @ctx.keystore_pass = 'blahblah'
+      ctx.keystore =  File.expand_path "../../examples/puma/client-certs/keystore.jks", __FILE__
+      ctx.keystore_pass = 'blahblah'
     else
-      @ctx.key = File.expand_path "../../examples/puma/client-certs/server.key", __FILE__
-      @ctx.cert = File.expand_path "../../examples/puma/client-certs/server.crt", __FILE__
-      @ctx.ca = File.expand_path "../../examples/puma/client-certs/ca.crt", __FILE__
+      ctx.key = File.expand_path "../../examples/puma/client-certs/server.key", __FILE__
+      ctx.cert = File.expand_path "../../examples/puma/client-certs/server.crt", __FILE__
+      ctx.ca = File.expand_path "../../examples/puma/client-certs/ca.crt", __FILE__
     end
-    @ctx.verify_mode = Puma::MiniSSL::VERIFY_PEER | Puma::MiniSSL::VERIFY_FAIL_IF_NO_PEER_CERT
+    ctx.verify_mode = Puma::MiniSSL::VERIFY_PEER | Puma::MiniSSL::VERIFY_FAIL_IF_NO_PEER_CERT
 
     events = SSLEventsHelper.new STDOUT, STDERR
-    @server = Puma::Server.new @app, events
-    @server.add_ssl_listener @host, @port, @ctx
-    @server.run
+    server = Puma::Server.new app, events
+    ssl_listener = server.add_ssl_listener host, port, ctx
+    server.run
 
-    @http = Net::HTTP.new @host, @port
-    @http.use_ssl = true
-    @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    http = Net::HTTP.new host, port
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
-    blk.call(@http)
+    blk.call(http)
 
     client_error = false
     begin
-      @http.start do
+      http.start do
         req = Net::HTTP::Get.new "/", {}
-        @http.request(req)
+        http.request(req)
       end
     rescue OpenSSL::SSL::SSLError
       client_error = true
@@ -168,11 +182,14 @@ class TestPumaServerSSLClient < Minitest::Test
     # messages here
     unless Puma.jruby?
       assert_match error, events.error.message if error
-      assert_equal @host, events.addr if error
+      assert_equal host, events.addr if error
       assert_equal subject, events.cert.subject.to_s if subject
     end
-  ensure
-    @server.stop(true)
+
+    server.stop(true)
+    if windows? && ssl_listener && !ssl_listener.closed?
+      ssl_listener.close
+    end
   end
 
   def test_verify_fail_if_no_client_cert


### PR DESCRIPTION
This PR stabilizes Appveyor testing, along with removing Ruby 2.1, and adding Ruby 2.5.  I realize that using Puma in a Windows production environment is probably uncommon, but it may be used for development.

Also, current windows Ruby builds (2.5 & trunk) are compiled with gcc 7.3.0 and using OpenSSL 1.1.0.  Since Travis is using an older toolset, Appveyor testing may show issues due to the newer 'toolset' used to build & test Puma.

Since:
1. I am not familiar with using Puma in a production environment
2. Testing may not show all issues, and often cannot duplicate production loading 
3. Some of my previous PR's required patching (sorry @evanphx )
4. I do use Puma locally, but normally without SSL.

I thought I'd describe what issues were involved and my solutions.  They are probably not optimal.

### Issue 1 - SSLv3 Rejection
```
TestPumaServerSSL#test_ssl_v3_rejection`:
TimeoutEveryTestCase::TestTookTooLong: execution expired
C:/projects/puma/lib/puma/server.rb:940:in `join'
C:/projects/puma/lib/puma/server.rb:940:in `stop'
C:/projects/puma/test/test_puma_server_ssl.rb:54:in `
```

This issue was consistent with both Ruby 2.5 & trunk, both of which build using OpenSSL 1.1.0g.  The solution chosen was to use `@server.thread.kill` instead of `@server.close` for this test, along with a test for `windows?`.  A boolean `@no_teardown` variable is used in `test_puma_server_ssl.rb` to bypass `teardown` when this is done.

### Issue 2 - IOError - stream already closed
```
TestConfigFile#test_config_files_with_rack_env = C:/projects/puma/lib/puma/minissl.rb:252:in `close': closed stream (IOError)
	from C:/projects/puma/lib/puma/minissl.rb:252:in `close'
```

Currently, `Puma::MiniSSL::Server#close` consistes of `@socket.close`.  Changed to `@socket.close unless @socket.closed?`.

### Issue 3 - Intermittent Errno::EADDRINUSE

These errors originate in `add_ssl_listener` or `add_tcp_listener`, although tcp seems to be affected only when ssl tests were run previously.  Fixes were windows specific changes to `test_puma_server_ssl.rb`.

### Issue 4 - Intermittent ragel build failures

Added the ragel package to the MSYS2 system before compiling, this was done in appveyor.yml.

### Notes:

From working with ruby trunk testing for well over a year, Windows sockets do have some differences from *nix sockets.  For quite a while, both Windows MinGW & MSWin builds have been passing all Ruby Core tests.

Cleaned up caching on AV, the last test on my Puma fork showed all gems coming from the cache.

As mentioned, these fixes may not be optimal, but even it they're a starting point, they do seem to consistently pass AV tests.

The only build warning from OpenSSL 1.1.0g is:
```
compiling ../../../../ext/puma_http11/mini_ssl.c
../../../../ext/puma_http11/mini_ssl.c: In function 'engine_init_client':
../../../../ext/puma_http11/mini_ssl.c:211:3: warning: 'DTLSv1_method' is deprecated [-Wdeprecated-declarations]
   conn->ctx = SSL_CTX_new(DTLSv1_method());
   ^~~~
In file included from C:/msys64/mingw64/include/openssl/ct.h:13:0,
                 from C:/msys64/mingw64/include/openssl/ssl.h:61,
                 from ../../../../ext/puma_http11/mini_ssl.c:15:
C:/msys64/mingw64/include/openssl/ssl.h:1642:1: note: declared here
 DEPRECATEDIN_1_1_0(__owur const SSL_METHOD *DTLSv1_method(void)) /* DTLSv1.0 */
 ^
```
If I need to change anything or resubmit this PR with changes, I'd be happy to.  I would just like to get Appveyor testing to be consistent and passing.

Thanks, Greg