### PR TITLE
Configuration: Get environment from RAILS_ENV, too

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@
   * Strip whitespace at end of HTTP headers (#2010)
   * Optimize HTTP parser for JRuby (#2012)
   * Add SSL support for the control app (#2046)
+  * Configuration: `environment` is read from `RAILS_ENV`, if `RACK_ENV` can't be found (#2022)
 
 * Bugfixes
   * Fix Errno::EINVAL when SSL is enabled and browser rejects cert (#1564)

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ You can also provide a configuration file with the `-C` (or `--config`) flag:
 $ puma -C /path/to/config
 ```
 
-If no configuration file is specified, Puma will look for a configuration file at `config/puma.rb`. If an environment is specified, either via the `-e` and `--environment` flags, or through the `RACK_ENV` environment variable, Puma looks for configuration at `config/puma/<environment_name>.rb`.
+If no configuration file is specified, Puma will look for a configuration file at `config/puma.rb`. If an environment is specified, either via the `-e` and `--environment` flags, or through the `RACK_ENV` or the `RAILS_ENV` environment variables, Puma looks for configuration at `config/puma/<environment_name>.rb`.
 
 If you want to prevent Puma from looking for a configuration file in those locations, provide a dash as the argument to the `-C` (or `--config`) flag:
 
@@ -273,7 +273,7 @@ reliability in production environments:
 
 ## Community Plugins
 
-* [puma-heroku](https://github.com/evanphx/puma-heroku) — default Puma configuration for running on Heroku
+* [puma-heroku](https://github.com/puma/puma-heroku) — default Puma configuration for running on Heroku
 * [puma-metrics](https://github.com/harmjanblok/puma-metrics) — export Puma metrics to Prometheus
 * [puma-plugin-statsd](https://github.com/yob/puma-plugin-statsd) — send Puma metrics to statsd
 * [puma-plugin-systemd](https://github.com/sj26/puma-plugin-systemd) — deeper integration with systemd for notify, status and watchdog

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -182,7 +182,7 @@ module Puma
         :worker_shutdown_timeout => DefaultWorkerShutdownTimeout,
         :remote_address => :socket,
         :tag => method(:infer_tag),
-        :environment => -> { ENV['RACK_ENV'] || "development" },
+        :environment => -> { ENV['RACK_ENV'] || ENV['RAILS_ENV'] || "development" },
         :rackup => DefaultRackup,
         :logger => STDOUT,
         :persistent_timeout => Const::PERSISTENT_TIMEOUT,

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -22,7 +22,7 @@ module Puma
       @control_auth_token = nil
       @config_file = nil
       @command = nil
-      @environment = ENV['RACK_ENV']
+      @environment = ENV['RACK_ENV'] || ENV['RAILS_ENV']
 
       @argv = argv.dup
       @stdout = stdout

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -360,11 +360,22 @@ class TestCLI < Minitest::Test
     assert_equal %w[a b], extra_dependencies
   end
 
-  def test_environment
+  def test_environment_rack_env
     ENV.delete 'RACK_ENV'
 
     Puma::CLI.new ["--environment", @environment]
 
-    assert_equal ENV['RACK_ENV'], @environment
+    assert_equal @environment, ENV['RACK_ENV']
+  end
+
+  def test_environment_rails_env
+    ENV.delete 'RACK_ENV'
+    ENV['RAILS_ENV'] = @environment
+
+    Puma::CLI.new []
+
+    assert_equal @environment, ENV['RACK_ENV']
+
+    ENV.delete 'RAILS_ENV'
   end
 end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -230,6 +230,15 @@ class TestConfigFileWithFakeEnv < TestConfigFileBase
     end
   end
 
+  def test_config_files_with_rails_env
+    with_env('RAILS_ENV' => 'fake-env', 'RACK_ENV' => nil) do
+      conf = Puma::Configuration.new do
+      end
+
+      assert_equal ['config/puma/fake-env.rb'], conf.config_files
+    end
+  end
+
   def test_config_files_with_specified_environment
     conf = Puma::Configuration.new do
     end

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -49,7 +49,7 @@ class TestPumaControlCli < TestConfigFileBase
   end
 
   def test_environment_without_rack_env
-    with_env("RACK_ENV" => nil) do
+    with_env("RACK_ENV" => nil, 'RAILS_ENV' => nil) do
       control_cli = Puma::ControlCLI.new ["halt"]
       assert_nil control_cli.instance_variable_get("@environment")
 
@@ -91,7 +91,7 @@ class TestPumaControlCli < TestConfigFileBase
     puma_config_file = "config/puma.rb"
     development_config_file = "config/puma/development.rb"
 
-    with_env("RACK_ENV" => nil) do
+    with_env("RACK_ENV" => nil, 'RAILS_ENV' => nil) do
       with_config_file(puma_config_file, port) do
         control_cli = Puma::ControlCLI.new ["halt"]
         assert_equal puma_config_file, control_cli.instance_variable_get("@config_file")


### PR DESCRIPTION
This PR changes configuration defaults.

The **default value for environment** is also read from `RAILS_ENV`, if `RACK_ENV` can't be found.

## Overview

See #1949

The goal of that Issue is that configuration defaults in [puma/puma-heroku](https://github.com/puma/puma-heroku/blob/master/lib/puma/plugin/heroku.rb) move into [lib/puma/configuration.rb](https://github.com/puma/puma/blob/master/lib/puma/configuration.rb).
