### PR TITLE
Close file stream when reading pid from pidfile

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,6 +7,7 @@
 * Bugfixes
   * Fix Errno::EINVAL when SSL is enabled and browser rejects cert (#1564)
   * Fix pumactl defaulting puma to development if an environment was not specified (#2035)
+  * Fix closing file stream when reading pid from pidfile (#2048)
 
 ## 4.2.1 / 2019-10-07
 

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -132,7 +132,7 @@ module Puma
         @pid = sf.pid
       elsif @pidfile
         # get pid from pid_file
-        @pid = File.open(@pidfile).gets.to_i
+        File.open(@pidfile) { |f| @pid = f.read.to_i }
       end
     end
 


### PR DESCRIPTION
### Description
Fixes closing of file stream when reading pid from pidfile - closes https://github.com/puma/puma/issues/1985

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [HISTORY.md](../HISTORY.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the commit messages.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.