### PR TITLE
Plugin hooks for WebSockets

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,15 +1,22 @@
 ## Plugins
 
-Puma 3.0 added support for plugins that can augment configuration and service operations.
+Puma 3.0 added support for plugins that can augment configuration and service
+operations.
 
 2 canonical plugins to look to aid in development of further plugins:
 
-* [tmp\_restart](https://github.com/puma/puma/blob/master/lib/puma/plugin/tmp_restart.rb): Restarts the server if the file `tmp/restart.txt` is touched
-* [heroku](https://github.com/puma/puma-heroku/blob/master/lib/puma/plugin/heroku.rb): Packages up the default configuration used by puma on Heroku
+* [tmp\_restart](https://github.com/puma/puma/blob/master/lib/puma/plugin/tmp_restart.rb):
+  Restarts the server if the file `tmp/restart.txt` is touched
+* [heroku](https://github.com/puma/puma-heroku/blob/master/lib/puma/plugin/heroku.rb):
+  Packages up the default configuration used by puma on Heroku
 
-Plugins are activated in a puma configuration file (such as `config/puma.rb'`) by adding `plugin "name"`, such as `plugin "heroku"`.
+Plugins are activated in a puma configuration file (such as `config/puma.rb'`)
+by adding `plugin "name"`, such as `plugin "heroku"`.
 
-Plugins are activated based simply on path requirements so, activating the `heroku` plugin will simply be doing `require "puma/plugin/heroku"`. This allows gems to provide multiple plugins (as well as unrelated gems to provide puma plugins).
+Plugins are activated based simply on path requirements so, activating the
+`heroku` plugin will simply be doing `require "puma/plugin/heroku"`. This
+allows gems to provide multiple plugins (as well as unrelated gems to provide
+puma plugins).
 
 The `tmp_restart` plugin is bundled with puma, so it can always be used.
 
@@ -19,10 +26,11 @@ To use the `heroku` plugin, add `puma-heroku` to your Gemfile or install it.
 
 At present, there are 2 hooks that plugins can use: `start` and `config`.
 
-`start` runs when the server has started and allows the plugin to start other functionality to augment puma.
+`start` runs when the server has started and allows the plugin to start other
+functionality to augment puma.
 
-`config` runs when the server is being configured and is passed a `Puma::DSL` object that can be used to add additional configuration.
+`config` runs when the server is being configured and is passed a `Puma::DSL`
+object that can be used to add additional configuration.
 
-Any public methods in `Puma::Plugin` are the public API that any plugin may use.
-
-In the future, more hooks and APIs will be added.
+Any public methods in `Puma::Plugin` are the public API that any plugin may
+use.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -44,9 +44,9 @@ invoked. The called hook may modify `env` just like any Rack middleware.
 
 `#on_after_rack(env, headers, io)` will be called after the Rack application
 has completed its execution and before any response content is written to the
-client. A plugin may take over from here by returning an instance of a
-`Puma::StreamClient` descendant. Check out `lib/puma/stream_client.rb` to know
-more about this interface.
+client. A plugin may take over from here by returning an object that responds
+to `#stream?` with a truthy value. Check out `lib/puma/stream_client.rb` to
+know more about this interface.
 
 If more than one plugin arises interest in taking over, an exception will
 be happen and Puma will serve a 500.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -24,7 +24,9 @@ To use the `heroku` plugin, add `puma-heroku` to your Gemfile or install it.
 
 ### API
 
-At present, there are 2 hooks that plugins can use: `start` and `config`.
+## Server-wide hooks
+
+Plugins can use a couple of hooks at server level: `start` and `config`.
 
 `start` runs when the server has started and allows the plugin to start other
 functionality to augment puma.
@@ -34,3 +36,17 @@ object that can be used to add additional configuration.
 
 Any public methods in `Puma::Plugin` are the public API that any plugin may
 use.
+
+## Per request hooks
+
+`#on_before_rack(env)` will be called right before the Rack application is
+invoked. The called hook may modify `env` just like any Rack middleware.
+
+`#on_after_rack(env, headers, io)` will be called after the Rack application
+has completed its execution and before any response content is written to the
+client. A plugin may take over from here by returning an instance of a
+`Puma::StreamClient` descendant. Check out `lib/puma/stream_client.rb` to know
+more about this interface.
+
+If more than one plugin arises interest in taking over, an exception will
+be happen and Puma will serve a 500.

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -145,6 +145,10 @@ module Puma
       close
     end
 
+    def stream?
+      false
+    end
+
     # The object used for a request with no body. All requests with
     # no body share this one object since it has no state.
     EmptyBody = NullIO.new

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -141,6 +141,10 @@ module Puma
       end
     end
 
+    def on_shutdown
+      close
+    end
+
     # The object used for a request with no body. All requests with
     # no body share this one object since it has no state.
     EmptyBody = NullIO.new

--- a/lib/puma/plugin.rb
+++ b/lib/puma/plugin.rb
@@ -57,6 +57,10 @@ module Puma
       raise UnknownPlugin, "file failed to register a plugin"
     end
 
+    def each
+      @plugins.each_value { |plugin| yield plugin }
+    end
+
     def add_background(blk)
       @background << blk
     end

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -215,7 +215,7 @@ module Puma
                 end
               end
 
-              if c.is_a? StreamClient
+              if c.stream?
                 if c.on_read_ready
                   @app_pool << c
                 end

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -216,9 +216,19 @@ module Puma
               end
 
               begin
-                if c.try_to_finish
-                  @app_pool << c
-                  clear_monitor mon
+                if c.respond_to?(:stream?) && c.stream?
+                  if c.read_more
+                    @app_pool << c
+                  end
+
+                  if c.closed?
+                    clear_monitor mon
+                  end
+                else
+                  if c.try_to_finish
+                    @app_pool << c
+                    clear_monitor mon
+                  end
                 end
 
               # Don't report these to the lowlevel_error handler, otherwise

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -711,7 +711,7 @@ module Puma
           @on_after_rack.reverse_each do |hook|
             stream_client = hook.call(env, headers, req.io)
 
-            if stream_client.stream?
+            if stream_client && stream_client.stream?
               if is_async
                 raise "Only one #on_after_rack hook should take over"
               else

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -672,7 +672,7 @@ module Puma
       #
       after_reply = env[RACK_AFTER_REPLY] = []
 
-      unless @on_before_rack.nil?
+      if @on_before_rack
         @on_before_rack.each { |hook| hook.call(env) }
       end
 
@@ -705,7 +705,7 @@ module Puma
           status, headers, res_body = lowlevel_error(e, env)
         end
 
-        unless @on_after_rack.nil?
+        if @on_after_rack
           is_async = false
 
           @on_after_rack.reverse_each do |hook|

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -711,7 +711,7 @@ module Puma
           @on_after_rack.reverse_each do |hook|
             stream_client = hook.call(env, headers, req.io)
 
-            if stream_client.is_a? StreamClient
+            if stream_client.stream?
               if is_async
                 raise "Only one #on_after_rack hook should take over"
               else

--- a/lib/puma/stream_client.rb
+++ b/lib/puma/stream_client.rb
@@ -5,11 +5,13 @@ module Puma
   # The subclasses are expected to implement:
   #
   #  1. Methods to respond to changes in the underlying socket. These are
-  #     `#on_read_ready`, `#on_shutdown` & `#on_broken_pipe`.
+  #     `#on_read_ready`, `#on_broken_pipe` & `#on_shutdown`.
   #  2. A `#churn` method that runs within the thread pool, this is what can
   #     be used to invoke app's logic.
   #
   # The underlying socket is available through `@io`.
+  #
+  # The other methods should never be overriden.
   class StreamClient
     def initialize(io)
       @io = io

--- a/lib/puma/stream_client.rb
+++ b/lib/puma/stream_client.rb
@@ -1,0 +1,52 @@
+module Puma
+  # This serves as a base class for any plugin that wants to take over the
+  # socket and wait on IO.
+  #
+  # The subclasses are expected to implement these two methods: `#read_more` &
+  # `#churn`.
+  #
+  # The underlying socket is available through `@io`.
+  class StreamClient
+    def initialize(io)
+      @io = io
+    end
+
+    def to_io
+      @io
+    end
+
+    def stream?
+      true
+    end
+
+    def timeout_at
+      false
+    end
+
+    def close
+      @io.close
+    end
+
+    def closed?
+      @io.closed?
+    end
+
+    # This method will be invoked when the IO descriptor has new data pending
+    # to be read. You can read from `@io` at this time.
+    #
+    # You can return a truthy value to add this client to the thread pool.
+    def read_more
+      raise NotImplementedError
+    end
+
+    # This is the method that the thread pool will be consuming. A "churn" is
+    # enqueued on the thread pool each time `#churn` or `#read_more` return a
+    # truthy value.
+    #
+    # You can return a truthy value to add this client to the thread pool
+    # again.
+    def churn
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/puma/stream_client.rb
+++ b/lib/puma/stream_client.rb
@@ -62,6 +62,9 @@ module Puma
     #
     # You can return a truthy value to add this client to the thread pool
     # again.
+    #
+    # This allows the plugin to process its work on the thread pool as any
+    # other regular HTTP request.
     def churn
       raise NotImplementedError
     end

--- a/lib/puma/stream_client.rb
+++ b/lib/puma/stream_client.rb
@@ -29,6 +29,10 @@ module Puma
       @io.closed?
     end
 
+    def stream?
+      true
+    end
+
     # This method will be invoked when the IO descriptor has new data pending
     # to be read. You can read from `@io` at this time.
     #


### PR DESCRIPTION
This is a proof of concept and it's not ready for merge at all, I'm opening this PR just to gauge interest.

What I'm trying here is to design a minimal interface that would allow an external plugin to implement WebSocket support. This has some advantages for Puma compared to the previous proposal:

 1. Less maintenance burden for Puma maintainers.
 2. Independent release cycle, the new code from the plugin won't hurt Puma if it has bugs.
 3. Allow users to opt-in for this, therefore `websocket-driver` won't be a dependency.
 4. Other features can fall down from plugins without requiring any update in Puma. Not that I can foresee any atm but who knows... (maybe SSE?).

But also some minor disadvantages:
 1. Changes in the hooks interface between the plugin & Puma may be troublesome. However it should be the plugin's responsibility to specify the correct Puma version it depends on. Ideally we won't need to make changes.
 2. Integration tests will be more difficult, but again this'll often be the plugins problem.

The current prototype as it stands has been able to run a [basic chat application](https://github.com/jesus/rat) and this [ActionCable experiment](https://github.com/baweaver/actioncable_symphony), using this [`puma-websockets` plugin](https://github.com/Jesus/puma-websockets).

I understand this PR as it is doesn't cover many edge cases and it lacks tests, but I'd be happy to work further if you think this approach is worth more time.