### PR TITLE
Indent SIGINFO thread backtraces [changelog skip]

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -455,7 +455,7 @@ module Puma
         Signal.trap "SIGINFO" do
           thread_status do |name, backtrace|
             @events.log name
-            @events.log backtrace
+            @events.log backtrace.map { |bt| "  #{bt}" }
           end
         end
       rescue Exception


### PR DESCRIPTION
Before this commit the SIGINFO thread backtraces looked like:

```
Thread: TID-owjccjjvw puma reactor
/path/to/puma/reactor.rb:136 in 'select'
/path/to/puma/reactor.rb:136 in 'run_internal'
/path/to/puma/reactor.rb:313 in 'run_in_thread'
Thread: TID-owjccjjrg puma threadpool reaper
/path/to/puma/thread_pool.rb:262 in 'sleep'
/path/to/puma/thread_pool.rb:262 in 'block in start!'
```

This format can make it a bit difficult to see where one backtrace ends
and the next begins. This commit indents the backtrace lines for clearer
visual separation.

```
Thread: TID-owjccjjvw puma reactor
  /path/to/puma/reactor.rb:136 in 'select'
  /path/to/puma/reactor.rb:136 in 'run_internal'
  /path/to/puma/reactor.rb:313 in 'run_in_thread'
Thread: TID-owjccjjrg puma threadpool reaper
  /path/to/puma/thread_pool.rb:262 in 'sleep'
  /path/to/puma/thread_pool.rb:262 in 'block in start!'
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
