### PR TITLE
Update url for binder parsing test for JRuby

### DIFF
--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -49,7 +49,7 @@ class TestBinder < Minitest::Test
 
     keystore = File.expand_path "../../examples/puma/keystore.jks", __FILE__
     ssl_cipher_list = "TLS_DHE_RSA_WITH_DES_CBC_SHA,TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA"
-    @binder.parse(["ssl://0.0.0.0?keystore=#{keystore}&ssl_cipher_list=#{ssl_cipher_list}"], @events)
+    @binder.parse(["ssl://0.0.0.0:8080?keystore=#{keystore}&keystore-pass=&ssl_cipher_list=#{ssl_cipher_list}"], @events)
 
     ssl= @binder.instance_variable_get(:@ios)[0]
     ctx = ssl.instance_variable_get(:@ctx)


### PR DESCRIPTION
This change will fix the [failing JRuby CI build](https://travis-ci.org/puma/puma/jobs/399748817). I suspect this test never worked, and something in how event errors were handled has changed.

In any case, I've added a keystore-pass url param to make MiniSSL happy (the `examples/puma/keystore.jks` has an empty password, which is fine).

I've also added a port to the URL string to fix a `no implicit conversion of nil into String` error that cam after fixing the keystore-pass (further supporting my suspicion that this never worked).