### PR TITLE
Fix chunked ending check

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -168,6 +168,7 @@ module Puma
           if len == 0
             @body.rewind
             rest = io.read
+            rest = rest[2..-1] if rest.start_with?("\r\n")
             @buffer = rest.empty? ? nil : rest
             @requests_served += 1
             @ready = true


### PR DESCRIPTION
As stated in #1480 according [to the spec](https://tools.ietf.org/html/rfc7230#section-3.3) a valid chunked body is formatted like this:

```
4.1.  Chunked Transfer Coding

   The chunked transfer coding wraps the payload body in order to
   transfer it as a series of chunks, each with its own size indicator,
   followed by an OPTIONAL trailer containing header fields.  Chunked
   enables content streams of unknown size to be transferred as a
   sequence of length-delimited buffers, which enables the sender to
   retain connection persistence and the recipient to know when it has
   received the entire message.

     chunked-body   = *chunk
                      last-chunk
                      trailer-part
                      CRLF

     chunk          = chunk-size [ chunk-ext ] CRLF
                      chunk-data CRLF
     chunk-size     = 1*HEXDIG
     last-chunk     = 1*("0") [ chunk-ext ] CRLF

     chunk-data     = 1*OCTET ; a sequence of chunk-size octets

   The chunk-size field is a string of hex digits indicating the size of
   the chunk-data in octets.  The chunked transfer coding is complete
   when a chunk with a chunk-size of zero is received, possibly followed
   by a trailer, and finally terminated by an empty line.

   A recipient MUST be able to parse and decode the chunked transfer
   coding.
```

An example would be something like this:

```
GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n
```

Notice the 2 CLRF's at the ending of the request. One is of the last last-chunk and the other one is the trailing CRLF of the chunked-body. Currently it Puma only accounts for a single CLRF and incorrectly sees the second CLRF as the start of a following request, which is malformed.

This PR checks for a second CLRF and skips it if present.

Fixes #1456 
Fixes #1480 

As a sidenode, does Puma parse trailer-parts?