### PR TITLE
Turn off LF normalization for PNG

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Auto detect text files and perform LF normalization
 * text eol=lf
+# Turn off normalization for PNGs
+*.png binary


### PR DESCRIPTION
## Why
Every time I checkout this repo my git goes crazy.
Due to `.gitattributes` entry git automatically normalizes LFs even in `.png` files:

```
❯ git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   docs/images/puma-connection-flow-no-reactor.png
	modified:   docs/images/puma-connection-flow.png
	modified:   docs/images/puma-general-arch.png

no changes added to commit (use "git add" and/or "git commit -a")
```

The diff command shows warning about CLRF:

```
❯ git diff docs/images/puma-connection-flow-no-reactor.png
warning: CRLF will be replaced by LF in docs/images/puma-connection-flow-no-reactor.png.
The file will have its original line endings in your working directory
diff --git a/docs/images/puma-connection-flow-no-reactor.png b/docs/images/puma-connection-flow-no-reactor.png
index 05ef8d0..99926a8 100644
Binary files a/docs/images/puma-connection-flow-no-reactor.png and b/docs/images/puma-connection-flow-no-reactor.png differ
```

## What
Turn off normalization for PNGs and treat it as binary file (as it should be treated)