### PR TITLE
Min worker timeout

### DIFF
--- a/examples/config.rb
+++ b/examples/config.rb
@@ -174,7 +174,8 @@
 # the given timeout. If not the worker process will be restarted. This is
 # not a request timeout, it is to protect against a hung or dead process.
 # Setting this value will not protect against slow requests.
-# Default value is 60 seconds.
+#
+# The minimum value is 6 seconds, the default value is 60 seconds.
 #
 # worker_timeout 60
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -434,6 +434,13 @@ module Puma
     # that have not checked in within the given +timeout+.
     # This mitigates hung processes. Default value is 60 seconds.
     def worker_timeout(timeout)
+      timeout = Integer(timeout)
+      min = Cluster::WORKER_CHECK_INTERVAL
+
+      if timeout <= min
+        raise "The minimum worker_timeout must be greater than the worker reporting interval (#{min})"
+      end
+
       @options[:worker_timeout] = Integer(timeout)
     end
 


### PR DESCRIPTION
Fixes #1714.

Abort on startup if the worker_timeout is too low and mention the limit.

6 is a bit awkward though, might be cleaner to set the minimum at 2 * the WORKER_CHECK_INTERVAL.