### PR TITLE
Travis - update Ruby/MacOS to Xenial, add skips based on functionality, misc test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
-dist: trusty
-sudo: false
-group: beta
+dist: xenial
 language: ruby
 cache: bundler
 
 before_install:
-  # rubygems 2.7.8 and greater include bundler
+  # rubygems 2.7.8 and greater include bundler, leave 2.6.0 untouched
   - |
     rv="$(ruby -e 'STDOUT.write RUBY_VERSION')";
     if   [ "$rv" \< "2.3" ]; then gem update --system 2.7.8 --no-document
@@ -13,13 +11,19 @@ before_install:
     fi
   - ruby -v && gem --version && bundle version
 
+before_script:
+  - bundle exec rake compile
+
+script:
+  - bundle exec rake
+
 rvm:
   - 2.2.10
   - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6
   - ruby-head
-  - jruby-9.2.0.0
 
 matrix:
   fast_finish: true
@@ -30,15 +34,21 @@ matrix:
       os: osx
     - rvm: 2.5.3
       os: osx
+    - rvm: jruby-9.2.5.0
+      dist: trusty
+      sudo: false
     - rvm: jruby-head
-    - rvm: rbx-3
-      
+      dist: trusty
+      sudo: false
+
   allow_failures:
+    - rvm: 2.6
     - rvm: ruby-head
     - rvm: ruby-head
       env: RUBYOPT="--jit"
     - rvm: jruby-head
-    - rvm: rbx-3
+      dist: trusty
+      sudo: false
 
 env:
   global:

--- a/test/rackup/hello-stuck-ci.ru
+++ b/test/rackup/hello-stuck-ci.ru
@@ -1,0 +1,1 @@
+run lambda { |env| sleep 10; [200, {"Content-Type" => "text/plain"}, ["Hello World"]] }

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -7,12 +7,12 @@ require "open3"
 # These don't run on travis because they're too fragile
 
 class TestIntegration < Minitest::Test
+
   def setup
     @state_path = "test/test_puma.state"
     @bind_path = "test/test_server.sock"
     @control_path = "test/test_control.sock"
     @token = "xxyyzz"
-    @tcp_port = 9998
 
     @server = nil
 
@@ -42,6 +42,7 @@ class TestIntegration < Minitest::Test
   end
 
   def server(argv)
+    @tcp_port = next_port
     base = "#{Gem.ruby} -Ilib bin/puma"
     base.prepend("bundle exec ") if defined?(Bundler)
     cmd = "#{base} -b tcp://127.0.0.1:#{@tcp_port} #{argv}"
@@ -53,6 +54,7 @@ class TestIntegration < Minitest::Test
   end
 
   def start_forked_server(argv)
+    @tcp_port = next_port
     pid = fork do
       exec "#{Gem.ruby} -I lib/ bin/puma -b tcp://127.0.0.1:#{@tcp_port} #{argv}"
     end
@@ -68,7 +70,6 @@ class TestIntegration < Minitest::Test
   end
 
   def restart_server_and_listen(argv)
-    skip_on :windows
     server(argv)
     s = connect
     initial_reply = read_body(s)
@@ -116,7 +117,7 @@ class TestIntegration < Minitest::Test
   end
 
   def test_stop_via_pumactl
-    skip_on :jruby, :windows
+    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
 
     conf = Puma::Configuration.new do |c|
       c.quiet
@@ -149,7 +150,10 @@ class TestIntegration < Minitest::Test
   end
 
   def test_phased_restart_via_pumactl
-    skip_on :jruby, :windows, :ci, suffix: " - UNIX sockets are not recommended"
+    skip NO_FORK_MSG unless HAS_FORK
+
+    # hello-stuck-ci uses sleep 10, hello-stuck uses sleep 60
+    rackup = "test/rackup/hello-stuck#{ ENV['CI'] ? '-ci' : '' }.ru"
 
     conf = Puma::Configuration.new do |c|
       c.quiet
@@ -158,7 +162,7 @@ class TestIntegration < Minitest::Test
       c.activate_control_app "unix://#{@control_path}", :auth_token => @token
       c.workers 2
       c.worker_shutdown_timeout 1
-      c.rackup "test/rackup/hello-stuck.ru"
+      c.rackup rackup
     end
 
     l = Puma::Launcher.new conf, :events => @events
@@ -196,11 +200,11 @@ class TestIntegration < Minitest::Test
   end
 
   def test_kill_unknown_via_pumactl
-    skip_on :jruby, :windows
+    skip_on :jruby
 
     # we run ls to get a 'safe' pid to pass off as puma in cli stop
     # do not want to accidently kill a valid other process
-    io = IO.popen("ls")
+    io = IO.popen(windows? ? "dir" : "ls")
     safe_pid = io.pid
     Process.wait safe_pid
 
@@ -211,17 +215,19 @@ class TestIntegration < Minitest::Test
       ccli.run
     end
     sout.rewind
-    assert_match(/No pid '\d+' found/, sout.readlines.join(""))
+    # windows bad URI(is not URI?)
+    assert_match(/No pid '\d+' found|bad URI\(is not URI\?\)/, sout.readlines.join(""))
     assert_equal(1, e.status)
   end
 
   def test_restart_closes_keepalive_sockets
+    skip_unless_signal_exist? :USR2
     _, new_reply = restart_server_and_listen("-q test/rackup/hello.ru")
     assert_equal "Hello World", new_reply
   end
 
   def test_restart_closes_keepalive_sockets_workers
-    skip_on :jruby
+    skip NO_FORK_MSG unless HAS_FORK
     _, new_reply = restart_server_and_listen("-q -w 2 test/rackup/hello.ru")
     assert_equal "Hello World", new_reply
   end
@@ -231,6 +237,7 @@ class TestIntegration < Minitest::Test
     # jruby has a bug where setting `nil` into the ENV or `delete` do not change the
     # next workers ENV
     skip_on :jruby
+    skip_unless_signal_exist? :USR2
 
     initial_reply, new_reply = restart_server_and_listen("-q test/rackup/hello-env.ru")
 
@@ -240,7 +247,7 @@ class TestIntegration < Minitest::Test
   end
 
   def test_term_signal_exit_code_in_single_mode
-    skip_on :jruby, :windows
+    skip NO_FORK_MSG unless HAS_FORK
 
     pid = start_forked_server("test/rackup/hello.ru")
     _, status = stop_forked_server(pid)
@@ -249,7 +256,7 @@ class TestIntegration < Minitest::Test
   end
 
   def test_term_signal_exit_code_in_clustered_mode
-    skip_on :jruby, :windows
+    skip NO_FORK_MSG unless HAS_FORK
 
     pid = start_forked_server("-w 2 test/rackup/hello.ru")
     _, status = stop_forked_server(pid)

--- a/test/test_unix_socket.rb
+++ b/test/test_unix_socket.rb
@@ -7,8 +7,7 @@ class TestPumaUnixSocket < Minitest::Test
   Path = "test/puma.sock"
 
   def setup
-    # UNIX sockets are not recommended on JRuby or Windows
-    skip_on :jruby, :windows, suffix: " - UNIX sockets are not recommended"
+    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
     @server = Puma::Server.new App
     @server.add_unix_listener Path
     @server.run


### PR DESCRIPTION
Commit 'Update travis & tests':

1. JRuby still using Trusty, as Xenial was broken.
2. Adds skip functionality for fork, UNIXSocket, available Signals.
3. A few test updates
4. TestCLI#test_control_gc_stats - create two tests, one unix, one tcp

Commit: 'fix TestIntegration#test_phased_restart_via_pumactl':

5. Test had a sixty second timeout, which exceeds the CI test timeout.  Changed to 10 for CI.  The test now takes a bit over ten seconds to complete...

**NOTE: Ruby 2.6.0 & ruby-head/trunk are not passing.**

Replaces PR #1713.