### PR TITLE
jungle: Using `ps -p` will check correctly whether $PID exists

### DIFF
--- a/tools/jungle/init.d/puma
+++ b/tools/jungle/init.d/puma
@@ -48,7 +48,7 @@ do_start_one() {
   if [ -e $PIDFILE ]; then
     PID=`cat $PIDFILE`
     # If the puma isn't running, run it, otherwise restart it.
-    if [ "`ps -A -o pid= | grep -c $PID`" -eq 0 ]; then
+    if ps -p $PID > /dev/null; then
       do_start_one_do $1
     else
       do_restart_one $1
@@ -105,7 +105,7 @@ do_stop_one() {
   STATEFILE=$1/tmp/puma/state
   if [ -e $PIDFILE ]; then
     PID=`cat $PIDFILE`
-    if [ "`ps -A -o pid= | grep -c $PID`" -eq 0 ]; then
+    if ps -p $PID > /dev/null; then
       log_daemon_msg "---> Puma $1 isn't running."
     else
       log_daemon_msg "---> About to kill PID `cat $PIDFILE`"


### PR DESCRIPTION
I think that It is appropriate to use `ps -p` in that place.

I think that under certain conditions, existing code ``[ "`ps -A -o pid=
| grep -c $PID`" -eq 0 ]`` may behave incorrectly.

For example, if the content of $PID happens to be a short string(such as `199`), and another process includes the string(process such as `2199`), then unfortunately `grep -c` will return
positive number even if `199` is not running.