### PR TITLE
cluster - worker shutdown - use WNOHANG with nil return tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ rvm:
   - 2.2.10
   - 2.3.8
   - 2.4.5
-  - 2.5.3
-  - 2.6
+  - 2.5.5
+  - 2.6.2
   - ruby-head
 
 matrix:
@@ -35,13 +35,12 @@ matrix:
       env: RUBYOPT="--jit"
     - rvm: 2.3.8
       os: osx
-    - rvm: 2.5.3
+    - rvm: 2.5.5
       os: osx
     - rvm: jruby-9.2.6.0
     - rvm: jruby-head
 
   allow_failures:
-    - rvm: 2.6
     - rvm: ruby-head
     - rvm: ruby-head
       env: RUBYOPT="--jit"

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -37,7 +37,25 @@ module Puma
       @workers.each { |x| x.term }
 
       begin
-        @workers.each { |w| Process.waitpid(w.pid) }
+        if RUBY_VERSION < '2.6'
+          @workers.each { |w| Process.waitpid(w.pid) }
+        else
+          # below code is for a bug in Ruby 2.6+, above waitpid call hangs
+          t_st = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          pids = @workers.map(&:pid)
+          loop do
+            pids.reject! do |w_pid|
+              if Process.waitpid(w_pid, Process::WNOHANG)
+                log "    worker status: #{$?}"
+                true
+              end
+            end
+            break if pids.empty?
+            sleep 0.5
+          end
+          t_end = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          log format("    worker shutdown time: %6.2f", t_end - t_st)
+        end
       rescue Interrupt
         log "! Cancelled waiting for workers"
       end


### PR DESCRIPTION
Ruby 2.6 introduced a change that affects worker shutdown.  I believe the change occurred between 'commits' r64316 and r64376 of ruby trunk.

1. Added code using `Process::WNOHANG` along with needed logic.  Adds worker status (via `$?`) and total shutdown time to log.

2. Logged status matches status returned by current code (exit 0) for Ruby 2.5.x and lower.

Co-authored-by: MSP-Greg <greg.mpls@gmail.com>
Co-authored-by: guilleiguaran <guilleiguaran@gmail.com>