### PR TITLE
Getting a failure in the tests:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ sudo: false
 group: beta
 language: ruby
 cache: bundler
-before_install:
-  # https://github.com/travis-ci/travis-ci/issues/9383#issuecomment-377680108
-  # recent versions of RubyGems include bundler
-  - gem update --system
 
 rvm:
   - 2.2.10
@@ -27,7 +23,7 @@ matrix:
       os: osx
     - rvm: jruby-head
     - rvm: rbx-3
-      
+
   allow_failures:
     - rvm: ruby-head
     - rvm: ruby-head


### PR DESCRIPTION
```
2.93s$ gem update --system
Updating rubygems-update
Fetching: rubygems-update-3.0.2.gem (100%)
ERROR:  Error installing rubygems-update:
	rubygems-update requires Ruby version >= 2.3.0.
ERROR:  While executing gem ... (NoMethodError)
    undefined method `version' for nil:NilClass
The command "gem update --system" failed and exited with 1 during .
```