### PR TITLE
1756 pid monitoring

### DIFF
--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -121,9 +121,11 @@ module Puma
         @control_url = sf.control_url
         @control_auth_token = sf.control_auth_token
         @pid = sf.pid
-      elsif @pidfile
+      elsif @pidfile && File.readable?(@pidfile)
         # get pid from pid_file
         @pid = File.open(@pidfile).gets.to_i
+      else
+        @pid = nil
       end
     end
 
@@ -205,6 +207,16 @@ module Puma
 
         when "phased-restart"
           Process.kill "SIGUSR1", @pid
+
+        when "status"
+          begin
+            Process.kill 0, @pid
+            puts "Puma is started"
+          rescue Errno::ESRCH
+            raise "Puma is not running"
+          end
+
+          return
 
         else
           return

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -124,8 +124,6 @@ module Puma
       elsif @pidfile && File.readable?(@pidfile)
         # get pid from pid_file
         @pid = File.open(@pidfile).gets.to_i
-      else
-        @pid = nil
       end
     end
 

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -44,14 +44,9 @@ class TestPumaControlCli < Minitest::Test
     t = Thread.new do
       Thread.current.abort_on_exception = true
       control_cli.run
-
-      sleep 3
-      raise control_cli.inspect
     end
 
     wait_booted
-
-    sleep 5
 
     s = TCPSocket.new host, 9292
     s << "GET / HTTP/1.0\r\n\r\n"

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -72,7 +72,7 @@ class TestPumaControlCli < Minitest::Test
     control_cli = Puma::ControlCLI.new ["--config-file", "test/config/app.rb", "status"]
 
     out, err = capture_subprocess_io do
-      assert_raises(SystemExit){control_cli.run}
+      assert_raises(SystemExit) {control_cli.run}
     end
 
     assert_match "Neither pid nor control url available", out
@@ -112,7 +112,10 @@ class TestPumaControlCli < Minitest::Test
 
     File.delete(pid_file) if File.file? pid_file
 
-    temp_pid = Process.fork {}
+    temp_pid = Process.fork do
+      # nothing
+    end
+
     Process.waitpid(temp_pid)
 
     File.write(pid_file, temp_pid.to_s)
@@ -124,7 +127,7 @@ class TestPumaControlCli < Minitest::Test
 
     status_cmd = Puma::ControlCLI.new opts + ["status"]
     out, err = capture_subprocess_io do
-      assert_raises(SystemExit){status_cmd.run}
+      assert_raises(SystemExit) {status_cmd.run}
     end
 
     assert_match "Puma is not running", out

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -12,12 +12,6 @@ class TestPumaControlCli < Minitest::Test
     line = @wait.gets until line =~ /Listening on/
   end
 
-  def wait_pid_file(file)
-    until File.file?(file) && !File.zero?(file)
-      sleep 0.1
-    end
-  end
-
   def teardown
     @wait.close
     @ready.close
@@ -50,9 +44,14 @@ class TestPumaControlCli < Minitest::Test
     t = Thread.new do
       Thread.current.abort_on_exception = true
       control_cli.run
+
+      sleep 3
+      raise control_cli.inspect
     end
 
     wait_booted
+
+    sleep 5
 
     s = TCPSocket.new host, 9292
     s << "GET / HTTP/1.0\r\n\r\n"
@@ -66,70 +65,5 @@ class TestPumaControlCli < Minitest::Test
     # TODO: assert something about the stop command
 
     t.join
-  end
-
-  def test_status_pid_no_file
-    control_cli = Puma::ControlCLI.new ["--config-file", "test/config/app.rb", "status"]
-
-    out, err = capture_subprocess_io do
-      assert_raises(SystemExit) {control_cli.run}
-    end
-
-    assert_match "Neither pid nor control url available", out
-  end
-
-  def test_status_pid_running
-    pid_file = "/tmp/pidfile.pid"
-
-    File.delete(pid_file) if File.file? pid_file
-
-    opts = [
-      "--config-file", "test/config/app.rb",
-      "--pidfile", pid_file
-    ]
-
-    start_cmd = Puma::ControlCLI.new opts + ["start"], @ready, @ready
-
-    pid = Process.fork do
-      start_cmd.run
-    end
-
-    wait_pid_file(pid_file)
-
-    status_cmd = Puma::ControlCLI.new opts + ["status"]
-    out, err = capture_io {status_cmd.run}
-
-    assert_match "Puma is started", out
-
-    shutdown_cmd = Puma::ControlCLI.new(opts + ["halt"])
-    shutdown_cmd.run
-
-    Process.wait(pid)
-  end
-
-  def test_status_pid_not_running
-    pid_file = "/tmp/pidfile.pid"
-
-    File.delete(pid_file) if File.file? pid_file
-
-    temp_pid = Process.fork do
-      # nothing
-    end
-
-    Process.waitpid(temp_pid)
-
-    File.write(pid_file, temp_pid.to_s)
-
-    opts = [
-      "--config-file", "test/config/app.rb",
-      "--pidfile", pid_file
-    ]
-
-    status_cmd = Puma::ControlCLI.new opts + ["status"]
-    out, err = capture_subprocess_io do
-      assert_raises(SystemExit) {status_cmd.run}
-    end
-
-    assert_match "Puma is not running", out
   end
 end


### PR DESCRIPTION
Pull request to add status reporting while using pids.

I had some tests that I ended up reverting.  TestPumaControlCli#test_control_url interfered with any other threaded tests and the fact that signals are used to kill the puma process means the tests were self destructing.

Testing was doable using forked processes but they aren't supported by windows.