### PR TITLE
WIP: Better: Restart workers in batches / clustered mode.

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -156,7 +156,14 @@ module Puma
       diff = @options[:workers] - @workers.size
       return if diff < 1
 
+      if @options[:restart_workers_in_batch_of]
+        return unless @workers.all?(&:booted?) 
+        diff = [diff, @options[:restart_workers_in_batch_of]].min
+      end
+
       master = Process.pid
+
+      log "Booting #{diff} workers"
 
       diff.times do
         idx = next_worker_index

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -157,7 +157,7 @@ module Puma
       return if diff < 1
 
       if @options[:restart_workers_in_batch_of]
-        return unless @workers.all?(&:booted?) 
+        return unless @workers.all?(&:booted?)
         diff = [diff, @options[:restart_workers_in_batch_of]].min
       end
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -236,6 +236,13 @@ module Puma
       @options[:restart_cmd] = cmd.to_s
     end
 
+    # In clustered mode, instead of restarting all workers at once,
+    # restart workers in batch of `count`
+    # Usually count is set to the number of processors available
+    def restart_workers_in_batch_of(count)
+      @options[:restart_workers_in_batch_of] = count
+    end
+
     # Store the pid of the server in the file at +path+.
     def pidfile(path)
       @options[:pidfile] = path.to_s


### PR DESCRIPTION
This PR adds the option `restart_workers_in_batch_of` so that not all workers boot at the same time.

Before:

```
=> Booting Puma
=> Rails 5.2.3 application starting in development 
=> Run `rails server -h` for more startup options
[11938] Puma starting in cluster mode...
[11938] * Version 4.0.1 (ruby 2.5.5-p157), codename: 4 Fast 4 Furious
[11938] * Min threads: 4, max threads: 4
[11938] * Environment: development
[11938] * Process workers: 17
[11938] * Phased restart available
[11938] * Listening on tcp://localhost:3000
[11938] Use Ctrl-C to stop
[11938] * Starting control server on unix:///tmp/puma-status-1563997129438-11938
[11938] - Worker 0 (pid: 11964) booted, phase: 0
[11938] - Worker 1 (pid: 11976) booted, phase: 0
[11938] - Worker 2 (pid: 11978) booted, phase: 0
[11938] - Worker 3 (pid: 11997) booted, phase: 0
[11938] - Worker 4 (pid: 12012) booted, phase: 0
[11938] - Worker 5 (pid: 12024) booted, phase: 0
[11938] - Worker 6 (pid: 12036) booted, phase: 0
[11938] - Worker 7 (pid: 12048) booted, phase: 0
[11938] - Worker 8 (pid: 12061) booted, phase: 0
[11938] - Worker 9 (pid: 12074) booted, phase: 0
[11938] - Worker 10 (pid: 12086) booted, phase: 0
[11938] - Worker 11 (pid: 12096) booted, phase: 0
[11938] - Worker 12 (pid: 12111) booted, phase: 0
[11938] - Worker 13 (pid: 12124) booted, phase: 0
[11938] - Worker 14 (pid: 12138) booted, phase: 0
[11938] - Worker 15 (pid: 12150) booted, phase: 0
[11938] - Worker 16 (pid: 12163) booted, phase: 0
```

With the option set to 3:

```
=> Booting Puma
=> Rails 5.2.3 application starting in development 
=> Run `rails server -h` for more startup options
[11556] Puma starting in cluster mode...
[11556] * Version 4.0.1 (ruby 2.5.5-p157), codename: 4 Fast 4 Furious
[11556] * Min threads: 4, max threads: 4
[11556] * Environment: development
[11556] * Process workers: 17
[11556] * Phased restart available
[11556] * Listening on tcp://localhost:3000
[11556] Use Ctrl-C to stop
[11556] * Starting control server on unix:///tmp/puma-status-1563997022501-11556
[11556] Booting 3 workers
[11556] - Worker 0 (pid: 11583) booted, phase: 0
[11556] - Worker 1 (pid: 11585) booted, phase: 0
[11556] - Worker 2 (pid: 11606) booted, phase: 0
[11556] Booting 3 workers
[11556] - Worker 3 (pid: 11622) booted, phase: 0
[11556] - Worker 4 (pid: 11626) booted, phase: 0
[11556] - Worker 5 (pid: 11648) booted, phase: 0
[11556] Booting 3 workers
[11556] - Worker 6 (pid: 11661) booted, phase: 0
[11556] - Worker 7 (pid: 11674) booted, phase: 0
[11556] - Worker 8 (pid: 11687) booted, phase: 0
[11556] Booting 3 workers
[11556] - Worker 9 (pid: 11691) booted, phase: 0
[11556] - Worker 10 (pid: 11713) booted, phase: 0
[11556] - Worker 11 (pid: 11726) booted, phase: 0
[11556] Booting 3 workers
[11556] - Worker 12 (pid: 11739) booted, phase: 0
[11556] - Worker 13 (pid: 11743) booted, phase: 0
[11556] - Worker 14 (pid: 11746) booted, phase: 0
[11556] Booting 2 workers
[11556] - Worker 15 (pid: 11778) booted, phase: 0
[11556] - Worker 16 (pid: 11791) booted, phase: 0
```

Test TBD