### PR TITLE
test/test_puma_server_ssl.rb - add Ruby OpenSSL version info

### DIFF
--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -19,14 +19,15 @@ end
 DISABLE_SSL = begin
               Puma::Server.class
               Puma::MiniSSL.check
-              puts "", RUBY_DESCRIPTION
-              puts "Puma::MiniSSL OPENSSL_LIBRARY_VERSION: #{Puma::MiniSSL::OPENSSL_LIBRARY_VERSION}",
-                   "                      OPENSSL_VERSION: #{Puma::MiniSSL::OPENSSL_VERSION}", ""
+              # net/http (loaded in helper) does not necessarily load OpenSSL
+              require "openssl" unless Object.const_defined? :OpenSSL
+              puts "", RUBY_DESCRIPTION,
+                   "                         Puma::MiniSSL                   OpenSSL",
+                   "OPENSSL_LIBRARY_VERSION: #{Puma::MiniSSL::OPENSSL_LIBRARY_VERSION.ljust 32}#{OpenSSL::OPENSSL_LIBRARY_VERSION}",
+                   "        OPENSSL_VERSION: #{Puma::MiniSSL::OPENSSL_VERSION.ljust 32}#{OpenSSL::OPENSSL_VERSION}", ""
             rescue
               true
             else
-              # net/http (loaded in helper) does not necessarily load OpenSSL
-              require "openssl" unless Object.const_defined? :OpenSSL
               false
             end
 


### PR DESCRIPTION
Recent CI experimentation has shown system OpenSSL to be different than Ruby OpenSSL.  May cause testing issues.

Adds Ruby OpenSSL version info to test log by test_puma_server_ssl.rb when Minitest loads test files.