### PR TITLE
Remove confusing `private` call

### DIFF
--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -88,7 +88,7 @@ module Rack
           "Verbose"         => "Don't report each request (default: false)"
         }
       end
-    private
+
       def self.set_host_port_to_config(host, port, config)
         config.clear_binds! if host || port
 


### PR DESCRIPTION
`private` method doesn't make class methods private.
(To make class methods private, use `private_class_method`.)
That was confusing so it's removed.