### PR TITLE
Fix ssl_v3_rejection test hanging

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,13 +43,25 @@ install:
   - bundle install --without documentation --path C:/av_bundle
 
   # Download & install current OpenSSL package for later RubyInstaller2 version(s)
-  - set openssl=mingw-w64-x86_64-openssl-1.1.0.g-1-any.pkg.tar.xz
+  - if %ruby_version%==25-x64 (
+      set openssl=mingw-w64-x86_64-openssl-1.1.0.g-1-any.pkg.tar.xz
+    )
+  - if %ruby_version%==25 (
+      set openssl=mingw-w64-i686-openssl-1.1.0.g-1-any.pkg.tar.xz
+    )
   - set  dl_uri=https://dl.bintray.com/msp-greg/ruby_trunk
   - if %ruby_version%==25-x64 (
       C:\msys64\usr\bin\bash -lc "pacman-key -r 77D8FA18 --keyserver na.pool.sks-keyservers.net && pacman-key -f 77D8FA18 && pacman-key --lsign-key 77D8FA18" &
       appveyor DownloadFile %dl_uri%/%openssl%     -FileName C:\%openssl%      &
       appveyor DownloadFile %dl_uri%/%openssl%.sig -FileName C:\%openssl%.sig  &
       C:\msys64\usr\bin\pacman -Rdd --noconfirm mingw-w64-x86_64-openssl &
+      C:\msys64\usr\bin\pacman -Udd --noconfirm --force C:\%openssl%
+    )
+  - if %ruby_version%==25 (
+      C:\msys64\usr\bin\bash -lc "pacman-key -r 77D8FA18 --keyserver na.pool.sks-keyservers.net && pacman-key -f 77D8FA18 && pacman-key --lsign-key 77D8FA18" &
+      appveyor DownloadFile %dl_uri%/%openssl%     -FileName C:\%openssl%      &
+      appveyor DownloadFile %dl_uri%/%openssl%.sig -FileName C:\%openssl%.sig  &
+      C:\msys64\usr\bin\pacman -Rdd --noconfirm mingw-w64-686-openssl &
       C:\msys64\usr\bin\pacman -Udd --noconfirm --force C:\%openssl%
     )
 
@@ -68,6 +80,9 @@ environment:
     - ruby_version: _trunk
       b_config: "--use-system-libraries"
       ri_file: x64_2
+    - ruby_version: 25
+      b_config: "--use-system-libraries"
+      ri_file: x86_2
     - ruby_version: 25-x64
       b_config: "--use-system-libraries"
       ri_file: x64_2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
       7z x -y openssl-1.0.2j-x86-windows.tar -oC:\ruby23\DevKit\mingw &
       set b_config="--with-ssl-dir=C:/ruby23/DevKit/mingw --with-opt-include=C:/ruby23/DevKit/mingw/include" &
       set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem &
-      C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-x86_64-ragel &
+      C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-i686-ragel &
       set PATH=%PATH%;C:\msys64\ming32\bin
     )
   - if "%ri_file%"=="x64" (
@@ -32,7 +32,7 @@ install:
       7z x -y openssl-1.0.2j-x64-windows.tar -oC:\ruby23-x64\DevKit\mingw &
       set b_config="--with-ssl-dir=C:/ruby23-x64/DevKit/mingw --with-opt-include=C:/ruby23-x64/DevKit/mingw/include" &
       set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem &
-      C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-i686-ragel &
+      C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-x86_64-ragel &
       set PATH=%PATH%;C:\msys64\ming64\bin
     )
   - RAKEOPT: 

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -124,7 +124,7 @@ module Puma
 
       def read_and_drop(timeout = 1)
         return :timeout unless IO.select([@socket], nil, nil, timeout)
-        read_nonblock(1024)
+        return :eof unless read_nonblock(1024)
         :drop
       rescue Errno::EAGAIN
         # do nothing
@@ -141,7 +141,7 @@ module Puma
           # Don't let this socket hold this loop forever.
           # If it can't send more packets within 1s, then give up.
           while should_drop_bytes?
-            return if read_and_drop(1) == :timeout
+            return if [:timeout, :eof].include?(read_and_drop(1))
           end
         rescue IOError, SystemCallError
           Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -250,7 +250,12 @@ module Puma
         STDERR.puts "Exception handling servers: #{e.message} (#{e.class})"
         STDERR.puts e.backtrace
       ensure
-        @check.close
+        begin
+          @check.close
+        rescue
+          Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+        end
+
         @notify.close
 
         if @status != :restart and @own_binder

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -47,18 +47,12 @@ class TestPumaServerSSL < Minitest::Test
     @http = Net::HTTP.new host, port
     @http.use_ssl = true
     @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    @no_teardown = false
   end
 
   def teardown
-    return if DISABLE_SSL || @no_teardown
+    return if DISABLE_SSL
     @http.finish if @http.started?
     @server.stop(true)
-  ensure
-    if windows? && @ssl_listener && !@ssl_listener.closed?
-      @ssl_listener.close
-      @ssl_listener = nil
-    end
   end
 
   def test_url_scheme_for_https
@@ -117,13 +111,6 @@ class TestPumaServerSSL < Minitest::Test
     unless Puma.jruby?
       assert_match(/wrong version number|no protocols available/, @events.error.message) if @events.error
     end
-    if windows?
-      @http.finish if @http.started?
-      @http = nil
-      @server.thread.kill
-      @server = nil
-      @no_teardown = true
-    end
   end
 
 end
@@ -180,9 +167,6 @@ class TestPumaServerSSLClient < Minitest::Test
     end
 
     server.stop(true)
-    if windows? && ssl_listener && !ssl_listener.closed?
-      ssl_listener.close
-    end
   end
 
   def test_verify_fail_if_no_client_cert


### PR DESCRIPTION
I wanted to run the tests locally so I can understand how `puma` works better. But I would consistently get a hang on the `server.stop(true)` call in the teardown of the `ssl_v3_rejection` test.

The change in https://github.com/puma/puma/commit/d03b125640efa46e539f053996515b28bc62c13f seems to fix it.

In order to reproduce the problem in CI, so you can see the error, I figured I could remove all the Windows specific tweaks in the test, since they seemed to be written specifically to avoid the issue from happening. I came to think that because the hang was happening on the test teardown, and those tweaks seemed to try to prevent that specific teardown from being run. My guess was right and the hang reproduced on Windows after doing that (see [here](https://ci.appveyor.com/project/deivid-rodriguez/puma/build/1.0.9/job/4rm4bos4866h32xr)). With the patch, closing the server seems to consistently never hang on any platform, at least not in that test.

Note that I'm actually getting the hang on MRI 2.5.1 on Linux, but for some reason Travis wouldn't hit it.