### PR TITLE
cluster.rb - remove worker #dead?, #dead!, @dead

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -74,7 +74,6 @@ module Puma
         @started_at = Time.now
         @last_checkin = Time.now
         @last_status = '{}'
-        @dead = false
         @term = false
       end
 
@@ -87,14 +86,6 @@ module Puma
       def boot!
         @last_checkin = Time.now
         @stage = :booted
-      end
-
-      def dead?
-        @dead
-      end
-
-      def dead!
-        @dead = true
       end
 
       def term?
@@ -507,7 +498,7 @@ module Puma
                   log "- Worker #{w.index} (pid: #{pid}) booted, phase: #{w.phase}"
                   force_check = true
                 when "t"
-                  w.dead!
+                  w.term
                   force_check = true
                 when "p"
                   w.ping!(result.sub(/^\d+/,'').chomp)


### PR DESCRIPTION
While working on PR #1908, I added a Worker method `#term?` to indicate whether `Worker#term` had been called.  Also, previous code that rejected workers from the `@workers` array where `dead?` was true was removed.

At the time, I wondered what `dead`'s purpose was.  It was also bothersome that workers contain threads, and `alive?` is a thread method, and most would consider `dead` to be the inverse.  Also, it's confusing, especially since code and comments in `thread_pool.rb` refer to `dead_workers`...

Upon reviewing the code, I cannot see anywhere where the state of `Worker#dead?` or `@dead` is used.  It is set here on line 510:

https://github.com/puma/puma/blob/9fb12283dbadf6e2bad04d5e67fe3fc9c29eede5/lib/puma/cluster.rb#L503-L512

This PR changes line 510 to 'w.term' and removes the two 'dead' methods.  If this seems improper, the PR could be changed to call `#term` in `Cluster#check_workers` for any dead workers...

**EDIT:** This may also help intermittent  test_integration.rb failures in macOS builds on Travis, which I've seen in my fork, as I can't test cluster locally..