### PR TITLE
Meter accept(2) while taking into account races around thread pool mutex

### DIFF
--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -157,12 +157,12 @@ module Puma
       @mutex.synchronize do
         while true
           return if @shutdown
-          return if @waiting > 0
 
           # If we can still spin up new threads and there
-          # is work queued, then accept more work until we would
+          # is work queued that cannot be handled by waiting
+          # threads, then accept more work until we would
           # spin up the max number of threads.
-          return if @todo.size < @max - @spawned
+          return if @todo.size - @waiting < @max - @spawned
 
           @not_full.wait @mutex
         end


### PR DESCRIPTION
As part of the work in #1278 we refactored the conditional in
`ThreadPool#wait_until_not_full` because we found it difficult to reason about
at the RailsConf '17 roundtable. We broke it up a bit and everyone went away
happier. However it turns out that you need to account for both `@waiting` and
`@todo.size` together to make a determination on whether to accept more work
from the socket and the refactor was not equivalent to the old code.

There are no guarantees that request threads that have been signalled due to
work being added to the thread pool's queue will become active, take the mutex
and decrement `@waiting` before the main worker's thread runs
`ThreadPool#wait_until_not_full`. If we run that before the request thread
decrements `@waiting` we end up hitting the early exit of `return @waiting > 0`,
taking more work off the socket than the pool's capacity.

The correct way to determine the number of requests we have queued in the pool
that are outstanding is `@todo.size - @waiting`, so I've reverted to the old
behaviour and augmented the comment above it.

Fixes https://github.com/puma/puma/issues/1471