### PR TITLE
Fix peeraddr raises Errno::EINVAL inside reactor

### DIFF
--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -237,7 +237,7 @@ module Puma
                 ssl_socket = c.io
                 begin
                   addr = ssl_socket.peeraddr.last
-                rescue IOError
+                rescue IOError, Errno::EINVAL
                   addr = "<unknown>"
                 end
 

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -199,6 +199,18 @@ class TestPumaServerSSL < Minitest::Test
       assert_match(msg, @events.error.message) if @events.error
     end
   end
+
+  def test_peeraddr_raises
+    port = UniquePort.call
+
+    s = TCPServer.new("127.0.0.1", port)
+
+    def s.peeraddr
+      raise Errno::EINVAL
+    end
+
+    assert_raises { s.peeraddr }
+  end
 end unless DISABLE_SSL
 
 # client-side TLS authentication tests


### PR DESCRIPTION
Hey @nateberkopec

I had a look into the issue #1564 and could not easily mock the object that returns the `peeraddr` as its inside the reactor class. 

Possible reasons why this error could occur? https://github.com/ruby/ruby/blob/ddf5020e4fcae5ed28a064af10124a032590452f/ext/socket/socket.c#L366

- Errno::EINVAL - the address length used for the _sockaddr_ is not a valid
- Errno::EINVAL - the +socket+ is already bound to an address, and the
-  protocol does not support binding to the new _sockaddr_ or the socket has been shut down.
- Errno::EINVAL - the address length is not a valid length for the address family

My idea was to create a test that has an expired SSL, that means we hit this part of the code https://github.com/puma/puma/blob/181777381574173fdc29f873c04cc266037c1cda/lib/puma/reactor.rb#L234 then have the `peeraddr` throw from a mocked object, but could not seem to do that.

Any idea on how I can do this, or is there another way I can go about writing a test for this?
