### PR TITLE
Add max_threads to `Puma.stats`

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -293,7 +293,8 @@ module Puma
             b = server.backlog || 0
             r = server.running || 0
             t = server.pool_capacity || 0
-            payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r}, "pool_capacity":#{t} }\n!
+            m = server.max_threads || 0
+            payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r}, "pool_capacity":#{t}, "max_threads": #{m} }\n!
             io << payload
           rescue IOError
             Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -15,7 +15,8 @@ module Puma
       b = @server.backlog || 0
       r = @server.running || 0
       t = @server.pool_capacity || 0
-      %Q!{ "backlog": #{b}, "running": #{r}, "pool_capacity": #{t} }!
+      m = @server.max_threads || 0
+      %Q!{ "backlog": #{b}, "running": #{r}, "pool_capacity": #{t}, "max_threads": #{m} }!
     end
 
     def restart

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -56,8 +56,8 @@ class TestCLI < Minitest::Test
     s = TCPSocket.new "127.0.0.1", 9877
     s << "GET /stats HTTP/1.0\r\n\r\n"
     body = s.read
-    assert_equal '{ "backlog": 0, "running": 0, "pool_capacity": 16 }', body.split(/\r?\n/).last
-    assert_equal '{ "backlog": 0, "running": 0, "pool_capacity": 16 }', Puma.stats
+    assert_equal '{ "backlog": 0, "running": 0, "pool_capacity": 16, "max_threads": 16 }', body.split(/\r?\n/).last
+    assert_equal '{ "backlog": 0, "running": 0, "pool_capacity": 16, "max_threads": 16 }', Puma.stats
 
     cli.launcher.stop
     t.join
@@ -95,7 +95,7 @@ class TestCLI < Minitest::Test
     s = UNIXSocket.new @tmp_path
     s << "GET /stats HTTP/1.0\r\n\r\n"
     body = s.read
-    assert_match(/\{ "workers": 2, "phase": 0, "booted_workers": 2, "old_workers": 0, "worker_status": \[\{ "pid": \d+, "index": 0, "phase": 0, "booted": true, "last_checkin": "[^"]+", "last_status": \{ "backlog":0, "running":2, "pool_capacity":2 \} \},\{ "pid": \d+, "index": 1, "phase": 0, "booted": true, "last_checkin": "[^"]+", "last_status": \{ "backlog":0, "running":2, "pool_capacity":2 \} \}\] \}/, body.split("\r\n").last)
+    assert_match(/\{ "workers": 2, "phase": 0, "booted_workers": 2, "old_workers": 0, "worker_status": \[\{ "pid": \d+, "index": 0, "phase": 0, "booted": true, "last_checkin": "[^"]+", "last_status": \{ "backlog":0, "running":2, "pool_capacity":2, "max_threads": 2 \} \},\{ "pid": \d+, "index": 1, "phase": 0, "booted": true, "last_checkin": "[^"]+", "last_status": \{ "backlog":0, "running":2, "pool_capacity":2, "max_threads": 2 \} \}\] \}/, body.split("\r\n").last)
 
     cli.launcher.stop
     t.join
@@ -118,7 +118,7 @@ class TestCLI < Minitest::Test
     s << "GET /stats HTTP/1.0\r\n\r\n"
     body = s.read
 
-    assert_equal '{ "backlog": 0, "running": 0, "pool_capacity": 16 }', body.split("\r\n").last
+    assert_equal '{ "backlog": 0, "running": 0, "pool_capacity": 16, "max_threads": 16 }', body.split("\r\n").last
 
     cli.launcher.stop
     t.join


### PR DESCRIPTION
Currently we don’t know the max bound of the `pool_capacity` metric. We know `spawned` which is confusingly under the “running” keyword, however we don’t know if spawned is the highest it will possibly be.

By adding `max_threads` we know the upper bound for `running` threads and therefore the upper bound for pool capacity.

It should be noted that it’s not always guaranteed that puma will always create up to `max_threads`, a separate relationship between `running` and `max_threads` should be monitored as well (if min threads != max threads).