### PR TITLE
Swallow connection errors when sending early hints

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -631,19 +631,23 @@ module Puma
 
       if @early_hints
         env[EARLY_HINTS] = lambda { |headers|
-          fast_write client, "HTTP/1.1 103 Early Hints\r\n".freeze
+          begin
+            fast_write client, "HTTP/1.1 103 Early Hints\r\n".freeze
 
-          headers.each_pair do |k, vs|
-            if vs.respond_to?(:to_s) && !vs.to_s.empty?
-              vs.to_s.split(NEWLINE).each do |v|
-                fast_write client, "#{k}: #{v}\r\n"
+            headers.each_pair do |k, vs|
+              if vs.respond_to?(:to_s) && !vs.to_s.empty?
+                vs.to_s.split(NEWLINE).each do |v|
+                  fast_write client, "#{k}: #{v}\r\n"
+                end
+              else
+                fast_write client, "#{k}: #{vs}\r\n"
               end
-            else
-              fast_write client, "#{k}: #{vs}\r\n"
             end
-          end
 
-          fast_write client, "\r\n".freeze
+            fast_write client, "\r\n".freeze
+          rescue ConnectionError
+            # noop, if we lost the socket we just won't send the early hints
+          end
         }
       end
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -190,29 +190,25 @@ EOF
   end
 
   def test_early_hints_are_ignored_if_connection_lost
-    # Have a long early hints header so we have time to close connection
-    # before the server sends the whole content.
-    links = Array.new(100) { |n| "</script_#{n}.js>; rel=preload" }.join("\n")
-
     app = proc { |env|
-      env['rack.early_hints'].call("Link" => links)
+      env['rack.early_hints'].call("Link" => "</script.js>; rel=preload")
       [200, { "X-Hello" => "World" }, ["Hello world!"]]
     }
 
     events = Puma::Events.strings
     server = Puma::Server.new app, events
-
+    def server.fast_write(*args)
+      raise Puma::ConnectionError
+    end
     server.add_tcp_listener @host, @port
     server.early_hints = true
     server.run
 
-    # Make a request and close the socket immediately, we expect the
-    # connection to be closed while the server is sending the early hints
+    # This request will cause the server to try and send early hints
     sock = TCPSocket.new @host, server.connected_port
     sock << "HEAD / HTTP/1.0\r\n\r\n"
-    sock.close
 
-    # Let the server fail...
+    # Give the server some time to try to write (and fail)
     sleep 0.1
 
     # Expect no errors in stderr


### PR DESCRIPTION
I've been thinking on how Puma should behave when the early hints
can't be sent because the connection has been lost.

I first thought that it should behave the same way it does when the
connection is lost before main response is sent, I've seen that it
swallows those errors (https://git.io/fjVtg) so perhaps we should do
the same here.

There's one consideration though. Because the early hints are sent at
the very beginning of the app execution, we may want to abort this
request altogether and save resources by throwing an exception and
causing Rails to interrupt execution.

Finally I decided to overlook that case just because I believe it's
least surprising from the Rack app point of view. Also
I haven't seen any other example of the web server interrupting
the apps execution due to an error on the lower layer.

Fixes #1640.