### PR TITLE
Avoid Ruby warnings

### DIFF
--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -2,7 +2,7 @@
 
 begin
   require 'io/wait'
-  rescue LoadError
+rescue LoadError
 end
 
 module Puma

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -147,7 +147,7 @@ class TestPumaServerSSLClient < Minitest::Test
 
     events = SSLEventsHelper.new STDOUT, STDERR
     server = Puma::Server.new app, events
-    ssl_listener = server.add_ssl_listener host, port, ctx
+    server.add_ssl_listener host, port, ctx
     server.run
 
     http = Net::HTTP.new host, port


### PR DESCRIPTION
This PR avoids two **Ruby warnings** output when running the test suite.

```
/Users/olle/opensource/puma/lib/puma/minissl.rb:5: warning: mismatched indentations at 'rescue' with 'begin' at 3
```


and

```
/Users/olle/opensource/puma/test/test_puma_server_ssl.rb:150: warning: assigned but unused variable - ssl_listener
```