### PR TITLE
test_puma_server_ssl.rb - remove fixed port, add http.send :do_finish

### DIFF
--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -204,8 +204,8 @@ end unless DISABLE_SSL
 class TestPumaServerSSLClient < Minitest::Test
 
   def assert_ssl_client_error_match(error, subject=nil, &blk)
-    port = 3212
     host = "127.0.0.1"
+    port = UniquePort.call
 
     app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
 
@@ -239,6 +239,8 @@ class TestPumaServerSSLClient < Minitest::Test
       end
     rescue OpenSSL::SSL::SSLError, EOFError
       client_error = true
+      # closes socket if open, may not close on error
+      http.send :do_finish
     end
 
     sleep 0.1


### PR DESCRIPTION
See errors in :
https://travis-ci.org/puma/puma/jobs/576834408

`UniquePort.call` is a safety valve, ideally serial (non-parallel) tests should cleanup well enough to not require it, but parallel testing, busy CI VM's, etc make that difficult.

I added `http.send :do_finish` and reverted the port back to 3212, and in two Travis runs in my fork, it passed.  This has been intermittent, so `do_finish` may not fix the real problem.  Regardless, it can't hurt.

`Net::HTTP#do_finish` is a private method that closes the underlying socket.  See:

https://github.com/ruby/ruby/blob/d5b237325b631e06775c2c7b5a8012b61ca5bccf/lib/net/http.rb#L1027-L1032