### PR TITLE
Use Process::WNOHANG flag when stoping child workers processes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ matrix:
       sudo: false
 
   allow_failures:
-    - rvm: 2.6
     - rvm: ruby-head
     - rvm: ruby-head
       env: RUBYOPT="--jit"

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -37,7 +37,7 @@ module Puma
       @workers.each { |x| x.term }
 
       begin
-        @workers.each { |w| Process.waitpid(w.pid) }
+        @workers.each { |w| Process.waitpid(w.pid, Process::WNOHANG) }
       rescue Interrupt
         log "! Cancelled waiting for workers"
       end

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -37,7 +37,14 @@ module Puma
       @workers.each { |x| x.term }
 
       begin
-        @workers.each { |w| Process.waitpid(w.pid, Process::WNOHANG) }
+        pids = @workers.map(&:pid)
+        until pids.empty?
+          if pid = Process.waitpid(-1, Process::WNOHANG)
+            pids.delete(pid)
+            sleep 0.5
+            break
+          end
+        end
       rescue Interrupt
         log "! Cancelled waiting for workers"
       end


### PR DESCRIPTION
In cluster mode, puma/launcher propagates `SIGTERM` to worker process
then call `Process.waitpid`. But in case worker process exits quickly
after receiving the signal, launcher process's `Process.waitpid` can
hang because the target process does not exist anymore.

Adding `Process::WNOHANG` makes `waitpid` ignore when child process
already exited.

I can reproduce this in a server using Linux/systemd/Docker and in my local machine (macOS 10.14).
I can reproduce this running [test_term_signal_exit_code_in_clustered_mode](https://github.com/puma/puma/blob/e04c030ac70202de188160e4d8838bc4b7522a01/test/test_integration.rb#L258) as well (running this just hang the Puma process).

This seems to be related to https://github.com/puma/puma/pull/467
This should fix https://github.com/puma/puma/issues/1720 and https://github.com/puma/puma/issues/1674