### PR TITLE
    .travis.yml - switch to xenial, adjust to pass, JRuby allow failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
-dist: trusty
-sudo: false
-group: beta
+dist: xenial
 language: ruby
 cache: bundler
 
 before_install:
-  # rubygems 2.7.8 and greater include bundler
+  # rubygems 2.7.8 and greater include bundler, leave 2.6.0 untouched
   - |
     rv="$(ruby -e 'STDOUT.write RUBY_VERSION')";
     if   [ "$rv" \< "2.3" ]; then gem update --system 2.7.8 --no-document
@@ -13,13 +11,21 @@ before_install:
     fi
   - ruby -v && gem --version && bundle version
 
+before_script:
+  - bundle exec rake compile
+
+script:
+  - bundle exec rake
+
 rvm:
   - 2.2.10
   - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6
   - ruby-head
-  - jruby-9.2.0.0
+  - jruby-9.2.5.0
+  - jruby-head
 
 matrix:
   fast_finish: true
@@ -30,15 +36,14 @@ matrix:
       os: osx
     - rvm: 2.5.3
       os: osx
-    - rvm: jruby-head
-    - rvm: rbx-3
-      
+
   allow_failures:
+    - rvm: 2.6
     - rvm: ruby-head
     - rvm: ruby-head
       env: RUBYOPT="--jit"
+    - rvm: jruby-9.2.5.0
     - rvm: jruby-head
-    - rvm: rbx-3
 
 env:
   global:

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -1,6 +1,8 @@
 require_relative "helper"
 require "puma/minissl"
 require "puma/puma_http11"
+# net/http (loaded in helper) does not necessarily load OpenSSL
+require "openssl" unless Object.const_defined? :OpenSSL
 
 #———————————————————————————————————————————————————————————————————————————————
 #             NOTE: ALL TESTS BYPASSED IF DISABLE_SSL IS TRUE
@@ -113,13 +115,15 @@ class TestPumaServerSSL < Minitest::Test
 
   def test_ssl_v3_rejection
     @http.ssl_version= :SSLv3
-    assert_raises(OpenSSL::SSL::SSLError) do
+    # Ruby 2.4.5 on Travis raises ArgumentError
+    assert_raises(OpenSSL::SSL::SSLError, ArgumentError) do
       @http.start do
         Net::HTTP::Get.new '/'
       end
     end
     unless Puma.jruby?
-      assert_match(/wrong version number|no protocols available/, @events.error.message) if @events.error
+      msg = /wrong version number|no protocols available|unknown SSL method/
+      assert_match(msg, @events.error.message) if @events.error
     end
   end
 
@@ -147,7 +151,7 @@ class TestPumaServerSSLClient < Minitest::Test
 
     events = SSLEventsHelper.new STDOUT, STDERR
     server = Puma::Server.new app, events
-    ssl_listener = server.add_ssl_listener host, port, ctx
+    server.add_ssl_listener host, port, ctx
     server.run
 
     http = Net::HTTP.new host, port


### PR DESCRIPTION
test_puma_server_ssl.rb - add error info for ArgumentError raised in Ruby 2.4.5

Currently, problems with ruby-head/trunk, Ruby 2.6.0, & JRuby

Use 'before_script' to take advantage of html 'folding'

There may be intermittent errors