### PR TITLE
Fix Puma::DSL.load

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -104,10 +104,8 @@ module Puma
     end
 
     # Load additional configuration from a file
-    # Files get loaded later via Configuration#load
     def load(file)
-      @options[:config_files] ||= []
-      @options[:config_files] << file
+      _load_from(file)
     end
 
     # Adds a binding for the server to +url+. tcp://, unix://, and ssl:// are the only accepted


### PR DESCRIPTION
The comment in DSL.load says that files loaded with this method
will get loaded later via Configuration.load. I find this to be not the
case, because by the time DSL.load is called, Configuration.load has
already been called so it does nothing. The only way I can load inside
my config file is to call DSL._load_from directly.

Please correct me if I'm wrong, but I would like a fix, thanks.