### PR TITLE
Close connection in web server tests [skip changelog]

### DIFF
--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -19,7 +19,7 @@ end
 class WebServerTest < Minitest::Test
   parallelize_me!
 
-  VALID_REQUEST = "GET / HTTP/1.1\r\nHost: www.zedshaw.com\r\nContent-Type: text/plain\r\n\r\n"
+  VALID_REQUEST = "GET / HTTP/1.1\r\nHost: www.zedshaw.com\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n"
 
   def setup
     @tester = TestHandler.new
@@ -63,10 +63,9 @@ class WebServerTest < Minitest::Test
     end
   end
 
-  # TODO: Why does this test take exactly 20 seconds?
   def test_file_streamed_request
     body = "a" * (Puma::Const::MAX_BODY * 2)
-    long = "GET /test HTTP/1.1\r\nContent-length: #{body.length}\r\n\r\n" + body
+    long = "GET /test HTTP/1.1\r\nContent-length: #{body.length}\r\nConnection: close\r\n\r\n" + body
     socket = do_test(long, (Puma::Const::CHUNK_SIZE * 2) - 400)
     assert_match "hello", socket.read
     socket.close


### PR DESCRIPTION
Closes #2049

Before this commit, `test_trickle_attack` and
`test_file_streamed_request` were each taking an extra 20 seconds to run.

Without the `Connection: close` header, the [connection was kept
alive][keep alive] until it timed out after the
[`PERSISTENT_TIMEOUT`][PERSISTENT_TIMEOUT] duration of 20 seconds.

[keep alive]: https://github.com/puma/puma/blob/3835ac74dec5511d637cbc4ebc140c3b8632b447/lib/puma/server.rb#L706-L708
[PERSISTENT_TIMEOUT]: https://github.com/puma/puma/blob/3835ac74dec5511d637cbc4ebc140c3b8632b447/lib/puma/const.rb#L109-L111

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
