### PR TITLE
update puma.ps1 for nio4r & Ruby 2.2 [skip travis]

### DIFF
--- a/win_gem_test/puma.ps1
+++ b/win_gem_test/puma.ps1
@@ -34,6 +34,15 @@ function Pre-Compile {
   Write-Host Compiling With $env:SSL_VERS
 }
 
+#———————————————————————————————————————————————————————————————— Pre-Gem-Install
+function Pre-Gem-Install {
+  if ($ruby -lt '23') {
+    gem install -N --no-user-install nio4r:2.3.1
+  } else {
+    gem install -N --no-user-install nio4r
+  }
+}
+
 #———————————————————————————————————————————————————————————————— Run-Tests
 function Run-Tests {
   # call with comma separated list of gems to install or update


### PR DESCRIPTION
Allows Appveyor Ruby 2.2 jobs to install a compatible nio4r version.