### PR TITLE
Make the check for the availability of fork() more precise

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -63,8 +63,8 @@ module Puma
 
       generate_restart_data
 
-      if clustered? && (Puma.jruby? || Puma.windows?)
-        unsupported 'worker mode not supported on JRuby or Windows'
+      if clustered? && !Process.respond_to?(:fork)
+        unsupported "worker mode not supported on #{RUBY_ENGINE} on this platform"
       end
 
       if @options[:daemon] && Puma.windows?


### PR DESCRIPTION
So that it also triggers for TruffleRuby which currently doesn't support `fork`.

Methods can have `respond_to?` => `false` if they are "unimplemented"/"not supported on this platform", but yet be actually defined and be part of `Module#methods`.
Those methods usually just raise a NotImplementedError like
`fork is not available (NotImplementedError)`.
This is what MRI does and it's also supported in at least JRuby, Rubinius and TruffleRuby.

The error message is made generic and now looks like this:
```
# For TruffleRuby
ERROR: worker mode not supported on truffleruby on this platform
# For JRuby
ERROR: worker mode not supported on jruby on this platform
```

Related: I wonder, why does the cluster mode of Puma needs `fork` and not just `spawn`?