### PR TITLE
Allow reversed word order for skipping changelog [skip ci]

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: actions/checkout@v1
     - name: Check that CHANGELOG is touched or PR is [ci skip]-d
       run: |
-        cat $GITHUB_EVENT_PATH | jq .pull_request.title | grep -i '\[\(\(changelog skip\)\|\(ci skip\)\)\]' ||  git diff remotes/origin/${{ github.base_ref }} --name-only | grep History.md
+        cat $GITHUB_EVENT_PATH | jq .pull_request.title | grep -i '\[\(\(changelog skip\)\|\(skip changelog\)\|\(ci skip\)\|\(skip ci\)\)\]' ||  git diff remotes/origin/${{ github.base_ref }} --name-only | grep History.md


### PR DESCRIPTION
[Travis][] allows both "\<KEYWORD\> skip" and "skip \<KEYWORD\>", as does
[Circleci][]. I never remember which order the words should go in, so it
is a nice convenience if either order works.

I am skipping ci with the reversed word order on this PR to hopefully demonstrate that this still does the right thing. 🤞 

[Travis]: https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build
[Circleci]: https://circleci.com/docs/2.0/skip-build/#skipping-a-build