### PR TITLE
extconf.rb - fix for new gcc on MingW

### DIFF
--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -1,6 +1,11 @@
 require 'mkmf'
 
 dir_config("puma_http11")
+if RUBY_PLATFORM[/mingw32/]
+  append_cflags '-D_FORTIFY_SOURCE=2'
+  append_ldflags '-fstack-protector'
+  have_library 'ssp'
+end
 
 unless ENV["DISABLE_SSL"]
   dir_config("openssl")


### PR DESCRIPTION
This fix allows Puma to build when one is starting with a fresh MSYS2 installation.

Ubuntu on Actions is using gcc 7.4.0, MSYS2/MinGW is using 9.2.0.  The changes are currently just used on MinGW.