### PR TITLE
Fix test server ssl.rb warning

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@
 
 * Bugfixes
   * Your bugfix goes here (#Github Number)
+  * Fix warning in test_puma_server_ssl.rb, issue #1997
 
 ## 4.2.0 / 2019-09-23
 


### PR DESCRIPTION
Error is generated in 'client code', swap $VERBOSE for statement only, ensure in case...

See https://github.com/puma/puma/issues/1997