### PR TITLE
add missing require in spec

### DIFF
--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -1,6 +1,7 @@
 require_relative "helper"
 require_relative "helpers/config_file"
 
+require 'pathname'
 require 'puma/control_cli'
 
 class TestPumaControlCli < TestConfigFileBase


### PR DESCRIPTION
### Description
The `pathname` lib was missing from requirements in `test/test_pumactl.rb` file. This file was failing when ran alone.

Before:
```
20:09:39 ❯ ruby -Ilib test/test_pumactl.rb
           
Run options: --seed 18025

# Running:

...EE...

Fabulous run in 0.133826s, 59.7790 runs/s, 119.5581 assertions/s.

  1) Error:
TestPumaControlCli#test_default_config_file_exist:
NameError: uninitialized constant TestPumaControlCli::Pathname
    test/test_pumactl.rb:29:in `with_config_file'
    test/test_pumactl.rb:95:in `block in test_default_config_file_exist'
    /home/sebastien/Projects/puma/test/helpers/config_file.rb:10:in `with_env'
    test/test_pumactl.rb:94:in `test_default_config_file_exist'

  2) Error:
TestPumaControlCli#test_environment_specific_config_file_exist:
NameError: uninitialized constant TestPumaControlCli::Pathname
    test/test_pumactl.rb:29:in `with_config_file'
    test/test_pumactl.rb:77:in `block in test_environment_specific_config_file_exist'
    /home/sebastien/Projects/puma/test/helpers/config_file.rb:10:in `with_env'
    test/test_pumactl.rb:76:in `test_environment_specific_config_file_exist'
```

After:
```
20:09:40 ❯ ruby -Ilib test/test_pumactl.rb
Run options: --seed 5982

# Running:

........

Fabulous run in 0.125035s, 63.9821 runs/s, 159.9552 assertions/s.

8 runs, 20 assertions, 0 failures, 0 errors, 0 skips
```