### PR TITLE
JRuby - move to Xenial, set all to 'allow_failures'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     r_eng="$(ruby -e 'STDOUT.write RUBY_ENGINE')";
     rv="$(ruby -e 'STDOUT.write RUBY_VERSION')";
     if [ "$r_eng" == "ruby" ]; then
-      if   [ "$rv" \< "2.3" ]; then gem update --system 2.7.8 --no-document
+      if   [ "$rv" \< "2.3" ]; then gem update --system 2.7.9 --no-document
       elif [ "$rv" \< "2.6" ]; then gem update --system --no-document --conservative
       fi
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ cache: bundler
 before_install:
   # rubygems 2.7.8 and greater include bundler, leave 2.6.0 untouched
   - |
+    r_eng="$(ruby -e 'STDOUT.write RUBY_ENGINE')";
     rv="$(ruby -e 'STDOUT.write RUBY_VERSION')";
-    if   [ "$rv" \< "2.3" ]; then gem update --system 2.7.8 --no-document
-    elif [ "$rv" \< "2.6" ]; then gem update --system --no-document --conservative
+    if [ "$r_eng" == "ruby" ]; then
+      if   [ "$rv" \< "2.3" ]; then gem update --system 2.7.8 --no-document
+      elif [ "$rv" \< "2.6" ]; then gem update --system --no-document --conservative
+      fi
     fi
   - ruby -v && gem --version && bundle version
 
@@ -34,21 +37,16 @@ matrix:
       os: osx
     - rvm: 2.5.3
       os: osx
-    - rvm: jruby-9.2.5.0
-      dist: trusty
-      sudo: false
+    - rvm: jruby-9.2.6.0
     - rvm: jruby-head
-      dist: trusty
-      sudo: false
 
   allow_failures:
     - rvm: 2.6
     - rvm: ruby-head
     - rvm: ruby-head
       env: RUBYOPT="--jit"
+    - rvm: jruby-9.2.6.0
     - rvm: jruby-head
-      dist: trusty
-      sudo: false
 
 env:
   global:


### PR DESCRIPTION
Recent Travis 'CRON' jobs are failing on JRuby 9.2.5.0.

I don't use JRuby.  I looked at `ruby/psych`, both of it's JRuby jobs are 'allow failure'.  Couldn't find a repo/gem using OpenSSL that tests on JRuby.

The PR allows Travis to pass.  Note that jruby-head normally passes.  I don't know enough about JRuby to know why 9.2.5.0/9.2.6.0 is failing.  Also, http://rubies.travis-ci.org/