### PR TITLE
Prefer localhost over 0.0.0.0 when in "development" mode

### DIFF
--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -16,6 +16,10 @@ module Rack
 
         default_options = DEFAULT_OPTIONS.dup
 
+        if options[:environment] == "development"
+          default_options[:Host] = "localhost"
+        end
+
         # Libraries pass in values such as :Port and there is no way to determine
         # if it is a default provided by the library or a special value provided
         # by the user. A special key `user_supplied_options` can be passed. This

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -79,6 +79,16 @@ class TestUserSuppliedOptionsPortIsSet < Minitest::Test
       end
     end
   end
+
+  def test_localhost_is_used_when_environment_is_development
+    user_port = 5001
+    @options[:environment] = "development"
+    @options[:Port] = user_port
+    conf = Rack::Handler::Puma.config(->{}, @options)
+    conf.load
+
+    assert_equal ["tcp://localhost:#{user_port}"], conf.options[:binds]
+  end
 end
 
 class TestUserSuppliedOptionsHostIsSet < Minitest::Test


### PR DESCRIPTION
When booting Puma via a `rails server` command it is desired to bind to `localhost` over `0.0.0.0`. It is less secure to run a development application on `0.0.0.0`.

To understand the differences here is a SO post https://stackoverflow.com/questions/20778771/what-is-the-difference-between-0-0-0-0-127-0-0-1-and-localhost

This PR works by detecting the "environment" option passed by default from Rails https://github.com/rails/rails/blob/663f6cc14fd01650546ed508efb3f7ad8e30135c/railties/lib/rails/commands/server/server_command.rb#L175. When it is set to "development" then `localhost` is used.