### PR TITLE
Fixes a few spelling errors in docs/deployment.md

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,18 +40,18 @@ Here are some rules of thumb:
 
 #### Worker utilization
 
-**How do you know if you're got enough (or too many workers)?**
+**How do you know if you've got enough (or too many workers)?**
 
 A good question. Due to MRI's GIL, only one thread can be executing Ruby code at a time.
 But since so many apps are waiting on IO from DBs, etc., they can utilize threads
 to make better use of the process.
 
 The rule of thumb is you never want processes that are pegged all the time. This
-means that there is more work to do that the process can get through. On the other
+means that there is more work to do than the process can get through. On the other
 hand, if you have processes that sit around doing nothing, then they're just eating
 up resources.
 
-Watching your CPU utilization over time and aim for about 70% on average. This means
+Watch your CPU utilization over time and aim for about 70% on average. This means
 you've got capacity still but aren't starving threads.
 
 ## Daemonizing
@@ -62,7 +62,7 @@ makes it easy to figure out what is going on. Additionally, unlike `unicorn`,
 puma does not require daemonization to do zero-downtime restarts.
 
 I see people using daemonization because they start puma directly via capistrano
-task and thus want it to live on past the `cap deploy`. To this people I said:
+task and thus want it to live on past the `cap deploy`. To these people I say:
 You need to be using a process monitor. Nothing is making sure puma stays up in
 this scenario! You're just waiting for something weird to happen, puma to die,
 and to get paged at 3am. Do yourself a favor, at least the process monitoring


### PR DESCRIPTION
I was reading through the documentation and found a couple spelling errors. Just thought you may be interested in the corrections. No worries if you're not interested.

Thanks!
Tanner J.