### PR TITLE
[close #1802] Close listeners on SIGTERM

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -401,6 +401,8 @@ module Puma
           log "Early termination of worker"
           exit! 0
         else
+          @launcher.send(:close_binder_listeners)
+
           stop_workers
           stop
 

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -411,7 +411,7 @@ module Puma
           log "Early termination of worker"
           exit! 0
         else
-          @launcher.send(:close_binder_listeners)
+          @launcher.close_binder_listeners
 
           stop_workers
           stop

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -214,6 +214,15 @@ module Puma
       end
     end
 
+    def close_binder_listeners
+      @binder.listeners.each do |l, io|
+        io.close
+        uri = URI.parse(l)
+        next unless uri.scheme == 'unix'
+        File.unlink("#{uri.host}#{uri.path}")
+      end
+    end
+
     private
 
     def reload_worker_directory
@@ -318,16 +327,6 @@ module Puma
     def prune_bundler?
       @options[:prune_bundler] && clustered? && !@options[:preload_app]
     end
-
-    def close_binder_listeners
-      @binder.listeners.each do |l, io|
-        io.close
-        uri = URI.parse(l)
-        next unless uri.scheme == 'unix'
-        File.unlink("#{uri.host}#{uri.path}")
-      end
-    end
-
 
     def generate_restart_data
       if dir = @options[:directory]

--- a/test/rackup/1second.ru
+++ b/test/rackup/1second.ru
@@ -1,0 +1,4 @@
+run lambda { |env|
+  sleep 1
+  [200, {}, ["Hello World"]]
+}


### PR DESCRIPTION
Currently when a SIGTERM is sent to a puma cluster, the signal is trapped, then sent to all children, it then waits for children to exit and then the parent process exits. The socket that accepts connections is only closed when the parent process calls `exit 0`. The problem with this flow is there is a period of time where there are no child processes to work on an incoming connection, however the socket is still open so clients can connect to it. When this happens, the client will connect, but the connection will be closed with no response. Instead, the desired behavior is for the connection from the client to be rejected. This allows the client to re-connect, or if there is a load balance between the client and the puma server, it allows the request to be routed to another node.

This PR fixes the existing behavior by manually closing the socket when SIGTERM is received before shutting down the workers/children processes. When the socket is closed, any incoming requests will fail to connect and they will be rejected, this is our desired behavior. Existing requests that are in-flight can still respond.

 ## Test


This behavior is quite difficult to test, you'll notice that the test is far longer than the code change. In this test we send an initial request to an endpoint that sleeps for 1 second. We then signal to other threads that they can continue. We send the parent process a SIGTERM, while simultaneously sending other requests. Some of these will happen after the SIGTERM is received by the server. When that happens we want none of the requests to get a `ECONNRESET` error, this would indicate the request was accepted but then closed. Instead we want `ECONNREFUSED`.

I ran this test in a loop for a few hours and it passes with my patch, it fails immediately if you remove the call to close the listeners.

```
$ while m test/test_integration.rb:235; do :; done
```

 ## Considerations

This PR only fixes the problem for "cluster" (i.e. multi-worker) mode. When trying to reproduce the test with single mode, on (removing the `-w 2` config) it already passes. This leads us to believe that either the bug does not exist in single threaded mode, or at the very least reproducing the bug via a test in the single threaded mode requires a different approach.
