### PR TITLE
Refactor tests, fix errors shown [changelog skip]

### DIFF
--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -11,8 +11,8 @@ require 'stringio'
 require 'thread'
 
 module Puma
-  autoload :Const, 'puma/const'
-  autoload :Server, 'puma/server'
+  autoload :Const   , 'puma/const'
+  autoload :Server  , 'puma/server'
   autoload :Launcher, 'puma/launcher'
 
   def self.stats_object=(val)

--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -16,47 +16,51 @@ module Puma
 
       def call(env)
         unless authenticate(env)
-          return rack_response(403, 'Invalid auth token', 'text/plain')
+          return rack_response 403, 'Invalid auth token', 'text/plain'
         end
 
         case env['PATH_INFO']
         when /\/stop$/
           @cli.stop
-          rack_response(200, OK_STATUS)
+          rack_response 200, OK_STATUS
 
         when /\/halt$/
           @cli.halt
-          rack_response(200, OK_STATUS)
+          rack_response 200, OK_STATUS
 
         when /\/restart$/
           @cli.restart
-          rack_response(200, OK_STATUS)
+          rack_response 200, OK_STATUS
 
         when /\/phased-restart$/
           if !@cli.phased_restart
-            rack_response(404, '{ "error": "phased restart not available" }')
+            rack_response 404, '{ "error": "phased restart not available" }'
           else
-            rack_response(200, OK_STATUS)
+            rack_response 200, OK_STATUS
           end
 
         when /\/reload-worker-directory$/
           if !@cli.send(:reload_worker_directory)
-            rack_response(404, '{ "error": "reload_worker_directory not available" }')
+            rack_response 404, '{ "error": "reload_worker_directory not available" }'
           else
-            rack_response(200, OK_STATUS)
+            rack_response 200, OK_STATUS
           end
 
         when /\/gc$/
           GC.start
-          rack_response(200, OK_STATUS)
+          rack_response 200, OK_STATUS
 
         when /\/gc-stats$/
-          rack_response(200, GC.stat.to_json)
+          rack_response 200, GC.stat.to_json
 
         when /\/stats$/
-          rack_response(200, @cli.stats)
+          rack_response 200, @cli.stats
+
+        when /\/thread-status$/
+          rack_response 200, @cli.thread_status, 'text/plain'
+
         else
-          rack_response 404, "Unsupported action", 'text/plain'
+          rack_response 404, 'Unsupported action', 'text/plain'
         end
       end
 

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -50,7 +50,7 @@ module Puma
     end
 
     def close
-      @ios.each { |i| i.close }
+      @ios.each { |i| i.close unless i.to_io.closed? }
     end
 
     def import_from_env
@@ -361,8 +361,8 @@ module Puma
 
     def close_listeners
       @listeners.each do |l, io|
-        io.close
-        uri = URI.parse(l)
+        io.close unless io.to_io.closed?
+        uri = URI.parse l
         next unless uri.scheme == 'unix'
         unix_path = "#{uri.host}#{uri.path}"
         File.unlink unix_path if @unix_paths.include? unix_path

--- a/lib/puma/detect.rb
+++ b/lib/puma/detect.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'socket'
+
 module Puma
   IS_JRUBY = defined?(JRUBY_VERSION)
 
@@ -12,4 +14,8 @@ module Puma
   def self.windows?
     IS_WINDOWS
   end
+
+  HAS_FORK = ::Process.respond_to? :fork
+  HAS_UNIX = Object.const_defined? :UNIXSocket
+
 end

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -244,7 +244,8 @@ module Puma
 
                 cert = ssl_socket.peercert
 
-                c.close
+                # may generate another SSL error, continue to remove the monitor
+                c.close rescue nil
                 clear_monitor mon
 
                 @events.ssl_error @server, addr, cert, e
@@ -302,6 +303,7 @@ module Puma
     def run
       run_internal
     ensure
+      @selector.close
       @trigger.close
       @ready.close
     end
@@ -316,6 +318,7 @@ module Puma
           STDERR.puts e.backtrace
           retry
         ensure
+          @selector.close
           @trigger.close
           @ready.close
         end

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -88,6 +88,20 @@ module Puma
       @control = control
     end
 
+    def end_control(type)
+      if @control && [:halt, :stop].include?(type)
+        @control.send type, true
+        @control.binder.close
+        @control.binder.close_unix_paths
+      end
+    end
+
+    def close_control_io
+      return unless @control
+      @control.binder.close
+      @control.binder.close_unix_paths
+    end
+
     def ruby_engine
       if !defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby"
         "ruby #{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -258,6 +258,7 @@ module Puma
         STDERR.puts e.backtrace
       ensure
         begin
+          @notify.close rescue nil
           @check.close
         rescue
           Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
@@ -428,8 +429,8 @@ module Puma
         STDERR.puts "Exception handling servers: #{e.message} (#{e.class})"
         STDERR.puts e.backtrace
       ensure
-        @check.close
-        @notify.close
+        @check.close  rescue nil
+        @notify.close rescue nil
       end
 
       @events.fire :state, :done
@@ -983,17 +984,17 @@ module Puma
     # off the request queue before finally exiting.
 
     def stop(sync=false)
-      notify_safely(STOP_COMMAND)
+      notify_safely STOP_COMMAND
       @thread.join if @thread && sync
     end
 
     def halt(sync=false)
-      notify_safely(HALT_COMMAND)
+      notify_safely HALT_COMMAND
       @thread.join if @thread && sync
     end
 
     def begin_restart
-      notify_safely(RESTART_COMMAND)
+      notify_safely RESTART_COMMAND
     end
 
     def fast_write(io, str)

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -30,13 +30,14 @@ module Puma
     end
 
     def halt
-      @server.halt
+      @server.halt if @server
     end
 
     def stop_blocked
       log "- Gracefully stopping, waiting for requests to finish"
+      @server.stop(true)  if @server
       @control.stop(true) if @control
-      @server.stop(true) if @server
+      close_control_io
     end
 
     def jruby_daemon?
@@ -104,7 +105,7 @@ module Puma
 
       start_control
 
-      @server = server = start_server
+      @server = start_server
 
       unless daemon?
         log "Use Ctrl-C to stop"
@@ -114,7 +115,7 @@ module Puma
       @launcher.events.fire_on_booted!
 
       begin
-        server.run.join
+        @server.run.join
       rescue Interrupt
         # Swallow it
       end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -24,6 +24,10 @@ Thread.abort_on_exception = true
 $debugging_info = ''.dup
 $debugging_hold = false    # needed for TestCLI#test_control_clustered
 
+$ORIG_OUT = STDOUT
+
+Dir.mkdir('tmp') unless Dir.exist?('tmp')
+
 require "puma"
 require "puma/events"
 require "puma/detect"
@@ -42,6 +46,35 @@ def hit(uris)
 
     assert response, "Didn't get a response: #{u}"
     response
+  end
+end
+
+module WaitForServerLogs
+  def assert_io(re, io: @server, debug: false, timeout: 10)
+    regex = Regexp === re ? re : Regexp.new(Regexp.escape re)
+
+    STDOUT.puts('',
+      "#{' ' * 20}*** #{full_name} assert_io #{re} ***") if debug
+    l = ''
+
+    ttf = Time.now.to_f + 10
+
+    while IO.select([io], nil, nil, timeout) do
+      l = io.gets
+      break if l.nil?
+      STDOUT.puts "io  #{l}" if debug
+      break if l[regex]
+      if (now = Time.now.to_f) > ttf
+        l = ''
+        break
+      end
+      timeout = ttf - now
+      sleep 0.05
+    end
+    t = caller(1..3).join "\n    "
+    refute_nil l, "Server returned nil waiting for '#{re}' in:\n    #{t}"
+    assert_match regex, l, "Server timeout waiting for '#{re}' in:\n    #{t}"
+    l[regex]
   end
 end
 
@@ -79,12 +112,11 @@ module TestSkips
 
   # usage: skip NO_FORK_MSG unless HAS_FORK
   # windows >= 2.6 fork is not defined, < 2.6 fork raises NotImplementedError
-  HAS_FORK = ::Process.respond_to? :fork
+  HAS_FORK = ::Puma::HAS_FORK
   NO_FORK_MSG = "Kernel.fork isn't available on the #{RUBY_PLATFORM} platform"
 
-  # socket is required by puma
-  # usage: skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
-  UNIX_SKT_EXIST = Object.const_defined? :UNIXSocket
+  # usage: skip UNIX_SKT_MSG unless HAS_UNIXHAS_UNIX
+  HAS_UNIX = ::Puma::HAS_UNIX
   UNIX_SKT_MSG = "UnixSockets aren't available on the #{RUBY_PLATFORM} platform"
 
   SIGNAL_LIST = Signal.list.keys.map(&:to_sym) - (Puma.windows? ? [:INT, :TERM] : [])
@@ -125,6 +157,31 @@ module TestSkips
     end
     skip skip_msg, bt if skip_msg
   end
+
+  def out_io
+    GC.start
+    ary = ObjectSpace.each_object(IO).select do |io|
+      begin
+        io.to_i
+      rescue
+      end
+    end.sort_by(&:to_i)
+
+    return if ary.length == 3
+
+    STDOUT.puts ''
+    ary.each do |io|
+      begin
+        if File === io
+          STDOUT.puts "    #{io.to_i.to_s.rjust 3}  #{io.path}"
+        else
+          STDOUT.puts "    #{io.to_i.to_s.rjust 3}  #{io.inspect}"
+        end
+      rescue
+      end
+    end
+  end
+  module_function :out_io
 end
 
 Minitest::Test.include TestSkips
@@ -135,18 +192,35 @@ class Minitest::Test
     super
   end
 
+  def after_teardown
+    return if passed? || skipped?
+    out_io unless Puma.jruby? or RUBY_VERSION < '2.3'
+  end
+
   def full_name
     "#{self.class.name}##{name}"
+  end
+
+  def full_file_name
+    cls_name = self.class.name.gsub(/([a-z])([A-Z])/, '\1_\2').downcase
+    "#{cls_name}__#{name}"
   end
 end
 
 Minitest.after_run do
   # needed for TestCLI#test_control_clustered
   unless $debugging_hold
-    out = $debugging_info.strip
-    unless out.empty?
+    out = "#{$debugging_info.rstrip}\n".dup
+    files = Dir.glob('tmp/*').map { |s| s.sub 'tmp/', '' }
+      .join("\n").sub(RUBY_PLATFORM, '')
+
+    out << files
+
+    unless out.strip.empty?
       puts "", " Debugging Info".rjust(75, '-'),
         out, '-' * 75, ""
     end
+    TestSkips.out_io unless Puma.jruby? or RUBY_VERSION < '2.3'
+    puts ''
   end
 end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -1,13 +1,34 @@
 # frozen_string_literal: true
 
 require "puma/control_cli"
-require "open3"
 
-# Only single mode tests go here. Cluster and pumactl tests
-# have their own files, use those instead
+# TestIntegration is used with tests that start Puma and then control it, either
+# via signals or sockets.  Since control via signals requires a separate process,
+# the tests need to create a Puma instance separate from the test process.
+# Since the code paths for control via signals vs sockets is somewhat different,
+# these tests often test both, althought the 'socket control' tests really don't
+# require a separate process.
+#
+# The main method is #setup_puma, which specifies the bindings and control type.
+# Most of the helper methods use variables defined by #setup_puma.
+# #setup_puma also allows similar tests to be created where one test uses a
+# signal to control Puma, while the companion test uses a tcp or unix socket to
+# do the same.
+#
+# The following methods make use of variables set in #setup_puma:
+# * #cli_server - starts an instance of Puma via IO.popen
+# * #connect - specify a GET request path, returns the response
+# * #run_pumactl - sends a command via Puma::ControlCLI
+#
+# All methods keep track of opened IO's, and they will be closed in `teardown`.
+#
 class TestIntegration < Minitest::Test
-  HOST  = "127.0.0.1"
-  TOKEN = "xxyyzz"
+  include WaitForServerLogs
+
+  DARWIN = !!RUBY_PLATFORM[/darwin/]
+
+  HOST  = '127.0.0.1'
+  TOKEN = 'xxyyzz'
   WORKERS = 2
 
   BASE = defined?(Bundler) ? "bundle exec #{Gem.ruby} -Ilib" :
@@ -15,20 +36,48 @@ class TestIntegration < Minitest::Test
 
   def setup
     @ios_to_close = []
-    @bind_path    = "test/#{name}_server.sock"
+
+    # below defined so we don't have to check defined? before use
+    @pid  = nil
+    @bind = nil
+    @ctrl = nil
+    @server = nil
+    @path_bind = nil
+    @path_ctrl = nil
+    # restarts change the pid of the server due to Kernel.exec
+    @path_pid = nil
   end
 
   def teardown
-    if defined?(@server) && @server
-      stop_server @pid, signal: :INT
-    end
+    return if skipped?
+
+    sgnl = windows? ? :KILL : :INT
+    begin
+      Process.kill sgnl, @pid
+    rescue Errno::ESRCH, Errno::EINVAL
+    end if @pid
+
+    begin
+      Process.wait @pid
+    rescue Errno::ECHILD
+    end if @pid
 
     @ios_to_close.each do |io|
       io.close if io.is_a?(IO) && !io.closed?
       io = nil
     end
-    refute File.exist?(@bind_path), "Bind path must be removed after stop"
-    File.unlink(@bind_path) rescue nil
+
+    if @path_bind
+      refute File.exist?(@path_bind), "Bind path must be removed after stop"
+      File.unlink(@path_bind) rescue nil
+    end
+
+    if @path_ctrl
+      refute File.exist?(@path_ctrl), "Ctrl path must be removed after stop"
+      File.unlink(@path_ctrl) rescue nil
+    end
+
+    File.unlink(@path_pid) rescue nil
 
     # wait until the end for OS buffering?
     if defined?(@server) && @server
@@ -39,68 +88,233 @@ class TestIntegration < Minitest::Test
 
   private
 
-  def cli_server(argv, unix: false)
-    if unix
-      cmd = "#{BASE} bin/puma -b unix://#{@bind_path} #{argv}"
-    else
-      @tcp_port = UniquePort.call
-      cmd = "#{BASE} bin/puma -b tcp://#{HOST}:#{@tcp_port} #{argv}"
+  # Main method to setup Puma configuration.  Loads the following variables,
+  # depending on the parameters. All path variables are based on the test class
+  # and method name with specific extension.
+  #
+  # * Path Variables
+  #   * +@path_bind+ - unix binding - +.bind+ extension
+  #   * +@path_ctrl+ - unix control - +.ctrl+ extension
+  #   * +@path_pid+  - control pid file - +.pid+ extension
+  #   * +@path_state+ - control state file - +.state+ extension
+  #
+  # * TCP Port Variables
+  #   * +@port_bind+ - binding
+  #   * +@port_ctrl+ - control url
+  #
+  # @param bind: [:Symbol] The protocol used for the binding.  Either :tcp or :unix
+  # @param ctrl: [:Symbol] Sets some of the parameters passed to a Puma::ControlCLI
+  # instance. One of the following: :pid, :pidfile, :tcp, :tcp_state, :unix,
+  # :unix_state. The 'state' ctrl options use the prefix for the protocol, along
+  # with a state file.
+  #
+  def setup_puma(bind: :nil, ctrl: :nil)
+
+    if bind.nil? && ctrl.nil?
+      raise ArgumentError, "both bind and ctrl cannot be nil"
     end
-    @server = IO.popen(cmd, "r")
-    wait_for_server_to_boot
-    @pid = @server.pid
+
+    if (bind == :unix) || [:unix, :unix_state].include?(ctrl)
+      skip UNIX_SKT_MSG unless HAS_UNIX
+    end
+
+    if windows? && [:pid, :pidfile].include?(ctrl)
+      skip "Puma::ControlCLI doesn't support pid/signal on Windows"
+    end
+
+    case bind
+    when :tcp
+      @port_bind = UniquePort.call
+    when :unix
+      @path_bind = "tmp/#{full_file_name}.bind"
+    when nil
+    else
+      raise ArgumentError, "cli_server invalid bind: value - #{ctrl}"
+    end
+    @bind = bind
+
+    case ctrl
+    when :pid
+    when :pidfile
+    when :tcp
+      @port_ctrl  = UniquePort.call
+    when :tcp_state
+      @port_ctrl  = UniquePort.call
+      @path_state = "tmp/#{full_file_name}.state"
+    when :unix
+      @path_ctrl  = "tmp/#{full_file_name}.ctrl"
+    when :unix_state
+      @path_ctrl  = "tmp/#{full_file_name}.ctrl"
+      @path_state = "tmp/#{full_file_name}.state"
+    when nil
+    else
+      raise ArgumentError, "cli_server invalid ctrl: value - #{ctrl}"
+    end
+    @ctrl = ctrl
+  end
+
+  # Starts an instance of Puma in a sepate process via IO.popen.
+  # @param args [:String] Additional options not set via #setup_puma.
+  # @return [IO] IO object return from IO.popen.
+  def cli_server(args)
+    cmd = "#{BASE} bin/puma -b ".dup
+
+    case @bind
+    when :tcp
+      cmd << "tcp://#{HOST}:#{@port_bind} "
+    when :unix
+      cmd << "unix://#{@path_bind} "
+    else
+      raise ArgumentError, "cli_server invalid @bind value - #{@bind}"
+    end
+
+    case @ctrl
+    when :pid, :pidfile
+    when :tcp
+      cmd << "--control-url tcp://#{HOST}:#{@port_ctrl} --control-token #{TOKEN} "
+    when :tcp_state
+      cmd << "--control-url tcp://#{HOST}:#{@port_ctrl} --control-token #{TOKEN} "
+      cmd << "-S #{@path_state} "
+    when :unix
+      cmd << "--control-url unix://#{@path_ctrl} --control-token #{TOKEN} "
+    when :unix_state
+      cmd << "--control-url unix://#{@path_ctrl} --control-token #{TOKEN} "
+      cmd << "-S #{@path_state} "
+    else
+      raise ArgumentError, "cli_server invalid @ctrl value - #{@ctrl}"
+    end
+
+    # alwys write pid file
+    @path_pid = "tmp/#{full_file_name}.pid"
+    cmd << "--pidfile #{@path_pid} "
+
+    cmd << args
+    @server = IO.popen(cmd.split, err: :out)
+    @ios_to_close << @server
+    assert_io 'Ctrl-C'
+    @pid = File.read(@path_pid, mode: 'rb').strip.to_i
+
     @server
   end
 
-  # rescue statements are just in case method is called with a server
-  # that is already stopped/killed, especially since Process.wait2 is
-  # blocking
-  def stop_server(pid = @pid, signal: :TERM)
+  # Creates a Puma::ControlCLI object and runs it.
+  # @param cmd_str [:String] The command to run.
+  # @return [IO, IO] the out and err IO objects passed to Puma::ControlCLI.new
+  #
+  def run_pumactl(cmd_str)
+    cmd = case @ctrl
+      when :pid
+        @pid = File.read(@path_pid, mode: 'rb').strip.to_i
+        "-p #{@pid} "
+      when :pidfile    then "-P #{@path_pid} "
+      when :tcp        then "-C tcp://#{HOST}:#{@port_ctrl} -T #{TOKEN} "
+      when :tcp_state  then "-S #{@path_state} "
+      when :unix       then "-C unix://#{@path_ctrl} -T #{TOKEN} "
+      when :unix_state then "-S #{@path_state} "
+      else
+        raise ArgumentError, "run_pumactl invalid @ctrl value - #{@ctrl}"
+      end.dup
+    cmd << cmd_str
+
+    out_r, out_w = IO.pipe
+    err_r, err_w = IO.pipe
+
+    Puma::ControlCLI.new(cmd.split, out_w, err_w).run
+
+    out_w.close      ; err_w.close
+    out = out_r.read ; err = err_r.read
+    out_r.close      ; err_r.close
+    [out, err]
+  end
+
+  # Issues a stop command to the Puma server, and waits for 'Goodbye'.  Use with
+  # `Single` Puma instances.
+  #
+  def stop_server_goodbye
+    run_pumactl 'stop'
+    assert_io 'Goodbye'
+  end
+
+  # Issues a stop command to the Puma server, and waits via `Process.wait`. Use
+  # with `Cluster` Puma instances.
+  #
+  def stop_server_wait
+    run_pumactl 'stop'
     begin
-      Process.kill signal, pid
-    rescue Errno::ESRCH
-    end
-    begin
-      Process.wait2 pid
+      Process.wait @pid
     rescue Errno::ECHILD
     end
   end
 
-  def restart_server_and_listen(argv)
-    cli_server argv
-    connection = connect
-    initial_reply = read_body(connection)
-    restart_server connection
-    [initial_reply, read_body(connect)]
+  # Start a server with provided arguements, connects, restarts, connects again,
+  # and returns the two connection replies.
+  # @param args [:String] Additional options not set via #setup_puma.
+  # @return [String, String] Response bodies from the connection before and after
+  # the restart.
+  # @note 'restart', not 'phased-restart'
+  def restart_server_and_listen(args)
+    cli_server args
+
+    pre = read_body
+
+    restart_server
+
+    [pre, read_body]
   end
 
-  # reuses an existing connection to make sure that works
-  def restart_server(connection)
-    Process.kill :USR2, @pid
-    connection.write "GET / HTTP/1.1\r\n\r\n" # trigger it to start by sending a new request
-    wait_for_server_to_boot
+  # Restarts a server (not phased-restart), and waits for 'Ctrl-C'.  Since
+  # 'restart' performs a `Kernel.exec`, reads the PID file and loads the new
+  # value into `@pid`.
+  #
+  def restart_server
+    run_pumactl 'restart'
+    assert_io 'Restarting...'
+    assert_io 'Ctrl-C'
+    @pid = File.read(@path_pid, mode: 'rb').strip.to_i
   end
 
+  # Waits for 'Ctrl-C'
+  #
   def wait_for_server_to_boot
-    true while @server.gets !~ /Ctrl-C/ # wait for server to say it booted
+    assert_io 'Ctrl-C'  # wait for server to say it booted
   end
 
-  def connect(path = nil, unix: false)
-    s = unix ? UNIXSocket.new(@bind_path) : TCPSocket.new(HOST, @tcp_port)
+  # Opens a simple http connection.  Waits until "\\r\\n" is read/gotten.
+  # @param path [String, nil] path to use
+  # @return [TCPSocket, UNIXSocket]
+  #
+  def connect(path = nil)
+    s = @bind == :unix ?
+      UNIXSocket.new(@path_bind) :
+      TCPSocket.new(HOST, @port_bind)
+
     @ios_to_close << s
     s << "GET /#{path} HTTP/1.1\r\n\r\n"
     true until s.gets == "\r\n"
     s
   end
 
-  def read_body(connection)
-    Timeout.timeout(10) do
-      loop do
-        response = connection.readpartial(1024)
-        body = response.split("\r\n\r\n", 2).last
-        return body if body && !body.empty?
-        sleep 0.01
-      end
+  # Returns the body of a simple http connection.
+  # @param arg [:IO, :String, nil] if IO, uses it for reading, if a string,
+  #   opens the connection with the arg as the path, if nil, path is nil for a
+  #   new connection
+  # @return [String, nil] returns the body or nil on timeout
+  #
+  def read_body(arg = nil)
+    connection = case arg
+    when IO       then arg
+    when String   then connect arg
+    when NilClass then connect
+    else
+      raise ArgumentError, "read_body arg must be IO, String, or nil"
+    end
+
+    loop do
+      break unless IO.select [connection], nil, nil, 10
+      response = connection.readpartial(1024)
+      body = response.split("\r\n\r\n", 2).last
+      return body if body && !body.empty?
+      sleep 0.01
     end
   end
 
@@ -116,5 +330,91 @@ class TestIntegration < Minitest::Test
       end
     end
     pids.map(&:to_i)
+  end
+
+  # Send requests 10 per second.  Send 10, then :TERM server, then send another 30.
+  # No more than 10 should throw Errno::ECONNRESET.
+  def stop_closes_listeners(args = nil)
+    threads = []
+    replies = []
+    mutex = Mutex.new
+    div   = 10
+
+    cli_server "#{args} -q test/rackup/sleep_step.ru"
+
+    refused = thread_run_refused
+
+    41.times.each do |i|
+      if i == 10
+        threads << Thread.new do
+          sleep i.to_f/div
+          run_pumactl 'stop'
+          mutex.synchronize { replies[i] = :term_sent }
+        end
+      else
+        threads << Thread.new do
+          thread_run_step replies, i.to_f/div, 1, i, mutex, refused
+        end
+      end
+    end
+
+    threads.each(&:join)
+
+    failures  = replies.count(:failure)
+    successes = replies.count(:success)
+    resets    = replies.count(:reset)
+    refused   = replies.count(:refused)
+
+    r_success = replies.rindex(:success)
+    l_reset   = replies.index(:reset)
+    r_reset   = replies.rindex(:reset)
+    l_refused = replies.index(:refused)
+
+    msg = "#{successes} successes, #{resets} resets, #{refused} refused, failures #{failures}"
+
+    assert_equal 0, failures, msg
+    assert_equal 0, resets  , msg
+
+    # successes are sometimes between 9 and 11 on macOS
+    assert_operator  9, :<=, successes, msg
+    assert_operator 29, :<=, refused  , msg
+
+    # Interleaved asserts
+    # UNIX binders do not generate :reset items
+    if l_reset
+      assert_operator r_success, :<, l_reset  , "Interleaved success and reset"
+      assert_operator r_reset  , :<, l_refused, "Interleaved reset and refused"
+    else
+      assert_operator r_success, :<, l_refused, "Interleaved success and refused"
+    end
+  end
+
+  # used with thread_run to define correct 'refused' errors
+  def thread_run_refused
+    if @bind == :unix
+      DARWIN ? [Errno::ENOENT, IOError] : [Errno::ENOENT]
+    elsif @bind == :tcp
+      DARWIN ? [Errno::ECONNREFUSED, Errno::EPIPE, EOFError, IOError] :
+        [Errno::ECONNREFUSED]
+    end
+  end
+
+  # Used in #stop_closes_listeners
+  def thread_run_step(replies, delay, sleep_time, step, mutex, refused)
+    begin
+      sleep delay
+      body = read_body "sleep#{sleep_time}-#{step}"
+      if body[/\ASlept /]
+        mutex.synchronize { replies[step] = :success }
+      else
+        mutex.synchronize { replies[step] = :failure }
+      end
+    rescue Errno::ECONNRESET
+      # connection was accepted but then closed
+      # client would see an empty response
+      mutex.synchronize { replies[step] = :reset }
+    rescue *refused
+      mutex.synchronize { replies[step] = :refused }
+    end
   end
 end

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -80,7 +80,7 @@ class TestBinder < TestBinderBase
   end
 
   def test_pre_existing_unix
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    skip UNIX_SKT_MSG unless HAS_UNIX
     unix_path = "test/#{name}_server.sock"
 
     File.open(unix_path, mode: 'wb') { |f| f.puts 'pre existing' }
@@ -95,7 +95,7 @@ class TestBinder < TestBinderBase
     assert File.exist?(unix_path)
 
   ensure
-    if UNIX_SKT_EXIST
+    if HAS_UNIX
       File.unlink unix_path if File.exist? unix_path
     end
   end
@@ -134,7 +134,7 @@ class TestBinder < TestBinderBase
   private
 
   def assert_parsing_logs_uri(order = [:unix, :tcp])
-    skip UNIX_SKT_MSG if order.include?(:unix) && !UNIX_SKT_EXIST
+    skip UNIX_SKT_MSG if order.include?(:unix) && !HAS_UNIX
 
     prepared_paths = {
         ssl: "ssl://127.0.0.1:#{UniquePort.call}?#{ssl_query}",
@@ -150,7 +150,7 @@ class TestBinder < TestBinderBase
     assert stdout.include?(prepared_paths[order[0]]), "\n#{stdout}\n"
     assert stdout.include?(prepared_paths[order[1]]), "\n#{stdout}\n"
   ensure
-    @binder.close_unix_paths if order.include?(:unix) && UNIX_SKT_EXIST
+    @binder.close_unix_paths if order.include?(:unix) && HAS_UNIX
   end
 end
 

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -60,13 +60,11 @@ class TestLauncher < Minitest::Test
     launcher.send(:log_thread_status)
     events.stdout.rewind
 
-    assert_match "Thread TID", events.stdout.read
+    assert_match 'Thread: TID', events.stdout.read
   end
 
   def test_pid_file
-    tmp_file = Tempfile.new("puma-test")
-    tmp_path = tmp_file.path
-    tmp_file.close!
+    tmp_path = "tmp/#{full_file_name}.pid"
 
     conf = Puma::Configuration.new do |c|
       c.pidfile tmp_path

--- a/test/test_plugin.rb
+++ b/test/test_plugin.rb
@@ -2,38 +2,18 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestPlugin < TestIntegration
-  def test_plugin
-    skip "Skipped on Windows Ruby < 2.5.0, Ruby bug" if windows? && RUBY_VERSION < '2.5.0'
-    @tcp_bind = UniquePort.call
-    @tcp_ctrl = UniquePort.call
+  def test_plugin_sock
+    setup_puma bind: :tcp, ctrl: :tcp
 
-    Dir.mkdir("tmp") unless Dir.exist?("tmp")
+    cli_server "-C test/config/plugin1.rb test/rackup/hello.ru"
 
-    cli_server "-b tcp://#{HOST}:#{@tcp_bind} --control-url tcp://#{HOST}:#{@tcp_ctrl} --control-token #{TOKEN} -C test/config/plugin1.rb test/rackup/hello.ru"
     File.open('tmp/restart.txt', mode: 'wb') { |f| f.puts "Restart #{Time.now}" }
 
-    true while (l = @server.gets) !~ /Restarting\.\.\./
-    assert_match(/Restarting\.\.\./, l)
+    assert_io 'Restarting...'
+    assert_io 'Ctrl-C'
+    @pid = File.read(@path_pid, mode: 'rb').strip.to_i
 
-    true while (l = @server.gets) !~ /Ctrl-C/
-    assert_match(/Ctrl-C/, l)
-
-    out = StringIO.new
-
-    cli_pumactl "-C tcp://#{HOST}:#{@tcp_ctrl} -T #{TOKEN} stop"
-    true while (l = @server.gets) !~ /Goodbye/
-
-    @server.close
-    @server = nil
-    out.close
-  end
-
-  private
-
-  def cli_pumactl(argv)
-    pumactl = IO.popen("#{BASE} bin/pumactl #{argv}", "r")
-    @ios_to_close << pumactl
-    Process.wait pumactl.pid
-    pumactl
+  ensure
+    File.unlink('tmp/restart.txt') if File.exist? 'tmp/restart.txt'
   end
 end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -727,7 +727,7 @@ EOF
 
     sock.gets
 
-    assert_operator request_body_wait, :>=, 1000
+    assert_operator request_body_wait, :>=, 990
   end
 
   def test_request_body_wait_chunked
@@ -743,6 +743,6 @@ EOF
 
     sock.gets
 
-    assert_operator request_body_wait, :>=, 1000
+    assert_operator request_body_wait, :>=, 990
   end
 end

--- a/test/test_unix_socket.rb
+++ b/test/test_unix_socket.rb
@@ -9,19 +9,16 @@ class TestPumaUnixSocket < Minitest::Test
   Path = "test/puma.sock"
 
   def setup
-    return unless UNIX_SKT_EXIST
     @server = Puma::Server.new App
     @server.add_unix_listener Path
     @server.run
   end
 
   def teardown
-    return unless UNIX_SKT_EXIST
     @server.stop(true)
   end
 
   def test_server
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
     sock = UNIXSocket.new Path
 
     sock << "GET / HTTP/1.0\r\nHost: blah.com\r\n\r\n"
@@ -30,4 +27,4 @@ class TestPumaUnixSocket < Minitest::Test
 
     assert_equal expected, sock.read(expected.size)
   end
-end
+end if ::Puma::HAS_UNIX


### PR DESCRIPTION
1. Clean up leaked fd's both in test & lib code

2. Delete control io's and unix paths

3. Fix code differences between signal and control_cli behavior

4. control_cli.rb - refactor, add thread-status using sock control

5. launcher.rb - add thread-status via sock control

6. detect.rb - Add Puma::HAS_FORK and Puma::HAS_UNIX, adjust tests to match

7. Fixed connection handling during stop (both Single & Clustered)

8. split some test files into two classes, one running parallel, one 'serial'