### PR TITLE
fix Binder#close

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -50,14 +50,6 @@ module Puma
 
     def close
       @ios.each { |i| i.close }
-      @unix_paths.each do |i|
-        # Errno::ENOENT is intermittently raised
-        begin
-          unix_socket = UNIXSocket.new i
-          unix_socket.close
-        rescue Errno::ENOENT
-        end
-      end
     end
 
     def import_from_env


### PR DESCRIPTION
Previous to #1829, `Binder#close` looped thru @unix_paths and unlinked all of them.  This seems to cause issues with UNIXSockets on some restarts (phased?).

#1829 removed the `unlink`, but also added two lines that create a UNIXSocket and immediately close it.  I've seen the code often, and I'm not sure what effect it has.  Hence, removed it.

Travis test: https://travis-ci.org/MSP-Greg/puma/builds/568149578

macOS Ruby 2.4 seems to behaving issues, seen that more than once today.  Maybe time to jump to xcode11 from xcode10.2?