### PR TITLE
Change README.md URI to https [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="http://puma.io/images/logos/puma-logo-large.png">
+  <img src="https://puma.io/images/logos/puma-logo-large.png">
 </p>
 
 # Puma: A Ruby Web Server Built For Concurrency


### PR DESCRIPTION
Removes warning in Chrome about loading an http resource from an https file.