### PR TITLE
Using at_exit for graceful stop upon receiving a SIGINT in JRuby

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -406,12 +406,6 @@ module Puma
 
       begin
         Signal.trap "SIGINT" do
-          if Puma.jruby?
-            @status = :exit
-            at_exit { graceful_stop }
-            exit
-          end
-
           stop
         end
       rescue Exception

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -408,7 +408,7 @@ module Puma
         Signal.trap "SIGINT" do
           if Puma.jruby?
             @status = :exit
-            graceful_stop
+            at_exit { graceful_stop }
             exit
           end
 

--- a/test/rackup/jruby-sigint.ru
+++ b/test/rackup/jruby-sigint.ru
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+java_import java.util.concurrent.ThreadPoolExecutor
+java_import java.lang.Runnable
+
+# From https://github.com/ruby-concurrency/concurrent-ruby/blob/d11b29c37b81320ca7126cc9cd85f4f3d17a78a3/lib/concurrent/executor/java_thread_pool_executor.rb#L111-L117
+pool = java.util.concurrent.ThreadPoolExecutor.new(
+    2,
+    2,
+    60,
+    java.util.concurrent.TimeUnit::SECONDS,
+    java.util.concurrent.LinkedBlockingQueue.new,
+    java.util.concurrent.ThreadPoolExecutor::AbortPolicy.new
+  )
+
+# From concurrent-ruby: https://github.com/ruby-concurrency/concurrent-ruby/blob/d11b29c37b81320ca7126cc9cd85f4f3d17a78a3/lib/concurrent/executor/java_executor_service.rb#L77-L87
+class Job
+  include Runnable
+  def initialize(args, block)
+    @args = args
+    @block = block
+  end
+
+  def run
+    @block.call(*@args)
+  end
+end
+
+2.times do
+  pool.submit Job.new(nil, proc { sleep })
+end
+
+at_exit do
+  # Request threadpool shutdown.
+  pool.shutdown
+  # Add two seconds wait to let the threads finish and then kill the threads.
+  deadline = Time.now + 2
+  while true
+    break if pool.get_active_count.zero?
+    if Time.now > deadline
+      pool.shutdownNow
+      break
+    end
+  end
+end
+
+run lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Hello World"]] }

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -339,11 +339,22 @@ class TestIntegration < Minitest::Test
     sleep 2.2
     shutdown_complete = (t.status != 'run')
 
+    port_vacated =
+      begin
+        sock = Socket.new(Socket::Constants::AF_INET, Socket::SOCK_STREAM, 0);
+        sock.bind(Socket.pack_sockaddr_in(@tcp_port, '0.0.0.0'));
+        sock.close
+        true
+      rescue Errno::EADDRINUSE;
+        false
+      end
+
     # `#teardown` uses INT, needs KILL here.
     Process.kill :KILL, @server.pid unless shutdown_complete
 
     @server = nil # prevent `#teardown` from killing already killed server
     assert_equal true, shutdown_complete
+    assert_equal true, port_vacated
   end
 
   def test_term_signal_suppress_in_clustered_mode

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -327,18 +327,18 @@ class TestIntegration < Minitest::Test
     assert_equal 0, status
   end
 
-  def test_int_signal_main_thread_usage_in_jruby
+  def test_int_signal_with_background_thread_in_jruby
     skip_unless :jruby
 
     @server = Struct.new(:pid, :close).new(spawn(server_cmd('test/rackup/jruby-sigint.ru')))
     sleep 6 # Wait until bootup. IO#popen is not working as expected and passes always.
-    signal :INT
+    Process.kill :INT, @server.pid
 
     thr = Thread.new { Process.wait @server.pid }
     sleep 5
 
     if thr.status == 'run'.freeze
-      signal :KILL
+      Process.kill :KILL, @server.pid
       result = false
     else
       result = true

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -334,13 +334,13 @@ class TestIntegration < Minitest::Test
     wait_for_server_to_boot(@wait)
     sleep 0.1
 
-    signal :INT
+    Process.kill :INT, @server.pid
 
     t = Thread.new { Process.wait @server.pid }
     sleep 3
 
     if t.status == 'run'
-      signal :KILL
+      Process.kill :KILL, @server.pid
       result = false
     else
       result = true


### PR DESCRIPTION
This resolves https://github.com/puma/puma/issues/1675.
Sorry about the noise in that issue but you can find a sample app [here](https://github.com/puma/puma/issues/1675#issuecomment-515584846) demonstrating the problem.

The `graceful_stop` is not using the same thread as the `at_exit` blocks and is being run in the JVM signal handling thread in JRuby.

So, the `thread.join` [here](https://github.com/puma/puma/blob/31d91c351a2bdd4d1aad3ec5434ae3da8306a8ae/lib/puma/server.rb#L980) is joining `@thread` on the signal handler thread and I'm not sure if that is the intention.

This fix will execute `graceful_stop` within the `at_exit` block on the main thread.

Link: https://github.com/jruby/jruby/issues/5437
