### PR TITLE
Stop the CRLF warnings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text eol=lf
+*.png binary


### PR DESCRIPTION
Fixes #1672.

Locally I'm seeing 

```
mkent@mkvps01 ~/git/puma % git diff
warning: CRLF will be replaced by LF in docs/images/puma-connection-flow-no-reactor.png.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in docs/images/puma-connection-flow.png.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in docs/images/puma-general-arch.png.
The file will have its original line endings in your working directory.
diff --git a/docs/images/puma-connection-flow-no-reactor.png b/docs/images/puma-connection-flow-no-reactor.png
index 05ef8d0..99926a8 100644
Binary files a/docs/images/puma-connection-flow-no-reactor.png and b/docs/images/puma-connection-flow-no-reactor.png differ
diff --git a/docs/images/puma-connection-flow.png b/docs/images/puma-connection-flow.png
index afae5df..3f53768 100644
Binary files a/docs/images/puma-connection-flow.png and b/docs/images/puma-connection-flow.png differ
diff --git a/docs/images/puma-general-arch.png b/docs/images/puma-general-arch.png
index 89e26bd..82d3b08 100644
Binary files a/docs/images/puma-general-arch.png and b/docs/images/puma-general-arch.png differ
```
on linux if I so much as run a gif diff.