### PR TITLE
Openssl updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: xenial
+env: OS="Xenial 16.04 OpenSSL 1.0.2"
 language: ruby
 cache: bundler
 
@@ -19,6 +20,7 @@ before_install:
   - ruby -v && gem --version && bundle version
 
 before_script:
+  - if [ "$jit" == "yes" ]; then export RUBYOPT=--jit ; fi ; echo RUBYOPT is $RUBYOPT
   - bundle exec rake compile
 
 script:
@@ -37,18 +39,20 @@ matrix:
   include:
     - rvm: 2.2 
       dist: trusty 
-      env: NOTES="Trusty OpenSSL 1.0.1"
+      env: OS="Trusty 14.04 OpenSSL 1.0.1"
+    - rvm: 2.6
+      dist: bionic
+      env: OS="Bionic 18.04 OpenSSL 1.1.1"
     - rvm: ruby-head
-      env: RUBYOPT="--jit"
+      env: jit=yes
     - rvm: 2.4.6
       os: osx
       osx_image: xcode10.2
+      env: OS="osx xcode10.2"
     - rvm: 2.5.5
       os: osx
       osx_image: xcode10.2
-    - rvm: 2.6.3
-      os: osx
-      osx_image: xcode10.2
+      env: OS="osx xcode10.2"
     - rvm: jruby-9.2.7.0
       env: JRUBY_OPTS="--debug" JAVA_OPTS="--add-opens java.base/sun.nio.ch=org.jruby.dist --add-opens java.base/java.io=org.jruby.dist --add-opens java.base/java.util.zip=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.security.cert=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED"
     - rvm: jruby-head
@@ -56,7 +60,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: ruby-head
-      env: RUBYOPT="--jit"
+      env: jit=yes
     - rvm: jruby-9.2.7.0
     - rvm: jruby-head
 

--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -166,6 +166,10 @@ public class MiniSSL extends RubyObject {
         protocols = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
     }
 
+    if(miniSSLContext.callMethod(threadContext, "no_tlsv1_1").isTrue()) {
+        protocols = new String[] { "TLSv1.2" };
+    }
+
     engine.setEnabledProtocols(protocols);
     engine.setUseClientMode(false);
 

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -195,6 +195,7 @@ module Puma
           end
 
           ctx.no_tlsv1 = true if params['no_tlsv1'] == 'true'
+          ctx.no_tlsv1_1 = true if params['no_tlsv1_1'] == 'true'
 
           if params['verify_mode']
             ctx.verify_mode = case params['verify_mode']

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -307,14 +307,15 @@ module Puma
     def ssl_bind(host, port, opts)
       verify = opts.fetch(:verify_mode, 'none')
       no_tlsv1 = opts.fetch(:no_tlsv1, 'false')
+      no_tlsv1_1 = opts.fetch(:no_tlsv1_1, 'false')
       ca_additions = "&ca=#{opts[:ca]}" if ['peer', 'force_peer'].include?(verify)
 
       if defined?(JRUBY_VERSION)
         keystore_additions = "keystore=#{opts[:keystore]}&keystore-pass=#{opts[:keystore_pass]}"
-        bind "ssl://#{host}:#{port}?cert=#{opts[:cert]}&key=#{opts[:key]}&#{keystore_additions}&verify_mode=#{verify}&no_tlsv1=#{no_tlsv1}#{ca_additions}"
+        bind "ssl://#{host}:#{port}?cert=#{opts[:cert]}&key=#{opts[:key]}&#{keystore_additions}&verify_mode=#{verify}&no_tlsv1=#{no_tlsv1}&no_tlsv1_1=#{no_tlsv1_1}#{ca_additions}"
       else
         ssl_cipher_filter = "&ssl_cipher_filter=#{opts[:ssl_cipher_filter]}" if opts[:ssl_cipher_filter]
-        bind "ssl://#{host}:#{port}?cert=#{opts[:cert]}&key=#{opts[:key]}#{ssl_cipher_filter}&verify_mode=#{verify}&no_tlsv1=#{no_tlsv1}#{ca_additions}"
+        bind "ssl://#{host}:#{port}?cert=#{opts[:cert]}&key=#{opts[:key]}#{ssl_cipher_filter}&verify_mode=#{verify}&no_tlsv1=#{no_tlsv1}&no_tlsv1_1=#{no_tlsv1_1}#{ca_additions}"
       end
     end
 

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -176,10 +176,11 @@ module Puma
 
     class Context
       attr_accessor :verify_mode
-      attr_reader :no_tlsv1
+      attr_reader :no_tlsv1, :no_tlsv1_1
 
       def initialize
-        @no_tlsv1 = false
+        @no_tlsv1   = false
+        @no_tlsv1_1 = false
       end
 
       if defined?(JRUBY_VERSION)
@@ -219,16 +220,22 @@ module Puma
           @ca = ca
         end
 
-
         def check
           raise "Key not configured" unless @key
           raise "Cert not configured" unless @cert
         end
       end
 
+      # disables TLSv1
       def no_tlsv1=(tlsv1)
         raise ArgumentError, "Invalid value of no_tlsv1" unless ['true', 'false', true, false].include?(tlsv1)
         @no_tlsv1 = tlsv1
+      end
+
+      # disables TLSv1 and TLSv1.1.  Overrides `#no_tlsv1=`
+      def no_tlsv1_1=(tlsv1_1)
+        raise ArgumentError, "Invalid value of no_tlsv1" unless ['true', 'false', true, false].include?(tlsv1_1)
+        @no_tlsv1_1 = tlsv1_1
       end
 
     end

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -77,9 +77,22 @@ class TestBinderMRI < TestBinderBase
     refute ssl_context_for_binder(@binder).no_tlsv1
   end
 
-  def test_binder_parses_tlsv1_unspecified_defaults_to_enabled
+  def test_binder_parses_tlsv1_tlsv1_1_unspecified_defaults_to_enabled
     @binder.parse(["ssl://0.0.0.0?key=#{@key}&cert=#{@cert}"], @events)
 
     refute ssl_context_for_binder(@binder).no_tlsv1
+    refute ssl_context_for_binder(@binder).no_tlsv1_1
+  end
+
+  def test_binder_parses_tlsv1_1_disabled
+    @binder.parse(["ssl://0.0.0.0?key=#{@key}&cert=#{@cert}&no_tlsv1_1=true"], @events)
+
+    assert ssl_context_for_binder(@binder).no_tlsv1_1
+  end
+
+  def test_binder_parses_tlsv1_1_enabled
+    @binder.parse(["ssl://0.0.0.0?key=#{@key}&cert=#{@cert}&no_tlsv1_1=false"], @events)
+
+    refute ssl_context_for_binder(@binder).no_tlsv1_1
   end
 end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -75,7 +75,7 @@ class TestConfigFile < TestConfigFileBase
 
     conf.load
 
-    ssl_binding = "ssl://0.0.0.0:9292?cert=/path/to/cert&key=/path/to/key&verify_mode=the_verify_mode&no_tlsv1=false"
+    ssl_binding = "ssl://0.0.0.0:9292?cert=/path/to/cert&key=/path/to/key&verify_mode=the_verify_mode&no_tlsv1=false&no_tlsv1_1=false"
     assert_equal [ssl_binding], conf.options[:binds]
   end
 


### PR DESCRIPTION
**1st commit - OpenSSL 1.1.1 updates, add `#no_tlsv1_1`**
1.1 Adds three constants to MiniSSL, as many OpenSSL builds cannot/will not connect with older protocols:
```
   OPENSSL_NO_SSL3
   OPENSSL_NO_TLS1
   OPENSSL_NO_TLS1_1
```
1.2 Uses `SSL_CTX_set_min_proto_version` when available
1.3 Add `#no_tlsv1_1` method to `Puma::MiniSSL::Context`

**2nd commit - travis.yml - add bionic 18.04 job**
2.1 Add Ubuntu bionic 18.04 job with Ruby 2.6.3.  This tests with OpenSSL 1.1.1

**3rd commit - test_puma_server_ssl.rb - add tests for `#no_tlsv1`, `#no_tlsv1_1`**
3.1 Adds tests for `#no_tlsv1` and `#no_tlsv1_1`
3.2 Changes setup (via adding a `start_server` method), allowing the context to be passed to a block

**4th commit - add no_tlsv1_1 to binder, config, etc**
4.1 Adds use of `#no_tlsv1_1` with binder.rb and dsl.rb
4.2 Adds tests to test_binder.rb and test_config.rb for above
4.3 Adds feature to MiniSSL.java