### PR TITLE
Balance incoming requests across processes

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -396,7 +396,7 @@ module Puma
                     end
 
                     pool << client
-                    pool.wait_until_not_full
+                    pool.wait_until_not_full(sock)
                   end
                 rescue SystemCallError
                   # nothing


### PR DESCRIPTION
This is my first pass at a minimal solution to #1254. It adds an extra heuristic to `wait_until_not_full` that tries to balance incoming requests across all idle workers first before accepting requests for additional threads in a busy (but not full) worker. The theory is that minimizing thread contention through a more balanced request load should optimize multi-thread, multi-process performance in some use-cases.

The load-balancing heuristic should work something like this:

1. If the worker is idle (zero threads have work), always accept a request.
2. If the worker is busy (some but not all threads have work), perform a non-blocking (timeout = 0) [`select`](https://ruby-doc.org/core-2.5.1/IO.html#method-c-select) on the socket. If the socket has work available, then accept another request.
    - The socket should only ever have work available to this non-blocking `select` when all workers are already busy with at least one request, because step 1 has all idle workers waiting on the socket with a blocking `accept`.
3. If the worker is full (all threads have work), wait for a thread to finish, then repeat.
4. If some threads are busy and the socket is empty, wait either for a thread to finish its work or 1 second (whichever comes first), then repeat.
    - The timeout duration controls the minimum time between `select`-polling when none of the busy threads finish their work sooner. Maybe 1 second is a bit high- not sure yet what would work best for most cases.

So far I've only run this PR through some manual load-testing on a single Rails route with some potentially-promising results, but I haven't done exhaustive testing/validation yet. I plan to eventually test out these changes on my production workload described in https://github.com/puma/puma/issues/1254#issuecomment-420112799. If anyone has any self-contained benchmark scripts or concurrency-test harnesses that might be useful to test this PR against please let me know.