### PR TITLE
mini_ssl.c - DTLSv1_method -> DTLS_method

### DIFF
--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -217,7 +217,7 @@ VALUE engine_init_client(VALUE klass) {
   VALUE obj;
   ms_conn* conn = engine_alloc(klass, &obj);
 
-  conn->ctx = SSL_CTX_new(DTLSv1_method());
+  conn->ctx = SSL_CTX_new(DTLS_method());
   conn->ssl = SSL_new(conn->ctx);
   SSL_set_app_data(conn->ssl, NULL);
   SSL_set_verify(conn->ssl, SSL_VERIFY_NONE, NULL);


### PR DESCRIPTION
mini_ssl.c is currently using `DTLSv1_method`, which is a version specific method that is deprecated as of OpenSSL 1.1.0.

[`DTLS_method`](https://www.openssl.org/docs/man1.1.0/ssl/DTLS_method.html) is a 'version-flexible DTLS method'.

This also eliminates compile warnings in both Appveyor & Travis when compiling with OpenSSL 1.1.0 or greater.