### PR TITLE
Avoid casting worker_timeout twice

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -476,7 +476,7 @@ module Puma
         raise "The minimum worker_timeout must be greater than the worker reporting interval (#{min})"
       end
 
-      @options[:worker_timeout] = Integer(timeout)
+      @options[:worker_timeout] = timeout
     end
 
     # *Cluster mode only* Set the timeout for workers to boot


### PR DESCRIPTION
While reading the pull request that added a minimum worker_timeout I've stumbled across [this yellow line in it](https://github.com/puma/puma/pull/1716/files#diff-d9e00ab028817951ecfdbbe7e661a141R444) and asked myself
> Shouldn't this use the already casted timeout here now? Why cast again?

This is what this pull request is about, it changes this line as well. Nothing more.

Disclaimer: I only created this PR through the UI and didn't test ANYTHING and am not aware of the puma code base. Feel free to discard this PR for that reason.