### PR TITLE
fix Binder#close via rescue addition

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -55,7 +55,7 @@ module Puma
         begin
           unix_socket = UNIXSocket.new i
           unix_socket.close
-        rescue Errno::ENOENT
+        rescue Errno::ENOENT, Errno::ECONNREFUSED
         end
       end
     end


### PR DESCRIPTION
Add Errno::ECONNREFUSED to rescue, removes extraneous test log output.

An alternative to PR #1886.