### PR TITLE
PluginRegistry#fire_background - fix up per issue 1972

### DIFF
--- a/lib/puma/plugin.rb
+++ b/lib/puma/plugin.rb
@@ -62,9 +62,9 @@ module Puma
     end
 
     def fire_background
-      @background.each do |b|
+      @background.each_with_index do |b, i|
         Thread.new do
-          set_thread_name "plugin background"
+          Puma.set_thread_name "plugin background #{i}"
           b.call
         end
       end

--- a/test/config/plugin1.rb
+++ b/test/config/plugin1.rb
@@ -1,0 +1,1 @@
+plugin 'tmp_restart'

--- a/test/test_plugin.rb
+++ b/test/test_plugin.rb
@@ -1,0 +1,39 @@
+require_relative "helper"
+require_relative "helpers/integration"
+
+class TestPlugin < TestIntegration
+  def test_plugin
+    skip "Skipped on Windows Ruby < 2.5.0, Ruby bug" if windows? && RUBY_VERSION < '2.5.0'
+    @tcp_bind = UniquePort.call
+    @tcp_ctrl = UniquePort.call
+
+    Dir.mkdir("tmp") unless Dir.exist?("tmp")
+
+    cli_server "-b tcp://#{HOST}:#{@tcp_bind} --control-url tcp://#{HOST}:#{@tcp_ctrl} --control-token #{TOKEN} -C test/config/plugin1.rb test/rackup/hello.ru"
+    File.open('tmp/restart.txt', mode: 'wb') { |f| f.puts "Restart #{Time.now}" }
+
+    true while (l = @server.gets) !~ /Restarting\.\.\./
+    assert_match(/Restarting\.\.\./, l)
+
+    true while (l = @server.gets) !~ /Ctrl-C/
+    assert_match(/Ctrl-C/, l)
+
+    out = StringIO.new
+
+    cli_pumactl "-C tcp://#{HOST}:#{@tcp_ctrl} -T #{TOKEN} stop"
+    true while (l = @server.gets) !~ /Goodbye/
+
+    @server.close
+    @server = nil
+    out.close
+  end
+
+  private
+
+  def cli_pumactl(argv)
+    pumactl = IO.popen("#{BASE} bin/pumactl #{argv}", "r")
+    @ios_to_close << pumactl
+    Process.wait pumactl.pid
+    pumactl
+  end
+end


### PR DESCRIPTION
1. PluginRegistry#fire_background - fix

2. Add test_plugin.rb with a simple test

May be the first test with `Puma::ControlCLI` that's using TCP, so it runs on Windows...