### PR TITLE
Travis: jruby-9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ rvm:
   - 2.4.4
   - 2.5.1
   - ruby-head
-  - jruby-9.1.17.0
+  - jruby-9.2.0.0
   - jruby-head
   - rbx-3
 matrix:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/05/24/jruby-9-2-0-0.html