### PR TITLE
Fix systemd unix path handling

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,7 +4,7 @@
   * Your feature goes here (#Github Number)
 
 * Bugfixes
-  * Fix handling of pre-existing/systemd unix binder files (#1842, #1988)
+  * Fix socket activation of systemd (pre-existing) unix binder files (#1842, #1988)
   * Deal with multiple calls to bind correctly (#1986, #1994, #2006)
 
 ## 4.2.0 / 2019-09-23

--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@
   * Your feature goes here (#Github Number)
 
 * Bugfixes
+  * Fix handling of pre-existing/systemd unix binder files (#1842, #1988)
   * Deal with multiple calls to bind correctly (#1986, #1994, #2006)
 
 ## 4.2.0 / 2019-09-23

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -361,7 +361,7 @@ module Puma
     # Tell the server to listen on +path+ as a UNIX domain socket.
     #
     def add_unix_listener(path, umask=nil, mode=nil, backlog=1024)
-      @unix_paths << path
+      @unix_paths << path unless File.exist? path
 
       # Let anyone connect by default
       umask ||= 0
@@ -399,7 +399,7 @@ module Puma
     end
 
     def inherit_unix_listener(path, fd)
-      @unix_paths << path
+      @unix_paths << path unless File.exist? path
 
       if fd.kind_of? TCPServer
         s = fd
@@ -420,7 +420,8 @@ module Puma
         io.close
         uri = URI.parse(l)
         next unless uri.scheme == 'unix'
-        File.unlink("#{uri.host}#{uri.path}")
+        unix_path = "#{uri.host}#{uri.path}"
+        File.unlink unix_path if @unix_paths.include? unix_path
       end
     end
 

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -529,7 +529,6 @@ module Puma
         @suicide_pipe.close
         read.close
         @wakeup.close
-        @launcher.close_binder_unix_paths
       end
     end
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -184,6 +184,7 @@ module Puma
       when :exit
         # nothing
       end
+      @binder.close_unix_paths
     end
 
     # Return which tcp port the launcher is using, if it's using TCP
@@ -202,10 +203,6 @@ module Puma
 
     def close_binder_listeners
       @binder.close_listeners
-    end
-
-    def close_binder_unix_paths
-      @binder.close_unix_paths
     end
 
     private

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -118,7 +118,6 @@ module Puma
       rescue Interrupt
         # Swallow it
       end
-      @launcher.close_binder_unix_paths
     end
   end
 end

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -78,6 +78,23 @@ class TestBinder < TestBinderBase
     assert_parsing_logs_uri [:tcp, :unix]
   end
 
+  def test_pre_existing_unix
+    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    unix_path = "test/#{name}_server.sock"
+
+    File.open(unix_path, mode: 'wb') { |f| f.puts 'pre eixisting' }
+    @binder.parse ["unix://#{unix_path}"], @events
+
+    assert_match %r!unix://#{unix_path}!, @events.stdout.string
+
+    refute_includes @binder.instance_variable_get(:@unix_paths), unix_path
+
+  ensure
+    if UNIX_SKT_EXIST
+      File.unlink unix_path if File.exist? unix_path
+    end
+  end
+
   private
 
   def assert_parsing_logs_uri(order = [:unix, :tcp])

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -82,12 +82,16 @@ class TestBinder < TestBinderBase
     skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
     unix_path = "test/#{name}_server.sock"
 
-    File.open(unix_path, mode: 'wb') { |f| f.puts 'pre eixisting' }
+    File.open(unix_path, mode: 'wb') { |f| f.puts 'pre existing' }
     @binder.parse ["unix://#{unix_path}"], @events
 
     assert_match %r!unix://#{unix_path}!, @events.stdout.string
 
     refute_includes @binder.instance_variable_get(:@unix_paths), unix_path
+
+    @binder.close_unix_paths
+
+    assert File.exist?(unix_path)
 
   ensure
     if UNIX_SKT_EXIST

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -19,9 +19,9 @@ class TestIntegrationCluster < TestIntegration
   def test_pre_existing_unix
     skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
 
-    File.open(@bind_path, mode: 'wb') { |f| f.puts 'pre eixisting' }
+    File.open(@bind_path, mode: 'wb') { |f| f.puts 'pre existing' }
 
-    cli_server "-w #{WORKERS} -t 0:6 -q test/rackup/sleep_step.ru", unix: :unix
+    cli_server "-w #{WORKERS} -q test/rackup/sleep_step.ru", unix: :unix
 
     stop_server
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -12,7 +12,25 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def teardown
-    super if HAS_FORK
+    return if skipped?
+    super
+  end
+
+  def test_pre_existing_unix
+    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+
+    File.open(@bind_path, mode: 'wb') { |f| f.puts 'pre eixisting' }
+
+    cli_server "-w #{WORKERS} -t 0:6 -q test/rackup/sleep_step.ru", unix: :unix
+
+    stop_server
+
+    assert File.exist?(@bind_path)
+
+  ensure
+    if UNIX_SKT_EXIST
+      File.unlink @bind_path if File.exist? @bind_path
+    end
   end
 
   def test_siginfo_thread_print


### PR DESCRIPTION
Puma should not unlink pre-existing UNIXSocket files. which causes issues with systemd.  See: https://github.com/puma/puma/issues/1842, https://github.com/puma/puma/issues/1988

1st Commit: 'Fix Binder @unix_paths handling'

1. Move removal to launcher from single and cluster.

2. @unix_paths only contains files that Puma creates (pre-existing files are not)

2nd Commit: 'Add tests for pre-existing unix paths'

1. test_binder.rb - test_pre_existing_unix

2. test_integration_cluster.rb - test_pre_existing_unix