### PR TITLE
Clean up 4.0.0 changelog

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,7 +5,7 @@ x bugfixes
 
 ## 4.0.0 / 2019-06-25
 
-9 features
+* 8 features
   * Add support for disabling TLSv1.0 (#1562)
   * Request body read time metric (#1569)
   * Add out_of_band hook (#1648)
@@ -14,7 +14,8 @@ x bugfixes
   * Add option to suppress SignalException on SIGTERM (#1690)
   * Allow mutual TLS CA to be set using `ssl_bind` DSL (#1689)
   * Reactor now uses nio4r instead of `select` (#1728)
-9 bugfixes
+
+* 9 bugfixes
   * Do not accept new requests on shutdown (#1685, #1808)
   * Fix 3 corner cases when request body is chunked (#1508)
   * Change pid existence check's condition branches (#1650)


### PR DESCRIPTION
Just noticed that the markdown formatting was off.

Also, is it 8 or 9 features? I count 8 bullet points, but I noticed the tag mentions 9 features as well: https://github.com/puma/puma/releases/tag/v4.0.0