### PR TITLE
Docs update. Using a configuration file should be prioritized higher …

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,6 +38,10 @@ Here are some rules of thumb:
 * As you grow more confident in the thread safety of your app, you can tune the
   workers down and the threads up.
 
+#### Ubuntu / Systemd (Systemctl) Installation
+
+See [systemd.md](systemd.md)
+
 #### Worker utilization
 
 **How do you know if you're got enough (or too many workers)?**

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -32,21 +32,26 @@ Type=simple
 # Preferably configure a non-privileged user
 # User=
 
-# The path to the puma application root
-# Also replace the "<WD>" place holders below with this path.
-WorkingDirectory=
+# The path to the your application code root directory.
+# Also replace the "<YOUR_APP_PATH>" place holders below with this path.
+# Example /home/username/myapp
+WorkingDirectory=<YOUR_APP_PATH>
 
 # Helpful for debugging socket activation, etc.
 # Environment=PUMA_DEBUG=1
 
-# The command to start Puma. This variant uses a binstub generated via
-# `bundle binstubs puma --path ./sbin` in the WorkingDirectory
-# (replace "<WD>" below)
-ExecStart=<WD>/sbin/puma -b tcp://0.0.0.0:9292 -b ssl://0.0.0.0:9293?key=key.pem&cert=cert.pem
+# SystemD will not run puma even if it is in your path. You must specify
+# an absolute URL to puma. For example /usr/local/bin/puma
+# Alternatively, create a binstub with `bundle binstubs puma --path ./sbin` in the WorkingDirectory
+ExecStart=/<FULLPATH>/bin/puma -C <YOUR_APP_PATH>/puma.rb
 
-# Variant: Use config file with `bind` directives instead:
-# ExecStart=<WD>/sbin/puma -C config.rb
+# Variant: Rails start.
+# ExecStart=/<FULLPATH>/bin/puma -C <YOUR_APP_PATH>/config/puma.rb ../config.ru
+
 # Variant: Use `bundle exec --keep-file-descriptors puma` instead of binstub
+# Variant: Specify directives inline.
+# ExecStart=/<FULLPATH>/puma -b tcp://0.0.0.0:9292 -b ssl://0.0.0.0:9293?key=key.pem&cert=cert.pem
+
 
 Restart=always
 


### PR DESCRIPTION
Updated installation docs.

1. Using a configuration file should be prioritized higher than putting all the options inline.

2. Variables that the installer must edit are clarified with improved names. Previous documentation was less clear regarding directory paths.

3. Adds variant example for a Rails application with a Config.ru file.