### PR TITLE
Using RbConfig for host os check

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -105,7 +105,7 @@ module Puma
     # On Linux, use TCP_CORK to better control how the TCP stack
     # packetizes our stream. This improves both latency and throughput.
     #
-    if RUBY_PLATFORM =~ /linux/
+    if RbConfig::CONFIG['host_os'] =~ /linux/
       UNPACK_TCP_STATE_FROM_TCP_INFO = "C".freeze
 
       # 6 == Socket::IPPROTO_TCP


### PR DESCRIPTION
I'm browsing through the code and came across this piece of code which is initially added in https://github.com/puma/puma/commit/6da831aec3eb4bd237008a30a539e0885475dc8a

https://github.com/puma/puma/blob/818aa4a12e643606a1fd8a6cd3557c51a1521d80/lib/puma/server.rb#L108-L109


This condition will not return a truthy value for JRuby even on Linux and I wanted to see the results from travis with this change to understand if it's intentional.

```
$ docker run -it jruby /bin/bash
root@097863b86e82:/# irb
irb(main):001:0> RUBY_PLATFORM =~ /linux/
=> nil
irb(main):002:0> RUBY_PLATFORM
=> "java"
irb(main):003:0> RbConfig::CONFIG['host_os'] =~ /linux/
=> 0
```