### PR TITLE
add out_of_band hook

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -365,6 +365,21 @@ module Puma
 
     alias_method :after_worker_boot, :after_worker_fork
 
+    # Code to run out-of-band when the worker is idle.
+    # These hooks run immediately after a request has finished
+    # processing and there are no busy threads on the worker.
+    # The worker doesn't accept new requests until this code finishes.
+    #
+    # This hook is useful for running out-of-band garbage collection
+    # or scheduling asynchronous tasks to execute after a response.
+    #
+    # This can be called multiple times to add hooks.
+    #
+    def out_of_band(&block)
+      @options[:out_of_band] ||= []
+      @options[:out_of_band] << block
+    end
+
     # The directory to operate out of.
     def directory(dir)
       @options[:directory] = dir.to_s

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -396,7 +396,10 @@ module Puma
                     end
 
                     pool << client
-                    pool.wait_until_not_full
+                    busy_threads = pool.wait_until_not_full
+                    if busy_threads == 0
+                      @options[:out_of_band].each(&:call) if @options[:out_of_band]
+                    end
                   end
                 rescue SystemCallError
                   # nothing

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -192,6 +192,9 @@ module Puma
     # method would not block and another request would be added into the reactor
     # by the server. This would continue until a fully bufferend request
     # makes it through the reactor and can then be processed by the thread pool.
+    #
+    # Returns the current number of busy threads, or +nil+ if shutting down.
+    #
     def wait_until_not_full
       @mutex.synchronize do
         while true
@@ -201,7 +204,8 @@ module Puma
           # is work queued that cannot be handled by waiting
           # threads, then accept more work until we would
           # spin up the max number of threads.
-          return if @todo.size - @waiting < @max - @spawned
+          busy_threads = @spawned - @waiting + @todo.size
+          return busy_threads if @max > busy_threads
 
           @not_full.wait @mutex
         end


### PR DESCRIPTION
This PR adds an `out_of_band` hook that is invoked when the worker is idle.

The hook runs immediately after a request has finished processing and there are no busy threads on the worker. The worker doesn't accept new requests until this code finishes.

This hook can be used for running out-of-band garbage collection as a solution to #450, e.g.:

```
# config/puma.rb
require 'gctools/oobgc'
out_of_band {GC::OOB.run}
```

It could also be useful for scheduling/deferring other asynchronous tasks to be run during idle periods on the server.