### PR TITLE
Fix  running test_puma_server_ssl.rb alone

### DIFF
--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -1,4 +1,6 @@
 require_relative "helper"
+require "puma/minissl"
+require "puma/puma_http11"
 
 class SSLEventsHelper < ::Puma::Events
   attr_accessor :addr, :cert, :error


### PR DESCRIPTION
Puma::MiniSSL.check must be defined for DISABLE_SSL to be false, it is defined for 'MRI' ruby in puma_http11, assuming gem was built with SSL.

Test file cannot be run alone without patch.