### PR TITLE
Remove unnecessary SIGINT trap for Jruby

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -424,12 +424,6 @@ module Puma
 
       begin
         Signal.trap "SIGINT" do
-          if Puma.jruby?
-            @status = :exit
-            graceful_stop
-            exit
-          end
-
           stop
         end
       rescue Exception


### PR DESCRIPTION
See #1868

The original intent of the trap was to ensure that the socket was removed
properly. It now does, so the trap is no longer necessary.