### PR TITLE
Ability to silence pumactl backtraces

### DIFF
--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -16,6 +16,7 @@ module Puma
     def initialize(argv, stdout=STDOUT, stderr=STDERR)
       @state = nil
       @quiet = false
+      @no_backtrace = false
       @pidfile = nil
       @pid = nil
       @control_url = nil
@@ -37,6 +38,10 @@ module Puma
 
         o.on "-Q", "--quiet", "Not display messages" do |arg|
           @quiet = true
+        end
+
+        o.on "-N", "--no-backtrace", "Suppress internal backtraces" do |arg|
+          @no_backtrace = true
         end
 
         o.on "-P", "--pidfile PATH", "Pid file" do |arg|
@@ -71,7 +76,7 @@ module Puma
       end
 
       opts.order!(argv) { |a| opts.terminate a }
-      opts.parse!
+      opts.parse!(argv)
 
       @command = argv.shift
 
@@ -101,7 +106,7 @@ module Puma
 
     rescue => e
       @stdout.puts e.message
-      @stdout.puts e.backtrace
+      @stdout.puts e.backtrace unless @no_backtrace
       exit 1
     end
 
@@ -234,7 +239,7 @@ module Puma
 
     rescue => e
       message e.message
-      message e.backtrace
+      message e.backtrace unless @no_backtrace
       exit 1
     end
 

--- a/test/config/bad.rb
+++ b/test/config/bad.rb
@@ -1,0 +1,1 @@
+invalid_option

--- a/test/config/bad.rb
+++ b/test/config/bad.rb
@@ -1,1 +1,0 @@
-invalid_option

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -69,8 +69,7 @@ class TestPumaControlCli < Minitest::Test
     end
 
     out.strip!
-    assert_match(/Neither pid nor control url available.+/m, out)
-    assert_match "/", out
+    assert out.include?('/')
     assert out.lines.length > 1
 
     control_cli = Puma::ControlCLI.new (["stats", "-N"])
@@ -79,7 +78,8 @@ class TestPumaControlCli < Minitest::Test
     end
 
     out.strip!
-    assert_equal "Neither pid nor control url available", out
+    assert !out.include?('/')
+    assert_equal 1, out.lines.length
 
     control_cli = Puma::ControlCLI.new (["stats", "--no-backtrace"])
     out, _err = capture_subprocess_io do
@@ -87,8 +87,8 @@ class TestPumaControlCli < Minitest::Test
     end
 
     out.strip!
-    assert_equal "Neither pid nor control url available", out
-
+    assert !out.include?('/')
+    assert_equal 1, out.lines.length
   end
 
   def test_no_backtraces_init
@@ -97,8 +97,7 @@ class TestPumaControlCli < Minitest::Test
     end
 
     out.strip!
-    assert_match(/Invalid command: badcommand.+/m, out)
-    assert_match "/", out
+    assert out.include?('/')
     assert out.lines.length > 1
 
     out, _err = capture_subprocess_io do
@@ -106,13 +105,15 @@ class TestPumaControlCli < Minitest::Test
     end
 
     out.strip!
-    assert_equal "Invalid command: badcommand", out
+    assert !out.include?('/')
+    assert_equal 1, out.lines.length
 
     out, _err = capture_subprocess_io do
       assert_raises(SystemExit) {Puma::ControlCLI.new (['badcommand', '--no-backtrace'])}
     end
 
     out.strip!
-    assert_equal "Invalid command: badcommand", out
+    assert !out.include?('/')
+    assert_equal 1, out.lines.length
   end
 end

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -61,4 +61,58 @@ class TestPumaControlCli < Minitest::Test
 
     t.join
   end
+
+  def test_no_backtraces_run
+    control_cli = Puma::ControlCLI.new (["stats"])
+    out, _err = capture_subprocess_io do
+      assert_raises(SystemExit) {control_cli.run}
+    end
+
+    out.strip!
+    assert_match(/Neither pid nor control url available.+/m, out)
+    assert_match "/", out
+    assert out.lines.length > 1
+
+    control_cli = Puma::ControlCLI.new (["stats", "-N"])
+    out, _err = capture_subprocess_io do
+      assert_raises(SystemExit) {control_cli.run}
+    end
+
+    out.strip!
+    assert_equal "Neither pid nor control url available", out
+
+    control_cli = Puma::ControlCLI.new (["stats", "--no-backtrace"])
+    out, _err = capture_subprocess_io do
+      assert_raises(SystemExit) {control_cli.run}
+    end
+
+    out.strip!
+    assert_equal "Neither pid nor control url available", out
+
+  end
+
+  def test_no_backtraces_init
+    out, _err = capture_subprocess_io do
+      assert_raises(SystemExit) {Puma::ControlCLI.new (['badcommand'])}
+    end
+
+    out.strip!
+    assert_match(/Invalid command: badcommand.+/m, out)
+    assert_match "/", out
+    assert out.lines.length > 1
+
+    out, _err = capture_subprocess_io do
+      assert_raises(SystemExit) {Puma::ControlCLI.new (['badcommand', '-N'])}
+    end
+
+    out.strip!
+    assert_equal "Invalid command: badcommand", out
+
+    out, _err = capture_subprocess_io do
+      assert_raises(SystemExit) {Puma::ControlCLI.new (['badcommand', '--no-backtrace'])}
+    end
+
+    out.strip!
+    assert_equal "Invalid command: badcommand", out
+  end
 end


### PR DESCRIPTION
Addresses #1769

Adds a new flag (-N, --no-backtrace) to pumactl to prevent displaying of backtraces.

I would think this should be default behavior (and add a --verbose flag), but I didn't want to break backward compatibility.