### PR TITLE
http11: Remove qsort code paths [changelog skip]

### DIFF
--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -111,21 +111,6 @@ static struct common_field common_http_fields[] = {
 # undef f
 };
 
-/*
- * qsort(3) and bsearch(3) improve average performance slightly, but may
- * not be worth it for lack of portability to certain platforms...
- */
-#if defined(HAVE_QSORT_BSEARCH)
-/* sort by length, then by name if there's a tie */
-static int common_field_cmp(const void *a, const void *b)
-{
-  struct common_field *cfa = (struct common_field *)a;
-  struct common_field *cfb = (struct common_field *)b;
-  signed long diff = cfa->len - cfb->len;
-  return diff ? diff : memcmp(cfa->name, cfb->name, cfa->len);
-}
-#endif /* HAVE_QSORT_BSEARCH */
-
 static void init_common_fields(void)
 {
   unsigned i;
@@ -142,28 +127,10 @@ static void init_common_fields(void)
     }
     rb_global_variable(&cf->value);
   }
-
-#if defined(HAVE_QSORT_BSEARCH)
-  qsort(common_http_fields,
-        ARRAY_SIZE(common_http_fields),
-        sizeof(struct common_field),
-        common_field_cmp);
-#endif /* HAVE_QSORT_BSEARCH */
 }
 
 static VALUE find_common_field_value(const char *field, size_t flen)
 {
-#if defined(HAVE_QSORT_BSEARCH)
-  struct common_field key;
-  struct common_field *found;
-  key.name = field;
-  key.len = (signed long)flen;
-  found = (struct common_field *)bsearch(&key, common_http_fields,
-                                         ARRAY_SIZE(common_http_fields),
-                                         sizeof(struct common_field),
-                                         common_field_cmp);
-  return found ? found->value : Qnil;
-#else /* !HAVE_QSORT_BSEARCH */
   unsigned i;
   struct common_field *cf = common_http_fields;
   for(i = 0; i < ARRAY_SIZE(common_http_fields); i++, cf++) {
@@ -171,7 +138,6 @@ static VALUE find_common_field_value(const char *field, size_t flen)
       return cf->value;
   }
   return Qnil;
-#endif /* !HAVE_QSORT_BSEARCH */
 }
 
 void http_field(puma_parser* hp, const char *field, size_t flen,

--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -10,6 +10,7 @@
 #include "ext_help.h"
 #include <assert.h>
 #include <string.h>
+#include <ctype.h>
 #include "http11_parser.h"
 
 #ifndef MANAGED_STRINGS


### PR DESCRIPTION
### Description
I was just trying to familiarize myself a bit with puma and was trying to track down the usage of the code behind the `if defined(HAVE_QSORT_BSEARCH)`. Looks like it was added back to mongrel in https://github.com/engineyard/mongrel/commit/cd44d2ebc79986933a641b026265867280bf82ea and then added to puma in https://github.com/puma/puma/commit/7c9d988d4de2e08d67f95ca209196427fd89c9af but I don't see it being used.

Looks like it was removed form the Unicorn web server in https://bogomips.org/unicorn.git/commit/?id=9625ad39b73d3d1443ff097e9113d1ec9c9d5f00

Of course this isn't a super helpful change if there's plans to move from the c extension entirely (#1889)..

It doesn't look like there was any test coverage so I didn't add/remove there, but not skipping CI since it is a code change.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] ~I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature~. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
