### PR TITLE
⚠ mismatched indentations at 'rescue' with 'begin'

### DIFF
--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -2,7 +2,7 @@
 
 begin
   require 'io/wait'
-  rescue LoadError
+rescue LoadError
 end
 
 module Puma


### PR DESCRIPTION
This warns on puma (3.12.0):
`% ruby -wrpuma/minissl -ep`