### PR TITLE
[close #1577] Negative Backpressure Metric

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -292,7 +292,8 @@ module Puma
           begin
             b = server.backlog || 0
             r = server.running || 0
-            payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r} }\n!
+            t = server.pool_capacity || 0
+            payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r}, "pool_capacity": #{t} }\n!
             io << payload
           rescue IOError
             Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -293,7 +293,7 @@ module Puma
             b = server.backlog || 0
             r = server.running || 0
             t = server.pool_capacity || 0
-            payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r}, "pool_capacity": #{t} }\n!
+            payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r}, "pool_capacity":#{t} }\n!
             io << payload
           rescue IOError
             Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -169,8 +169,15 @@ module Puma
     end
 
 
+    # This number represents the number of requests that
+    # the server is capable of taking right now.
+    #
+    # For example if the number is 5 then it means
+    # there are 5 threads sitting idle ready to take
+    # a request. If one request comes in, then the
+    # value would be 4 until it finishes processing.
     def pool_capacity
-      @thread_pool and @thread_pool.waiting
+      @thread_pool and @thread_pool.pool_capacity
     end
 
     # Lopez Mode == raw tcp apps

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -168,6 +168,11 @@ module Puma
       @thread_pool and @thread_pool.spawned
     end
 
+
+    def pool_capacity
+      @thread_pool and @thread_pool.waiting
+    end
+
     # Lopez Mode == raw tcp apps
 
     def run_lopez_mode(background=true)

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -14,7 +14,8 @@ module Puma
     def stats
       b = @server.backlog || 0
       r = @server.running || 0
-      %Q!{ "backlog": #{b}, "running": #{r} }!
+      t = @server.pool_capacity || 0
+      %Q!{ "backlog": #{b}, "running": #{r}, "pool_capacity": #{t} }!
     end
 
     def restart

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -58,7 +58,7 @@ module Puma
       @clean_thread_locals = false
     end
 
-    attr_reader :spawned, :trim_requested
+    attr_reader :spawned, :trim_requested, :waiting
     attr_accessor :clean_thread_locals
 
     def self.clean_thread_locals

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -73,6 +73,10 @@ module Puma
       @mutex.synchronize { @todo.size }
     end
 
+    def pool_capacity
+      waiting + (@max - spawned)
+    end
+
     # :nodoc:
     #
     # Must be called with @mutex held!

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -56,8 +56,8 @@ class TestCLI < Minitest::Test
     s = TCPSocket.new "127.0.0.1", 9877
     s << "GET /stats HTTP/1.0\r\n\r\n"
     body = s.read
-    assert_equal '{ "backlog": 0, "running": 0 }', body.split(/\r?\n/).last
-    assert_equal '{ "backlog": 0, "running": 0 }', Puma.stats
+    assert_equal '{ "backlog": 0, "running": 0, "pool_capacity": 16 }', body.split(/\r?\n/).last
+    assert_equal '{ "backlog": 0, "running": 0, "pool_capacity": 16 }', Puma.stats
 
     cli.launcher.stop
     t.join
@@ -95,7 +95,7 @@ class TestCLI < Minitest::Test
     s = UNIXSocket.new @tmp_path
     s << "GET /stats HTTP/1.0\r\n\r\n"
     body = s.read
-    assert_match(/\{ "workers": 2, "phase": 0, "booted_workers": 2, "old_workers": 0, "worker_status": \[\{ "pid": \d+, "index": 0, "phase": 0, "booted": true, "last_checkin": "[^"]+", "last_status": \{ "backlog":0, "running":2 \} \},\{ "pid": \d+, "index": 1, "phase": 0, "booted": true, "last_checkin": "[^"]+", "last_status": \{ "backlog":0, "running":2 \} \}\] \}/, body.split("\r\n").last)
+    assert_match(/\{ "workers": 2, "phase": 0, "booted_workers": 2, "old_workers": 0, "worker_status": \[\{ "pid": \d+, "index": 0, "phase": 0, "booted": true, "last_checkin": "[^"]+", "last_status": \{ "backlog":0, "running":2, "pool_capacity":2 \} \},\{ "pid": \d+, "index": 1, "phase": 0, "booted": true, "last_checkin": "[^"]+", "last_status": \{ "backlog":0, "running":2, "pool_capacity":2 \} \}\] \}/, body.split("\r\n").last)
 
     cli.launcher.stop
     t.join
@@ -118,7 +118,7 @@ class TestCLI < Minitest::Test
     s << "GET /stats HTTP/1.0\r\n\r\n"
     body = s.read
 
-    assert_equal '{ "backlog": 0, "running": 0 }', body.split("\r\n").last
+    assert_equal '{ "backlog": 0, "running": 0, "pool_capacity": 16 }', body.split("\r\n").last
 
     cli.launcher.stop
     t.join


### PR DESCRIPTION
This PR introduces the `pool_capacity` stat which can be used as a “negative back pressure metric”. 

What does a “negative backpressure metric” mean? It means when this number is low, we have a higher amount of backpressure. When it is zero it means that our worker has no ability to process additional requests. This information could be used to scale out by adding additional servers. When that happens the requests should be re-distributed between the extra server and the “pool capacity” number for each individual server should go up.