### PR TITLE
Remove SSL session warning from tests

### DIFF
--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -91,9 +91,18 @@ class TestPumaServerSSL < Minitest::Test
   def test_request_wont_block_thread
     start_server
     # Open a connection and give enough data to trigger a read, then wait
+    key_contents = File.read File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
+    cert_contents = File.read File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
+    cert = OpenSSL::X509::Certificate.new(cert_contents)
+    key = OpenSSL::PKey.read(key_contents)
+
     ctx = OpenSSL::SSL::SSLContext.new
     ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    ctx.cert = cert
+    ctx.key = key
+
     socket = OpenSSL::SSL::SSLSocket.new TCPSocket.new(@host, @port), ctx
+    socket.connect_nonblock
     socket.write "x"
     sleep 0.1
 


### PR DESCRIPTION
### Description

This PR removes the SSL warning during test runs as described in https://github.com/puma/puma/issues/1997

closes https://github.com/puma/puma/issues/1997

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
