### PR TITLE
[RFC] Add a --plugin option. #1761

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -161,6 +161,10 @@ module Puma
             user_config.prune_bundler
           end
 
+          o.on "--plugins PLUGINS", "Add plugins to the $LOAD_PATH" do |arg|
+            user_config.plugins arg.split(':')
+          end
+
           o.on "-q", "--quiet", "Do not log requests internally (default true)" do
             user_config.quiet
           end

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -133,6 +133,7 @@ module Puma
 
       @options     = UserFileDefaultOptions.new(user_options, default_options)
       @plugins     = PluginLoader.new
+      @plugins_to_load = []
       @user_dsl    = DSL.new(@options.user_options, self)
       @file_dsl    = DSL.new(@options.file_options, self)
       @default_dsl = DSL.new(@options.default_options, self)
@@ -142,7 +143,12 @@ module Puma
       end
     end
 
-    attr_reader :options, :plugins
+    attr_reader :options, :plugins, :plugins_to_load
+
+    def add_plugins_to_load(plugin)
+      @plugins_to_load << plugin
+      @plugins_to_load.flatten!
+    end
 
     def configure
       yield @user_dsl, @file_dsl, @default_dsl

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -37,6 +37,7 @@ module Puma
       @options = options
 
       @plugins = []
+      @plugins_to_load = []
     end
 
     def _load_from(path)
@@ -79,6 +80,11 @@ module Puma
     #
     def plugin(name)
       @plugins << @config.load_plugin(name)
+    end
+
+    # LOAD_PATH for plugins
+    def plugins(plugins_to_load)
+      @plugins_to_load << plugins_to_load
     end
 
     # Use +obj+ or +block+ as the Rack app. This allows a config file to

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -37,7 +37,6 @@ module Puma
       @options = options
 
       @plugins = []
-      @plugins_to_load = []
     end
 
     def _load_from(path)
@@ -84,7 +83,7 @@ module Puma
 
     # LOAD_PATH for plugins
     def plugins(plugins_to_load)
-      @plugins_to_load << plugins_to_load
+      @config.add_plugins_to_load plugins_to_load
     end
 
     # Use +obj+ or +block+ as the Rack app. This allows a config file to

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -254,6 +254,8 @@ module Puma
       dirs = puma.require_paths.map { |x| File.join(puma.full_gem_path, x) }
       puma_lib_dir = dirs.detect { |x| File.exist? File.join(x, '../bin/puma-wild') }
 
+      dirs << Bundler.rubygems.loaded_specs('puma-heroku').require_paths.map { |x| File.join(puma.full_gem_path, x) }
+
       unless puma_lib_dir
         log "! Unable to prune Bundler environment, continuing"
         return

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -254,7 +254,8 @@ module Puma
       dirs = puma.require_paths.map { |x| File.join(puma.full_gem_path, x) }
       puma_lib_dir = dirs.detect { |x| File.exist? File.join(x, '../bin/puma-wild') }
 
-      dirs << Bundler.rubygems.loaded_specs('puma-heroku').require_paths.map { |x| File.join(puma.full_gem_path, x) }
+      puma_heroku = Bundler.rubygems.loaded_specs('puma-heroku')
+      dirs << puma_heroku.require_paths.map { |x| File.join(puma_heroku.full_gem_path, x) }
 
       unless puma_lib_dir
         log "! Unable to prune Bundler environment, continuing"

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -254,8 +254,11 @@ module Puma
       dirs = puma.require_paths.map { |x| File.join(puma.full_gem_path, x) }
       puma_lib_dir = dirs.detect { |x| File.exist? File.join(x, '../bin/puma-wild') }
 
-      puma_heroku = Bundler.rubygems.loaded_specs('puma-heroku')
-      dirs << puma_heroku.require_paths.map { |x| File.join(puma_heroku.full_gem_path, x) }
+
+      @config.plugins_to_load.each do |plugin_name|
+        plugin = Bundler.rubygems.loaded_specs(plugin_name)
+        dirs << plugin.require_paths.map { |x| File.join(plugin.full_gem_path, x) }
+      end
 
       unless puma_lib_dir
         log "! Unable to prune Bundler environment, continuing"


### PR DESCRIPTION
This is a fix that requires less changes to the current base code to fix #1761 

It adds a --plugin option that takes the name of the gems loaded in the configuration with the plugin dsl.
When puma-wild is launched, the require paths of the plugin are added to the dependency to load into $LOAD_PATH when puma-wild starts up.

The code is not beautiful, I'll do a cleanup if the overall idea is approved. 