### PR TITLE
Appveyor - Create fat-binary gems and test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,11 @@ Gemfile.lock
 /test/test_puma.state
 /test/test_server.sock
 /test/test_control.sock
+
+# windows local build artifacts
+/win_gem_test/shared/
+/win_gem_test/packages/
+/win_gem_test/test_logs/
+/Rakefile_wintest
+*.gem
+/lib/puma/puma_http11.rb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,110 +1,20 @@
-init:
-  - set PATH=C:\Ruby%ruby_version%\bin;C:\Program Files\7-Zip;C:\Program Files\AppVeyor\BuildAgent;C:\Program Files\Git\cmd;C:\Windows\system32
-  # Download current trunk, install OpenSSL via trunk_pkgs.cmd file
-  - ps: >-
-      if ($env:ruby_version -eq '_trunk') {
-        $trunk_uri = 'https://ci.appveyor.com/api/projects/MSP-Greg/ruby-loco/artifacts/ruby_trunk.7z'
-        (New-Object Net.WebClient).DownloadFile($trunk_uri, 'C:\ruby_trunk.7z')
-        7z.exe x C:\ruby_trunk.7z -oC:\Ruby_trunk
-      }
-
 install:
-  # Install ragel
+  # download shared script files
   - ps: >-
-      if ($env:ri_file -lt 'x86') {
-        C:\msys64\usr\bin\pacman -S --noconfirm --noprogressbar mingw-w64-x86_64-ragel
-      } else {
-        C:\msys64\usr\bin\pacman -S --noconfirm --noprogressbar mingw-w64-i686-ragel
-      }
-
-  # For RI builds, set SSL_CERT_FILE & add path for ragel
-  - ps: >-
-      if ($env:ruby_version -lt '24') {
-        $env:SSL_CERT_FILE = C:/Ruby25-x64/ssl/cert.pem
-        $env:path += ";C:\msys64\ming32\bin;"
-      }
-
-  # Download RubyInstaller OpenSSL Knapsack packages
-  # DevKit is installed in Ruby23 and Ruby23-x64 folders
-  - ps: >-
-      if ($env:ri_file -eq "x86") {
-        appveyor DownloadFile https://dl.bintray.com/oneclick/OpenKnapsack/x86/openssl-1.0.2j-x86-windows.tar.lzma
-        7z e openssl-1.0.2j-x86-windows.tar.lzma
-        7z x -y openssl-1.0.2j-x86-windows.tar -oC:\ruby23\DevKit\mingw\i686-w64-mingw32
-        # $env:b_config = "--with-ssl-dir=C:/Ruby23/DevKit/mingw --with-opt-include=C:/Ruby23/DevKit/mingw/include"
-      } elseif ($env:ri_file -eq "x64") {
-        appveyor DownloadFile https://dl.bintray.com/oneclick/OpenKnapsack/x64/openssl-1.0.2j-x64-windows.tar.lzma
-        7z e openssl-1.0.2j-x64-windows.tar.lzma
-        7z x -y openssl-1.0.2j-x64-windows.tar -oC:\ruby23-x64\DevKit\mingw\x86_64-w64-mingw32
-        # $env:b_config = "--with-ssl-dir=C:/Ruby23-x64/DevKit/mingw --with-opt-include=C:/Ruby23-x64/DevKit/mingw/include"
-      }
-
-  - RAKEOPT:
-  - APPVEYOR: true
-  - ruby --version
-  - gem --version
-  - bundle --version
-  - bundle install --without documentation --path C:/av_bundle
-
-  # Download & install current OpenSSL package for later RubyInstaller2/MSYS2 versions
-  - ps: >-
-      if ($env:ruby_version -ge '25' -or $env:ruby_version -eq '_trunk') {
-        if ($env:ruby_version -eq '25-x64' -or $env:ruby_version -eq '_trunk') {
-          $openssl = "mingw-w64-x86_64-openssl"
-          $dl_uri = "https://dl.bintray.com/msp-greg/ruby_trunk/"
-          $key = "77D8FA18"
-        } elseif ($env:ruby_version -eq '25') {
-          $openssl = "mingw-w64-i686-openssl"
-          $dl_uri = "https://dl.bintray.com/larskanis/rubyinstaller2-packages/"
-          $key = "BE8BF1C5"
-        }
-        Appveyor-Retry C:\msys64\usr\bin\bash.exe -lc "pacman-key -r $key --keyserver hkp://pool.sks-keyservers.net && pacman-key -f $key && pacman-key --lsign-key $key" 2> $null
-        C:\msys64\usr\bin\pacman.exe -Rdd --noconfirm --noprogressbar $openssl
-        $openssl += "-1.1.0.h-1-any.pkg.tar.xz"
-        $dl_uri += $openssl
-        $wc = $(New-Object System.Net.WebClient)
-        $wc.DownloadFile($dl_uri      , "C:\$openssl")
-        $wc.DownloadFile("$dl_uri.sig", "C:\$openssl.sig")
-        C:\msys64\usr\bin\pacman.exe -Udd --noconfirm --noprogressbar --force C:\$openssl
-        $env:b_config = "--use-system-libraries"
+      if ( !(Test-Path -Path ./shared -PathType Container) ) {
+        $uri = 'https://ci.appveyor.com/api/projects/MSP-Greg/av-gem-build-test/artifacts/shared.7z'
+        $7z  = 'C:\Program Files\7-Zip\7z.exe'
+        $fn = "$env:TEMP\shared.7z"
+        (New-Object System.Net.WebClient).DownloadFile($uri, $fn)
+        &$7z x $fn -owin_gem_test 1> $null
+        Remove-Item  -LiteralPath $fn -Force
+        Write-Host "Downloaded shared files" -ForegroundColor Yellow
       }
 
 build_script:
-  - bundle exec rake -rdevkit compile -- %b_config%
-
-test_script:
-  # clear path to test with ruby packaged dll's
-  - set PATH=C:\Ruby%ruby_version%\bin;C:\Program Files\7-Zip;C:\Program Files\AppVeyor\BuildAgent;C:\Program Files\Git\cmd;C:\Windows\system32
-  - set OPENSSL_DIR=
-  - bundle exec rake test TESTOPTS="--verbose"
-
-on_finish:
-  - ruby -v
+  - ps: .\win_gem_test\puma.ps1 $env:gem_bits
 
 environment:
   matrix:
-    - ruby_version: _trunk
-      ri_file: x64_2
-    - ruby_version: 25
-      ri_file: x86_2
-    - ruby_version: 25-x64
-      ri_file: x64_2
-    - ruby_version: 24
-      ri_file: x86_2
-    - ruby_version: 24-x64
-      ri_file: x64_2
-    - ruby_version: 23
-      ri_file: x86
-    - ruby_version: 23-x64
-      ri_file: x64
-    - ruby_version: 22
-      ri_file: x86
-    - ruby_version: 22-x64
-      ri_file: x64
-
-cache:
-  - C:\av_bundle
-
-branches:
-  only:
-    - master
+    - gem_bits: 64
+    - gem_bits: 32

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -10,7 +10,7 @@ class TestBinder < Minitest::Test
   end
 
   def test_localhost_addresses_dont_alter_listeners_for_tcp_addresses
-    skip_on_jruby
+    skip_on :jruby
 
     @binder.parse(["tcp://localhost:10001"], @events)
 
@@ -18,8 +18,7 @@ class TestBinder < Minitest::Test
   end
 
   def test_localhost_addresses_dont_alter_listeners_for_ssl_addresses
-    skip_on_appveyor
-    skip_on_jruby
+    skip_on :jruby
 
     key =  File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
     cert = File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
@@ -30,8 +29,7 @@ class TestBinder < Minitest::Test
   end
 
   def test_binder_parses_ssl_cipher_filter
-    skip_on_appveyor
-    skip_on_jruby
+    skip_on :jruby
 
     key =  File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
     cert = File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
@@ -45,7 +43,7 @@ class TestBinder < Minitest::Test
   end
 
   def test_binder_parses_jruby_ssl_options
-    skip unless Puma.jruby?
+    skip_unless :jruby
 
     keystore = File.expand_path "../../examples/puma/keystore.jks", __FILE__
     ssl_cipher_list = "TLS_DHE_RSA_WITH_DES_CBC_SHA,TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA"

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -63,8 +63,8 @@ class TestCLI < Minitest::Test
     t.join
   end
 
-  unless Puma.jruby? || Puma.windows?
   def test_control_clustered
+    skip_on :jruby, :windows, suffix: " - Puma::Binder::UNIXServer is not defined"
     url = "unix://#{@tmp_path}"
 
     cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
@@ -102,6 +102,7 @@ class TestCLI < Minitest::Test
   end
 
   def test_control
+    skip_on :jruby, :windows, suffix: " - Puma::Binder::UNIXServer is not defined"
     url = "unix://#{@tmp_path}"
 
     cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
@@ -125,6 +126,7 @@ class TestCLI < Minitest::Test
   end
 
   def test_control_stop
+    skip_on :jruby, :windows, suffix: " - Puma::Binder::UNIXServer is not defined"
     url = "unix://#{@tmp_path}"
 
     cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
@@ -147,6 +149,7 @@ class TestCLI < Minitest::Test
   end
 
   def test_control_gc_stats
+    skip_on :jruby, :windows, suffix: " - Puma::Binder::UNIXServer is not defined"
     url = "unix://#{@tmp_path}"
 
     cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
@@ -201,6 +204,7 @@ class TestCLI < Minitest::Test
   end
 
   def test_tmp_control
+    skip_on :jruby
     url = "tcp://127.0.0.1:8232"
     cli = Puma::CLI.new ["--state", @tmp_path, "--control", "auto"]
     cli.launcher.write_state
@@ -217,6 +221,7 @@ class TestCLI < Minitest::Test
   end
 
   def test_state_file_callback_filtering
+    skip_on :jruby, :windows, suffix: " - worker mode not supported"
     cli = Puma::CLI.new [ "--config", "test/config/state_file_testing_config.rb",
                           "--state", @tmp_path ]
     cli.launcher.write_state
@@ -226,8 +231,6 @@ class TestCLI < Minitest::Test
     keys_not_stripped = data.keys & Puma::CLI::KEYS_NOT_TO_PERSIST_IN_STATE
     assert_empty keys_not_stripped
   end
-
-  end # JRUBY or Windows
 
   def test_state
     url = "tcp://127.0.0.1:8232"

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -67,7 +67,7 @@ class TestIntegration < Minitest::Test
   end
 
   def restart_server_and_listen(argv)
-    skip_on_appveyor
+    skip_on :windows 
     server(argv)
     s = connect
     initial_reply = read_body(s)
@@ -115,7 +115,7 @@ class TestIntegration < Minitest::Test
   end
 
   def test_stop_via_pumactl
-    skip if Puma.jruby? || Puma.windows?
+    skip_on :jruby, :windows
 
     conf = Puma::Configuration.new do |c|
       c.quiet
@@ -148,7 +148,7 @@ class TestIntegration < Minitest::Test
   end
 
   def test_phased_restart_via_pumactl
-    skip if Puma.jruby? || Puma.windows? || ENV['CI']
+    skip_on :jruby, :windows, :ci, suffix: " - UNIX sockets are not recommended"
 
     conf = Puma::Configuration.new do |c|
       c.quiet
@@ -195,7 +195,7 @@ class TestIntegration < Minitest::Test
   end
 
   def test_kill_unknown_via_pumactl
-    skip if Puma.jruby? || Puma.windows?
+    skip_on :jruby, :windows
 
     # we run ls to get a 'safe' pid to pass off as puma in cli stop
     # do not want to accidently kill a valid other process
@@ -220,7 +220,7 @@ class TestIntegration < Minitest::Test
   end
 
   def test_restart_closes_keepalive_sockets_workers
-    skip_on_jruby
+    skip_on :jruby
     _, new_reply = restart_server_and_listen("-q -w 2 test/rackup/hello.ru")
     assert_equal "Hello World", new_reply
   end
@@ -229,7 +229,7 @@ class TestIntegration < Minitest::Test
   def test_restart_restores_environment
     # jruby has a bug where setting `nil` into the ENV or `delete` do not change the
     # next workers ENV
-    skip_on_jruby
+    skip_on :jruby
 
     initial_reply, new_reply = restart_server_and_listen("-q test/rackup/hello-env.ru")
 
@@ -239,7 +239,7 @@ class TestIntegration < Minitest::Test
   end
 
   def test_term_signal_exit_code_in_single_mode
-    skip if Puma.jruby? || Puma.windows?
+    skip_on :jruby, :windows
 
     pid = start_forked_server("test/rackup/hello.ru")
     _, status = stop_forked_server(pid)
@@ -248,7 +248,7 @@ class TestIntegration < Minitest::Test
   end
 
   def test_term_signal_exit_code_in_clustered_mode
-    skip if Puma.jruby? || Puma.windows?
+    skip_on :jruby, :windows
 
     pid = start_forked_server("-w 2 test/rackup/hello.ru")
     _, status = stop_forked_server(pid)

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -48,7 +48,7 @@ class TestPathHandler < Minitest::Test
 
 
   def test_handler_boots
-    skip_on_appveyor
+    skip_on :windows
     in_handler(app) do |launcher|
       hit(["http://0.0.0.0:#{ launcher.connected_port }/test"])
       assert_equal("/test", @input["PATH_INFO"])

--- a/test/test_unix_socket.rb
+++ b/test/test_unix_socket.rb
@@ -1,35 +1,33 @@
 require_relative "helper"
 
-# UNIX sockets are not recommended on JRuby
-# (or Windows)
-unless Puma.jruby? || Puma.windows?
-  class TestPumaUnixSocket < Minitest::Test
+class TestPumaUnixSocket < Minitest::Test
 
-    App = lambda { |env| [200, {}, ["Works"]] }
+  App = lambda { |env| [200, {}, ["Works"]] }
 
-    Path = "test/puma.sock"
+  Path = "test/puma.sock"
 
-    def setup
-      @server = Puma::Server.new App
-      @server.add_unix_listener Path
-      @server.run
-    end
+  def setup
+    # UNIX sockets are not recommended on JRuby or Windows
+    skip_on :jruby, :windows, suffix: " - UNIX sockets are not recommended"
+    @server = Puma::Server.new App
+    @server.add_unix_listener Path
+    @server.run
+  end
 
-    def teardown
-      @server.stop(true)
-      File.unlink Path if File.exist? Path
-    end
+  def teardown
+    @server.stop(true) if @server
+    File.unlink Path if File.exist? Path
+  end
 
-    def test_server
-      sock = UNIXSocket.new Path
+  def test_server
+    sock = UNIXSocket.new Path
 
-      sock << "GET / HTTP/1.0\r\nHost: blah.com\r\n\r\n"
+    sock << "GET / HTTP/1.0\r\nHost: blah.com\r\n\r\n"
 
-      expected = "HTTP/1.0 200 OK\r\nContent-Length: 5\r\n\r\nWorks"
+    expected = "HTTP/1.0 200 OK\r\nContent-Length: 5\r\n\r\nWorks"
 
-      assert_equal expected, sock.read(expected.size)
+    assert_equal expected, sock.read(expected.size)
 
-      sock.close
-    end
+    sock.close
   end
 end

--- a/win_gem_test/Rakefile_wintest
+++ b/win_gem_test/Rakefile_wintest
@@ -1,0 +1,11 @@
+# rake -f Rakefile_wintest -N -R norakelib
+
+require "rake/testtask"
+
+Rake::TestTask.new(:win_test) do |t|
+  t.libs << "test"
+  t.warning = false
+  t.options = '--verbose'
+end
+
+task :default => [:win_test]

--- a/win_gem_test/package_gem.rb
+++ b/win_gem_test/package_gem.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'rubygems/package'
+
+spec = Gem::Specification.load("./puma.gemspec")
+
+spec.files.concat ['Rakefile_wintest', 'lib/puma/puma_http11.rb']
+spec.files.concat Dir['lib/**/*.so']
+spec.test_files = Dir['{examples,test}/**/*.*']
+
+# below lines are required and not gem specific
+spec.platform = ARGV[0]
+spec.required_ruby_version = [">= #{ARGV[1]}", "< #{ARGV[2]}"]
+spec.extensions = []
+if spec.respond_to?(:metadata=)
+  spec.metadata.delete("msys2_mingw_dependencies")
+  spec.metadata['commit'] = ENV['commit_info']
+end
+
+Gem::Package.build(spec)

--- a/win_gem_test/puma.ps1
+++ b/win_gem_test/puma.ps1
@@ -1,0 +1,58 @@
+# PowerShell script for building & testing SQLite3-Ruby fat binary gem
+# Code by MSP-Greg, see https://github.com/MSP-Greg/av-gem-build-test
+
+# load utility functions, pass 64 or 32
+. $PSScriptRoot\shared\appveyor_setup.ps1 $args[0]
+if ($LastExitCode) { exit }
+
+# above is required code
+#———————————————————————————————————————————————————————————————— above for all repos
+
+Make-Const gem_name  'puma'
+Make-Const repo_name 'puma'
+Make-Const url_repo  'https://github.com/puma/puma.git'
+
+#———————————————————————————————————————————————————————————————— lowest ruby version
+Make-Const ruby_vers_low 22
+# nil  = don't compile; false = compile, ignore test (allow failure);
+# true = compile & test
+Make-Const trunk     $false ; Make-Const trunk_x64     $true
+Make-Const trunk_JIT $null  ; Make-Const trunk_x64_JIT $false
+
+#———————————————————————————————————————————————————————————————— make info
+Make-Const dest_so   'lib\puma'
+Make-Const exts      @(
+  @{ 'conf' = 'ext/puma_http11/extconf.rb' ; 'so' = 'puma_http11' }
+)
+Make-Const write_so_require $true
+
+#———————————————————————————————————————————————————————————————— Pre-Compile
+# runs before compiling starts on every ruby version
+function Pre-Compile {
+  # load the correct OpenSSL version in the build system
+  Check-OpenSSL
+  Write-Host Compiling With $env:SSL_VERS
+}
+
+#———————————————————————————————————————————————————————————————— Run-Tests
+function Run-Tests {
+  # call with comma separated list of gems to install or update
+  Update-Gems minitest, minitest-retry, rack, rake
+  $env:CI = 1
+  rake -f Rakefile_wintest -N -R norakelib | Set-Content -Path $log_name -PassThru -Encoding UTF8
+  # add info after test results
+  $(ruby -ropenssl -e "STDOUT.puts $/ + OpenSSL::OPENSSL_LIBRARY_VERSION") |
+    Add-Content -Path $log_name -PassThru -Encoding UTF8
+  minitest  # collects test results
+}
+
+#———————————————————————————————————————————————————————————————— below for all repos
+# below is required code
+Make-Const dir_gem  $(Convert-Path $PSScriptRoot\..)
+Make-Const dir_ps   $PSScriptRoot
+
+Push-Location $PSScriptRoot
+.\shared\make.ps1
+.\shared\test.ps1
+Pop-Location
+exit $ttl_errors_fails + $exit_code


### PR DESCRIPTION
Two jobs on Appveyor, 64 bit & 32 bit:
1. Builds Windows fat binary gems - currently for 2.2 thru 2.5. 64 bit also includes trunk.
2. Loops thru all Ruby versions, installs the gem, and tests.
3. Tests are shown on the Appveyor job test tab.
4. Gems and a 7z of test logs are saved as artifacts.
5. Current commit info (date, short SHA, summary) is stored in gemspec as metadata.
6. Shared Powershell files are downloaded from Appveyor.  Only three files added to repo.

Built three times on my [fork](https://ci.appveyor.com/project/MSP-Greg/puma/history), builds 10-12. Approx time is 11 minutes.