### PR TITLE
[ci skip] Require Changelog at PR time

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: actions/checkout@v1
     - name: Check that CHANGELOG is touched or PR is [ci skip]-d
       run: |
-        cat $GITHUB_EVENT_PATH | jq .pull_request.title | grep -i '\[\(\(changelog skip\)\|\(ci skip\)\)\]' || $( git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md )
+        cat $GITHUB_EVENT_PATH | jq .pull_request.title | grep -i '\[\(\(changelog skip\)\|\(ci skip\)\)\]' || $( git diff remotes/origin/${{ github.base_ref }} --name-only | grep History.md )

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,0 +1,13 @@
+name: Check Changelog
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Check that CHANGELOG is touched or PR is [ci skip]-d
+      run: |
+        cat $GITHUB_EVENT_PATH | jq .pull_request.title | grep -i '\[\(\(changelog skip\)\|\(ci skip\)\)\]' || $( git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md )


### PR DESCRIPTION
We frequently forget to ask for a changelog entry, and then when we want to release the release maintainer has to go back and manually add them all. It would be better if the changelog was required at PR time so the original submitter can think of the best wording. If a PR is trivial people can add `[ci skip]` or `[changelog skip]`.

This implementation uses github actions.