### PR TITLE
Fix restart for Ruby 2.6 and Bundler 2

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -376,7 +376,7 @@ module Puma
       # The code below makes sure that the process spawned during a restart
       # will require the same version of Bundler as is used by the current process.
       if spec = Gem.loaded_specs['bundler']
-        arg0[1,0] = spec.full_require_paths.flat_map {|p| ['-I', p] }
+        arg0[1, 0] = spec.full_require_paths.flat_map { |path| ['-I', path] }
       end
 
       if defined? Puma::WILD_ARGS


### PR DESCRIPTION
Ruby 2.6 ships with Bundler 1.17, and we're requiring it early
by putting `-rbundler/setup` in `ENV['RUBYOPT']`. If an application
is using Bundler 2, the app's Gemfile will cause an error
for Bundler 1.17, something along the lines of "You must use
Bundler 2 or greater with this lockfile. (Bundler::LockfileError)".

The code in PR makes sure that the process spawned during a restart
will require the same version of Bundler as is used by the current process.