### PR TITLE
Add pumactl command to print thread backtraces

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,7 +1,7 @@
 ## Master
 
 * Features
-  * Your feature goes here (#Github Number)
+  * Add pumactl `thread-backtraces` command to print thread backtraces (#2053)
 
 * Bugfixes
   * Your bugfix goes here (#Github Number)

--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -57,9 +57,12 @@ module Puma
           rack_response(200, @cli.stats)
 
         when /\/thread-backtraces$/
-          strings = Puma::Events.strings
-          @cli.log_thread_status(strings)
-          rack_response(200, strings.stdout.string)
+          backtraces = []
+          @cli.thread_status do |name, backtrace|
+            backtraces << { name: name, backtrace: backtrace }
+          end
+
+          rack_response(200, backtraces.to_json)
         else
           rack_response 404, "Unsupported action", 'text/plain'
         end

--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -55,6 +55,11 @@ module Puma
 
         when /\/stats$/
           rack_response(200, @cli.stats)
+
+        when /\/thread-backtraces$/
+          strings = Puma::Events.strings
+          @cli.log_thread_status(strings)
+          rack_response(200, strings.stdout.string)
         else
           rack_response 404, "Unsupported action", 'text/plain'
         end

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -11,7 +11,8 @@ require 'socket'
 module Puma
   class ControlCLI
 
-    COMMANDS = %w{halt restart phased-restart start stats status stop reload-worker-directory gc gc-stats}
+    COMMANDS = %w{halt restart phased-restart start stats status stop reload-worker-directory gc gc-stats thread-backtraces}
+    PRINTABLE_COMMANDS = %w{gc-stats stats thread-backtraces}
 
     def initialize(argv, stdout=STDOUT, stderr=STDERR)
       @state = nil
@@ -187,7 +188,7 @@ module Puma
         end
 
         message "Command #{@command} sent success"
-        message response.last if @command == "stats" || @command == "gc-stats"
+        message response.last if PRINTABLE_COMMANDS.include?(@command)
       end
     ensure
       server.close if server && !server.closed?

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -203,6 +203,30 @@ class TestCLI < Minitest::Test
     t.join if UNIX_SKT_EXIST
   end
 
+  def test_control_thread_backtraces
+    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    url = "unix://#{@tmp_path}"
+
+    cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
+                         "--control-url", url,
+                         "--control-token", "",
+                         "test/rackup/lobster.ru"], @events
+
+    t = Thread.new { cli.run }
+
+    wait_booted
+
+    s = UNIXSocket.new @tmp_path
+    s << "GET /thread-backtraces HTTP/1.0\r\n\r\n"
+    body = s.read
+    s.close
+
+    assert_match %r{Thread: TID-}, body.split("\r\n").last
+  ensure
+    cli.launcher.stop if cli
+    t.join if UNIX_SKT_EXIST
+  end
+
   def control_gc_stats(uri, cntl)
     cli = Puma::CLI.new ["-b", uri,
                          "--control-url", cntl,

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -44,7 +44,7 @@ class TestIntegrationCluster < TestIntegration
     Process.kill :INT , @pid
     t.join
 
-    assert_match "Thread TID", output.join
+    assert_match "Thread: TID", output.join
   end
 
   def test_usr2_restart

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -99,6 +99,6 @@ class TestIntegrationSingle < TestIntegration
     Process.kill :INT , @pid
     t.join
 
-    assert_match "Thread TID", output.join
+    assert_match "Thread: TID", output.join
   end
 end

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -57,7 +57,7 @@ class TestLauncher < Minitest::Test
   end
 
   def test_prints_thread_traces
-    launcher.send(:log_thread_status)
+    launcher.log_thread_status(events)
     events.stdout.rewind
 
     assert_match "Thread TID", events.stdout.read

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -57,10 +57,9 @@ class TestLauncher < Minitest::Test
   end
 
   def test_prints_thread_traces
-    launcher.log_thread_status(events)
-    events.stdout.rewind
-
-    assert_match "Thread TID", events.stdout.read
+    launcher.thread_status do |name, _backtrace|
+      assert_match "Thread: TID", name
+    end
   end
 
   def test_pid_file


### PR DESCRIPTION
Completes 1 of 2 items from #1964

This commit adds an endpoint to the status app to print thread
backtraces, and control cli command to call that endpoint.

I tried this locally by starting a server with:

```sh
bundle exec bin/puma test/rackup/hello.ru \
  --control-url="unix://test.sock" \
  --control-token="token"
```

and then printing the backtraces with:

```sh
bundle exec bin/pumactl thread-backtraces \
  --control-url="unix://test.sock" \
  --control-token="token"
```

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [X] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the commit messages.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
