### PR TITLE
Add ability to control the maximum number of worker terminations

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -100,6 +100,8 @@ module Puma
     def setup_options
       @conf = Configuration.new do |user_config, file_config|
         @parser = OptionParser.new do |o|
+          o.set_summary_width 38
+
           o.on "-b", "--bind URI", "URI to bind to (tcp://, unix://, ssl://)" do |arg|
             user_config.bind arg
           end
@@ -204,6 +206,11 @@ module Puma
           o.on "-w", "--workers COUNT",
             "Activate cluster mode: How many worker processes to create" do |arg|
             user_config.workers arg
+          end
+
+          o.on "--max-worker-terminations COUNT",
+            "Cluster mode: How many worker terminations to allow before terminating the parent process" do |arg|
+            user_config.max_worker_terminations arg
           end
 
           o.on "--tag NAME", "Additional text to display in process listing" do |arg|

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -175,6 +175,7 @@ module Puma
         :debug => false,
         :binds => ["tcp://#{DefaultTCPHost}:#{DefaultTCPPort}"],
         :workers => 0,
+        :max_worker_terminations => nil,
         :daemon => false,
         :mode => :http,
         :worker_timeout => DefaultWorkerTimeout,

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -309,6 +309,13 @@ module Puma
       @options[:workers] = count.to_i
     end
 
+    # *Cluster mode only* The maximum number of worker terminations
+    # before the entire process is terminated.
+    #
+    def max_worker_terminations(count)
+      @options[:max_worker_terminations] = count.to_i
+    end
+
     # *Cluster mode only* Code to run immediately before master process
     # forks workers (once on boot). These hooks can block if necessary
     # to wait for background operations unknown to puma to finish before


### PR DESCRIPTION
This is an initial cut at fixing #1663 by adding a new configuration parameter that will enable you to set the maximum number of worker terminations you will accept before nuking the entire parent process.

The other idea instead of a count was to simply set if you accept worker terminations or not when running in clustered mode which would probably simplify things even more.