### PR TITLE
Purge interrupt queue when closing socket fails

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -220,7 +220,11 @@ module Puma
                   # nothing
                 rescue Errno::ECONNABORTED
                   # client closed the socket even before accept
-                  io.close rescue nil
+                  begin
+                    io.close
+                  rescue
+                    Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+                  end
                 end
               end
             end
@@ -372,7 +376,11 @@ module Puma
                   # nothing
                 rescue Errno::ECONNABORTED
                   # client closed the socket even before accept
-                  io.close rescue nil
+                  begin
+                    io.close
+                  rescue
+                    Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+                  end
                 end
               end
             end


### PR DESCRIPTION
This workaround for https://bugs.ruby-lang.org/issues/13632 was applied to all places where IOError is rescued explicitly in https://github.com/puma/puma/pull/1345, but the inline `rescue nil` here will also catch IOError and needs the fix too.

The underlying bug has been fixed upstream in Ruby, but the patch was never backported to the 2.2 branch. I realise that Ruby 2.2 is EOL tomorrow, but it would be great if there was a version of Puma that fully fixed this issue on Ruby 2.2 even if support for it will be dropped at some point.

See https://github.com/rails/rails/pull/31955 for the discussion where this problem was tracked down (by @matthewd 🙇‍♂️)

👋 @nateberkopec @NickolasVashchenko 