### PR TITLE
Update pumactl to remove development as default environment

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,7 @@
 
 * Bugfixes
   * Fix Errno::EINVAL when SSL is enabled and browser rejects cert (#1564)
+  * Fix pumactl defaulting puma to development if an environment was not specified (#2035)
 
 ## 4.2.1 / 2019-10-07
 

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -22,7 +22,7 @@ module Puma
       @control_auth_token = nil
       @config_file = nil
       @command = nil
-      @environment = ENV['RACK_ENV'] || "development"
+      @environment = ENV['RACK_ENV']
 
       @argv = argv.dup
       @stdout = stdout
@@ -82,8 +82,10 @@ module Puma
       @command = argv.shift
 
       unless @config_file == '-'
+        environment = @environment || 'development'
+
         if @config_file.nil?
-          @config_file = %W(config/puma/#{@environment}.rb config/puma.rb).find do |f|
+          @config_file = %W(config/puma/#{environment}.rb config/puma.rb).find do |f|
             File.exist?(f)
           end
         end

--- a/test/helpers/config_file.rb
+++ b/test/helpers/config_file.rb
@@ -1,0 +1,16 @@
+class TestConfigFileBase < Minitest::Test
+  private
+
+  def with_env(env = {})
+    original_env = {}
+    env.each do |k, v|
+      original_env[k] = ENV[k]
+      ENV[k] = v
+    end
+    yield
+  ensure
+    original_env.each do |k, v|
+      ENV[k] = v
+    end
+  end
+end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -1,25 +1,9 @@
 # frozen_string_literal: true
 
 require_relative "helper"
+require_relative "helpers/config_file"
 
 require "puma/configuration"
-
-class TestConfigFileBase < Minitest::Test
-  private
-
-  def with_env(env = {})
-    original_env = {}
-    env.each do |k, v|
-      original_env[k] = ENV[k]
-      ENV[k] = v
-    end
-    yield
-  ensure
-    original_env.each do |k, v|
-      ENV[k] = v
-    end
-  end
-end
 
 class TestConfigFile < TestConfigFileBase
   parallelize_me!


### PR DESCRIPTION
# What changed?

This PR:
 - removes the default environment of `development` from `pumactl`
 - defaults to development when searching for config files to load, if one is not provided to `pumactl`
 - passes the value passed to the `environment` option over `RACK_ENV` to `pumactl`, if provided

fixes #2023 