### PR TITLE
lib\puma\accept_nonblock.rb - fix socket closing on error

### DIFF
--- a/lib/puma/accept_nonblock.rb
+++ b/lib/puma/accept_nonblock.rb
@@ -15,7 +15,11 @@ module OpenSSL
             ssl.accept if @start_immediately
             ssl
           rescue SSLError => ex
-            sock.close
+            if ssl
+              ssl.close
+            else
+              sock.close
+            end
             raise ex
           end
         end

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -523,5 +523,5 @@ class TestIntegration < Minitest::Test
     @wait.sysread 1
 
     [thr, launcher, @events]
-   end
+  end
 end


### PR DESCRIPTION
See:
https://github.com/ruby/ruby/commit/68ac33a511929268ff5b0e05601b855a3a031b31