### PR TITLE
Appveyor - change lower Ruby version to 2.3 [skip travis]

### DIFF
--- a/win_gem_test/puma.ps1
+++ b/win_gem_test/puma.ps1
@@ -13,7 +13,7 @@ Make-Const repo_name 'puma'
 Make-Const url_repo  'https://github.com/puma/puma.git'
 
 #———————————————————————————————————————————————————————————————— lowest ruby version
-Make-Const ruby_vers_low 22
+Make-Const ruby_vers_low 23
 # null = don't compile; false = compile, ignore test (allow failure);
 # true = compile & test
 Make-Const trunk     $false ; Make-Const trunk_x64     $false


### PR DESCRIPTION
Current nio4r gem (2.4.0) requires Ruby 2.3 or greater.  The Appveyor build/test system uses 'gem install puma'.

At present, RubyGems ignores ruby version constraints when installing dependencies.