### PR TITLE
Ensure Puma.stats_object available using handler

### DIFF
--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -9,6 +9,7 @@ module Rack
       }
 
       def self.config(app, options = {})
+        require 'puma'
         require 'puma/configuration'
         require 'puma/events'
         require 'puma/launcher'


### PR DESCRIPTION
When requiring only the handler puma.rb is not loaded. This defines a method that is used in the launcher https://github.com/puma/puma/pull/1532#discussion_r176171578.