### PR TITLE
Use correct var in early hints

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -606,7 +606,7 @@ module Puma
                 fast_write client, "#{k}: #{v}\r\n"
               end
             else
-              fast_write client, "#{k}: #{v}\r\n"
+              fast_write client, "#{k}: #{vs}\r\n"
             end
           end
 


### PR DESCRIPTION
Oops this was using `v` instead of `vs` here which means it couldn't
have been working.

Ref https://github.com/rails/rails/issues/32329
and https://github.com/puma/puma/pull/1403/files#r176663645