### PR TITLE
Freeze all the strings!

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 require 'socket'
 

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'optparse'
 require 'uri'
 

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class IO
   # We need to use this for a jruby work around on both 1.8 and 1.9.
   # So this either creates the constant (on 1.8), or harmlessly

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puma/runner'
 require 'puma/util'
 require 'puma/plugin'

--- a/lib/puma/commonlogger.rb
+++ b/lib/puma/commonlogger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Puma
   # Rack::CommonLogger forwards every request to the given +app+, and
   # logs a line in the

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puma/rack/builder'
 require 'puma/plugin'
 require 'puma/const'

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -1,4 +1,6 @@
 #encoding: utf-8
+# frozen_string_literal: true
+
 module Puma
   class UnsupportedOption < RuntimeError
   end

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'optparse'
 require 'puma/state_file'
 require 'puma/const'

--- a/lib/puma/convenient.rb
+++ b/lib/puma/convenient.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puma/launcher'
 require 'puma/configuration'
 

--- a/lib/puma/daemon_ext.rb
+++ b/lib/puma/daemon_ext.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Process
 
   # This overrides the default version because it is broken if it

--- a/lib/puma/delegation.rb
+++ b/lib/puma/delegation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Puma
   module Delegation
     def forward(what, who)

--- a/lib/puma/detect.rb
+++ b/lib/puma/detect.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Puma
   IS_JRUBY = defined?(JRUBY_VERSION)
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Puma
   # The methods that are available for use inside the config file.
   # These same methods are used in Puma cli and the rack handler

--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puma/const'
 require "puma/null_io"
 require 'stringio'

--- a/lib/puma/io_buffer.rb
+++ b/lib/puma/io_buffer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puma/detect'
 
 if Puma.jruby?

--- a/lib/puma/java_io_buffer.rb
+++ b/lib/puma/java_io_buffer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'java'
 
 # Conservative native JRuby/Java implementation of IOBuffer

--- a/lib/puma/jruby_restart.rb
+++ b/lib/puma/jruby_restart.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ffi'
 
 module Puma

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puma/events'
 require 'puma/detect'
 

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'io/wait'
   rescue LoadError

--- a/lib/puma/null_io.rb
+++ b/lib/puma/null_io.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Puma
   # Provides an IO-like object that always appears to contain no data.
   # Used as the value for rack.input when the request has no body.

--- a/lib/puma/plugin.rb
+++ b/lib/puma/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Puma
   class UnknownPlugin < RuntimeError; end
 

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puma/util'
 require 'puma/minissl'
 

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puma/server'
 require 'puma/const'
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 
 require 'puma/thread_pool'

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puma/runner'
 require 'puma/detect'
 require 'puma/plugin'

--- a/lib/puma/state_file.rb
+++ b/lib/puma/state_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 
 module Puma

--- a/lib/puma/tcp_logger.rb
+++ b/lib/puma/tcp_logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Puma
   class TCPLogger
     def initialize(logger, app, quiet=false)

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Puma

--- a/lib/puma/util.rb
+++ b/lib/puma/util.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 major, minor, patch = RUBY_VERSION.split('.').map { |v| v.to_i }
 
 if major == 1 && minor == 9 && patch == 3 && RUBY_PATCHLEVEL < 125


### PR DESCRIPTION
Reduces runtime allocation by freezing string literals by default.

We could also remove a ton of manual `.freeze` calls, however the ruby supported version is 2.2 and the magic comment only targets 2.3+.