### PR TITLE
Fix typo "c" -> "user_config" for --extra_runtime_dependencies

### DIFF
--- a/History.md
+++ b/History.md
@@ -9,6 +9,7 @@
   * Fix Errno::EINVAL when SSL is enabled and browser rejects cert (#1564)
   * Fix pumactl defaulting puma to development if an environment was not specified (#2035)
   * Fix closing file stream when reading pid from pidfile (#2048)
+  * Fix a typo in configuration option `--extra_runtime_dependencies` (#2050)
 
 ## 4.2.1 / 2019-10-07
 

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -162,7 +162,7 @@ module Puma
           end
 
           o.on "--extra-runtime-dependencies GEM1,GEM2", "Defines any extra needed gems when using --prune-bundler" do |arg|
-            c.extra_runtime_dependencies arg.split(',')
+            user_config.extra_runtime_dependencies arg.split(',')
           end
 
           o.on "-q", "--quiet", "Do not log requests internally (default true)" do

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -352,6 +352,14 @@ class TestCLI < Minitest::Test
     $LOAD_PATH.shift
   end
 
+  def test_extra_runtime_dependencies
+    cli = Puma::CLI.new ['--extra-runtime-dependencies', 'a,b']
+    extra_dependencies = cli.instance_variable_get(:@conf)
+                            .instance_variable_get(:@options)[:extra_runtime_dependencies]
+
+    assert_equal %w[a b], extra_dependencies
+  end
+
   def test_environment
     ENV.delete 'RACK_ENV'
 


### PR DESCRIPTION
### Description

There was a `c` here, and it seemed, out of place.

```ruby
o.on "--extra-runtime-dependencies GEM1,GEM2", "Defines any extra needed gems when using --prune-bundler" do |arg|
  c.extra_runtime_dependencies arg.split(',')
end
```

Comparing with `--prune_bundler`, which was mentioned next to this long option, we could try using `user_config` instead.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the commit messages.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
