### PR TITLE
Use public ios method in test [changelog skip]

### DIFF
--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -22,7 +22,7 @@ class TestBinderBase < Minitest::Test
   end
 
   def ssl_context_for_binder(binder)
-    binder.instance_variable_get(:@ios)[0].instance_variable_get(:@ctx)
+    binder.ios[0].instance_variable_get(:@ctx)
   end
 end
 


### PR DESCRIPTION
ios is an `attr_reader`, so this effectively the same thing, but testing
a public method instead of reaching into the internal state of the class
being tested seems like a win to me.