### PR TITLE
test_binder.rb - refactor

### DIFF
--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -13,28 +13,38 @@ class TestBinderBase < Minitest::Test
 
   private
 
-  def key
-    @key ||= File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
-  end
-
-  def cert
-    @cert ||= File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
-  end
-
-  def ssl_context_for_binder(binder)
+  def ssl_context_for_binder(binder = @binder)
     binder.ios[0].instance_variable_get(:@ctx)
+  end
+
+  def ssl_query
+    @ssl_query ||= if Puma.jruby?
+      @keystore = File.expand_path "../../examples/puma/keystore.jks", __FILE__
+      @ssl_cipher_list = "TLS_DHE_RSA_WITH_DES_CBC_SHA,TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA"
+      "keystore=#{@keystore}&keystore-pass=pswd&ssl_cipher_list=#{@ssl_cipher_list}"
+    else
+      @cert = File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
+      @key  = File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
+      "key=#{@key}&cert=#{@cert}"
+    end
   end
 end
 
 class TestBinder < TestBinderBase
   def test_localhost_addresses_dont_alter_listeners_for_tcp_addresses
-    @binder.parse(["tcp://localhost:10001"], @events)
+    @binder.parse ["tcp://localhost:10001"], @events
+
+    assert_equal [], @binder.instance_variable_get(:@listeners)
+  end
+
+  def test_localhost_addresses_dont_alter_listeners_for_ssl_addresses
+    @binder.parse ["ssl://localhost:10002?#{ssl_query}"], @events
 
     assert_equal [], @binder.instance_variable_get(:@listeners)
   end
 
   def test_correct_zero_port
-    @binder.parse(["tcp://localhost:0"], @events)
+    @binder.parse ["tcp://localhost:0"], @events
 
     m = %r!tcp://127.0.0.1:(\d+)!.match(@events.stdout.string)
     port = m[1].to_i
@@ -43,7 +53,7 @@ class TestBinder < TestBinderBase
   end
 
   def test_logs_all_localhost_bindings
-    @binder.parse(["tcp://localhost:0"], @events)
+    @binder.parse ["tcp://localhost:0"], @events
 
     assert_match %r!tcp://127.0.0.1:(\d+)!, @events.stdout.string
     if @binder.loopback_addresses.include?("::1")
@@ -53,7 +63,7 @@ class TestBinder < TestBinderBase
 
   def test_correct_zero_port_ssl
     skip("Implement in 4.3")
-    @binder.parse(["ssl://localhost:0?key=#{key}&cert=#{cert}"], @events)
+    @binder.parse ["ssl://localhost:0?#{ssl_query}"], @events
 
     stdout = @events.stdout.string
     m = %r!tcp://127.0.0.1:(\d+)!.match(stdout)
@@ -61,7 +71,7 @@ class TestBinder < TestBinderBase
 
     refute_equal 0, port
     assert_match %r!ssl://127.0.0.1:(\d+)!, stdout
-    if @binder.loopback_addresses.include?("::1")
+    if @binder.loopback_addresses.include? '::1'
       assert_match %r!ssl://\[::1\]:(\d+)!, stdout
     end
   end
@@ -99,20 +109,51 @@ class TestBinder < TestBinderBase
     end
   end
 
+  def test_binder_parses_tlsv1_disabled
+    @binder.parse ["ssl://0.0.0.0:0?#{ssl_query}&no_tlsv1=true"], @events
+
+    assert ssl_context_for_binder.no_tlsv1
+  end
+
+  def test_binder_parses_tlsv1_enabled
+    @binder.parse ["ssl://0.0.0.0:0?#{ssl_query}&no_tlsv1=false"], @events
+
+    refute ssl_context_for_binder.no_tlsv1
+  end
+
+  def test_binder_parses_tlsv1_tlsv1_1_unspecified_defaults_to_enabled
+    @binder.parse ["ssl://0.0.0.0:0?#{ssl_query}"], @events
+
+    refute ssl_context_for_binder.no_tlsv1
+    refute ssl_context_for_binder.no_tlsv1_1
+  end
+
+  def test_binder_parses_tlsv1_1_disabled
+    @binder.parse ["ssl://0.0.0.0:0?#{ssl_query}&no_tlsv1_1=true"], @events
+
+    assert ssl_context_for_binder.no_tlsv1_1
+  end
+
+  def test_binder_parses_tlsv1_1_enabled
+    @binder.parse ["ssl://0.0.0.0:0?#{ssl_query}&no_tlsv1_1=false"], @events
+
+    refute ssl_context_for_binder.no_tlsv1_1
+  end
+
   private
 
   def assert_parsing_logs_uri(order = [:unix, :tcp])
     skip UNIX_SKT_MSG if order.include?(:unix) && !UNIX_SKT_EXIST
 
     prepared_paths = {
-        ssl: "ssl://127.0.0.1:#{UniquePort.call}?key=#{key}&cert=#{cert}",
+        ssl: "ssl://127.0.0.1:#{UniquePort.call}?#{ssl_query}",
         tcp: "tcp://127.0.0.1:#{UniquePort.call}",
         unix: "unix://test/#{name}_server.sock"
       }
 
     tested_paths = [prepared_paths[order[0]], prepared_paths[order[1]]]
 
-    @binder.parse(tested_paths, @events)
+    @binder.parse tested_paths, @events
     stdout = @events.stdout.string
 
     assert stdout.include?(prepared_paths[order[0]]), "\n#{stdout}\n"
@@ -123,70 +164,23 @@ class TestBinder < TestBinderBase
 end
 
 class TestBinderJRuby < TestBinderBase
-  def setup
-    super
-    skip_unless :jruby
-  end
-
   def test_binder_parses_jruby_ssl_options
     keystore = File.expand_path "../../examples/puma/keystore.jks", __FILE__
     ssl_cipher_list = "TLS_DHE_RSA_WITH_DES_CBC_SHA,TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA"
 
-    @binder.parse(["ssl://0.0.0.0:8080?keystore=#{keystore}&keystore-pass=&ssl_cipher_list=#{ssl_cipher_list}"], @events)
+    @binder.parse ["ssl://0.0.0.0:8080?#{ssl_query}"], @events
 
-    assert_equal keystore, ssl_context_for_binder(@binder).keystore
-    assert_equal ssl_cipher_list, ssl_context_for_binder(@binder).ssl_cipher_list
+    assert_equal keystore, ssl_context_for_binder.keystore
+    assert_equal ssl_cipher_list, ssl_context_for_binder.ssl_cipher_list
   end
-end
+end if ::Puma::IS_JRUBY
 
 class TestBinderMRI < TestBinderBase
-  def setup
-    super
-    skip_on :jruby
-  end
-
-  def test_localhost_addresses_dont_alter_listeners_for_ssl_addresses
-    @binder.parse(["ssl://localhost:10002?key=#{key}&cert=#{cert}"], @events)
-
-    assert_equal [], @binder.instance_variable_get(:@listeners)
-  end
-
   def test_binder_parses_ssl_cipher_filter
     ssl_cipher_filter = "AES@STRENGTH"
 
-    @binder.parse(["ssl://0.0.0.0?key=#{key}&cert=#{cert}&ssl_cipher_filter=#{ssl_cipher_filter}"], @events)
+    @binder.parse ["ssl://0.0.0.0?#{ssl_query}&ssl_cipher_filter=#{ssl_cipher_filter}"], @events
 
-    assert_equal ssl_cipher_filter, ssl_context_for_binder(@binder).ssl_cipher_filter
+    assert_equal ssl_cipher_filter, ssl_context_for_binder.ssl_cipher_filter
   end
-
-  def test_binder_parses_tlsv1_disabled
-    @binder.parse(["ssl://0.0.0.0?key=#{key}&cert=#{cert}&no_tlsv1=true"], @events)
-
-    assert ssl_context_for_binder(@binder).no_tlsv1
-  end
-
-  def test_binder_parses_tlsv1_enabled
-    @binder.parse(["ssl://0.0.0.0?key=#{key}&cert=#{cert}&no_tlsv1=false"], @events)
-
-    refute ssl_context_for_binder(@binder).no_tlsv1
-  end
-
-  def test_binder_parses_tlsv1_tlsv1_1_unspecified_defaults_to_enabled
-    @binder.parse(["ssl://0.0.0.0?key=#{key}&cert=#{cert}"], @events)
-
-    refute ssl_context_for_binder(@binder).no_tlsv1
-    refute ssl_context_for_binder(@binder).no_tlsv1_1
-  end
-
-  def test_binder_parses_tlsv1_1_disabled
-    @binder.parse(["ssl://0.0.0.0?key=#{key}&cert=#{cert}&no_tlsv1_1=true"], @events)
-
-    assert ssl_context_for_binder(@binder).no_tlsv1_1
-  end
-
-  def test_binder_parses_tlsv1_1_enabled
-    @binder.parse(["ssl://0.0.0.0?key=#{key}&cert=#{cert}&no_tlsv1_1=false"], @events)
-
-    refute ssl_context_for_binder(@binder).no_tlsv1_1
-  end
-end
+end unless ::Puma::IS_JRUBY


### PR DESCRIPTION
1. Add ssl_query method to allow all platforms to run non platform specific tests

2. Small refactor, rearrange tests, etc

3. No additional tests added