### PR TITLE
Update systemd.md

### DIFF
--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -247,6 +247,12 @@ PIDFile=<WD>/shared/tmp/pids/puma.pid
 # reconsider if you actually need the forking config.
 Restart=no
 
+# `puma_ctl restart` wouldn't work without this. It's because `pumactl`
+# changes PID on restart and systemd stops the service afterwards
+# because of the PID change. This option prevents stopping after PID 
+# change.  
+RemainAfterExit=yes
+
 [Install]
 WantedBy=multi-user.target
 ~~~~


### PR DESCRIPTION
With previous forking configuration `pumactl restart` would't work. It would stop puma instead of restarting if it was started by systemd before. This also occurs when capistrano restarts puma after deploy.