### PR TITLE
Allow running individual tests via the `m` gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,5 @@ gem "rubocop", "~> 0.58.0"
 if %w(2.2.7 2.2.8 2.2.9 2.2.10 2.3.4 2.4.1).include? RUBY_VERSION
   gem "stopgap_13632", "~> 1.0", :platforms => ["mri", "mingw", "x64_mingw"]
 end
+
+gem 'm'


### PR DESCRIPTION
```
$ bundle exec m test/test_rack_handler.rb:34
```

If it's not in the Gemfile, then you can't execute `m` with `bundle exec`.