### PR TITLE
cluster.rb - no zombies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,25 +37,27 @@ rvm:
 matrix:
   fast_finish: true
   include:
-    - rvm: 2.2 
-      dist: trusty 
+    - rvm: 2.2.10
+      dist: trusty
       env: OS="Trusty 14.04 OpenSSL 1.0.1"
-    - rvm: 2.6
+    - rvm: 2.6.3
       dist: bionic
       env: OS="Bionic 18.04 OpenSSL 1.1.1"
     - rvm: ruby-head
       env: jit=yes
     - rvm: 2.4.6
       os: osx
-      osx_image: xcode10.2
-      env: OS="osx xcode10.2"
+      osx_image: xcode11
+      env: OS="osx xcode11"
     - rvm: 2.5.5
       os: osx
-      osx_image: xcode10.2
-      env: OS="osx xcode10.2"
+      osx_image: xcode11
+      env: OS="osx xcode11"
     - rvm: jruby-9.2.7.0
       env: JRUBY_OPTS="--debug" JAVA_OPTS="--add-opens java.base/sun.nio.ch=org.jruby.dist --add-opens java.base/java.io=org.jruby.dist --add-opens java.base/java.util.zip=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.security.cert=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED"
     - rvm: jruby-head
+      dist: bionic
+      env: OS="Bionic 18.04"
 
   allow_failures:
     - rvm: ruby-head
@@ -63,6 +65,8 @@ matrix:
       env: jit=yes
     - rvm: jruby-9.2.7.0
     - rvm: jruby-head
+      dist: bionic
+      env: OS="Bionic 18.04"
 
 env:
   global:

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -227,9 +227,11 @@ module Puma
       # during this loop by giving the kernel time to kill them.
       sleep 1 if any
 
-      @workers.reject! { |w| Process.waitpid(w.pid, Process::WNOHANG) }
-
-      @workers.reject!(&:dead?)
+      pids = []
+      while pid = Process.waitpid(-1, Process::WNOHANG) do
+        pids << pid
+      end
+      @workers.reject! { |w| w.dead? || pids.include?(w.pid) }
 
       cull_workers
       spawn_workers


### PR DESCRIPTION
Commits:

1. **'cluster.rb - fixup for Cluster#check_workers, removes zombies?'** - reverts problematic code in `Cluster#check_workers` to a simplified version of what was used for several years, thru 3.12.1.  Current code has been revised from previous due to issues with newer Ruby versions, etc.  Simplified version appears to be working correctly.

2. **'test_integration.rb - add zombie test'** - uses test from PR #1864 (not merged, closed)

3. **'travis.yml - misc updates'** - updates a few items to make use of current/newer releases.  Hoping to fix some issues with intermittent failures.