### PR TITLE
Expose puma stats as prometheus metrics

### DIFF
--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -65,6 +65,9 @@ module Puma
 
         when /\/stats$/
           return rack_response(200, @cli.stats)
+
+        when /\/metrics$/
+          return rack_response(200, @cli.metrics.join("\r\n"), 'text/plain')
         else
           rack_response 404, "Unsupported action", 'text/plain'
         end

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -9,7 +9,7 @@ require 'socket'
 module Puma
   class ControlCLI
 
-    COMMANDS = %w{halt restart phased-restart start stats status stop reload-worker-directory gc gc-stats}
+    COMMANDS = %w{halt restart phased-restart start stats status stop reload-worker-directory gc gc-stats metrics}
 
     def initialize(argv, stdout=STDOUT, stderr=STDERR)
       @state = nil

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -98,6 +98,11 @@ module Puma
       @runner.stats
     end
 
+    # Return metrics about the server
+    def metrics
+      @runner.metrics
+    end
+
     # Write a state file that can be used by pumactl to control
     # the server
     def write_state

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -19,6 +19,24 @@ module Puma
       %Q!{ "backlog": #{b}, "running": #{r}, "pool_capacity": #{t}, "max_threads": #{m} }!
     end
 
+    def metrics
+      metrics = <<~METRICS
+        # HELP puma_backlog Number of established but unaccepted connections in the backlog
+        # TYPE puma_backlog gauge
+        puma_backlog #{@server.backlog || 0}
+        # HELP puma_running State of the server
+        # TYPE puma_running gauge
+        puma_running #{@server.running || 0}
+        # HELP puma_pool_capacity Number of allocatable worker threads
+        # TYPE puma_pool_capacity gauge
+        puma_pool_capacity #{@server.pool_capacity || 0}
+        # HELP puma_max_threads Maximum number of worker threads
+        # TYPE puma_max_threads gauge
+        puma_max_threads #{@server.max_threads || 0}
+      METRICS
+      metrics.split("\n")
+    end
+
     def restart
       @server.begin_restart
     end

--- a/test/test_app_status.rb
+++ b/test/test_app_status.rb
@@ -25,6 +25,10 @@ class TestAppStatus < Minitest::Test
     def stats
       "{}"
     end
+
+    def metrics
+      ["# HELP puma_metrics Some real metrics"]
+    end
   end
 
   def setup
@@ -84,6 +88,12 @@ class TestAppStatus < Minitest::Test
 
     assert_equal 200, status
     assert_equal ['{}'], app.enum_for.to_a
+  end
+
+  def test_metrics
+    status, _ , app = lint('/metrics')
+    assert_equal 200, status
+    assert_equal ['# HELP puma_metrics Some real metrics'], app.enum_for.to_a
   end
 
   def test_alternate_location


### PR DESCRIPTION
We use prometheus for monitoring our application. We would like to be able to get the `Puma.stats` in prometheus metrics format, so we can include this in our dashboards (and alarmings).

This is a proposal implementation, I think at least following should be added:

- [ ] extract metric boilerplate into method/class, for example `Metric::gauge`
- [ ] add `#metrics` for clustered mode
- [ ] add example in `config.rb` for `activate_control_app` on `tcp...`

Instead of using the `prometheus-client` gem, I've chosen to use the prometheus text-based format as defined on https://prometheus.io/docs/instrumenting/exposition_formats/.