### PR TITLE
Fixing issue with remote_addr persisting between requests

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -102,6 +102,7 @@ module Puma
       @tempfile = nil
       @parsed_bytes = 0
       @ready = false
+      @peerip = nil
 
       if @buffer
         @parsed_bytes = @parser.execute(@env, @buffer, @parsed_bytes)


### PR DESCRIPTION
Ran into an issue when keepalive is used where the REMOTE_ADDR of a previous request was used instead of the current users IP.

Place where it is called and not currently reset: https://github.com/puma/puma/blob/50b23bb2c1942b6a1a38f7c6da1aa26df83b8b64/lib/puma/server.rb#L480 