### PR TITLE
PR template Directs Contributors to add "[skip ci]" to PR title

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Please describe your pull request. Thank you for contributing! You're the best.
 - [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
 - [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
 - [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
-- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the commit messages.
+- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
 - [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
 - [ ] I have updated the documentation accordingly.
 - [ ] All new and existing tests passed, including Rubocop.


### PR DESCRIPTION
### Description
My other PR failed the CI check, because the template directs contributors to add `[skip ci]` to the commit message, but it's checking the PR title. I figured the check was correct and the template was in need of an update, but I can see how the reverse might be true, so feel free to close this PR if that is the case.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the commit messages.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
