### PR TITLE
fix(jungle): change pid existence check's condition branches

### DIFF
--- a/tools/jungle/init.d/puma
+++ b/tools/jungle/init.d/puma
@@ -47,11 +47,11 @@ do_start_one() {
   PIDFILE=$1/tmp/puma/pid
   if [ -e $PIDFILE ]; then
     PID=`cat $PIDFILE`
-    # If the puma isn't running, run it, otherwise restart it.
+    # If the puma is running, restart it, otherwise run it.
     if ps -p $PID > /dev/null; then
-      do_start_one_do $1
-    else
       do_restart_one $1
+    else
+      do_start_one_do $1
     fi
   else
     do_start_one_do $1
@@ -106,8 +106,6 @@ do_stop_one() {
   if [ -e $PIDFILE ]; then
     PID=`cat $PIDFILE`
     if ps -p $PID > /dev/null; then
-      log_daemon_msg "---> Puma $1 isn't running."
-    else
       log_daemon_msg "---> About to kill PID `cat $PIDFILE`"
       if [ "$USE_LOCAL_BUNDLE" -eq 1 ]; then
         cd $1 && bundle exec pumactl --state $STATEFILE stop
@@ -116,6 +114,8 @@ do_stop_one() {
       fi
       # Many daemons don't delete their pidfiles when they exit.
       rm -f $PIDFILE $STATEFILE
+    else
+      log_daemon_msg "---> Puma $1 isn't running."
     fi
   else
     log_daemon_msg "---> No puma here..."


### PR DESCRIPTION
Pull request https://github.com/puma/puma/pull/1545 broke the ability to stop and restart running instances. The old version of checking $PID existence was truthy **on non-existence**, now it's truthy **on existence**.

Example in case of existing PID 1209:

```sh
$ if [ "`ps -A -o pid= | grep -c 1209`" -eq 0 ]; then echo true; else echo false; fi;
true
```

```sh
$ if ps -p 1209 > /dev/null; then echo true; else echo false; fi;
false
```