### PR TITLE
Add ssl support to the control_cli

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,7 +3,7 @@
 * Features
   * Strip whitespace at end of HTTP headers (#2010)
   * Optimize HTTP parser for JRuby (#2012)
-  * Add SSL support for the control app (#2046)
+  * Add SSL support for the control app and cli (#2046, #2052)
 
 * Bugfixes
   * Fix Errno::EINVAL when SSL is enabled and browser rejects cert (#1564)

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -141,6 +141,12 @@ module Puma
 
       # create server object by scheme
       server = case uri.scheme
+                when "ssl"
+                  require 'openssl'
+                  OpenSSL::SSL::SSLSocket.new(
+                    TCPSocket.new(uri.host, uri.port),
+                    OpenSSL::SSL::SSLContext.new
+                  ).tap(&:connect)
                 when "tcp"
                   TCPSocket.new uri.host, uri.port
                 when "unix"

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -1,16 +1,19 @@
 require_relative "helper"
 require_relative "helpers/config_file"
+require_relative "helpers/ssl"
 
 require 'puma/control_cli'
 
 class TestPumaControlCli < TestConfigFileBase
+  include SSLHelper
+
   def setup
     # use a pipe to get info across thread boundary
     @wait, @ready = IO.pipe
   end
 
   def wait_booted
-    line = @wait.gets until line =~ /Listening on/
+    line = @wait.gets until line =~ /Use Ctrl-C to stop/
   end
 
   def teardown
@@ -138,18 +141,43 @@ class TestPumaControlCli < TestConfigFileBase
     assert_match "200 OK", body
     assert_match "embedded app", body
 
-    status_cmd = Puma::ControlCLI.new(opts + ["status"])
-    out, _ = capture_subprocess_io do
-      status_cmd.run
-    end
-    assert_match "Puma is started\n", out
-
-    shutdown_cmd = Puma::ControlCLI.new(opts + ["halt"])
-    out, _ = capture_subprocess_io do
-      shutdown_cmd.run
-    end
-    assert_match "Command halt sent success\n", out
+    assert_command_cli_output opts + ["status"], "Puma is started"
+    assert_command_cli_output opts + ["stop"], "Command stop sent success"
 
     assert_kind_of Thread, t.join, "server didn't stop"
+  end
+
+  def test_control_ssl
+    host = "127.0.0.1"
+    port = find_open_port
+    url = "ssl://#{host}:#{port}?#{ssl_query}"
+
+    opts = [
+      "--control-url", url,
+      "--control-token", "ctrl",
+      "--config-file", "test/config/app.rb",
+    ]
+
+    control_cli = Puma::ControlCLI.new (opts + ["start"]), @ready, @ready
+    t = Thread.new do
+      control_cli.run
+    end
+
+    wait_booted
+
+    assert_command_cli_output opts + ["status"], "Puma is started"
+    assert_command_cli_output opts + ["stop"], "Command stop sent success"
+
+    assert_kind_of Thread, t.join, "server didn't stop"
+  end
+
+  private
+
+  def assert_command_cli_output(options, expected_out)
+    cmd = Puma::ControlCLI.new(options)
+    out, _ = capture_subprocess_io do
+      cmd.run
+    end
+    assert_match expected_out, out
   end
 end


### PR DESCRIPTION
If I have a server running:

```sh
bundle exec bin/puma test/rackup/hello.ru \
  --control-url="ssl://127.0.0.1:9000?key=examples/puma/puma_keypair.pem&cert=examples/puma/cert_puma.pem" \
  --control-token="token"
```

This commit will allow me to restart that server (or run any other
control cli command) with:

```sh
bundle exec bin/pumactl restart \
  --control-url="ssl://127.0.0.1:9000" \
  --control-token="token"
```

Before this commit the pumactl restart command would have raised an
error: `"Invalid scheme: ssl"`


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [X] I have added an entry to [HISTORY.md](../HISTORY.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
- [X] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the commit messages.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
