### PR TITLE
Allow for symbols to be used in verify_mode

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,7 @@
 * Bugfixes
   * Fix socket activation of systemd (pre-existing) unix binder files (#1842, #1988)
   * Deal with multiple calls to bind correctly (#1986, #1994, #2006)
+  * Accepts symbols for `verify_mode` (#1222)
 
 ## 4.2.0 / 2019-09-23
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -396,7 +396,7 @@ module Puma
     #     keystore_pass: password
     #   }
     def ssl_bind(host, port, opts)
-      verify = opts.fetch(:verify_mode, 'none')
+      verify = opts.fetch(:verify_mode, 'none').to_s
       no_tlsv1 = opts.fetch(:no_tlsv1, 'false')
       no_tlsv1_1 = opts.fetch(:no_tlsv1_1, 'false')
       ca_additions = "&ca=#{opts[:ca]}" if ['peer', 'force_peer'].include?(verify)

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -97,6 +97,23 @@ class TestConfigFile < TestConfigFileBase
     assert ssl_binding.include?("&ssl_cipher_filter=#{cipher_filter}")
   end
 
+  def test_ssl_bind_with_ca
+    conf = Puma::Configuration.new do |c|
+      c.ssl_bind "0.0.0.0", "9292", {
+        cert: "/path/to/cert",
+        ca: "/path/to/ca",
+        key: "/path/to/key",
+        verify_mode: :peer,
+      }
+    end
+
+    conf.load
+
+    ssl_binding = conf.options[:binds].first
+    assert_match "ca=/path/to/ca", ssl_binding
+    assert_match "verify_mode=peer", ssl_binding
+  end
+
   def test_lowlevel_error_handler_DSL
     conf = Puma::Configuration.new do |c|
       c.load "test/config/app.rb"


### PR DESCRIPTION
Fixes #1222 

`:verify_mode` was expecting strings to be used so this line would fail: https://github.com/puma/puma/blob/master/lib/puma/dsl.rb#L402