### PR TITLE
Fix Worker external TERM signalling

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -216,8 +216,10 @@ module Puma
             log "- Stopping #{w.pid} for phased upgrade..."
           end
 
-          w.term
-          log "- #{w.signal} sent to #{w.pid}..."
+          unless w.term?
+            w.term
+            log "- #{w.signal} sent to #{w.pid}..."
+          end
         end
       end
     end
@@ -266,6 +268,7 @@ module Puma
       server = start_server
 
       Signal.trap "SIGTERM" do
+        @worker_write << "e#{Process.pid}\n" rescue nil
         server.stop
       end
 
@@ -497,8 +500,11 @@ module Puma
                   w.boot!
                   log "- Worker #{w.index} (pid: #{pid}) booted, phase: #{w.phase}"
                   force_check = true
+                when "e"
+                  # external term, see worker method, Signal.trap "SIGTERM"
+                  w.instance_variable_set :@term, true
                 when "t"
-                  w.term
+                  w.term unless w.term?
                   force_check = true
                 when "p"
                   w.ping!(result.sub(/^\d+/,'').chomp)


### PR DESCRIPTION
External Worker `TERM` signals 'enter' on the forked side of the worker, but need to be communicated to other side, especially when an  externally `TERM`'d worker is 'stuck'.

Without doing so, a stuck worker will never be `KILL`'ed by Puma, regardless of whether the timers run out...