### PR TITLE
Integration cleanup

### DIFF
--- a/test/config/plugin.rb
+++ b/test/config/plugin.rb
@@ -1,1 +1,0 @@
-plugin :tmp_restart

--- a/test/config/simple.rb
+++ b/test/config/simple.rb
@@ -1,2 +1,0 @@
-pidfile "/tmp/jruby.pid"
-switch_user "daemon", "daemon"

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -51,7 +51,6 @@ class TestCLI < Minitest::Test
                          "test/rackup/lobster.ru"], @events
 
     t = Thread.new do
-      Thread.current.abort_on_exception = true
       cli.run
     end
 
@@ -83,7 +82,6 @@ class TestCLI < Minitest::Test
                          "test/rackup/lobster.ru"], @events
 
     t = Thread.new { cli.run }
-    t.abort_on_exception = true
 
     wait_booted
 
@@ -117,7 +115,6 @@ class TestCLI < Minitest::Test
                          "test/rackup/lobster.ru"], @events
 
     t = Thread.new { cli.run }
-    t.abort_on_exception = true
 
     wait_booted
 
@@ -141,7 +138,6 @@ class TestCLI < Minitest::Test
                          "test/rackup/lobster.ru"], @events
 
     t = Thread.new { cli.run }
-    t.abort_on_exception = true
 
     wait_booted
 
@@ -161,7 +157,6 @@ class TestCLI < Minitest::Test
                          "test/rackup/lobster.ru"], @events
 
     t = Thread.new do
-      Thread.current.abort_on_exception = true
       cli.run
     end
 

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -146,9 +146,14 @@ class TestIntegration < Minitest::Test
   end
 
   def test_phased_restart_via_pumactl
+    skip "Test causes tests to run twice"
     skip NO_FORK_MSG unless HAS_FORK
+    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
 
-    delay = 40
+    # The intention of this test is to get a worker "stuck" sleeping and
+    # then force a phased restart via pumactl. This is why worker_shutdown_timeout is
+    # set to 2.
+    delay = 999
 
     conf = Puma::Configuration.new do |c|
       c.quiet

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -358,7 +358,7 @@ class TestIntegration < Minitest::Test
 
   # reuses an existing connection to make sure that works
   def restart_server(server, connection)
-    Process.kill :USR2, @server.pid
+    Process.kill :USR2, server.pid
 
     connection.write "GET / HTTP/1.1\r\n\r\n" # trigger it to start by sending a new request
 

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -13,7 +13,7 @@ class TestIntegration < Minitest::Test
     File.unlink bind_path if File.exist?(bind_path)
     File.unlink control_path if File.exist?(control_path)
 
-    stop_server if @server
+    stop_server if defined?(@server)
   end
 
   def test_stop_via_pumactl

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -13,7 +13,7 @@ class TestIntegration < Minitest::Test
     File.unlink bind_path if File.exist?(bind_path)
     File.unlink control_path if File.exist?(control_path)
 
-    stop_server if defined?(@server)
+    stop_server if defined?(@server) && @server
   end
 
   def test_stop_via_pumactl

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -153,13 +153,13 @@ class TestIntegration < Minitest::Test
     assert_equal(1, e.status)
   end
 
-  def test_restart_closes_keepalive_sockets
+  def test_restart_with_usr2_works
     skip_unless_signal_exist? :USR2
     _, new_reply = restart_server_and_listen("-q test/rackup/hello.ru")
     assert_equal "Hello World", new_reply
   end
 
-  def test_restart_closes_keepalive_sockets_workers
+  def test_restart_with_usr2_works_workers
     skip NO_FORK_MSG unless HAS_FORK
     _, new_reply = restart_server_and_listen("-q -w 2 test/rackup/hello.ru")
     assert_equal "Hello World", new_reply

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -21,9 +21,9 @@ class TestIntegration < Minitest::Test
   end
 
   def teardown
-    File.unlink state_path rescue nil
-    File.unlink bind_path rescue nil
-    File.unlink control_path rescue nil
+    File.unlink state_path if File.exist?(state_path)
+    File.unlink bind_path if File.exist?(bind_path)
+    File.unlink control_path if File.exist?(control_path)
 
     @wait.close
     @ready.close
@@ -305,9 +305,11 @@ class TestIntegration < Minitest::Test
   private
 
   def test_method_name
-    test_method = caller.detect { |l| l.match(/in `(test_.*)/) }
-    test_method = /in `(test_.*)'/.match(test_method)
-    test_method[1]
+    @test_method_name ||= begin
+      test_method = caller.detect { |l| l.match(/in `(test_.*)/) }
+      test_method = /in `(test_.*)'/.match(test_method)
+      test_method && test_method[1]
+    end
   end
 
   def server_cmd(argv)
@@ -377,14 +379,17 @@ class TestIntegration < Minitest::Test
   end
 
   def state_path
+    return "" unless test_method_name
     "test/#{test_method_name}_puma.state"
   end
 
   def bind_path
+    return "" unless test_method_name
     "test/#{test_method_name}_server.sock"
   end
 
   def control_path
+    return "" unless test_method_name
     "test/#{test_method_name}_control.sock"
   end
 end

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -365,15 +365,15 @@ class TestIntegration < Minitest::Test
     wait_for_server_to_boot(server)
   end
 
+  def wait_for_server_to_boot(server)
+    true while server.gets !~ /Ctrl-C/ # wait for server to say it booted
+  end
+
   def connect(path = nil)
     s = TCPSocket.new "localhost", @tcp_port
     s << "GET /#{path} HTTP/1.1\r\n\r\n"
     true until s.gets == "\r\n"
     s
-  end
-
-  def wait_for_server_to_boot(server)
-    true while server.gets !~ /Ctrl-C/ # wait for server to say it booted
   end
 
   def read_body(connection)

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -83,7 +83,6 @@ class TestPumaControlCli < Minitest::Test
 
     control_cli = Puma::ControlCLI.new (opts + ["start"]), @ready, @ready
     t = Thread.new do
-      Thread.current.abort_on_exception = true
       control_cli.run
     end
 

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -30,7 +30,6 @@ class TestPathHandler < Minitest::Test
         @launcher = s
       end
     end
-    thread.abort_on_exception = true
 
     # Wait for launcher to boot
     Timeout.timeout(10) do

--- a/tools/trickletest.rb
+++ b/tools/trickletest.rb
@@ -38,7 +38,6 @@ ARGV[1].to_i.times do
     do_test(st, size)
   end
 
-  t.abort_on_exception = true
   threads << t
 end
 


### PR DESCRIPTION
Still a very long way to go, but getting better.

TODO: 

* [x] Cleanup state_path and friends
* [x] Cleanup server instance variable
* [x] Cleanup wait/ready pipe 
* [x] Start server w/only one way (or two, maybe? using Puma::Launcher or other process if required)

This PR closes #1914