### PR TITLE
Do not accept new requests on shutdown

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -79,7 +79,6 @@ module Puma
       @first_data_timeout = options.fetch(:first_data_timeout, FIRST_DATA_TIMEOUT)
 
       @binder = Binder.new(events)
-      @own_binder = true
 
       @leak_stack_on_error = true
 
@@ -102,7 +101,6 @@ module Puma
 
     def inherit_binder(bind)
       @binder = bind
-      @own_binder = false
     end
 
     def tcp_mode!
@@ -272,7 +270,7 @@ module Puma
 
         @notify.close
 
-        if @status != :restart and @own_binder
+        if @status != :restart
           @binder.close
         end
       end
@@ -431,7 +429,7 @@ module Puma
         @check.close
         @notify.close
 
-        if @status != :restart and @own_binder
+        if @status != :restart
           @binder.close
         end
       end
@@ -940,6 +938,10 @@ module Puma
         end
 
         @events.debug "Drained #{count} additional connections."
+      end
+
+      if @status != :restart
+        @binder.close
       end
 
       if @thread_pool

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -269,10 +269,6 @@ module Puma
         end
 
         @notify.close
-
-        if @status != :restart
-          @binder.close
-        end
       end
 
       @events.fire :state, :done
@@ -428,10 +424,6 @@ module Puma
       ensure
         @check.close
         @notify.close
-
-        if @status != :restart
-          @binder.close
-        end
       end
 
       @events.fire :state, :done

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -79,7 +79,6 @@ module Puma
       @first_data_timeout = options.fetch(:first_data_timeout, FIRST_DATA_TIMEOUT)
 
       @binder = Binder.new(events)
-      @own_binder = true
 
       @leak_stack_on_error = true
 
@@ -102,7 +101,6 @@ module Puma
 
     def inherit_binder(bind)
       @binder = bind
-      @own_binder = false
     end
 
     def tcp_mode!
@@ -271,10 +269,6 @@ module Puma
         end
 
         @notify.close
-
-        if @status != :restart and @own_binder
-          @binder.close
-        end
       end
 
       @events.fire :state, :done
@@ -430,10 +424,6 @@ module Puma
       ensure
         @check.close
         @notify.close
-
-        if @status != :restart and @own_binder
-          @binder.close
-        end
       end
 
       @events.fire :state, :done
@@ -940,6 +930,10 @@ module Puma
         end
 
         @events.debug "Drained #{count} additional connections."
+      end
+
+      if @status != :restart
+        @binder.close
       end
 
       if @thread_pool

--- a/test/rackup/10seconds.ru
+++ b/test/rackup/10seconds.ru
@@ -1,0 +1,4 @@
+run lambda { |env|
+  sleep 10
+  [200, {}, ["Hello World"]]
+}


### PR DESCRIPTION
Related to https://github.com/puma/puma/pull/1186

**Problem:**

When puma process receives `TERM` signal it tries to finish all current requests and terminate. But... it also accepts "new requests" and these requests are hanged. When the processing of all current requests (which was made before shutdown signal is received) are finished, all "new requests" are closed with error `Connection reset by peer`.
This error prevents load balancers (like nginx) to forward these requests to other web-server, because this error does not guarantee that the request was not processed, but this guarantee is required to forward not idempotent HTTP request (like POST).

Seems like puma should refuse new requests by closing a socket that accepts new connections.

Read https://github.com/puma/puma/pull/1186#issuecomment-445462578 for implementation details.

This solution is simple and fast. But probably there is a better solution.