### PR TITLE
CI: Use 2.4.7 which now exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
 rvm:
   - 2.2.10
   - 2.3.8
-  - 2.4.6
+  - 2.4.7
   - 2.5.6
   - 2.6.4
   - ruby-head
@@ -45,7 +45,7 @@ matrix:
       env: OS="Bionic 18.04 OpenSSL 1.1.1"
     - rvm: ruby-head
       env: jit=yes
-    - rvm: 2.4.6
+    - rvm: 2.4.7
       os: osx
       osx_image: xcode11
       env: OS="osx xcode11"


### PR DESCRIPTION
Add 2.4.7 to the build matrix.

(There was a checksum issue which has now been fixed in rvm.)

https://github.com/rvm/rvm/commit/4eac3b9465a77a3c801ca66cc2e68785d922d465