### PR TITLE
Detach dead workers to prevent zombie processes

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -116,6 +116,7 @@ module Puma
       end
 
       def dead!
+        Process.detach(pid) # to prevent zombies
         @dead = true
       end
 

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -227,9 +227,8 @@ module Puma
       # during this loop by giving the kernel time to kill them.
       sleep 1 if any
 
-      @workers.reject! { |w| Process.waitpid(w.pid, Process::WNOHANG) }
-
       @workers.reject!(&:dead?)
+      @workers.reject! { |w| Process.waitpid(w.pid, Process::WNOHANG) }
 
       cull_workers
       spawn_workers

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -376,11 +376,12 @@ class TestIntegration < Minitest::Test
   end
 
   def test_no_zombie_children
-    num_workers = 2
+    skip_on :windows
+
     worker_pids = []
-    server = server("-w #{num_workers} test/rackup/hello.ru")
+    server = server("-w 2 test/rackup/hello.ru")
     # Get the PIDs of the child workers.
-    while worker_pids.size < num_workers
+    while worker_pids.size < 2
       next unless line = server.gets.match(/pid: (\d+)/)
       worker_pids << line.captures.first.to_i
     end

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -391,9 +391,11 @@ class TestIntegration < Minitest::Test
     # The happy path should raise the Errno::ESRCH exception,
     # indicating the process is dead and has been reaped.
     zombies = worker_pids.map do |pid|
-      pid if Process.kill 0, pid
-    rescue Errno::ESRCH
-      nil
+      begin
+        pid if Process.kill 0, pid
+      rescue Errno::ESRCH
+        nil
+      end
     end.compact
     assert_empty zombies
   end

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -376,7 +376,7 @@ class TestIntegration < Minitest::Test
   end
 
   def test_no_zombie_children
-    skip_on :windows
+    skip_on :jruby, :windows
 
     worker_pids = []
     server = server("-w 2 test/rackup/hello.ru")


### PR DESCRIPTION
Fixes #1855. When a worker is found dead, detach it from the master process with [`Process.detach`](https://ruby-doc.org/core-2.6.3/Process.html#method-c-detach). This will reap the dead process in a separate thread and prevent zombie children lingering in the process table.

Before:
```
bx puma --debug -w 4 test/rackup/hello-bind.ru
* snip *
[66227] - Worker 0 (pid: 66230) booted, phase: 0
[66227] - Worker 1 (pid: 66250) booted, phase: 0
[66227] - Worker 2 (pid: 66253) booted, phase: 0
[66227] - Worker 3 (pid: 66255) booted, phase: 0
```

```
$ kill 66230
$ kill 66250
$ kill 66253
$ ps aux | grep "[Z]+"
matt             66253   0.0  0.0        0      0 s004  Z+    8:58PM   0:00.00 (ruby)
matt             66250   0.0  0.0        0      0 s004  Z+    8:58PM   0:00.00 (ruby)
matt             66230   0.0  0.0        0      0 s004  Z+    8:58PM   0:00.00 (ruby)
```

After:
```
bx puma --debug -w 4 test/rackup/hello-bind.ru
* snip *
[67422] - Worker 0 (pid: 67468) booted, phase: 0
[67422] - Worker 1 (pid: 67469) booted, phase: 0
[67422] - Worker 2 (pid: 67470) booted, phase: 0
[67422] - Worker 3 (pid: 67471) booted, phase: 0
```
```
$ kill 67468
$ kill 67469
$ kill 67470
$ ps aux | grep "[Z]+"
# nothing
```