### PR TITLE
Don't call .stop on a server that doesn't exist

### DIFF
--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -24,7 +24,7 @@ module Puma
     end
 
     def stop
-      @server.stop false
+      @server.stop(false) if @server
     end
 
     def halt
@@ -34,7 +34,7 @@ module Puma
     def stop_blocked
       log "- Gracefully stopping, waiting for requests to finish"
       @control.stop(true) if @control
-      @server.stop(true)
+      @server.stop(true) if @server
     end
 
     def jruby_daemon?


### PR DESCRIPTION
Ignore the branch name - this turns out to work! Fixes #1523 for us on 3.12.0.

Issue we had was a misconfiguration was causing puma to be SIGTERM'd by ECS before it could set `@server` to anything, which meant that as it tried to graceful stop it hit #1523, confusing our debugging efforts.