### PR TITLE
do not set frozen-string-literal env var for ruby 2.2 [changelog skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ matrix:
   include:
     - rvm: 2.2.10
       dist: trusty
-      env: OS="Trusty 14.04 OpenSSL 1.0.1"
+      env:
+        - OS="Trusty 14.04 OpenSSL 1.0.1"
+        - RUBYOPT=""
     - rvm: 2.6.4
       dist: xenial
       env: OS="Xenial 16.04 OpenSSL 1.0.2"


### PR DESCRIPTION
### Description
Closes: https://github.com/puma/puma/issues/2064

Ruby 2.2 doesn't accept this literal with a warning in the Travis build:

```
ruby: warning: unknown argument for --enable: `frozen-string-literal'
```

Ideally I'd prefer to have this as a global variable and add an exception for Ruby 2.2 in case there are more versions added later on. But looking at the docs doesn't seem like there is a way to do that: https://docs.travis-ci.com/user/environment-variables/#global-variables.