### PR TITLE
Add ruby-head with enabled JIT option into Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ rvm:
   - rbx-3
 matrix:
   fast_finish: true
+  include:
+    - rvm: ruby-head
+      env: RUBYOPT="--jit"
   allow_failures:
     - rvm: jruby-head
     - rvm: rbx-3

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
     - rvm: jruby-head
     - rvm: rbx-3
     - rvm: ruby-head
+    - rvm: ruby-head
+      env: RUBYOPT="--jit"
 env:
   global:
     - TESTOPTS="-v"


### PR DESCRIPTION
I think Puma would be tested against Ruby JIT since Puma is one of the most important Ruby projects. And it'd be nice to have it prepared to work with JIT in the advance.