### PR TITLE
Avoid inifinte loop when read_nonblock constantly returns nil

### DIFF
--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -63,7 +63,7 @@ module Puma
                 IO.select(nil, [@socket.to_io])
               end
             elsif !data
-              return nil
+              raise IOError
             else
               break
             end


### PR DESCRIPTION
I must admit that I don't have a good understanding of the underlying problem, but I'd share anyway, so please feel free to close this pull request if you don't think it's a valid solution to a problem.

I was running puma with SSL enabled, but after a while, puma server started to use 100% of a CPU core without seemingly processing any requests. This kept happening, so I looked into it and it turned out that a thread was stuck in an infinite loop in `Puma::MiniSSL::Socket#close` as `read_nonblock` kept returning `nil` instantly.

A simplistic way to reproduce the problem was to run `curl` command to send a request then hit CTRL-C to interrupt the process, after repeating this a few times, I could invariably make puma stuck as described above.

I was able to fix the issue by making `read_nonblock` raise IOError instead of returning nil and my server has been running fine with the patch. Not sure if there's a better way to handle this.