### PR TITLE
Update binder, test_cli, test_integration - fix unix sockets

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -395,7 +395,7 @@ module Puma
     def inherit_unix_listener(path, fd)
       @unix_paths << path
 
-      if fd.kind_of? UNIXServer
+      if fd.kind_of? TCPServer
         s = fd
       else
         s = UNIXServer.for_fd fd

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -12,7 +12,7 @@ class TestCLI < Minitest::Test
 
     @tmp_path2 = "#{@tmp_path}2"
 
-    File.unlink @tmp_path if File.exist? @tmp_path
+    File.unlink @tmp_path  if File.exist? @tmp_path
     File.unlink @tmp_path2 if File.exist? @tmp_path2
 
     @wait, @ready = IO.pipe
@@ -26,9 +26,8 @@ class TestCLI < Minitest::Test
   end
 
   def teardown
-    File.unlink @tmp_path if File.exist? @tmp_path
+    File.unlink @tmp_path  if File.exist? @tmp_path
     File.unlink @tmp_path2 if File.exist? @tmp_path2
-
     @wait.close
     @ready.close
   end
@@ -107,6 +106,7 @@ class TestCLI < Minitest::Test
 
     cli.launcher.stop
     t.join
+    s.close
   end
 
   def test_control
@@ -131,6 +131,7 @@ class TestCLI < Minitest::Test
 
     cli.launcher.stop
     t.join
+    s.close
   end
 
   def test_control_stop
@@ -154,6 +155,7 @@ class TestCLI < Minitest::Test
     assert_equal '{ "status": "ok" }', body.split("\r\n").last
 
     t.join
+    s.close
   end
 
   def control_gc_stats(uri, cntl)

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -12,8 +12,8 @@ require "open3"
 class TestIntegration < Minitest::Test
 
   def setup
-    @state_path = "test/test_puma.state"
-    @bind_path = "test/test_server.sock"
+    @state_path   = "test/test_puma.state"
+    @bind_path    = "test/test_server.sock"
     @control_path = "test/test_control.sock"
     @token = "xxyyzz"
 
@@ -26,10 +26,6 @@ class TestIntegration < Minitest::Test
   end
 
   def teardown
-    File.unlink @state_path rescue nil
-    File.unlink @bind_path rescue nil
-    File.unlink @control_path rescue nil
-
     @wait.close
     @ready.close
 
@@ -42,6 +38,10 @@ class TestIntegration < Minitest::Test
 
       @server.close
     end
+
+    File.unlink @state_path   if File.exist? @state_path
+    File.unlink @bind_path    if File.exist? @bind_path
+    File.unlink @control_path if File.exist? @control_path
   end
 
   def server_cmd(argv)
@@ -198,6 +198,7 @@ class TestIntegration < Minitest::Test
         done = true
       end
     end
+
     # Stop
     ccli = Puma::ControlCLI.new ["-S", @state_path, "stop"], sout
     ccli.run


### PR DESCRIPTION
@nateberkopec

Since I'm UnixSocket challenged, I looked at some of the Core test code.  Possible fix may revolve around [`File.socket?`](https://msp-greg.github.io/ruby_trunk/Core/File.html#socket?-class_method).  Used it in the `Binder#close` method.  The rest is just cleanup, etc.

Don't know about the issue with deleted files (#1775)

Passed in my fork without all the errors...