### PR TITLE
small fixes - binder.rb client.rb test_integration.rb

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -50,7 +50,13 @@ module Puma
 
     def close
       @ios.each { |i| i.close }
-      @unix_paths.each { |i| File.unlink i }
+      @unix_paths.each do |i|
+        # Errno::ENOENT is intermittently raised
+        begin
+          File.unlink i
+        rescue Errno::ENOENT
+        end
+      end
     end
 
     def import_from_env

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -54,6 +54,7 @@ module Puma
       @ready = false
 
       @body = nil
+      @body_read_start = nil
       @buffer = nil
       @tempfile = nil
 

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -309,8 +309,8 @@ class TestIntegration < Minitest::Test
     curl_wait_thread.join
     rejected_curl_wait_thread.join
 
-    assert_match /Hello World/, curl_stdout.read
-    assert_match /Connection refused/, rejected_curl_stderr.read
+    assert_match(/Hello World/, curl_stdout.read)
+    assert_match(/Connection refused/, rejected_curl_stderr.read)
 
     Process.wait(@server.pid)
     @server = nil # prevent `#teardown` from killing already killed server


### PR DESCRIPTION
Fixes errors/warning shown in CI.

`binder.rb` fix removes error in CI when using a tempfile (which also rescues `Errno::ENOENT`), but not sure about rescue in general use...