### PR TITLE
Removes connected_port, implements connected_ports

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -226,19 +226,22 @@ module Puma
       end
 
       host = host[1..-2] if host and host[0..0] == '['
-      s = TCPServer.new(host, port)
+      tcp_server = TCPServer.new(host, port)
       if optimize_for_latency
-        s.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+        tcp_server.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
       end
-      s.setsockopt(Socket::SOL_SOCKET,Socket::SO_REUSEADDR, true)
-      s.listen backlog
-      @connected_port = s.addr[1]
+      tcp_server.setsockopt(Socket::SOL_SOCKET,Socket::SO_REUSEADDR, true)
+      tcp_server.listen backlog
 
-      @ios << s
-      s
+      @ios << tcp_server
+      tcp_server
     end
 
-    attr_reader :connected_port
+    attr_reader :connected_ports
+
+    def connected_ports
+      ios.map { |io| io.addr[1] }
+    end
 
     def inherit_tcp_listener(host, port, fd)
       if fd.kind_of? TCPServer

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -187,9 +187,9 @@ module Puma
       @binder.close_unix_paths
     end
 
-    # Return which tcp port the launcher is using, if it's using TCP
-    def connected_port
-      @binder.connected_port
+    # Return all tcp ports the launcher may be using, TCP or SSL
+    def connected_ports
+      @binder.connected_ports
     end
 
     def restart_args

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -270,6 +270,10 @@ module Puma
         Socket.new io, engine
       end
 
+      def addr
+        @socket.addr
+      end
+
       def close
         @socket.close unless @socket.closed?       # closed? call is for Windows
       end

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -89,7 +89,7 @@ module Puma
 
     attr_accessor :binder, :leak_stack_on_error, :early_hints
 
-    def_delegators :@binder, :add_tcp_listener, :add_ssl_listener, :add_unix_listener, :connected_port
+    def_delegators :@binder, :add_tcp_listener, :add_ssl_listener, :add_unix_listener, :connected_ports
 
     def inherit_binder(bind)
       @binder = bind

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -37,12 +37,10 @@ class TestCLI < Minitest::Test
   end
 
   def test_control_for_tcp
-    tcp  = UniquePort.call
     cntl = UniquePort.call
     url = "tcp://127.0.0.1:#{cntl}/"
 
-    cli = Puma::CLI.new ["-b", "tcp://127.0.0.1:#{tcp}",
-                         "--control-url", url,
+    cli = Puma::CLI.new [ "--control-url", url,
                          "--control-token", "",
                          "test/rackup/lobster.ru"], @events
 
@@ -66,14 +64,12 @@ class TestCLI < Minitest::Test
   end
 
   def test_control_for_ssl
-    app_port = UniquePort.call
     control_port = UniquePort.call
     control_host = "127.0.0.1"
     control_url = "ssl://#{control_host}:#{control_port}?#{ssl_query}"
     token = "token"
 
-    cli = Puma::CLI.new ["-b", "tcp://127.0.0.1:#{app_port}",
-                         "--control-url", control_url,
+    cli = Puma::CLI.new ["--control-url", control_url,
                          "--control-token", token,
                          "test/rackup/lobster.ru"], @events
 

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -167,7 +167,8 @@ class TestEvents < Minitest::Test
     server.add_tcp_listener host, port
     server.run
 
-    sock = TCPSocket.new host, server.connected_port
+    port = server.connected_ports[0]
+    sock = TCPSocket.new host, port
     path = "/"
     params = "a"*1024*10
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -39,14 +39,16 @@ class TestPumaServer < Minitest::Test
   end
 
   def send_http_and_read(req)
-    sock = TCPSocket.new @host, @server.connected_port
+    port = @server.connected_ports[0]
+    sock = TCPSocket.new @host, port
     @ios << sock
     sock << req
     sock.read
   end
 
   def send_http(req)
-    sock = TCPSocket.new @host, @server.connected_port
+    port = @server.connected_ports[0]
+    sock = TCPSocket.new @host, port
     @ios << sock
     sock << req
     sock
@@ -137,7 +139,8 @@ class TestPumaServer < Minitest::Test
     req = Net::HTTP::Get.new '/'
     req['HOST'] = 'example.com'
 
-    res = Net::HTTP.start @host, @server.connected_port do |http|
+    port = @server.connected_ports[0]
+    res = Net::HTTP.start @host, port do |http|
       http.request(req)
     end
 
@@ -153,7 +156,8 @@ class TestPumaServer < Minitest::Test
     req['HOST'] = "example.com"
     req['X_FORWARDED_PROTO'] = "https,http"
 
-    res = Net::HTTP.start @host, @server.connected_port do |http|
+    port = @server.connected_ports[0]
+    res = Net::HTTP.start @host, port do |http|
       http.request(req)
     end
 
@@ -740,7 +744,7 @@ EOF
     }
 
     sock = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n"
-    sleep 1
+    sleep 3
     sock << "4\r\nello\r\n0\r\n\r\n"
 
     sock.gets

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -49,7 +49,7 @@ class TestPathHandler < Minitest::Test
     host = windows? ? "127.0.1.1" : "0.0.0.0"
     opts = { Host: host }
     in_handler(app, opts) do |launcher|
-      hit(["http://#{host}:#{ launcher.connected_port }/test"])
+      hit(["http://#{host}:#{ launcher.connected_ports[0] }/test"])
       assert_equal("/test", @input["PATH_INFO"])
     end
   end

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -55,7 +55,7 @@ class TestRackServer < Minitest::Test
 
     @server.run
 
-    hit(["http://127.0.0.1:#{ @server.connected_port }/test"])
+    hit(["http://127.0.0.1:#{ @server.connected_ports[0] }/test"])
 
     stop
 
@@ -70,7 +70,7 @@ class TestRackServer < Minitest::Test
 
     big = "x" * (1024 * 16)
 
-    Net::HTTP.post_form URI.parse("http://127.0.0.1:#{ @server.connected_port }/test"),
+    Net::HTTP.post_form URI.parse("http://127.0.0.1:#{ @server.connected_ports[0] }/test"),
                  { "big" => big }
 
     stop
@@ -83,7 +83,7 @@ class TestRackServer < Minitest::Test
     @server.app = lambda { |env| input = env; @simple.call(env) }
     @server.run
 
-    hit(["http://127.0.0.1:#{ @server.connected_port }/test/a/b/c"])
+    hit(["http://127.0.0.1:#{ @server.connected_ports[0] }/test/a/b/c"])
 
     stop
 
@@ -100,7 +100,7 @@ class TestRackServer < Minitest::Test
 
     @server.run
 
-    hit(["http://127.0.0.1:#{ @server.connected_port }/test"])
+    hit(["http://127.0.0.1:#{ @server.connected_ports[0] }/test"])
 
     stop
 
@@ -116,7 +116,7 @@ class TestRackServer < Minitest::Test
 
     @server.run
 
-    hit(["http://127.0.0.1:#{ @server.connected_port }/test"])
+    hit(["http://127.0.0.1:#{ @server.connected_ports[0] }/test"])
 
     stop
 

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -34,7 +34,7 @@ class WebServerTest < Minitest::Test
   end
 
   def test_simple_server
-    hit(["http://127.0.0.1:#{@server.connected_port}/test"])
+    hit(["http://127.0.0.1:#{@server.connected_ports[0]}/test"])
     assert @tester.ran_test, "Handler didn't really run"
   end
 
@@ -75,7 +75,7 @@ class WebServerTest < Minitest::Test
 
   def do_test(string, chunk)
     # Do not use instance variables here, because it needs to be thread safe
-    socket = TCPSocket.new("127.0.0.1", @server.connected_port);
+    socket = TCPSocket.new("127.0.0.1", @server.connected_ports[0]);
     request = StringIO.new(string)
     chunks_out = 0
 
@@ -88,7 +88,7 @@ class WebServerTest < Minitest::Test
 
   def do_test_raise(string, chunk, close_after = nil)
     # Do not use instance variables here, because it needs to be thread safe
-    socket = TCPSocket.new("127.0.0.1", @server.connected_port);
+    socket = TCPSocket.new("127.0.0.1", @server.connected_ports[0]);
     request = StringIO.new(string)
     chunks_out = 0
 


### PR DESCRIPTION
### Description
This work starts the effort of removing connected_port. 

Referencing this issue:
https://github.com/puma/puma/issues/1996

I have moved the code around a bit to get all connected_ports, the tests seem
to pass in the appropriate areas.

I want to verify this path before attempting to remove all UniquePort calls in
the tests.

@nateberkopec Also, I wanna talk about removing UniquePort, as it seems like it is being used for some CLI specs and the `control-url`. Is that approriate? Do we expect to be able to pass `0` in as the port for the control and be able to get it's connected port? 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
