### PR TITLE
Avoid mutating global STDOUT & STDERR

### DIFF
--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -29,8 +29,8 @@ module Puma
     #
     def initialize(stdout, stderr)
       @formatter = DefaultFormatter.new
-      @stdout = stdout
-      @stderr = stderr
+      @stdout = stdout.dup
+      @stderr = stderr.dup
 
       @stdout.sync = true
       @stderr.sync = true

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -6,7 +6,6 @@ class TestEvents < Minitest::Test
 
     assert_instance_of Puma::NullIO, events.stdout
     assert_instance_of Puma::NullIO, events.stderr
-    assert_equal events.stdout, events.stderr
   end
 
   def test_strings
@@ -19,8 +18,17 @@ class TestEvents < Minitest::Test
   def test_stdio
     events = Puma::Events.stdio
 
-    assert_equal STDOUT, events.stdout
-    assert_equal STDERR, events.stderr
+    # events.stdout is a dup, so same file handle, different ruby object, but inspect should show the same file handle
+    assert_equal STDOUT.inspect, events.stdout.inspect
+    assert_equal STDERR.inspect, events.stderr.inspect
+  end
+
+  def test_stdio_respects_sync
+    STDOUT.sync = false
+    events = Puma::Events.stdio
+
+    assert !STDOUT.sync
+    assert events.stdout.sync
   end
 
   def test_register_callback_with_block

--- a/test/test_tcp_logger.rb
+++ b/test/test_tcp_logger.rb
@@ -18,6 +18,7 @@ class TestTCPLogger < Minitest::Test
     # in lib/puma/launcher.rb:85
     # Puma::Events is default tcp_logger for cluster mode
     logger = Puma::Events.new(STDOUT, STDERR)
+    logger.instance_variable_set(:@stdout, $stdout) # ensure capture_process_io has access to the loggers output
     out, err = capture_subprocess_io do
       Puma::TCPLogger.new(logger, @server.app).call({}, @socket)
     end


### PR DESCRIPTION
The current behavior prevents apps from benefitting from `STDOUT.sync = false` during configuration phases, since the initial call to `Event.stdio` is relatively late in the boot cycle.