### PR TITLE
Apply test patches from debug-fds, constants to detect.rb

### DIFF
--- a/lib/puma/detect.rb
+++ b/lib/puma/detect.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'socket'
+
 module Puma
   IS_JRUBY = defined?(JRUBY_VERSION)
 
@@ -12,4 +14,8 @@ module Puma
   def self.windows?
     IS_WINDOWS
   end
+
+  HAS_FORK = ::Process.respond_to? :fork
+  HAS_UNIX = Object.const_defined? :UNIXSocket
+
 end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -1,13 +1,34 @@
 # frozen_string_literal: true
 
 require "puma/control_cli"
-require "open3"
 
-# Only single mode tests go here. Cluster and pumactl tests
-# have their own files, use those instead
+# TestIntegration is used with tests that start Puma and then control it, either
+# via signals or sockets.  Since control via signals requires a separate process,
+# the tests need to create a Puma instance separate from the test process.
+# Since the code paths for control via signals vs sockets is somewhat different,
+# these tests often test both, althought the 'socket control' tests really don't
+# require a separate process.
+#
+# The main method is #setup_puma, which specifies the bindings and control type.
+# Most of the helper methods use variables defined by #setup_puma.
+# #setup_puma also allows similar tests to be created where one test uses a
+# signal to control Puma, while the companion test uses a tcp or unix socket to
+# do the same.
+#
+# The following methods make use of variables set in #setup_puma:
+# * #cli_server - starts an instance of Puma via IO.popen
+# * #connect - specify a GET request path, returns the response
+# * #run_pumactl - sends a command via Puma::ControlCLI
+#
+# All methods keep track of opened IO's, and they will be closed in `teardown`.
+#
 class TestIntegration < Minitest::Test
-  HOST  = "127.0.0.1"
-  TOKEN = "xxyyzz"
+  include WaitForServerLogs
+
+  DARWIN = !!RUBY_PLATFORM[/darwin/]
+
+  HOST  = '127.0.0.1'
+  TOKEN = 'xxyyzz'
   WORKERS = 2
 
   BASE = defined?(Bundler) ? "bundle exec #{Gem.ruby} -Ilib" :
@@ -15,20 +36,48 @@ class TestIntegration < Minitest::Test
 
   def setup
     @ios_to_close = []
-    @bind_path    = "test/#{name}_server.sock"
+
+    # below defined so we don't have to check defined? before use
+    @pid  = nil
+    @bind = nil
+    @ctrl = nil
+    @server = nil
+    @path_bind = nil
+    @path_ctrl = nil
+    # restarts change the pid of the server due to Kernel.exec
+    @path_pid = nil
   end
 
   def teardown
-    if defined?(@server) && @server
-      stop_server @pid, signal: :INT
-    end
+    return if skipped?
+
+    sgnl = windows? ? :KILL : :INT
+    begin
+      Process.kill sgnl, @pid
+    rescue Errno::ESRCH, Errno::EINVAL
+    end if @pid
+
+    begin
+      Process.wait @pid
+    rescue Errno::ECHILD
+    end if @pid
 
     @ios_to_close.each do |io|
       io.close if io.is_a?(IO) && !io.closed?
       io = nil
     end
-    refute File.exist?(@bind_path), "Bind path must be removed after stop"
-    File.unlink(@bind_path) rescue nil
+
+    if @path_bind
+      refute File.exist?(@path_bind), "Bind path must be removed after stop"
+      File.unlink(@path_bind) rescue nil
+    end
+
+    if @path_ctrl
+      refute File.exist?(@path_ctrl), "Ctrl path must be removed after stop"
+      File.unlink(@path_ctrl) rescue nil
+    end
+
+    File.unlink(@path_pid) rescue nil
 
     # wait until the end for OS buffering?
     if defined?(@server) && @server
@@ -39,68 +88,233 @@ class TestIntegration < Minitest::Test
 
   private
 
-  def cli_server(argv, unix: false)
-    if unix
-      cmd = "#{BASE} bin/puma -b unix://#{@bind_path} #{argv}"
-    else
-      @tcp_port = UniquePort.call
-      cmd = "#{BASE} bin/puma -b tcp://#{HOST}:#{@tcp_port} #{argv}"
+  # Main method to setup Puma configuration.  Loads the following variables,
+  # depending on the parameters. All path variables are based on the test class
+  # and method name with specific extension.
+  #
+  # * Path Variables
+  #   * +@path_bind+ - unix binding - +.bind+ extension
+  #   * +@path_ctrl+ - unix control - +.ctrl+ extension
+  #   * +@path_pid+  - control pid file - +.pid+ extension
+  #   * +@path_state+ - control state file - +.state+ extension
+  #
+  # * TCP Port Variables
+  #   * +@port_bind+ - binding
+  #   * +@port_ctrl+ - control url
+  #
+  # @param bind: [:Symbol] The protocol used for the binding.  Either :tcp or :unix
+  # @param ctrl: [:Symbol] Sets some of the parameters passed to a Puma::ControlCLI
+  # instance. One of the following: :pid, :pidfile, :tcp, :tcp_state, :unix,
+  # :unix_state. The 'state' ctrl options use the prefix for the protocol, along
+  # with a state file.
+  #
+  def setup_puma(bind: :nil, ctrl: :nil)
+
+    if bind.nil? && ctrl.nil?
+      raise ArgumentError, "both bind and ctrl cannot be nil"
     end
-    @server = IO.popen(cmd, "r")
-    wait_for_server_to_boot
-    @pid = @server.pid
+
+    if (bind == :unix) || [:unix, :unix_state].include?(ctrl)
+      skip UNIX_SKT_MSG unless HAS_UNIX
+    end
+
+    if windows? && [:pid, :pidfile].include?(ctrl)
+      skip "Puma::ControlCLI doesn't support pid/signal on Windows"
+    end
+
+    case bind
+    when :tcp
+      @port_bind = UniquePort.call
+    when :unix
+      @path_bind = "tmp/#{full_file_name}.bind"
+    when nil
+    else
+      raise ArgumentError, "cli_server invalid bind: value - #{ctrl}"
+    end
+    @bind = bind
+
+    case ctrl
+    when :pid
+    when :pidfile
+    when :tcp
+      @port_ctrl  = UniquePort.call
+    when :tcp_state
+      @port_ctrl  = UniquePort.call
+      @path_state = "tmp/#{full_file_name}.state"
+    when :unix
+      @path_ctrl  = "tmp/#{full_file_name}.ctrl"
+    when :unix_state
+      @path_ctrl  = "tmp/#{full_file_name}.ctrl"
+      @path_state = "tmp/#{full_file_name}.state"
+    when nil
+    else
+      raise ArgumentError, "cli_server invalid ctrl: value - #{ctrl}"
+    end
+    @ctrl = ctrl
+  end
+
+  # Starts an instance of Puma in a sepate process via IO.popen.
+  # @param args [:String] Additional options not set via #setup_puma.
+  # @return [IO] IO object return from IO.popen.
+  def cli_server(args)
+    cmd = "#{BASE} bin/puma -b ".dup
+
+    case @bind
+    when :tcp
+      cmd << "tcp://#{HOST}:#{@port_bind} "
+    when :unix
+      cmd << "unix://#{@path_bind} "
+    else
+      raise ArgumentError, "cli_server invalid @bind value - #{@bind}"
+    end
+
+    case @ctrl
+    when :pid, :pidfile
+    when :tcp
+      cmd << "--control-url tcp://#{HOST}:#{@port_ctrl} --control-token #{TOKEN} "
+    when :tcp_state
+      cmd << "--control-url tcp://#{HOST}:#{@port_ctrl} --control-token #{TOKEN} "
+      cmd << "-S #{@path_state} "
+    when :unix
+      cmd << "--control-url unix://#{@path_ctrl} --control-token #{TOKEN} "
+    when :unix_state
+      cmd << "--control-url unix://#{@path_ctrl} --control-token #{TOKEN} "
+      cmd << "-S #{@path_state} "
+    else
+      raise ArgumentError, "cli_server invalid @ctrl value - #{@ctrl}"
+    end
+
+    # alwys write pid file
+    @path_pid = "tmp/#{full_file_name}.pid"
+    cmd << "--pidfile #{@path_pid} "
+
+    cmd << args
+    @server = IO.popen(cmd.split, err: :out)
+    @ios_to_close << @server
+    assert_io 'Ctrl-C'
+    @pid = File.read(@path_pid, mode: 'rb').strip.to_i
+
     @server
   end
 
-  # rescue statements are just in case method is called with a server
-  # that is already stopped/killed, especially since Process.wait2 is
-  # blocking
-  def stop_server(pid = @pid, signal: :TERM)
+  # Creates a Puma::ControlCLI object and runs it.
+  # @param cmd_str [:String] The command to run.
+  # @return [IO, IO] the out and err IO objects passed to Puma::ControlCLI.new
+  #
+  def run_pumactl(cmd_str)
+    cmd = case @ctrl
+      when :pid
+        @pid = File.read(@path_pid, mode: 'rb').strip.to_i
+        "-p #{@pid} "
+      when :pidfile    then "-P #{@path_pid} "
+      when :tcp        then "-C tcp://#{HOST}:#{@port_ctrl} -T #{TOKEN} "
+      when :tcp_state  then "-S #{@path_state} "
+      when :unix       then "-C unix://#{@path_ctrl} -T #{TOKEN} "
+      when :unix_state then "-S #{@path_state} "
+      else
+        raise ArgumentError, "run_pumactl invalid @ctrl value - #{@ctrl}"
+      end.dup
+    cmd << cmd_str
+
+    out_r, out_w = IO.pipe
+    err_r, err_w = IO.pipe
+
+    Puma::ControlCLI.new(cmd.split, out_w, err_w).run
+
+    out_w.close      ; err_w.close
+    out = out_r.read ; err = err_r.read
+    out_r.close      ; err_r.close
+    [out, err]
+  end
+
+  # Issues a stop command to the Puma server, and waits for 'Goodbye'.  Use with
+  # `Single` Puma instances.
+  #
+  def stop_server_goodbye
+    run_pumactl 'stop'
+    assert_io 'Goodbye'
+  end
+
+  # Issues a stop command to the Puma server, and waits via `Process.wait`. Use
+  # with `Cluster` Puma instances.
+  #
+  def stop_server_wait
+    run_pumactl 'stop'
     begin
-      Process.kill signal, pid
-    rescue Errno::ESRCH
-    end
-    begin
-      Process.wait2 pid
+      Process.wait @pid
     rescue Errno::ECHILD
     end
   end
 
-  def restart_server_and_listen(argv)
-    cli_server argv
-    connection = connect
-    initial_reply = read_body(connection)
-    restart_server connection
-    [initial_reply, read_body(connect)]
+  # Start a server with provided arguements, connects, restarts, connects again,
+  # and returns the two connection replies.
+  # @param args [:String] Additional options not set via #setup_puma.
+  # @return [String, String] Response bodies from the connection before and after
+  # the restart.
+  # @note 'restart', not 'phased-restart'
+  def restart_server_and_listen(args)
+    cli_server args
+
+    pre = read_body
+
+    restart_server
+
+    [pre, read_body]
   end
 
-  # reuses an existing connection to make sure that works
-  def restart_server(connection)
-    Process.kill :USR2, @pid
-    connection.write "GET / HTTP/1.1\r\n\r\n" # trigger it to start by sending a new request
-    wait_for_server_to_boot
+  # Restarts a server (not phased-restart), and waits for 'Ctrl-C'.  Since
+  # 'restart' performs a `Kernel.exec`, reads the PID file and loads the new
+  # value into `@pid`.
+  #
+  def restart_server
+    run_pumactl 'restart'
+    assert_io 'Restarting...'
+    assert_io 'Ctrl-C'
+    @pid = File.read(@path_pid, mode: 'rb').strip.to_i
   end
 
+  # Waits for 'Ctrl-C'
+  #
   def wait_for_server_to_boot
-    true while @server.gets !~ /Ctrl-C/ # wait for server to say it booted
+    assert_io 'Ctrl-C'  # wait for server to say it booted
   end
 
-  def connect(path = nil, unix: false)
-    s = unix ? UNIXSocket.new(@bind_path) : TCPSocket.new(HOST, @tcp_port)
+  # Opens a simple http connection.  Waits until "\\r\\n" is read/gotten.
+  # @param path [String, nil] path to use
+  # @return [TCPSocket, UNIXSocket]
+  #
+  def connect(path = nil)
+    s = @bind == :unix ?
+      UNIXSocket.new(@path_bind) :
+      TCPSocket.new(HOST, @port_bind)
+
     @ios_to_close << s
     s << "GET /#{path} HTTP/1.1\r\n\r\n"
     true until s.gets == "\r\n"
     s
   end
 
-  def read_body(connection)
-    Timeout.timeout(10) do
-      loop do
-        response = connection.readpartial(1024)
-        body = response.split("\r\n\r\n", 2).last
-        return body if body && !body.empty?
-        sleep 0.01
-      end
+  # Returns the body of a simple http connection.
+  # @param arg [:IO, :String, nil] if IO, uses it for reading, if a string,
+  #   opens the connection with the arg as the path, if nil, path is nil for a
+  #   new connection
+  # @return [String, nil] returns the body or nil on timeout
+  #
+  def read_body(arg = nil)
+    connection = case arg
+    when IO       then arg
+    when String   then connect arg
+    when NilClass then connect
+    else
+      raise ArgumentError, "read_body arg must be IO, String, or nil"
+    end
+
+    loop do
+      break unless IO.select [connection], nil, nil, 10
+      response = connection.readpartial(1024)
+      body = response.split("\r\n\r\n", 2).last
+      return body if body && !body.empty?
+      sleep 0.01
     end
   end
 
@@ -116,5 +330,91 @@ class TestIntegration < Minitest::Test
       end
     end
     pids.map(&:to_i)
+  end
+
+  # Send requests 10 per second.  Send 10, then :TERM server, then send another 30.
+  # No more than 10 should throw Errno::ECONNRESET.
+  def stop_closes_listeners(args = nil)
+    threads = []
+    replies = []
+    mutex = Mutex.new
+    div   = 10
+
+    cli_server "#{args} -q test/rackup/sleep_step.ru"
+
+    refused = thread_run_refused
+
+    41.times.each do |i|
+      if i == 10
+        threads << Thread.new do
+          sleep i.to_f/div
+          run_pumactl 'stop'
+          mutex.synchronize { replies[i] = :term_sent }
+        end
+      else
+        threads << Thread.new do
+          thread_run_step replies, i.to_f/div, 1, i, mutex, refused
+        end
+      end
+    end
+
+    threads.each(&:join)
+
+    failures  = replies.count(:failure)
+    successes = replies.count(:success)
+    resets    = replies.count(:reset)
+    refused   = replies.count(:refused)
+
+    r_success = replies.rindex(:success)
+    l_reset   = replies.index(:reset)
+    r_reset   = replies.rindex(:reset)
+    l_refused = replies.index(:refused)
+
+    msg = "#{successes} successes, #{resets} resets, #{refused} refused, failures #{failures}"
+
+    assert_equal 0, failures, msg
+    assert_equal 0, resets  , msg
+
+    # successes are sometimes between 9 and 11 on macOS
+    assert_operator  9, :<=, successes, msg
+    assert_operator 29, :<=, refused  , msg
+
+    # Interleaved asserts
+    # UNIX binders do not generate :reset items
+    if l_reset
+      assert_operator r_success, :<, l_reset  , "Interleaved success and reset"
+      assert_operator r_reset  , :<, l_refused, "Interleaved reset and refused"
+    else
+      assert_operator r_success, :<, l_refused, "Interleaved success and refused"
+    end
+  end
+
+  # used with thread_run to define correct 'refused' errors
+  def thread_run_refused
+    if @bind == :unix
+      DARWIN ? [Errno::ENOENT, IOError] : [Errno::ENOENT]
+    elsif @bind == :tcp
+      DARWIN ? [Errno::ECONNREFUSED, Errno::EPIPE, EOFError, IOError] :
+        [Errno::ECONNREFUSED]
+    end
+  end
+
+  # Used in #stop_closes_listeners
+  def thread_run_step(replies, delay, sleep_time, step, mutex, refused)
+    begin
+      sleep delay
+      body = read_body "sleep#{sleep_time}-#{step}"
+      if body[/\ASlept /]
+        mutex.synchronize { replies[step] = :success }
+      else
+        mutex.synchronize { replies[step] = :failure }
+      end
+    rescue Errno::ECONNRESET
+      # connection was accepted but then closed
+      # client would see an empty response
+      mutex.synchronize { replies[step] = :reset }
+    rescue *refused
+      mutex.synchronize { replies[step] = :refused }
+    end
   end
 end

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -80,7 +80,7 @@ class TestBinder < TestBinderBase
   end
 
   def test_pre_existing_unix
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    skip UNIX_SKT_MSG unless HAS_UNIX
     unix_path = "test/#{name}_server.sock"
 
     File.open(unix_path, mode: 'wb') { |f| f.puts 'pre existing' }
@@ -95,7 +95,7 @@ class TestBinder < TestBinderBase
     assert File.exist?(unix_path)
 
   ensure
-    if UNIX_SKT_EXIST
+    if HAS_UNIX
       File.unlink unix_path if File.exist? unix_path
     end
   end
@@ -134,7 +134,7 @@ class TestBinder < TestBinderBase
   private
 
   def assert_parsing_logs_uri(order = [:unix, :tcp])
-    skip UNIX_SKT_MSG if order.include?(:unix) && !UNIX_SKT_EXIST
+    skip UNIX_SKT_MSG if order.include?(:unix) && !HAS_UNIX
 
     prepared_paths = {
         ssl: "ssl://127.0.0.1:#{UniquePort.call}?#{ssl_query}",
@@ -150,7 +150,7 @@ class TestBinder < TestBinderBase
     assert stdout.include?(prepared_paths[order[0]]), "\n#{stdout}\n"
     assert stdout.include?(prepared_paths[order[1]]), "\n#{stdout}\n"
   ensure
-    @binder.close_unix_paths if order.include?(:unix) && UNIX_SKT_EXIST
+    @binder.close_unix_paths if order.include?(:unix) && HAS_UNIX
   end
 end
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -4,100 +4,111 @@ require_relative "helpers/integration"
 class TestIntegrationCluster < TestIntegration
   parallelize_me!
 
-  DARWIN = !!RUBY_PLATFORM[/darwin/]
-
-  def setup
-    skip NO_FORK_MSG unless HAS_FORK
-    super
-  end
-
   def teardown
     return if skipped?
     super
   end
 
   def test_pre_existing_unix
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    skip UNIX_SKT_MSG unless HAS_UNIX
+    setup_puma bind: :unix, ctrl: :unix
 
-    File.open(@bind_path, mode: 'wb') { |f| f.puts 'pre existing' }
+    File.open(@path_bind, mode: 'wb') { |f| f.puts 'pre existing' }
 
-    cli_server "-w #{WORKERS} -q test/rackup/sleep_step.ru", unix: :unix
+    cli_server "-w #{WORKERS} -q test/rackup/sleep_step.ru"
 
-    stop_server
+    stop_server_wait
 
-    assert File.exist?(@bind_path)
+    assert File.exist?(@path_bind)
 
   ensure
-    if UNIX_SKT_EXIST
-      File.unlink @bind_path if File.exist? @bind_path
+    if HAS_UNIX
+      File.unlink(@path_bind) if File.exist? @path_bind
     end
   end
 
-  def test_siginfo_thread_print
+  def test_thread_status_sgnl
     skip_unless_signal_exist? :INFO
+    setup_puma bind: :tcp, ctrl: :tcp
 
     cli_server "-w #{WORKERS} -q test/rackup/hello.ru"
     worker_pids = get_worker_pids
-    output = []
-    t = Thread.new { output << @server.readlines }
+
     Process.kill :INFO, worker_pids.first
-    Process.kill :INT , @pid
-    t.join
-
-    assert_match "Thread TID", output.join
+    assert_io 'Thread: TID'
   end
 
-  def test_usr2_restart
-    _, new_reply = restart_server_and_listen("-q -w #{WORKERS} test/rackup/hello.ru")
-    assert_equal "Hello World", new_reply
-  end
-
-  # Next two tests, one tcp, one unix
+  # Next three tests, two signal, one with tcp bind, the other with unix.  Third
+  # is tcp bind and tcp control.
   # Send requests 10 per second.  Send 10, then :TERM server, then send another 30.
   # No more than 10 should throw Errno::ECONNRESET.
 
-  def test_term_closes_listeners_tcp
+  def test_stop_closes_listeners_tcp_sgnl
     skip_unless_signal_exist? :TERM
-    term_closes_listeners unix: false
+    setup_puma bind: :tcp, ctrl: :pid
+    stop_closes_listeners "-w #{WORKERS}"
   end
 
-  def test_term_closes_listeners_unix
+  def test_stop_closes_listeners_unix_sgnl
     skip_unless_signal_exist? :TERM
-    term_closes_listeners unix: true
+    setup_puma bind: :unix, ctrl: :pid
+    stop_closes_listeners "-w #{WORKERS}"
+  end
+
+  def test_stop_closes_listeners_tcp_sock
+    setup_puma bind: :tcp, ctrl: :tcp
+    stop_closes_listeners "-w #{WORKERS}"
   end
 
   # Next two tests, one tcp, one unix
-  # Send requests 1 per second.  Send 1, then :USR1 server, then send another 24.
+  # Send requests 1 per second.  Send 1, then :USR1 server, then send another 34.
   # All should be responded to, and at least three workers should be used
 
-  def test_usr1_all_respond_tcp
+  def test_phased_restart_all_respond_tcp_sgnl
     skip_unless_signal_exist? :USR1
-    usr1_all_respond unix: false
+    setup_puma bind: :tcp, ctrl: :pid
+    phased_restart_all_respond
   end
 
-  def test_usr1_all_respond_unix
+  def test_phased_restart_all_respond_unix_sgnl
     skip_unless_signal_exist? :USR1
-    usr1_all_respond unix: true
+    setup_puma bind: :unix, ctrl: :pid
+    phased_restart_all_respond
+  end
+
+  def test_phased_restart_all_respond_tcp_sock
+    setup_puma bind: :tcp, ctrl: :tcp
+    phased_restart_all_respond
   end
 
   def test_term_exit_code
+    setup_puma bind: :tcp, ctrl: :pid
     cli_server "-w #{WORKERS} test/rackup/hello.ru"
-    _, status = stop_server
+    run_pumactl 'stop'
 
-    assert_equal 15, status
+    begin
+      _, status = Process.wait2 @pid
+      assert_equal 15, status
+    rescue Errno::ECHILD
+    end
   end
 
   def test_term_suppress
+    setup_puma bind: :tcp, ctrl: :pid
     cli_server "-w #{WORKERS} -C test/config/suppress_exception.rb test/rackup/hello.ru"
+    run_pumactl 'stop'
 
-    _, status = stop_server
-
-    assert_equal 0, status
+    begin
+      _, status = Process.wait2 @pid
+      assert_equal 0, status
+    rescue Errno::ECHILD
+    end
   end
 
   def test_term_worker_clean_exit
     skip "Intermittent failure on Ruby 2.2" if RUBY_VERSION < '2.3'
 
+    setup_puma bind: :tcp, ctrl: :pid
     cli_server "-w #{WORKERS} test/rackup/hello.ru"
 
     # Get the PIDs of the child workers.
@@ -116,6 +127,7 @@ class TestIntegrationCluster < TestIntegration
   def test_stuck_external_term_spawn
     skip_unless_signal_exist? :TERM
 
+    setup_puma bind: :tcp, ctrl: :pid
     worker_respawn(0) do |phase0_worker_pids|
       last = phase0_worker_pids.last
       # test is tricky if only one worker is TERM'd, so kill all but
@@ -130,95 +142,30 @@ class TestIntegrationCluster < TestIntegration
   # mimicking stuck workers, test restart
   def test_stuck_phased_restart
     skip_unless_signal_exist? :USR1
+
+    setup_puma bind: :tcp, ctrl: :pid
     worker_respawn { |phase0_worker_pids| Process.kill :USR1, @pid }
   end
 
   private
 
-  # Send requests 10 per second.  Send 10, then :TERM server, then send another 30.
-  # No more than 10 should throw Errno::ECONNRESET.
-  def term_closes_listeners(unix: false)
-    skip_unless_signal_exist? :TERM
-
-    cli_server "-w #{WORKERS} -t 0:6 -q test/rackup/sleep_step.ru", unix: unix
-    threads = []
-    replies = []
-    mutex = Mutex.new
-    div   = 10
-
-    refused = thread_run_refused unix: unix
-
-    41.times.each do |i|
-      if i == 10
-        threads << Thread.new do
-          sleep i.to_f/div
-          Process.kill :TERM, @pid
-          mutex.synchronize { replies[i] = :term_sent }
-        end
-      else
-        threads << Thread.new do
-          thread_run_step replies, i.to_f/div, 1, i, mutex, refused, unix: unix
-        end
-      end
-    end
-
-    threads.each(&:join)
-
-    failures  = replies.count(:failure)
-    successes = replies.count(:success)
-    resets    = replies.count(:reset)
-    refused   = replies.count(:refused)
-
-    r_success = replies.rindex(:success)
-    l_reset   = replies.index(:reset)
-    r_reset   = replies.rindex(:reset)
-    l_refused = replies.index(:refused)
-
-    msg = "#{successes} successes, #{resets} resets, #{refused} refused, failures #{failures}"
-
-    assert_equal 0, failures, msg
-
-    assert_operator 9,  :<=, successes, msg
-
-    assert_operator 10, :>=, resets   , msg
-
-    assert_operator 20, :<=, refused  , msg
-
-    # Interleaved asserts
-    # UNIX binders do not generate :reset items
-    if l_reset
-      assert_operator r_success, :<, l_reset  , "Interleaved success and reset"
-      assert_operator r_reset  , :<, l_refused, "Interleaved reset and refused"
-    else
-      assert_operator r_success, :<, l_refused, "Interleaved success and refused"
-    end
-
-  ensure
-    if passed?
-      $debugging_info << "#{full_name}\n    #{msg}\n"
-    else
-      $debugging_info << "#{full_name}\n    #{msg}\n#{replies.inspect}\n"
-    end
-  end
-
-  # Send requests 1 per second.  Send 1, then :USR1 server, then send another 24.
+  # Send requests 1 per second.  Send 1, then :USR1 server, then send another 34.
   # All should be responded to, and at least three workers should be used
-  def usr1_all_respond(unix: false)
-    cli_server "-w #{WORKERS} -t 0:5 -q test/rackup/sleep_pid.ru", unix: unix
+  def phased_restart_all_respond
+    cli_server "-w #{WORKERS} -t 0:5 -q test/rackup/sleep_pid.ru"
     threads = []
     replies = []
     mutex = Mutex.new
 
-    s = connect "sleep1", unix: unix
-    replies << read_body(s)
+    replies << read_body('sleep1')
 
-    Process.kill :USR1, @pid
+    run_pumactl 'phased-restart'
 
-    refused = thread_run_refused unix: unix
+    refused = thread_run_refused
 
-    24.times do |delay|
+    34.times do |delay|
       threads << Thread.new do
-        thread_run_pid replies, delay, 1, mutex, refused, unix: unix
+        thread_run_pid replies, delay, 1, mutex, refused
       end
     end
 
@@ -233,7 +180,7 @@ class TestIntegrationCluster < TestIntegration
 
     msg = "#{responses} responses, #{qty_pids} uniq pids"
 
-    assert_equal 25, responses, msg
+    assert_equal 35, responses, msg
     assert_operator qty_pids, :>, 2, msg
 
     msg = "#{responses} responses, #{resets} resets, #{refused} refused"
@@ -241,10 +188,6 @@ class TestIntegrationCluster < TestIntegration
     refute_includes replies, :refused, msg
 
     refute_includes replies, :reset  , msg
-  ensure
-    unless passed?
-      $debugging_info << "#{full_name}\n    #{msg}\n#{replies.inspect}\n"
-    end
   end
 
   def worker_respawn(phase = 1, size = WORKERS)
@@ -307,22 +250,11 @@ class TestIntegrationCluster < TestIntegration
     end.compact
   end
 
-  # used with thread_run to define correct 'refused' errors
-  def thread_run_refused(unix: false)
-    if unix
-      DARWIN ? [Errno::ENOENT, IOError] : [Errno::ENOENT]
-    else
-      DARWIN ? [Errno::ECONNREFUSED, Errno::EPIPE, EOFError] :
-        [Errno::ECONNREFUSED]
-    end
-  end
-
   # used in loop to create several 'requests'
-  def thread_run_pid(replies, delay, sleep_time, mutex, refused, unix: false)
+  def thread_run_pid(replies, delay, sleep_time, mutex, refused)
     begin
       sleep delay
-      s = connect "sleep#{sleep_time}", unix: unix
-      body = read_body(s)
+      body = read_body(connect "sleep#{sleep_time}")
       mutex.synchronize { replies << body }
     rescue Errno::ECONNRESET
       # connection was accepted but then closed
@@ -332,26 +264,29 @@ class TestIntegrationCluster < TestIntegration
       mutex.synchronize { replies << :refused }
     end
   end
+end if ::Puma::HAS_FORK
 
-  # used in loop to create several 'requests'
-  def thread_run_step(replies, delay, sleep_time, step, mutex, refused, unix: false)
-    begin
-      sleep delay
-      s = connect "sleep#{sleep_time}-#{step}", unix: unix
-      body = read_body(s)
-      if body[/\ASlept /]
-        mutex.synchronize { replies[step] = :success }
-      else
-        mutex.synchronize { replies[step] = :failure }
-      end
-    rescue Errno::ECONNRESET
-      # connection was accepted but then closed
-      # client would see an empty response
-      mutex.synchronize { replies[step] = :reset }
-    rescue *refused
-      mutex.synchronize { replies[step] = :refused }
-    end
+# restart sets ENV variables, so these can't run parallel
+# note: not phased-restart
+class TestIntegrationClusterSerial < TestIntegration
+
+  def teardown
+    return if skipped?
+    super
   end
 
+  def test_restart_sgnl
+    skip_unless_signal_exist? :USR2
+    setup_puma bind: :tcp, ctrl: :pid
+    pre, post = restart_server_and_listen "-q -w #{WORKERS} test/rackup/hello.ru"
+    assert_equal "Hello World", pre
+    assert_equal "Hello World", post
+  end
 
-end
+  def test_restart_sock
+    setup_puma bind: :tcp, ctrl: :tcp
+    pre, post = restart_server_and_listen "-q -w #{WORKERS} test/rackup/hello.ru"
+    assert_equal "Hello World", pre
+    assert_equal "Hello World", post
+  end
+end if ::Puma::HAS_FORK

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -2,82 +2,60 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestIntegrationSingle < TestIntegration
-  parallelize_me!
+  parallelize_me! unless Puma.jruby?
 
-  def test_usr2_restart
-    skip_unless_signal_exist? :USR2
-    _, new_reply = restart_server_and_listen("-q test/rackup/hello.ru")
-    assert_equal "Hello World", new_reply
-  end
-
-  # It does not share environments between multiple generations, which would break Dotenv
-  def test_usr2_restart_restores_environment
-    # jruby has a bug where setting `nil` into the ENV or `delete` do not change the
-    # next workers ENV
-    skip_on :jruby
-    skip_unless_signal_exist? :USR2
-
-    initial_reply, new_reply = restart_server_and_listen("-q test/rackup/hello-env.ru")
-
-    assert_includes initial_reply, "Hello RAND"
-    assert_includes new_reply, "Hello RAND"
-    refute_equal initial_reply, new_reply
+  def teardown
+    return if skipped?
+    super
   end
 
   def test_term_exit_code
     skip_unless_signal_exist? :TERM
     skip_on :jruby # JVM does not return correct exit code for TERM
+    setup_puma bind: :tcp, ctrl: :pid
 
     cli_server "test/rackup/hello.ru"
-    _, status = stop_server
+    run_pumactl 'stop'
 
-    assert_equal 15, status
+    begin
+      _, status = Process.wait2 @pid
+      assert_equal 15, status
+    rescue Errno::ECHILD
+    end
   end
 
   def test_term_suppress
     skip_unless_signal_exist? :TERM
+    setup_puma bind: :tcp, ctrl: :pid
 
     cli_server "-C test/config/suppress_exception.rb test/rackup/hello.ru"
-    _, status = stop_server
+    run_pumactl 'stop'
 
-    assert_equal 0, status
+    begin
+      _, status = Process.wait2 @pid
+      assert_equal 0, status
+    rescue Errno::ECHILD
+    end
   end
 
-  def test_term_not_accepts_new_connections
+  def test_stop_closes_listeners_tcp_sgnl
     skip_unless_signal_exist? :TERM
-    skip_on :jruby
+    setup_puma bind: :tcp, ctrl: :pid
+    stop_closes_listeners
+  end
 
-    cli_server 'test/rackup/sleep.ru'
-
-    _stdin, curl_stdout, _stderr, curl_wait_thread = Open3.popen3("curl http://#{HOST}:#{@tcp_port}/sleep10")
-    sleep 1 # ensure curl send a request
-
-    Process.kill :TERM, @pid
-    true while @server.gets !~ /Gracefully stopping/ # wait for server to begin graceful shutdown
-
-    # Invoke a request which must be rejected
-    _stdin, _stdout, rejected_curl_stderr, rejected_curl_wait_thread = Open3.popen3("curl #{HOST}:#{@tcp_port}")
-
-    assert nil != Process.getpgid(@server.pid) # ensure server is still running
-    assert nil != Process.getpgid(rejected_curl_wait_thread[:pid]) # ensure first curl invokation still in progress
-
-    curl_wait_thread.join
-    rejected_curl_wait_thread.join
-
-    assert_match(/Slept 10/, curl_stdout.read)
-    assert_match(/Connection refused/, rejected_curl_stderr.read)
-
-    Process.wait(@server.pid)
-    @server.close unless @server.closed?
-    @server = nil # prevent `#teardown` from killing already killed server
+  def test_stop_closes_listeners_tcp_sock
+    setup_puma bind: :tcp, ctrl: :tcp
+    stop_closes_listeners
   end
 
   def test_int_refuse
     skip_unless_signal_exist? :INT
+    setup_puma bind: :tcp, ctrl: :tcp
 
     cli_server 'test/rackup/hello.ru'
     begin
-      sock = TCPSocket.new(HOST, @tcp_port)
+      sock = connect ''
       sock.close
     rescue => ex
       fail("Port didn't open properly: #{ex.message}")
@@ -86,19 +64,55 @@ class TestIntegrationSingle < TestIntegration
     Process.kill :INT, @pid
     Process.wait @pid
 
-    assert_raises(Errno::ECONNREFUSED) { TCPSocket.new(HOST, @tcp_port) }
+    assert_raises(Errno::ECONNREFUSED) { connect '' }
   end
 
-  def test_siginfo_thread_print
+  def test_thread_status_sgnl
     skip_unless_signal_exist? :INFO
+    setup_puma bind: :tcp, ctrl: :pid
 
     cli_server 'test/rackup/hello.ru'
-    output = []
-    t = Thread.new { output << @server.readlines }
-    Process.kill :INFO, @pid
-    Process.kill :INT , @pid
-    t.join
 
-    assert_match "Thread TID", output.join
+    Process.kill :INFO, @pid
+    assert_io 'Thread: TID'
+  end
+end
+
+# restart sets ENV variables, so these can't run parallel
+# note: not phased-restart
+class TestIntegrationSingleSerial < TestIntegration
+
+  def teardown
+    return if skipped?
+    super
+  end
+
+  # It does not share environments between multiple generations, which would break Dotenv
+  def test_restart_restores_environment_sgnl
+    # jruby has a bug where setting `nil` into the ENV or `delete` do not change the
+    # next workers ENV
+    skip_on :jruby
+    skip_unless_signal_exist? :USR2
+
+    setup_puma bind: :tcp, ctrl: :pid
+    pre, post = restart_server_and_listen "-q test/rackup/hello-env.ru"
+    assert_includes pre , 'Hello RAND'
+    assert_includes post, 'Hello RAND'
+    refute_equal pre, post
+  end
+
+  def test_restart_sgnl
+    skip_unless_signal_exist? :USR2
+    setup_puma bind: :tcp, ctrl: :pid
+    pre, post = restart_server_and_listen "-q test/rackup/hello.ru"
+    assert_equal 'Hello World', pre
+    assert_equal 'Hello World', post
+  end
+
+  def test_restart_sock
+    setup_puma bind: :tcp, ctrl: :tcp
+    pre, post = restart_server_and_listen "-q test/rackup/hello.ru"
+    assert_equal 'Hello World', pre
+    assert_equal 'Hello World', post
   end
 end

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -60,13 +60,11 @@ class TestLauncher < Minitest::Test
     launcher.send(:log_thread_status)
     events.stdout.rewind
 
-    assert_match "Thread TID", events.stdout.read
+    assert_match 'Thread: TID', events.stdout.read
   end
 
   def test_pid_file
-    tmp_file = Tempfile.new("puma-test")
-    tmp_path = tmp_file.path
-    tmp_file.close!
+    tmp_path = "tmp/#{full_file_name}.pid"
 
     conf = Puma::Configuration.new do |c|
       c.pidfile tmp_path

--- a/test/test_plugin.rb
+++ b/test/test_plugin.rb
@@ -2,38 +2,18 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestPlugin < TestIntegration
-  def test_plugin
-    skip "Skipped on Windows Ruby < 2.5.0, Ruby bug" if windows? && RUBY_VERSION < '2.5.0'
-    @tcp_bind = UniquePort.call
-    @tcp_ctrl = UniquePort.call
+  def test_plugin_sock
+    setup_puma bind: :tcp, ctrl: :tcp
 
-    Dir.mkdir("tmp") unless Dir.exist?("tmp")
+    cli_server "-C test/config/plugin1.rb test/rackup/hello.ru"
 
-    cli_server "-b tcp://#{HOST}:#{@tcp_bind} --control-url tcp://#{HOST}:#{@tcp_ctrl} --control-token #{TOKEN} -C test/config/plugin1.rb test/rackup/hello.ru"
     File.open('tmp/restart.txt', mode: 'wb') { |f| f.puts "Restart #{Time.now}" }
 
-    true while (l = @server.gets) !~ /Restarting\.\.\./
-    assert_match(/Restarting\.\.\./, l)
+    assert_io 'Restarting...'
+    assert_io 'Ctrl-C'
+    @pid = File.read(@path_pid, mode: 'rb').strip.to_i
 
-    true while (l = @server.gets) !~ /Ctrl-C/
-    assert_match(/Ctrl-C/, l)
-
-    out = StringIO.new
-
-    cli_pumactl "-C tcp://#{HOST}:#{@tcp_ctrl} -T #{TOKEN} stop"
-    true while (l = @server.gets) !~ /Goodbye/
-
-    @server.close
-    @server = nil
-    out.close
-  end
-
-  private
-
-  def cli_pumactl(argv)
-    pumactl = IO.popen("#{BASE} bin/pumactl #{argv}", "r")
-    @ios_to_close << pumactl
-    Process.wait pumactl.pid
-    pumactl
+  ensure
+    File.unlink('tmp/restart.txt') if File.exist? 'tmp/restart.txt'
   end
 end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -727,7 +727,7 @@ EOF
 
     sock.gets
 
-    assert_operator request_body_wait, :>=, 1000
+    assert_operator request_body_wait, :>=, 990
   end
 
   def test_request_body_wait_chunked
@@ -743,6 +743,6 @@ EOF
 
     sock.gets
 
-    assert_operator request_body_wait, :>=, 1000
+    assert_operator request_body_wait, :>=, 990
   end
 end

--- a/test/test_unix_socket.rb
+++ b/test/test_unix_socket.rb
@@ -9,19 +9,16 @@ class TestPumaUnixSocket < Minitest::Test
   Path = "test/puma.sock"
 
   def setup
-    return unless UNIX_SKT_EXIST
     @server = Puma::Server.new App
     @server.add_unix_listener Path
     @server.run
   end
 
   def teardown
-    return unless UNIX_SKT_EXIST
     @server.stop(true)
   end
 
   def test_server
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
     sock = UNIXSocket.new Path
 
     sock << "GET / HTTP/1.0\r\nHost: blah.com\r\n\r\n"
@@ -30,4 +27,4 @@ class TestPumaUnixSocket < Minitest::Test
 
     assert_equal expected, sock.read(expected.size)
   end
-end
+end if ::Puma::HAS_UNIX


### PR DESCRIPTION
This PR consists of only the test file changes contained in PR https://github.com/puma/puma/pull/2037.

These tests should pass, as shown by the CI for the PR.

The branch from my fork, which is currently just two commits past master, is here:

https://github.com/MSP-Greg/puma/tree/debug-fds

Only lib file change in this PR is a change that adds two constants to lib/puma/detect.rb, `HAS_FORK` and `HAS_UNIX`.

Anyone interested in pulling it apart, have at it...