### PR TITLE
Gemspec Changelog URI

### DIFF
--- a/puma.gemspec
+++ b/puma.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -- bin docs ext lib tools`.split("\n") +
             %w[History.md LICENSE README.md]
   s.homepage = "http://puma.io"
+  s.metadata["changelog_uri"] = "https://github.com/puma/puma/blob/master/History.md"
   s.license = "BSD-3-Clause"
   s.required_ruby_version = Gem::Requirement.new(">= 2.2")
 end


### PR DESCRIPTION
Add changelog uri to spec metadata so that there is a "Changelog" link on https://rubygems.org/gems/puma. I went looking for this when comparing an update recently.