### PR TITLE
PR template: link to contributing, changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,8 @@ Please describe your pull request. Thank you for contributing! You're the best.
 ### Your checklist for this pull request
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
-- [ ] I have added an entry to [HISTORY.md](../HISTORY.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
+- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
+- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
 - [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
 - [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
 - [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the commit messages.


### PR DESCRIPTION
Point to the "blob" on master, so that the link is clickable from the PR

### Description

I tried to use the links, and the links were ineffective.

This PR updates the PR template to make the links point directly to the documents.

