### PR TITLE
add support for disabling TLSv1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ $ puma -b 'ssl://127.0.0.1:9292?keystore=path_to_keystore&keystore-pass=keystore
 ```
 See https://www.openssl.org/docs/man1.0.2/apps/ciphers.html for cipher filter format and full list of cipher suites.
 
+Don't want to use insecure TLSv1.0 ?
+
+```
+$ puma -b 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert&no_tlsv1=true'
+```
+
 ### Control/Status Server
 
 Puma has a built-in status/control app that can be used to query and control Puma itself.

--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -142,6 +142,7 @@ VALUE engine_init_server(VALUE self, VALUE mini_ssl_ctx) {
   VALUE obj;
   SSL_CTX* ctx;
   SSL* ssl;
+  int ssl_options;
 
   ms_conn* conn = engine_alloc(self, &obj);
 
@@ -164,6 +165,10 @@ VALUE engine_init_server(VALUE self, VALUE mini_ssl_ctx) {
   ID sym_ssl_cipher_filter = rb_intern("ssl_cipher_filter");
   VALUE ssl_cipher_filter = rb_funcall(mini_ssl_ctx, sym_ssl_cipher_filter, 0);
 
+  ID sym_no_tlsv1 = rb_intern("no_tlsv1");
+  VALUE no_tlsv1 = rb_funcall(mini_ssl_ctx, sym_no_tlsv1, 0);
+
+
   ctx = SSL_CTX_new(SSLv23_server_method());
   conn->ctx = ctx;
 
@@ -175,7 +180,12 @@ VALUE engine_init_server(VALUE self, VALUE mini_ssl_ctx) {
     SSL_CTX_load_verify_locations(ctx, RSTRING_PTR(ca), NULL);
   }
 
-  SSL_CTX_set_options(ctx, SSL_OP_CIPHER_SERVER_PREFERENCE | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_SINGLE_DH_USE | SSL_OP_SINGLE_ECDH_USE | SSL_OP_NO_COMPRESSION);
+  ssl_options  = SSL_OP_CIPHER_SERVER_PREFERENCE | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_SINGLE_DH_USE | SSL_OP_SINGLE_ECDH_USE | SSL_OP_NO_COMPRESSION;
+
+  if(RTEST(no_tlsv1)) {
+    ssl_options |= SSL_OP_NO_TLSv1;
+  }
+  SSL_CTX_set_options(ctx, ssl_options);
   SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF);
 
   if (!NIL_P(ssl_cipher_filter)) {

--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -158,7 +158,13 @@ public class MiniSSL extends RubyObject {
     sslCtx.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
     engine = sslCtx.createSSLEngine();
 
-    String[] protocols = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
+    String[] protocols;
+    if(miniSSLContext.callMethod(threadContext, "no_tlsv1").isTrue()) {
+        protocols = new String[] { "TLSv1.1", "TLSv1.2" };
+    } else {
+        protocols = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
+    }
+
     engine.setEnabledProtocols(protocols);
     engine.setUseClientMode(false);
 

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -186,6 +186,8 @@ module Puma
             ctx.ssl_cipher_filter = params['ssl_cipher_filter'] if params['ssl_cipher_filter']
           end
 
+          ctx.no_tlsv1 = true if params['no_tlsv1'] == 'true'
+
           if params['verify_mode']
             ctx.verify_mode = case params['verify_mode']
                               when "peer"

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -285,12 +285,13 @@ module Puma
 
     def ssl_bind(host, port, opts)
       verify = opts.fetch(:verify_mode, 'none')
+      no_tlsv1 = opts.fetch(:no_tlsv1, 'false')
 
       if defined?(JRUBY_VERSION)
         keystore_additions = "keystore=#{opts[:keystore]}&keystore-pass=#{opts[:keystore_pass]}"
-        bind "ssl://#{host}:#{port}?cert=#{opts[:cert]}&key=#{opts[:key]}&#{keystore_additions}&verify_mode=#{verify}"
+        bind "ssl://#{host}:#{port}?cert=#{opts[:cert]}&key=#{opts[:key]}&#{keystore_additions}&verify_mode=#{verify}&no_tlsv1=#{no_tlsv1}"
       else
-        bind "ssl://#{host}:#{port}?cert=#{opts[:cert]}&key=#{opts[:key]}&verify_mode=#{verify}"
+        bind "ssl://#{host}:#{port}?cert=#{opts[:cert]}&key=#{opts[:key]}&verify_mode=#{verify}&no_tlsv1=#{no_tlsv1}"
       end
     end
 

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -175,6 +175,11 @@ module Puma
 
     class Context
       attr_accessor :verify_mode
+      attr_reader :no_tlsv1
+
+      def initialize
+        @no_tlsv1 = false
+      end
 
       if defined?(JRUBY_VERSION)
         # jruby-specific Context properties: java uses a keystore and password pair rather than a cert/key pair
@@ -213,11 +218,18 @@ module Puma
           @ca = ca
         end
 
+
         def check
           raise "Key not configured" unless @key
           raise "Cert not configured" unless @cert
         end
       end
+
+      def no_tlsv1=(tlsv1)
+        raise ArgumentError, "Invalid value of no_tlsv1" unless ['true', 'false', true, false].include?(tlsv1)
+        @no_tlsv1 = tlsv1
+      end
+
     end
 
     VERIFY_NONE = 0

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -56,4 +56,46 @@ class TestBinder < Minitest::Test
     assert_equal(keystore, ctx.keystore)
     assert_equal(ssl_cipher_list, ctx.ssl_cipher_list)
   end
+
+  def test_binder_parses_tlsv1_disabled
+    skip_on_appveyor
+    skip_on_jruby
+
+    key =  File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
+    cert = File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
+
+    @binder.parse(["ssl://0.0.0.0?key=#{key}&cert=#{cert}&no_tlsv1=true"], @events)
+
+    ssl = @binder.instance_variable_get(:@ios).first
+    ctx = ssl.instance_variable_get(:@ctx)
+    assert_equal(true, ctx.no_tlsv1)
+  end
+
+  def test_binder_parses_tlsv1_enabled
+    skip_on_appveyor
+    skip_on_jruby
+
+    key =  File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
+    cert = File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
+
+    @binder.parse(["ssl://0.0.0.0?key=#{key}&cert=#{cert}&no_tlsv1=false"], @events)
+
+    ssl = @binder.instance_variable_get(:@ios).first
+    ctx = ssl.instance_variable_get(:@ctx)
+    refute(ctx.no_tlsv1)
+  end
+
+  def test_binder_parses_tlsv1_unspecified_defaults_to_enabled
+    skip_on_appveyor
+    skip_on_jruby
+
+    key =  File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
+    cert = File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
+
+    @binder.parse(["ssl://0.0.0.0?key=#{key}&cert=#{cert}"], @events)
+
+    ssl = @binder.instance_variable_get(:@ios).first
+    ctx = ssl.instance_variable_get(:@ctx)
+    refute(ctx.no_tlsv1)
+  end
 end


### PR DESCRIPTION
Many organizations run their applications using in environments that fall into scope of PCI-DSS compliance audits. One of the requirements set out by standard is to migrate to more secure protocols if possible.

PCI Security Standards council has advised to migrate away from TLSv1.0 over last few years and recently set a migration deadline of 30 June 2018 (see [this article](https://blog.pcisecuritystandards.org/are-you-ready-for-30-june-2018-sayin-goodbye-to-ssl-early-tls) for more details).

Change proposed in this commit gives an user option to disable `TLSv1.0` during bind, while still leaving the `TLSv1.1` and `TLSv1.2` enabled. `SSLv2` and `SSLv3` are permanently disabled (as they should).

Default behaviour is not changed if the `no_tls` option is not defined.

Related: #980