### PR TITLE
Update test_integration files per PR #1956

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -92,10 +92,6 @@ module Puma
         @term
       end
 
-      def term?
-        @term
-      end
-
       def ping!(status)
         @last_checkin = Time.now
         @last_status = status

--- a/test/config/worker_shutdown_timeout_2.rb
+++ b/test/config/worker_shutdown_timeout_2.rb
@@ -1,0 +1,1 @@
+worker_shutdown_timeout 2

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -87,7 +87,7 @@ module TestSkips
   UNIX_SKT_EXIST = Object.const_defined? :UNIXSocket
   UNIX_SKT_MSG = "UnixSockets aren't available on the #{RUBY_PLATFORM} platform"
 
-  SIGNAL_LIST = Signal.list.keys.map(&:to_sym) - (Puma.windows? ? [:TERM] : [])
+  SIGNAL_LIST = Signal.list.keys.map(&:to_sym) - (Puma.windows? ? [:INT, :TERM] : [])
 
   # usage: skip_unless_signal_exist? :USR2
   def skip_unless_signal_exist?(sig, bt: caller)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -21,6 +21,9 @@ require_relative "helpers/apps"
 $LOAD_PATH << File.expand_path("../../lib", __FILE__)
 Thread.abort_on_exception = true
 
+$debugging_info = ''.dup
+$debugging_hold = false    # needed for TestCLI#test_control_clustered
+
 require "puma"
 require "puma/events"
 require "puma/detect"
@@ -131,5 +134,20 @@ class Minitest::Test
   def self.run(reporter, options = {}) # :nodoc:
     prove_it!
     super
+  end
+
+  def full_name
+    "#{self.class.name}##{name}"
+  end
+end
+
+Minitest.after_run do
+  # needed for TestCLI#test_control_clustered
+  unless $debugging_hold
+    out = $debugging_info.strip
+    unless out.empty?
+      puts "", " Debugging Info".rjust(75, '-'),
+        out, '-' * 75, ""
+    end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -84,10 +84,12 @@ module TestSkips
   UNIX_SKT_EXIST = Object.const_defined? :UNIXSocket
   UNIX_SKT_MSG = "UnixSockets aren't available on the #{RUBY_PLATFORM} platform"
 
+  SIGNAL_LIST = Signal.list.keys.map(&:to_sym) - (Puma.windows? ? [:TERM] : [])
+
   # usage: skip_unless_signal_exist? :USR2
   def skip_unless_signal_exist?(sig, bt: caller)
-    signal = sig.to_s
-    unless Signal.list.key? signal
+    signal = sig.to_s.sub(/\ASIG/, '').to_sym
+    unless SIGNAL_LIST.include? signal
       skip "Signal #{signal} isn't available on the #{RUBY_PLATFORM} platform", bt
     end
   end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -52,6 +52,9 @@ class TestIntegration < Minitest::Test
     @server
   end
 
+  # rescue statements are just in case method is called with a server
+  # that is already stopped/killed, especially since Process.wait2 is
+  # blocking
   def stop_server(pid = @pid, signal: :TERM)
     begin
       Process.kill signal, pid

--- a/test/rackup/sleep_pid.ru
+++ b/test/rackup/sleep_pid.ru
@@ -1,0 +1,8 @@
+# call with "GET /sleep<d> HTTP/1.1\r\n\r\n", where <d> is the number of
+# seconds to sleep, returns process pid
+
+run lambda { |env|
+  dly = (env['REQUEST_PATH'][/\/sleep(\d+)/,1] || '0').to_i
+  sleep dly
+  [200, {"Content-Type" => "text/plain"}, ["Slept #{dly} #{Process.pid}"]]
+}

--- a/test/rackup/sleep_step.ru
+++ b/test/rackup/sleep_step.ru
@@ -1,0 +1,10 @@
+# call with "GET /sleep<d>-<s> HTTP/1.1\r\n\r\n", where <d> is the number of
+# seconds to sleep and <s> is the step
+
+run lambda { |env|
+  p = env['REQUEST_PATH']
+  dly = (p[/\/sleep(\d+)/,1] || '0').to_i
+  step = p[/(\d+)\z/,1].to_i
+  sleep dly
+  [200, {"Content-Type" => "text/plain"}, ["Slept #{dly} #{step}"]]
+}

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -2,6 +2,8 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestIntegrationCluster < TestIntegration
+  DARWIN = !!RUBY_PLATFORM[/darwin/]
+
   def setup
     super
 
@@ -27,60 +29,37 @@ class TestIntegrationCluster < TestIntegration
     assert_equal "Hello World", new_reply
   end
 
-  def test_term_closes_listeners
-    pid = cli_server("-w #{WORKERS} -q test/rackup/sleep.ru").pid
-    threads = []
-    initial_reply = nil
-    next_replies = []
-    condition_variable = ConditionVariable.new
-    mutex = Mutex.new
+  # Next two tests, one tcp, one unix
+  # Send requests 10 per second.  Send 10, then :TERM server, then send another 30.
+  # No more than 10 should throw Errno::ECONNRESET.
 
-    threads << Thread.new do
-      s = connect "sleep1"
-      mutex.synchronize { condition_variable.broadcast }
-      initial_reply = read_body(s)
-    end
+  def test_term_closes_listeners_tcp
+    skip_unless_signal_exist? :TERM
+    term_closes_listeners unix: false
+  end
 
-    threads << Thread.new do
-      mutex.synchronize {
-        condition_variable.wait(mutex, 1)
-        Process.kill("SIGTERM", pid)
-      }
-    end
+  def test_term_closes_listeners_unix
+    skip_unless_signal_exist? :TERM
+    term_closes_listeners unix: true
+  end
 
-    10.times.each do |i|
-      threads << Thread.new do
-        mutex.synchronize { condition_variable.wait(mutex, 1.5) }
+  # Next two tests, one tcp, one unix
+  # Send requests 1 per second.  Send 1, then :USR1 server, then send another 24.
+  # All should be responded to, and at least three workers should be used
 
-        begin
-          s = connect "sleep1"
-          read_body(s)
-          next_replies << :success
-        rescue Errno::ECONNRESET
-          # connection was accepted but then closed
-          # client would see an empty response
-          next_replies << :connection_reset
-        rescue Errno::ECONNREFUSED
-          # connection was was never accepted
-          # it can therefore be re-tried before the
-          # client receives an empty response
-          next_replies << :connection_refused
-        end
-      end
-    end
+  def test_usr1_all_respond_tcp
+    skip_unless_signal_exist? :USR1
+    usr1_all_respond unix: false
+  end
 
-    threads.each(&:join)
-
-    assert_equal "Slept 1", initial_reply
-
-    assert_includes next_replies, :connection_refused
-
-    refute_includes next_replies, :connection_reset
+  def test_usr1_all_respond_unix
+    skip_unless_signal_exist? :USR1
+    usr1_all_respond unix: true
   end
 
   def test_term_exit_code
-    pid = cli_server("-w #{WORKERS} test/rackup/hello.ru").pid
-    _, status = send_term_to_server(pid)
+    cli_server "-w #{WORKERS} test/rackup/hello.ru"
+    _, status = stop_server
 
     assert_equal 15, status
   end
@@ -112,117 +91,166 @@ class TestIntegrationCluster < TestIntegration
     Process.kill :TERM, pid
     Process.wait pid
 
-    zombies = clean_exit_pids worker_pids
+    zombies = bad_exit_pids worker_pids
 
     assert_empty zombies, "Process ids #{zombies} became zombies"
   end
 
-  # mimicking stuck workers, test respawn with external SIGTERM
+  # mimicking stuck workers, test respawn with external TERM
   def test_stuck_external_term_spawn
-    worker_respawn { |l, phase0_worker_pids|
-      phase0_worker_pids.each { |p| Process.kill :TERM, p }
-    }
+    skip_unless_signal_exist? :TERM
+
+    worker_respawn(0) do |phase0_worker_pids|
+      last = phase0_worker_pids.last
+      phase0_worker_pids.each do |pid|
+        Process.kill :TERM, pid
+        sleep 4 unless pid == last
+      end
+    end
   end
 
   # mimicking stuck workers, test restart
   def test_stuck_phased_restart
-    worker_respawn { |l, phase0_worker_pids| l.phased_restart }
+    skip_unless_signal_exist? :USR1
+    worker_respawn { |phase0_worker_pids| Process.kill :USR1, @pid }
   end
 
   private
 
-  def worker_respawn
-    skip NO_FORK_MSG unless HAS_FORK
-    port = UniquePort.call
-    workers_booted = 0
+  # Send requests 10 per second.  Send 10, then :TERM server, then send another 30.
+  # No more than 10 should throw Errno::ECONNRESET.
+  def term_closes_listeners(unix: false)
+    skip_unless_signal_exist? :TERM
 
-    conf = Puma::Configuration.new do |c|
-      c.bind "tcp://#{HOST}:#{port}"
-      c.threads 1, 1
-      c.workers WORKERS
-      c.worker_shutdown_timeout 2
-      c.app TestApps::SLEEP
-      c.after_worker_fork { |idx| workers_booted += 1 }
+    cli_server "-w #{WORKERS} -t 0:6 -q test/rackup/sleep_pid.ru", unix: unix
+    threads = []
+    replies = []
+    mutex = Mutex.new
+    div   = 10
+
+    refused = thread_run_refused unix: unix
+
+    41.times.each do |i|
+      if i == 10
+        threads << Thread.new do
+          sleep i.to_f/div
+          Process.kill :TERM, @pid
+          mutex.synchronize { replies << :term_sent }
+        end
+      else
+        threads << Thread.new do
+          thread_run replies, i.to_f/div, 1, mutex, refused, unix: unix
+        end
+      end
     end
 
-    # start Puma via launcher
-    thr, launcher, _e = run_launcher conf
+    threads.each(&:join)
+
+    responses = replies.count { |r| r[/\ASlept 1/] }
+    resets    = replies.count { |r| r == :reset    }
+    refused   = replies.count { |r| r == :refused  }
+    msg = "#{responses} responses, #{resets} resets, #{refused} refused"
+
+    assert_operator 9,  :<=, responses, msg
+
+    assert_operator 10, :>=, resets   , msg
+
+    assert_operator 20, :<=, refused  , msg
+  end
+
+  # Send requests 1 per second.  Send 1, then :USR1 server, then send another 24.
+  # All should be responded to, and at least three workers should be used
+  def usr1_all_respond(unix: false)
+    cli_server "-w #{WORKERS} -t 0:5 -q test/rackup/sleep_pid.ru", unix: unix
+    threads = []
+    replies = []
+    mutex = Mutex.new
+
+    s = connect "sleep1", unix: unix
+    replies << read_body(s)
+    Process.kill :USR1, @pid
+
+    refused = thread_run_refused unix: unix
+
+    24.times do |delay|
+      threads << Thread.new do
+        thread_run replies, delay, 1, mutex, refused, unix: unix
+      end
+    end
+
+    threads.each(&:join)
+
+    responses = replies.count { |r| r[/\ASlept 1/] }
+    resets    = replies.count { |r| r == :reset    }
+    refused   = replies.count { |r| r == :refused  }
+
+    # get pids from replies, generate uniq array
+    qty_pids = replies.map { |body| body[/\d+\z/] }.uniq.compact.length
+
+    msg = "#{responses} responses, #{qty_pids} uniq pids"
+
+    assert_equal 25, responses, msg
+    assert_operator qty_pids, :>, 2, msg
+
+    msg = "#{responses} responses, #{resets} resets, #{refused} refused"
+
+    refute_includes replies, :refused, msg
+
+    refute_includes replies, :reset  , msg
+  end
+
+  def worker_respawn(phase = 1, size = WORKERS)
+    threads = []
+
+    cli_server "-w #{WORKERS} -t 1:1 -C test/config/worker_shutdown_timeout_2.rb test/rackup/sleep_pid.ru"
 
     # make sure two workers have booted
-    time = 0
-    until workers_booted >= WORKERS || time >= 10
-      sleep 2
-      time += 2
-    end
+    phase0_worker_pids = get_worker_pids
 
-    cluster = launcher.instance_variable_get :@runner
-
-    http0 = Net::HTTP.new HOST, port
-    http1 = Net::HTTP.new HOST, port
-    body0 = nil
-    body1 = nil
-
-    worker0 = Thread.new do
-      begin
-        req0 = Net::HTTP::Get.new "/sleep35", {}
-        http0.start.request(req0) { |rep0| body0 = rep0.body }
-      rescue
+    [35, 40].each do |sleep_time|
+      threads << Thread.new do
+        begin
+          connect "sleep#{sleep_time}"
+          # stuck connections will raise IOError or Errno::ECONNRESET
+          # when shutdown
+        rescue IOError, Errno::ECONNRESET
+        end
       end
     end
 
-    worker1 = Thread.new do
-      begin
-        req1 = Net::HTTP::Get.new "/sleep40", {}
-        http1.start.request(req1) { |rep1| body1 = rep1.body }
-      rescue
-      end
-    end
-
-    phase0_worker_pids = cluster.instance_variable_get(:@workers).map(&:pid)
-
-    start_time = Time.now.to_f
+    @start_time = Time.now.to_f
 
     # below should 'cancel' the phase 0 workers, either via phased_restart or
-    # externally SIGTERM'ing them
-    yield launcher, phase0_worker_pids
+    # externally TERM'ing them
+    yield phase0_worker_pids
 
-    # make sure four workers have booted
-    time = 0
-    until workers_booted >= 2 * WORKERS || time >= 45
-      sleep 2
-      time += 2
-    end
-
-    phase1_worker_pids = cluster.instance_variable_get(:@workers).map(&:pid)
+    # wait for new workers to boot
+    phase1_worker_pids = get_worker_pids phase
 
     # should be empty if all phase 0 workers cleanly exited
-    phase0_exited = clean_exit_pids phase0_worker_pids
-
-    Thread.kill worker0
-    Thread.kill worker1
-
-    launcher.stop
-    assert_kind_of Thread, thr.join, "server didn't stop"
-
-    refute_equal 'Slept 35', body0
-    refute_equal 'Slept 40', body1
+    phase0_exited = bad_exit_pids phase0_worker_pids
 
     # Since 35 is the shorter of the two requests, server should restart
     # and cancel both requests
-    assert_operator (Time.now.to_f - start_time).round(2), :<, 35
+    assert_operator (Time.now.to_f - @start_time).round(2), :<, 35
 
     msg = "phase0_worker_pids #{phase0_worker_pids.inspect}  phase1_worker_pids #{phase1_worker_pids.inspect}  phase0_exited #{phase0_exited.inspect}"
     assert_equal WORKERS, phase0_worker_pids.length, msg
+
     assert_equal WORKERS, phase1_worker_pids.length, msg
     assert_empty phase0_worker_pids & phase1_worker_pids, "#{msg}\nBoth workers should be replaced with new"
+
     assert_empty phase0_exited, msg
+
+    threads.each { |th| Thread.kill th }
+    stop_server signal: :KILL
   end
 
   # Returns an array of pids still in the process table, so it should
   # be empty for a clean exit.
   # Process.kill should raise the Errno::ESRCH exception, indicating the
   # process is dead and has been reaped.
-  def clean_exit_pids(pids)
+  def bad_exit_pids(pids)
     pids.map do |pid|
       begin
         pid if Process.kill 0, pid
@@ -232,19 +260,29 @@ class TestIntegrationCluster < TestIntegration
     end.compact
   end
 
-  def run_launcher(conf)
-    wait, ready = IO.pipe
-    @ios_to_close << wait << ready
-    events = Puma::Events.strings
-    events.on_booted { ready << "!" }
+  # used with thread_run to define correct 'refused' errors
+  def thread_run_refused(unix: false)
+    if unix
+      DARWIN ? [Errno::ENOENT, IOError] : [Errno::ENOENT]
+    else
+      DARWIN ? [Errno::ECONNREFUSED, Errno::EPIPE, EOFError] :
+        [Errno::ECONNREFUSED]
+    end
+  end
 
-    launcher = Puma::Launcher.new conf, :events => events
-
-    thr = Thread.new { launcher.run }
-
-    # wait for boot from `events.on_booted`
-    wait.sysread 1
-
-    [thr, launcher, events]
+  # used in loop to create several 'requests'
+  def thread_run(replies, delay, sleep_time, mutex, refused, unix: false)
+    begin
+      sleep delay
+      s = connect "sleep#{sleep_time}", unix: unix
+      body = read_body(s)
+      mutex.synchronize { replies << body }
+    rescue Errno::ECONNRESET
+      # connection was accepted but then closed
+      # client would see an empty response
+      mutex.synchronize { replies << :reset }
+    rescue *refused
+      mutex.synchronize { replies << :refused }
+    end
   end
 end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -100,6 +100,8 @@ class TestIntegrationCluster < TestIntegration
 
     worker_respawn(0) do |phase0_worker_pids|
       last = phase0_worker_pids.last
+      # test is tricky if only one worker is TERM'd, so kill all but
+      # spread out, so all aren't killed at once
       phase0_worker_pids.each do |pid|
         Process.kill :TERM, pid
         sleep 4 unless pid == last

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -25,7 +25,7 @@ class TestIntegrationSingle < TestIntegration
   end
 
   def test_term_exit_code
-    skip_on :windows # no SIGTERM
+    skip_unless_signal_exist? :TERM
     skip_on :jruby # JVM does not return correct exit code for TERM
 
     cli_server "test/rackup/hello.ru"
@@ -35,7 +35,7 @@ class TestIntegrationSingle < TestIntegration
   end
 
   def test_term_suppress
-    skip_on :windows # no TERM
+    skip_unless_signal_exist? :TERM
 
     cli_server "-C test/config/suppress_exception.rb test/rackup/hello.ru"
     _, status = stop_server
@@ -44,7 +44,8 @@ class TestIntegrationSingle < TestIntegration
   end
 
   def test_term_not_accepts_new_connections
-    skip_on :jruby, :windows
+    skip_unless_signal_exist? :TERM
+    skip_on :jruby
 
     cli_server 'test/rackup/sleep.ru'
 
@@ -71,8 +72,8 @@ class TestIntegrationSingle < TestIntegration
     @server = nil # prevent `#teardown` from killing already killed server
   end
 
-  def test_int_signal_with_background_thread_in_jruby
-    skip_unless :jruby
+  def test_int_refuse
+    skip_unless_signal_exist? :INT
 
     cli_server 'test/rackup/hello.ru'
     begin

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -26,17 +26,17 @@ class TestIntegrationSingle < TestIntegration
     skip_on :windows # no SIGTERM
     skip_on :jruby # JVM does not return correct exit code for TERM
 
-    pid = cli_server("test/rackup/hello.ru").pid
-    _, status = send_term_to_server(pid)
+    cli_server "test/rackup/hello.ru"
+    _, status = stop_server
 
     assert_equal 15, status
   end
 
   def test_term_suppress
-    skip_on :windows # no SIGTERM
+    skip_on :windows # no TERM
 
-    pid = cli_server("-C test/config/suppress_exception.rb test/rackup/hello.ru").pid
-    _, status = send_term_to_server(pid)
+    cli_server "-C test/config/suppress_exception.rb test/rackup/hello.ru"
+    _, status = stop_server
 
     assert_equal 0, status
   end


### PR DESCRIPTION
### test_integration_cluster.rb

#### Request handling during server TERM - two tests

`#test_term_closes_listeners_tcp`
`#test_term_closes_listeners_unix`

using `#term_closes_listeners`

Send requests 10 per second.  Send 10, then :TERM server, then send another 30.
No more than 10 should throw Errno::ECONNRESET.

#### Request handling during phased restart - two tests

`#test_usr1_all_respond_tcp`
`#test_usr1_all_respond_unix`

using `#usr1_all_respond`

Send requests 1 per second.  Send 1, then :USR1 server, then send another 24.
All should be responded to, and at least three workers should be used

#### Stuck worker tests - two tests

`#test_stuck_external_term_spawn`
Tests whether externally TERM'd 'stuck' workers are proper re-spawned.

`#test_stuck_phased_restart`
Tests whether 'stuck' workers are properly shutdown during phased-restart.

### helper files/methods changes

1. Changes to allow binding to TCP or UNIX, see kwarg unix:
2. Skip on Windows for signal TERM