### PR TITLE
Fix typos across puma repository

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -20,7 +20,7 @@ module Puma
   # In this class any "user" specified options take precedence over any
   # "file" specified options, take precedence over any "default" options.
   #
-  # User input is prefered over "defaults":
+  # User input is preferred over "defaults":
   #   user_options    = { foo: "bar" }
   #   default_options = { foo: "zoo" }
   #   options = UserFileDefaultOptions.new(user_options, default_options)
@@ -32,7 +32,7 @@ module Puma
   #   puts options.all_of(:foo)
   #   # => ["bar", "zoo"]
   #
-  # A "file" option can be set. This config will be prefered over "default" options
+  # A "file" option can be set. This config will be preferred over "default" options
   # but will defer to any available "user" specified options.
   #
   #   user_options    = { foo: "bar" }

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -23,7 +23,7 @@ module Puma
   # A connection comes into a `Puma::Server` instance, it is then passed to a `Puma::Reactor` instance,
   # which stores it in an array and waits for any of the connections to be ready for reading.
   #
-  # The waiting/wake up is performed with nio4r, which will use the apropriate backend (libev, Java NIO or
+  # The waiting/wake up is performed with nio4r, which will use the appropriate backend (libev, Java NIO or
   # just plain IO#select). The call to `NIO::Selector#select` will "wake up" and
   # return the references to any objects that caused it to "wake". The reactor
   # then loops through each of these request objects, and sees if they're complete. If they

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -210,7 +210,7 @@ class TestIntegration < Minitest::Test
     skip_on :jruby
 
     # we run ls to get a 'safe' pid to pass off as puma in cli stop
-    # do not want to accidently kill a valid other process
+    # do not want to accidentally kill a valid other process
     io = IO.popen(windows? ? "dir" : "ls")
     safe_pid = io.pid
     Process.wait safe_pid
@@ -276,7 +276,7 @@ class TestIntegration < Minitest::Test
         rescue Errno::ECONNREFUSED
           # connection was was never accepted
           # it can therefore be re-tried before the
-          # client receives an empty reponse
+          # client receives an empty response
           next_replies << :connection_refused
         end
       end

--- a/tools/jungle/init.d/puma
+++ b/tools/jungle/init.d/puma
@@ -398,7 +398,7 @@ case "$1" in
   ;;
   remove)
     if [ "$#" -lt 2 ]; then
-      echo "Please, specifiy the app's directory to remove."
+      echo "Please, specify the app's directory to remove."
       exit 1
     else
       do_remove $2


### PR DESCRIPTION
Fix typos across **puma repository**

**Fixed files**

```
puma/lib/puma/configuration.rb:23:18: "prefered" is a misspelling of "preferred"
puma/lib/puma/configuration.rb:35:52: "prefered" is a misspelling of "preferred"
puma/lib/puma/reactor.rb:26:68: "apropriate" is a misspelling of "appropriate"
puma/test/test_integration.rb:213:21: "accidently" is a misspelling of "accidentally"
puma/test/test_integration.rb:279:37: "reponse" is a misspelling of "response"
puma/tools/jungle/init.d/puma:401:20: "specifiy" is a misspelling of "specify"
```