### PR TITLE
test_integration.erb - fix intermittent test

### DIFF
--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -261,7 +261,7 @@ class TestIntegration < Minitest::Test
         mutex.synchronize { condition_variable.wait(mutex, 1.5) }
 
         begin
-          s = connect
+          s = connect "sleep1"
           read_body(s)
           next_replies << :success
         rescue Errno::ECONNRESET


### PR DESCRIPTION
Fixes test_sigterm_closes_listeners_on_forked_servers

When the test was added in PR #1802, it used the rackup/1second.ru file, which provided a fixed one second delay.

PR #1903 removed the 1second.ru file and added a sleep.ru file, which allowed variable timing.  But, the 'sleep1' path was added to only one of the test's two connect calls.

The test has passed most of the time, but intermittently fails.  This adds the 1 second delay to the 2nd connect call, which should make it stable.

The 2nd connect call loaded the next_replies array, which was the array that was failing in it's assert.

PR #1903 was my PR, so apologies for the mistake.