### PR TITLE
Remove debug backtrace from pumactl

### DIFF
--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -101,7 +101,6 @@ module Puma
 
     rescue => e
       @stdout.puts e.message
-      @stdout.puts e.backtrace
       exit 1
     end
 
@@ -244,7 +243,6 @@ module Puma
 
     rescue => e
       message e.message
-      message e.backtrace
       exit 1
     end
 


### PR DESCRIPTION
Resolves #1769. Remove backtrace output when invalid `pumactl` commands are run. Originally added as a debugging measure in #1239.