### PR TITLE
[PR 1952] 2st verification - updated tests & GitHub Actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,63 @@
+name: Puma
+
+on: [push]
+
+jobs:
+  build:
+    name: >-
+      OS: ${{ matrix.os }}  Ruby: ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-16.04', 'ubuntu-18.04', 'macos', 'windows-latest' ]
+        ruby: [ '2.3.x', '2.4.x', '2.5.x', '2.6.x' ]
+        exclude:
+        - os: ubuntu-16.04
+          ruby: 2.4.x
+        - os: ubuntu-16.04
+          ruby: 2.5.x
+        - os: ubuntu-16.04
+          ruby: 2.6.x
+        - os: ubuntu-18.04
+          ruby: 2.3.x
+        - os: macos
+          ruby: 2.3.x
+        - os: windows-latest
+          ruby: 2.3.x
+    steps:
+    - name: repo checkout
+      uses: actions/checkout@v1
+      with:
+        fetch-depth: 10
+    - name: load ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+
+    - name: Install ragel
+      if:   startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+      run:  |
+        if [ "${{ matrix.os }}" == "macos" ]; then
+          brew install ragel
+        else
+          sudo apt-get install ragel
+        fi
+    - name: Windows MSYS2
+      if:   startsWith(matrix.os, 'windows')
+      uses: MSP-Greg/msys2-action@master
+      with:
+        base:  update
+        mingw: openssl ragel
+
+    - name: RubyGems, Bundler Update
+      run:  gem update --system --no-document --conservative
+    - name: bundle install
+      run:  bundle install --jobs 4 --retry 3
+    - name: compile
+      run:  bundle exec rake compile
+    - name: test
+      run:  bundle exec rake
+      env:
+        CI: true
+        TESTOPTS: -v

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,6 +1,12 @@
 name: Puma
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   build:
@@ -35,7 +41,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
 
-    - name: Install ragel
+    - name: ubuntu & macos - install ragel
       if:   startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
       run:  |
         if [ "${{ matrix.os }}" == "macos" ]; then
@@ -43,7 +49,7 @@ jobs:
         else
           sudo apt-get install ragel
         fi
-    - name: Windows MSYS2
+    - name: windows - update MSYS2, openssl, ragel
       if:   startsWith(matrix.os, 'windows')
       uses: MSP-Greg/msys2-action@master
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
       env: OS="Bionic 18.04 OpenSSL 1.1.1"
     - rvm: ruby-head
       env: jit=yes
-    - rvm: 2.4.7
+    - rvm: 2.4.6
       os: osx
       osx_image: xcode11
       env: OS="osx xcode11"

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -50,14 +50,6 @@ module Puma
 
     def close
       @ios.each { |i| i.close }
-      @unix_paths.each do |i|
-        # Errno::ENOENT is intermittently raised
-        begin
-          unix_socket = UNIXSocket.new i
-          unix_socket.close
-        rescue Errno::ENOENT
-        end
-      end
     end
 
     def import_from_env

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -92,10 +92,6 @@ module Puma
         @term
       end
 
-      def term?
-        @term
-      end
-
       def ping!(status)
         @last_checkin = Time.now
         @last_status = status

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -68,7 +68,7 @@ module Puma
         @pid = pid
         @phase = phase
         @stage = :started
-        @signal = "TERM"
+        @signal = :TERM
         @options = options
         @first_term_sent = nil
         @started_at = Time.now
@@ -108,7 +108,7 @@ module Puma
       def term
         begin
           if @first_term_sent && (Time.now - @first_term_sent) > @options[:worker_shutdown_timeout]
-            @signal = "KILL"
+            @signal = :KILL
           else
             @term ||= true
             @first_term_sent ||= Time.now
@@ -119,12 +119,12 @@ module Puma
       end
 
       def kill
-        Process.kill "KILL", @pid
+        Process.kill :KILL, @pid
       rescue Errno::ESRCH
       end
 
       def hup
-        Process.kill "HUP", @pid
+        Process.kill :HUP, @pid
       rescue Errno::ESRCH
       end
     end
@@ -220,8 +220,10 @@ module Puma
             log "- Stopping #{w.pid} for phased upgrade..."
           end
 
-          w.term
-          log "- #{w.signal} sent to #{w.pid}..."
+          unless w.term?
+            w.term
+            log "- #{w.signal} sent to #{w.pid}..."
+          end
         end
       end
     end
@@ -270,6 +272,7 @@ module Puma
       server = start_server
 
       Signal.trap "SIGTERM" do
+        @worker_write << "e#{Process.pid}\n" rescue nil
         server.stop
       end
 
@@ -501,8 +504,10 @@ module Puma
                   w.boot!
                   log "- Worker #{w.index} (pid: #{pid}) booted, phase: #{w.phase}"
                   force_check = true
+                when "e"
+                  w.instance_variable_set :@term, true
                 when "t"
-                  w.term
+                  w.term unless w.term?
                   force_check = true
                 when "p"
                   w.ping!(result.sub(/^\d+/,'').chomp)

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -217,11 +217,12 @@ module Puma
     end
 
     def close_binder_listeners
-      @binder.listeners.each do |l, io|
-        io.close
+      # close binder listeners as fast as possible, so separate loop
+      @binder.listeners.each { |_, io| io.close }
+      @binder.listeners.each do |l, _|
         uri = URI.parse(l)
         next unless uri.scheme == 'unix'
-        File.unlink("#{uri.host}#{uri.path}")
+        File.unlink "#{uri.host}#{uri.path}"
       end
     end
 

--- a/test/config/worker_shutdown_timeout_2.rb
+++ b/test/config/worker_shutdown_timeout_2.rb
@@ -1,0 +1,1 @@
+worker_shutdown_timeout 2

--- a/test/helpers/apps.rb
+++ b/test/helpers/apps.rb
@@ -9,4 +9,12 @@ module TestApps
     [200, {"Content-Type" => "text/plain"}, ["Slept #{dly}"]]
   end
 
+  # call with "GET /sleep<d> HTTP/1.1\r\n\r\n", where is the number of
+  # seconds to sleep
+  # same as rackup/sleep_pid.ru
+  SLEEP_PID = -> (env) do
+    dly = (env['REQUEST_PATH'][/\/sleep(\d+)/,1] || '0').to_i
+    sleep dly
+    [200, {"Content-Type" => "text/plain"}, ["Slept #{dly} #{Process.pid}"]]
+  end
 end

--- a/test/rackup/sleep_pid.ru
+++ b/test/rackup/sleep_pid.ru
@@ -1,0 +1,8 @@
+# call with "GET /sleep<d> HTTP/1.1\r\n\r\n", where <d> is the number of
+# seconds to sleep, returns process pid
+
+run lambda { |env|
+  dly = (env['REQUEST_PATH'][/\/sleep(\d+)/,1] || '0').to_i
+  sleep dly
+  [200, {"Content-Type" => "text/plain"}, ["Slept #{dly} #{Process.pid}"]]
+}

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -1,110 +1,393 @@
 # frozen_string_literal: true
 
 require_relative "helper"
-require "puma/cli"
 require "puma/control_cli"
 require "open3"
 
-# TODO: Remove over-utilization of @instance variables
-# TODO: remove stdout logging, get everything out of my rainbow dots
-
 class TestIntegration < Minitest::Test
+  parallelize_me!
+
   HOST  = "127.0.0.1"
   TOKEN = "xxyyzz"
 
+  BASE = defined?(Bundler) ? "bundle exec #{Gem.ruby} -Ilib" :
+    "#{Gem.ruby} -Ilib"
+
+  WORKERS = 2
+
   def setup
-    @state_path   = "test/test_#{name}_puma.state"
-    @bind_path    = "test/test_#{name}_server.sock"
-    @control_path = "test/test_#{name}_control.sock"
-
-    @server = nil
-
-    @wait, @ready = IO.pipe
-
-    @events = Puma::Events.strings
-    @events.on_booted { @ready << "!" }
+    @ios_to_close = []
+    @state_path   = "test/#{name}_puma.state"
+    @bind_path    = "test/#{name}_server.sock"
+    @control_path = "test/#{name}_control.sock"
   end
 
   def teardown
+    if defined?(@server) && @server
+      begin
+        Process.kill :INT, @server.pid
+      rescue Errno::ESRCH
+      end
+      begin
+        Process.wait @pid
+      rescue Errno::ECHILD
+      end
+      @server.close unless @server.closed?
+      @server = nil
+    end
+
+    @ios_to_close.each do |io|
+      io.close if io.is_a?(IO) && !io.closed?
+      io = nil
+    end
+
     File.unlink @state_path   rescue nil
     File.unlink @bind_path    rescue nil
     File.unlink @control_path rescue nil
+  end
 
-    @wait.close
-    @ready.close
+  def test_pumactl_stop
+    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    cli_server "-q test/rackup/sleep.ru --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}"
 
-    if @server
-      Process.kill "INT", @server.pid
-      begin
-        Process.wait @server.pid
-      rescue Errno::ECHILD
+    cli_pumactl "stop", unix: true
+
+    _, status = Process.wait2 @pid
+    assert_equal 0, status
+
+    @server = nil
+  end
+
+  def test_pumactl_phased_restart_cluster
+    skip NO_FORK_MSG unless HAS_FORK
+
+    cli_server "-q -w #{WORKERS} test/rackup/sleep.ru --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}", unix: true
+
+    s = UNIXSocket.new @bind_path
+    @ios_to_close << s
+    s << "GET /sleep5 HTTP/1.0\r\n\r\n"
+
+    # Get the PIDs of the phase 0 workers.
+    phase0_worker_pids = get_worker_pids 0
+
+    # Phased restart
+    cli_pumactl "phased-restart", unix: true
+
+    # Get the PIDs of the phase 1 workers.
+    phase1_worker_pids = get_worker_pids 1
+
+    msg = "phase 0 pids #{phase0_worker_pids.inspect}  phase 1 pids #{phase1_worker_pids.inspect}"
+
+    assert_equal WORKERS, phase0_worker_pids.length, msg
+    assert_equal WORKERS, phase1_worker_pids.length, msg
+    assert_empty phase0_worker_pids & phase1_worker_pids, "#{msg}\nBoth workers should be replaced with new"
+
+    # Stop
+    cli_pumactl "stop", unix: true
+
+    _, status = Process.wait2 @pid
+    assert_equal 0, status
+
+    @server = nil
+  end
+
+  def test_pumactl_kill_unknown
+    skip_on :jruby
+
+    # we run ls to get a 'safe' pid to pass off as puma in cli stop
+    # do not want to accidentally kill a valid other process
+    io = IO.popen(windows? ? "dir" : "ls")
+    safe_pid = io.pid
+    Process.wait safe_pid
+
+    sout = StringIO.new
+
+    e = assert_raises SystemExit do
+      Puma::ControlCLI.new(%W!-p #{safe_pid} stop!, sout).run
+    end
+    sout.rewind
+    # windows bad URI(is not URI?)
+    assert_match(/No pid '\d+' found|bad URI\(is not URI\?\)/, sout.readlines.join(""))
+    assert_equal(1, e.status)
+  end
+
+  def test_usr2_restart_single
+    skip_unless_signal_exist? :USR2
+    _, new_reply = restart_server_and_listen("-q test/rackup/hello.ru")
+    assert_equal "Hello World", new_reply
+  end
+
+  def test_usr2_restart_cluster
+    skip NO_FORK_MSG unless HAS_FORK
+    _, new_reply = restart_server_and_listen("-q -w #{WORKERS} test/rackup/hello.ru")
+    assert_equal "Hello World", new_reply
+  end
+
+  # It does not share environments between multiple generations, which would break Dotenv
+  def test_usr2_restart_restores_environment
+    # jruby has a bug where setting `nil` into the ENV or `delete` do not change the
+    # next workers ENV
+    skip_on :jruby
+    skip_unless_signal_exist? :USR2
+
+    initial_reply, new_reply = restart_server_and_listen("-q test/rackup/hello-env.ru")
+
+    assert_includes initial_reply, "Hello RAND"
+    assert_includes new_reply, "Hello RAND"
+    refute_equal initial_reply, new_reply
+  end
+
+  # Send requests 10 per second.  Send 10, then :TERM server, then send another 30.
+  # No more than 10 should throw Errno::ECONNRESET.
+  def test_term_closes_listeners_cluster
+    skip NO_FORK_MSG unless HAS_FORK
+    skip_unless_signal_exist? :TERM
+
+    cli_server "-w #{WORKERS} -t 0:6 -q test/rackup/sleep_pid.ru"
+    threads = []
+    replies = []
+    mutex = Mutex.new
+    div   = 10
+
+    41.times.each do |i|
+      if i == 10
+        threads << Thread.new do
+          sleep i.to_f/div
+          Process.kill :TERM, @pid
+          mutex.synchronize { replies << :term_sent }
+        end
+      else
+        threads << Thread.new do
+          thread_run replies, i.to_f/div, 1, mutex
+        end
       end
+    end
 
-      @server.close
+    threads.each(&:join)
+
+    responses = replies.count { |r| r[/\ASlept 1/] }
+    resets    = replies.count { |r| r == :reset    }
+    refused   = replies.count { |r| r == :refused  }
+    msg = "#{responses} responses, #{resets} resets, #{refused} refused"
+
+    assert_operator 9,  :<=, responses, msg
+
+    assert_operator 10, :>=, resets   , msg
+
+    assert_operator 20, :<=, refused  , msg
+  end
+
+  # Send requests 1 per second.  Send 1, then :USR1 server, then send another 24.
+  # All should be responded to, and at least three workers should be used
+  def test_usr1_all_respond_cluster
+    skip NO_FORK_MSG unless HAS_FORK
+    skip_unless_signal_exist? :USR1
+
+    cli_server "-w #{WORKERS} -t 0:5 -q test/rackup/sleep_pid.ru"
+    threads = []
+    replies = []
+    mutex = Mutex.new
+
+    s = connect "sleep1"
+    replies << read_body(s)
+    Process.kill :USR1, @pid
+
+    24.times do |delay|
+      threads << Thread.new do
+        thread_run replies, delay, 1, mutex
+      end
+    end
+
+    threads.each(&:join)
+
+    responses = replies.count { |r| r[/\ASlept 1/] }
+    resets    = replies.count { |r| r == :reset    }
+    refused   = replies.count { |r| r == :refused  }
+
+    # get pids from replies, generate uniq array
+    qty_pids = replies.map { |body| body[/\d+\z/] }.uniq.compact.length
+
+    msg = "#{responses} responses, #{qty_pids} uniq pids"
+
+    assert_equal 25, responses, msg
+    assert_operator qty_pids, :>, 2, msg
+
+    msg = "#{responses} responses, #{resets} resets, #{refused} refused"
+
+    refute_includes replies, :refused, msg
+
+    refute_includes replies, :reset  , msg
+  end
+
+  def test_term_exit_code_single
+    skip_unless_signal_exist? :TERM
+
+    cli_server "test/rackup/hello.ru"
+    _, status = stop_server
+
+    assert_equal 15, status
+  end
+
+  def test_term_exit_code_cluster
+    skip NO_FORK_MSG unless HAS_FORK
+
+    cli_server "-w #{WORKERS} test/rackup/hello.ru"
+    _, status = stop_server
+
+    assert_equal 15, status
+  end
+
+  def test_term_suppress_single
+    skip_unless_signal_exist? :TERM
+
+    cli_server "-C test/config/suppress_exception.rb test/rackup/hello.ru"
+    _, status = stop_server
+
+    assert_equal 0, status
+  end
+
+  def test_term_suppress_cluster
+    skip NO_FORK_MSG unless HAS_FORK
+
+    cli_server "-w #{WORKERS} -C test/config/suppress_exception.rb test/rackup/hello.ru"
+
+    Process.kill :TERM, @pid
+    begin
+      Process.wait @pid
+    rescue Errno::ECHILD
+    end
+    status = $?.exitstatus
+
+    assert_equal 0, status
+    @server.close unless @server.closed?
+    @server = nil # prevent `#teardown` from killing already killed server
+  end
+
+  def test_load_path_includes_extra_deps
+    skip NO_FORK_MSG unless HAS_FORK
+
+    cli_server "-w 2 -C test/config/prune_bundler_with_deps.rb test/rackup/hello-last-load-path.ru"
+
+    last_load_path = read_body(connect)
+    assert_match(%r{gems/rdoc-[\d.]+/lib$}, last_load_path)
+  end
+
+  def test_term_not_accepts_new_connections
+    skip_unless_signal_exist? :TERM
+    skip_on :jruby
+
+    cli_server 'test/rackup/sleep.ru'
+
+    _stdin, curl_stdout, _stderr, curl_wait_thread = Open3.popen3("curl http://#{HOST}:#{@tcp_port}/sleep10")
+    sleep 1 # ensure curl send a request
+
+    Process.kill :TERM, @pid
+    true while @server.gets !~ /Gracefully stopping/ # wait for server to begin graceful shutdown
+
+    # Invoke a request which must be rejected
+    _stdin, _stdout, rejected_curl_stderr, rejected_curl_wait_thread = Open3.popen3("curl #{HOST}:#{@tcp_port}")
+
+    refute_nil Process.getpgid(@pid) # ensure server is still running
+    refute_nil Process.getpgid(rejected_curl_wait_thread[:pid]) # ensure first curl invokation still in progress
+
+    curl_wait_thread.join
+    rejected_curl_wait_thread.join
+
+    assert_match(/Slept 10/, curl_stdout.read)
+    assert_match(/Connection refused/, rejected_curl_stderr.read)
+
+    Process.wait @pid
+    @server.close unless @server.closed?
+    @server = nil # prevent `#teardown` from killing already killed server
+  end
+
+  def test_term_worker_clean_exit_cluster
+    skip NO_FORK_MSG unless HAS_FORK
+    skip_unless_signal_exist? :TERM
+    skip "Intermittent failure on Ruby 2.2" if RUBY_VERSION < '2.3'
+
+    cli_server "-w #{WORKERS} test/rackup/hello.ru"
+
+    # Get the PIDs of the child workers.
+    worker_pids = get_worker_pids 0
+
+    # Signal the workers to terminate, and wait for them to die.
+    Process.kill :TERM, @pid
+    Process.wait @pid
+
+    zombies = bad_exit_pids worker_pids
+
+    assert_empty zombies, "Process ids #{zombies} became zombies"
+  end
+
+  # mimicking stuck workers, test respawn with external TERM
+  def test_stuck_external_term_spawn_cluster
+    skip_unless_signal_exist? :TERM
+
+    worker_respawn(0) do |phase0_worker_pids|
+      last = phase0_worker_pids.last
+      phase0_worker_pids.each do |pid|
+        Process.kill :TERM, pid
+        sleep 4 unless pid == last
+      end
     end
   end
 
-  def server_cmd(argv)
-    @tcp_port = UniquePort.call
-    base = "#{Gem.ruby} -Ilib bin/puma"
-    base = "bundle exec #{base}" if defined?(Bundler)
-    "#{base} -b tcp://127.0.0.1:#{@tcp_port} #{argv}"
+  # mimicking stuck workers, test restart
+  def test_stuck_phased_restart_cluster
+    skip_unless_signal_exist? :USR1
+    worker_respawn { |phase0_worker_pids| Process.kill :USR1, @pid }
   end
 
-  def server(argv)
-    @server = IO.popen(server_cmd(argv), "r")
+  private
 
-    wait_for_server_to_boot(@server)
-
+  def cli_server(argv, unix: false)
+    if unix
+      cmd = "#{BASE} bin/puma -b unix://#{@bind_path} #{argv}"
+    else
+      @tcp_port = UniquePort.call
+      cmd = "#{BASE} bin/puma -b tcp://#{HOST}:#{@tcp_port} #{argv}"
+    end
+    @server = IO.popen(cmd, "r")
+    wait_for_server_to_boot
+    @pid = @server.pid
     @server
   end
 
-  def start_forked_server(argv)
-    servercmd = server_cmd(argv)
-    pid = fork do
-      exec servercmd
-    end
-
-    sleep 5
-    pid
-  end
-
-  def stop_forked_server(pid)
-    Process.kill(:TERM, pid)
+  def stop_server(pid = @pid, signal: :TERM)
+    Process.kill signal, pid
     sleep 1
-    Process.wait2(pid)
+    begin
+      Process.wait2 pid
+    rescue Errno::ECHILD
+    end
   end
 
   def restart_server_and_listen(argv)
-    server(argv)
+    cli_server argv
     connection = connect
     initial_reply = read_body(connection)
-    restart_server(@server, connection)
+    restart_server(connection)
     [initial_reply, read_body(connect)]
   end
 
-  def wait_booted
-    @wait.sysread 1
-  end
-
   # reuses an existing connection to make sure that works
-  def restart_server(server, connection)
-    Process.kill :USR2, @server.pid
-
+  def restart_server(connection)
+    Process.kill :USR2, @pid
     connection.write "GET / HTTP/1.1\r\n\r\n" # trigger it to start by sending a new request
-
-    wait_for_server_to_boot(server)
+    wait_for_server_to_boot
   end
 
-  def connect(path = nil)
-    s = TCPSocket.new "localhost", @tcp_port
+  def wait_for_server_to_boot
+    true while @server.gets !~ /Ctrl-C/ # wait for server to say it booted
+  end
+
+  def connect(path = nil, unix: false)
+    s = unix ? UNIXSocket.new("unix://#{@bind_path}") : TCPSocket.new(HOST, @tcp_port)
+    @ios_to_close << s
     s << "GET /#{path} HTTP/1.1\r\n\r\n"
     true until s.gets == "\r\n"
     s
-  end
-
-  def wait_for_server_to_boot(server)
-    true while server.gets !~ /Ctrl-C/ # wait for server to say it booted
   end
 
   def read_body(connection)
@@ -118,544 +401,112 @@ class TestIntegration < Minitest::Test
     end
   end
 
-  def test_stop_via_pumactl
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
-
-    conf = Puma::Configuration.new do |c|
-      c.quiet
-      c.state_path @state_path
-      c.bind "unix://#{@bind_path}"
-      c.activate_control_app "unix://#{@control_path}", :auth_token => TOKEN
-      c.rackup "test/rackup/hello.ru"
+  def cli_pumactl(argv, unix: false)
+    if unix
+      pumactl = IO.popen("#{BASE} bin/pumactl -C unix://#{@control_path} -T #{TOKEN} #{argv}", "r")
+    else
+      pumactl = IO.popen("#{BASE} bin/pumactl #{argv}", "r")
     end
-
-    l = Puma::Launcher.new conf, :events => @events
-
-    t = Thread.new do
-      Thread.current.abort_on_exception = true
-      l.run
-    end
-
-    wait_booted
-
-    s = UNIXSocket.new @bind_path
-    s << "GET / HTTP/1.0\r\n\r\n"
-    assert_equal "Hello World", read_body(s)
-
-    sout = StringIO.new
-
-    ccli = Puma::ControlCLI.new %W!-S #{@state_path} stop!, sout
-
-    ccli.run
-
-    assert_kind_of Thread, t.join, "server didn't stop"
+    @ios_to_close << pumactl
+    Process.wait pumactl.pid
+    pumactl
   end
 
-  def test_phased_restart_via_pumactl
+  def worker_respawn(phase = 1, size = WORKERS)
     skip NO_FORK_MSG unless HAS_FORK
-
-    delay = 40
-
-    conf = Puma::Configuration.new do |c|
-      c.quiet
-      c.state_path @state_path
-      c.bind "unix://#{@bind_path}"
-      c.activate_control_app "unix://#{@control_path}", :auth_token => TOKEN
-      c.workers 2
-      c.worker_shutdown_timeout 2
-      c.rackup "test/rackup/sleep.ru"
-    end
-
-    l = Puma::Launcher.new conf, :events => @events
-
-    t = Thread.new do
-      Thread.current.abort_on_exception = true
-      l.run
-    end
-
-    wait_booted
-
-    s = UNIXSocket.new @bind_path
-    s << "GET /sleep#{delay} HTTP/1.0\r\n\r\n"
-
-    sout = StringIO.new
-    # Phased restart
-    ccli = Puma::ControlCLI.new ["-S", @state_path, "phased-restart"], sout
-    ccli.run
-
-    done = false
-    until done
-      @events.stdout.rewind
-      log = @events.stdout.readlines.join("")
-      if log =~ /- Worker \d \(pid: \d+\) booted, phase: 1/
-        assert_match(/TERM sent/, log)
-        assert_match(/- Worker \d \(pid: \d+\) booted, phase: 1/, log)
-        done = true
-      end
-    end
-    # Stop
-    ccli = Puma::ControlCLI.new ["-S", @state_path, "stop"], sout
-    ccli.run
-
-    assert_kind_of Thread, t.join, "server didn't stop"
-    assert File.exist? @bind_path
-  end
-
-  def test_kill_unknown_via_pumactl
-    skip_on :jruby
-
-    # we run ls to get a 'safe' pid to pass off as puma in cli stop
-    # do not want to accidentally kill a valid other process
-    io = IO.popen(windows? ? "dir" : "ls")
-    safe_pid = io.pid
-    Process.wait safe_pid
-
-    sout = StringIO.new
-
-    e = assert_raises SystemExit do
-      ccli = Puma::ControlCLI.new %W!-p #{safe_pid} stop!, sout
-      ccli.run
-    end
-    sout.rewind
-    # windows bad URI(is not URI?)
-    assert_match(/No pid '\d+' found|bad URI\(is not URI\?\)/, sout.readlines.join(""))
-    assert_equal(1, e.status)
-  end
-
-  def test_restart_closes_keepalive_sockets
-    skip_unless_signal_exist? :USR2
-    _, new_reply = restart_server_and_listen("-q test/rackup/hello.ru")
-    assert_equal "Hello World", new_reply
-  end
-
-  def test_restart_closes_keepalive_sockets_workers
-    skip NO_FORK_MSG unless HAS_FORK
-    _, new_reply = restart_server_and_listen("-q -w 2 test/rackup/hello.ru")
-    assert_equal "Hello World", new_reply
-  end
-
-  def test_sigterm_closes_listeners_on_forked_servers
-    skip NO_FORK_MSG unless HAS_FORK
-    pid = start_forked_server("-w 2 -q test/rackup/sleep.ru")
     threads = []
-    initial_reply = nil
-    next_replies = []
-    condition_variable = ConditionVariable.new
-    mutex = Mutex.new
 
-    threads << Thread.new do
-      s = connect "sleep1"
-      mutex.synchronize { condition_variable.broadcast }
-      initial_reply = read_body(s)
-    end
+    cli_server "-w #{WORKERS} -t 1:1 -C test/config/worker_shutdown_timeout_2.rb test/rackup/sleep_pid.ru"
 
-    threads << Thread.new do
-      mutex.synchronize {
-        condition_variable.wait(mutex, 1)
-        Process.kill("SIGTERM", pid)
-      }
-    end
+    # make sure two workers have booted
+    phase0_worker_pids = get_worker_pids 0
 
-    10.times.each do |i|
+    [35, 40].each do |sleep_time|
       threads << Thread.new do
-        mutex.synchronize { condition_variable.wait(mutex, 1.5) }
-
         begin
-          s = connect "sleep1"
-          read_body(s)
-          next_replies << :success
-        rescue Errno::ECONNRESET
-          # connection was accepted but then closed
-          # client would see an empty response
-          next_replies << :connection_reset
-        rescue Errno::ECONNREFUSED
-          # connection was was never accepted
-          # it can therefore be re-tried before the
-          # client receives an empty response
-          next_replies << :connection_refused
+          connect "sleep#{sleep_time}"
+          # stuck connections will raise IOError or Errno::ECONNRESET
+          # when shutdown
+        rescue IOError, Errno::ECONNRESET
         end
       end
     end
 
-    threads.map(&:join)
+    @start_time = Time.now.to_f
 
-    assert_equal "Slept 1", initial_reply
+    # below should 'cancel' the phase 0 workers, either via phased_restart or
+    # externally TERM'ing them
+    yield phase0_worker_pids
 
-    assert_includes next_replies, :connection_refused
+    # wait for new workers to boot
+    phase1_worker_pids = get_worker_pids phase
 
-    refute_includes next_replies, :connection_reset
+    # should be empty if all phase 0 workers cleanly exited
+    phase0_exited = bad_exit_pids phase0_worker_pids
+
+    # Since 35 is the shorter of the two requests, server should restart
+    # and cancel both requests
+    assert_operator (Time.now.to_f - @start_time).round(2), :<, 35
+
+    msg = "phase0_worker_pids #{phase0_worker_pids.inspect}  phase1_worker_pids #{phase1_worker_pids.inspect}  phase0_exited #{phase0_exited.inspect}"
+    assert_equal WORKERS, phase0_worker_pids.length, msg
+
+    assert_equal WORKERS, phase1_worker_pids.length, msg
+    assert_empty phase0_worker_pids & phase1_worker_pids, "#{msg}\nBoth workers should be replaced with new"
+
+    assert_empty phase0_exited, msg
+
+    threads.each { |th| Thread.kill th }
+    stop_server signal: :KILL
   end
 
-  # It does not share environments between multiple generations, which would break Dotenv
-  def test_restart_restores_environment
-    # jruby has a bug where setting `nil` into the ENV or `delete` do not change the
-    # next workers ENV
-    skip_on :jruby
-    skip_unless_signal_exist? :USR2
-
-    initial_reply, new_reply = restart_server_and_listen("-q test/rackup/hello-env.ru")
-
-    assert_includes initial_reply, "Hello RAND"
-    assert_includes new_reply, "Hello RAND"
-    refute_equal initial_reply, new_reply
-  end
-
-  def test_term_signal_exit_code_in_single_mode
-    skip NO_FORK_MSG unless HAS_FORK
-
-    pid = start_forked_server("test/rackup/hello.ru")
-    _, status = stop_forked_server(pid)
-
-    assert_equal 15, status
-  end
-
-  def test_term_signal_exit_code_in_clustered_mode
-    skip NO_FORK_MSG unless HAS_FORK
-
-    pid = start_forked_server("-w 2 test/rackup/hello.ru")
-    _, status = stop_forked_server(pid)
-
-    assert_equal 15, status
-  end
-
-  def test_term_signal_suppress_in_single_mode
-    skip NO_FORK_MSG unless HAS_FORK
-
-    pid = start_forked_server("-C test/config/suppress_exception.rb test/rackup/hello.ru")
-    _, status = stop_forked_server(pid)
-
-    assert_equal 0, status
-  end
-
-  def test_term_signal_suppress_in_clustered_mode
-    skip NO_FORK_MSG unless HAS_FORK
-
-    server("-w 2 -C test/config/suppress_exception.rb test/rackup/hello.ru")
-
-    Process.kill(:TERM, @server.pid)
-    begin
-      Process.wait @server.pid
-    rescue Errno::ECHILD
+  # gets worker pids from @server output
+  # new workers created from 'phased-restart' increment phase
+  # new workers created from externally shutdown pids maintain same phase
+  def get_worker_pids(phase = 1, size = WORKERS)
+    pids = []
+    re = /pid: (\d+)\) booted, phase: #{phase}/
+    while pids.size < size
+      line = @server.gets          # line variable left for debugging
+      if pid = line[re, 1]
+        pids << pid
+      else
+        sleep 2
+      end
     end
-    status = $?.exitstatus
-
-    assert_equal 0, status
-    @server = nil # prevent `#teardown` from killing already killed server
+    pids.map(&:to_i)
   end
 
-  def test_load_path_includes_extra_deps
-    skip NO_FORK_MSG unless HAS_FORK
-
-    server("-w 2 -C test/config/prune_bundler_with_deps.rb test/rackup/hello-last-load-path.ru")
-
-    last_load_path = read_body(connect)
-    assert_match(%r{gems/rdoc-[\d.]+/lib$}, last_load_path)
-  end
-
-  def test_not_accepts_new_connections_after_term_signal
-    skip_on :jruby, :windows
-
-    server('test/rackup/sleep.ru')
-
-    _stdin, curl_stdout, _stderr, curl_wait_thread = Open3.popen3("curl http://127.0.0.1:#{@tcp_port}/sleep10")
-    sleep 1 # ensure curl send a request
-
-    Process.kill(:TERM, @server.pid)
-    true while @server.gets !~ /Gracefully stopping/ # wait for server to begin graceful shutdown
-
-    # Invoke a request which must be rejected
-    _stdin, _stdout, rejected_curl_stderr, rejected_curl_wait_thread = Open3.popen3("curl 127.0.0.1:#{@tcp_port}")
-
-    assert nil != Process.getpgid(@server.pid) # ensure server is still running
-    assert nil != Process.getpgid(rejected_curl_wait_thread[:pid]) # ensure first curl invokation still in progress
-
-    curl_wait_thread.join
-    rejected_curl_wait_thread.join
-
-    assert_match(/Slept 10/, curl_stdout.read)
-    assert_match(/Connection refused/, rejected_curl_stderr.read)
-
-    Process.wait(@server.pid)
-    @server = nil # prevent `#teardown` from killing already killed server
-  end
-
-  def test_no_zombie_children
-    skip NO_FORK_MSG unless HAS_FORK
-    skip "Intermittent failure on Ruby 2.2" if RUBY_VERSION < '2.3'
-
-    worker_pids = []
-    server = server("-w 2 test/rackup/hello.ru")
-    # Get the PIDs of the child workers.
-    while worker_pids.size < 2
-      next unless line = server.gets.match(/pid: (\d+)/)
-      worker_pids << line.captures.first.to_i
-    end
-
-    # Signal the workers to terminate, and wait for them to die.
-    Process.kill :TERM, @server.pid
-    Process.wait @server.pid
-    @server = nil # prevent `#teardown` from killing already killed server
-
-    # Check if the worker processes remain in the process table.
-    # Process.kill should raise the Errno::ESRCH exception,
-    # indicating the process is dead and has been reaped.
-    zombies = worker_pids.map do |pid|
+  # Returns an array of pids still in the process table, so it should
+  # be empty for a clean exit.
+  # Process.kill should raise the Errno::ESRCH exception, indicating the
+  # process is dead and has been reaped.
+  def bad_exit_pids(pids)
+    pids.map do |pid|
       begin
         pid if Process.kill 0, pid
       rescue Errno::ESRCH
         nil
       end
     end.compact
-    assert_empty zombies, "Process ids #{zombies} became zombies"
   end
 
-  def test_worker_spawn_external_term
-    worker_respawn { |l, old_pids|
-      old_pids.each { |p| Process.kill :TERM, p }
-    }
-  end
-
-  def test_worker_phased_restart
-    worker_respawn { |l, old_pids| l.phased_restart }
-  end
-
-  private
-
-  def worker_respawn
-    skip NO_FORK_MSG unless HAS_FORK
-    port = UniquePort.call
-    workers_booted = 0
-
-    conf = Puma::Configuration.new do |c|
-      c.bind "tcp://#{HOST}:#{port}"
-      c.threads 1, 1
-      c.workers 2
-      c.worker_shutdown_timeout 2
-      c.app TestApps::SLEEP
-      c.after_worker_fork { |idx| workers_booted += 1 }
+  def thread_run(replies, delay, sleep_time, mutex, unix: false)
+    begin
+      sleep delay
+      s = connect "sleep#{sleep_time}", unix: unix
+      body = read_body(s)
+      mutex.synchronize { replies << body }
+    rescue Errno::ECONNRESET
+      # connection was accepted but then closed
+      # client would see an empty response
+      mutex.synchronize { replies << :reset }
+    rescue Errno::ECONNREFUSED, Errno::EPIPE
+      # TCP  - Errno::ECONNREFUSED, Errno::EPIPE
+      # TODO UNIX
+      # connection was never accepted it can therefore be
+      # re-tried before the client receives an empty response
+      mutex.synchronize { replies << :refused }
     end
-
-    # start Puma via launcher
-    thr, launcher, _e = run_launcher conf
-
-    # make sure two workers have booted
-    time = 0
-    until workers_booted >= 2 || time >= 10
-      sleep 2
-      time += 2
-    end
-
-    cluster = launcher.instance_variable_get :@runner
-
-    http0 = Net::HTTP.new HOST, port
-    http1 = Net::HTTP.new HOST, port
-    body0 = nil
-    body1 = nil
-
-    worker0 = Thread.new do
-      begin
-        req0 = Net::HTTP::Get.new "/sleep35", {}
-        http0.start.request(req0) { |rep0| body0 = rep0.body }
-      rescue
-      end
-    end
-
-    worker1 = Thread.new do
-      begin
-        req1 = Net::HTTP::Get.new "/sleep40", {}
-        http1.start.request(req1) { |rep1| body1 = rep1.body }
-      rescue
-      end
-    end
-
-    old_pids = cluster.instance_variable_get(:@workers).map(&:pid)
-
-    start_time = Time.now.to_f
-
-    # below should 'cancel' the phase 0 workers, either via phased_restart or
-    # externally SIGTERM'ing them
-    yield launcher, old_pids
-
-    # make sure four workers have booted
-    time = 0
-    until workers_booted >= 4 || time >= 45
-      sleep 2
-      time += 2
-    end
-
-    new_pids = cluster.instance_variable_get(:@workers).map(&:pid)
-
-    # should be empty if all old workers removed
-    old_waited = old_pids.map { |pid|
-      begin
-        Process.wait(pid, Process::WNOHANG)
-        pid
-      rescue Errno::ECHILD
-        nil # child is already terminated
-      end
-    }.compact
-
-    Thread.kill worker0
-    Thread.kill worker1
-
-    launcher.stop
-    assert_kind_of Thread, thr.join, "server didn't stop"
-
-    refute_equal 'Slept 35', body0
-    refute_equal 'Slept 40', body1
-
-    # Since 35 is the shorter of the two requests, server should restart
-    # and cancel both requests
-    assert_operator (Time.now.to_f - start_time).round(2), :<, 35
-
-    msg = "old_pids #{old_pids.inspect}  new_pids #{new_pids.inspect}  old_waited #{old_waited.inspect}"
-    assert_equal 2, new_pids.length, msg
-    assert_equal 2, old_pids.length, msg
-    assert_empty new_pids & old_pids, "#{msg}\nBoth workers should be replaced with new"
-    assert_empty old_waited, msg
-  end
-
-  def run_launcher(conf)
-    # below for future PR
-    #@wait, @ready = IO.pipe
-    # @ios_to_close << @wait << @ready
-    #@events = Puma::Events.strings
-    #@events.on_booted { @ready << "!" }
-
-    launcher = Puma::Launcher.new conf, :events => @events
-
-    thr = Thread.new do
-      launcher.run
-    end
-
-    # wait for boot from #@events.on_booted
-    @wait.sysread 1
-
-    [thr, launcher, @events]
-  end
-
-  def test_worker_spawn_external_term
-    worker_respawn { |l, old_pids|
-      old_pids.each { |p| Process.kill :TERM, p }
-    }
-  end
-
-  def test_worker_phased_restart
-    worker_respawn { |l, old_pids| l.phased_restart }
-  end
-
-  private
-
-  def worker_respawn
-    skip NO_FORK_MSG unless HAS_FORK
-    port = UniquePort.call
-    workers_booted = 0
-
-    conf = Puma::Configuration.new do |c|
-      c.bind "tcp://#{HOST}:#{port}"
-      c.threads 1, 1
-      c.workers 2
-      c.worker_shutdown_timeout 2
-      c.app TestApps::SLEEP
-      c.after_worker_fork { |idx| workers_booted += 1 }
-    end
-
-    # start Puma via launcher
-    thr, launcher, _e = run_launcher conf
-
-    # make sure two workers have booted
-    time = 0
-    until workers_booted >= 2 || time >= 10
-      sleep 2
-      time += 2
-    end
-
-    cluster = launcher.instance_variable_get :@runner
-
-    http0 = Net::HTTP.new HOST, port
-    http1 = Net::HTTP.new HOST, port
-    body0 = nil
-    body1 = nil
-
-    worker0 = Thread.new do
-      begin
-        req0 = Net::HTTP::Get.new "/sleep35", {}
-        http0.start.request(req0) { |rep0| body0 = rep0.body }
-      rescue
-      end
-    end
-
-    worker1 = Thread.new do
-      begin
-        req1 = Net::HTTP::Get.new "/sleep40", {}
-        http1.start.request(req1) { |rep1| body1 = rep1.body }
-      rescue
-      end
-    end
-
-    old_pids = cluster.instance_variable_get(:@workers).map(&:pid)
-
-    start_time = Time.now.to_f
-
-    # below should 'cancel' the phase 0 workers, either via phased_restart or
-    # externally SIGTERM'ing them
-    yield launcher, old_pids
-
-    # make sure four workers have booted
-    time = 0
-    until workers_booted >= 4 || time >= 45
-      sleep 2
-      time += 2
-    end
-
-    new_pids = cluster.instance_variable_get(:@workers).map(&:pid)
-
-    # should be empty if all old workers removed
-    old_waited = old_pids.map { |pid|
-      begin
-        Process.wait(pid, Process::WNOHANG)
-        pid
-      rescue Errno::ECHILD
-        nil # child is already terminated
-      end
-    }.compact
-
-    Thread.kill worker0
-    Thread.kill worker1
-
-    launcher.stop
-    assert_kind_of Thread, thr.join, "server didn't stop"
-
-    refute_equal 'Slept 35', body0
-    refute_equal 'Slept 40', body1
-
-    # Since 35 is the shorter of the two requests, server should restart
-    # and cancel both requests
-    assert_operator (Time.now.to_f - start_time).round(2), :<, 35
-
-    msg = "old_pids #{old_pids.inspect}  new_pids #{new_pids.inspect}  old_waited #{old_waited.inspect}"
-    assert_equal 2, new_pids.length, msg
-    assert_equal 2, old_pids.length, msg
-    assert_empty new_pids & old_pids, "#{msg}\nBoth workers should be replaced with new"
-    assert_empty old_waited, msg
-  end
-
-  def run_launcher(conf)
-    # below for future PR
-    #@wait, @ready = IO.pipe
-    # @ios_to_close << @wait << @ready
-    #@events = Puma::Events.strings
-    #@events.on_booted { @ready << "!" }
-
-    launcher = Puma::Launcher.new conf, :events => @events
-
-    thr = Thread.new do
-      launcher.run
-    end
-
-    # wait for boot from #@events.on_booted
-    @wait.sysread 1
-
-    [thr, launcher, @events]
   end
 end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1,9 +1,10 @@
 require_relative "helper"
 
 class TestPumaServer < Minitest::Test
+  parallelize_me!
 
   def setup
-    @port = 0
+    @port = UniquePort.call
     @host = "127.0.0.1"
 
     @app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -32,6 +32,7 @@ DISABLE_SSL = begin
             end
 
 class TestPumaServerSSL < Minitest::Test
+  parallelize_me!
 
   def setup
     @http = nil
@@ -203,6 +204,7 @@ end unless DISABLE_SSL
 
 # client-side TLS authentication tests
 class TestPumaServerSSLClient < Minitest::Test
+  parallelize_me!
 
   def assert_ssl_client_error_match(error, subject=nil, &blk)
     host = "127.0.0.1"

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -17,6 +17,8 @@ class TestHandler
 end
 
 class WebServerTest < Minitest::Test
+  parallelize_me!
+
   VALID_REQUEST = "GET / HTTP/1.1\r\nHost: www.zedshaw.com\r\nContent-Type: text/plain\r\n\r\n"
 
   def setup


### PR DESCRIPTION
PR #1955 shows that the tests in this PR do not pass on current master.

Below is a summary of the changes here.  The last commit adds two tests that use UNIXSockets for the bind address, verifying that unix files seem to be handled correctly during shutdowns and restarts.

### lib files - binder.rb, cluster.rb, launcher.rb

1. binder.rb - Add PR #1886

2. cluster.rb - Add PR #1952, additional minor changes

3. launcher.rb - #close_binder_listeners - close io's as fast as possible.  Unlink files in separate iteration.

### test_integration.rb

#### Request handling during server TERM - two tests

`#test_term_closes_listeners_cluster_tcp`
`#test_term_closes_listeners_cluster_unix`

using `#term_closes_listeners_cluster`

Send requests 10 per second.  Send 10, then :TERM server, then send another 30.
No more than 10 should throw Errno::ECONNRESET.

#### Request handling during phased restart - two tests

`#test_usr1_all_respond_cluster_tcp`
`#test_usr1_all_respond_cluster_unix`

using `#usr1_all_respond_cluster`

Send requests 1 per second.  Send 1, then :USR1 server, then send another 24.
All should be responded to, and at least three workers should be used

#### Stuck worker tests - two tests

`#test_stuck_external_term_spawn_cluster`
Tests whether externally TERM'd 'stuck' workers are proper re-spawned.

`#test_stuck_phased_restart_cluster`
Tests whether 'stuck' workers are properly shutdown during phased-restart.

### GitHub Actions - workflow.yml

1. Install ragel for Ubuntu and macOS.  Both intermittently failed compile without doing so.

2. Windows - Add step to update MSYS2 gcc, install ragel and proper OpenSSL package.

3. Actions CI seems stable, and it finishes well before either Travis or AppVeyor.

### Misc test files changes

Added `parallelize_me!` to a few files, misc changes
