### PR TITLE
Inject small delay for busy workers to improve requests distribution

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@
   * Increases maximum URI path length from 2048 to 8196 bytes (#2167)
   * Force shutdown responses can be overridden by using the `lowlevel_error_handler` config (#2203)
   * Faster phased restart and worker timeout (#2121)
+  * Inject small delay for busy workers to improve requests distribution (#2079)
 
 * Deprecations, Removals and Breaking API Changes
   * `Puma.stats` now returns a Hash instead of a JSON string (#2086)

--- a/benchmarks/wrk/cpu_spin.sh
+++ b/benchmarks/wrk/cpu_spin.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -eo pipefail
+
+ITERATIONS=400000
+HOST=127.0.0.1:9292
+URL="http://$HOST/cpu/$ITERATIONS"
+
+MIN_WORKERS=1
+MAX_WORKERS=4
+
+MIN_THREADS=4
+MAX_THREADS=4
+
+DURATION=2
+MIN_CONCURRENT=1
+MAX_CONCURRENT=8
+
+retry() {
+  local tries="$1"
+  local sleep="$2"
+  shift 2
+
+  for i in $(seq 1 $tries); do
+    if eval "$@"; then
+      return 0
+    fi
+
+    sleep "$sleep"
+  done
+
+  return 1
+}
+
+ms() {
+  VALUE=$(cat)
+  FRAC=${VALUE%%[ums]*}
+  case "$VALUE" in
+    *us)
+      echo "scale=1; ${FRAC}/1000" | bc
+      ;;
+
+    *ms)
+      echo "scale=1; ${FRAC}/1" | bc
+      ;;
+
+    *s)
+      echo "scale=1; ${FRAC}*1000/1" | bc
+      ;;
+  esac
+}
+
+run_wrk() {
+  result=$(wrk -H "Connection: Close" -c "$wrk_c" -t "$wrk_t" -d "$DURATION" --latency "$@" | tee -a wrk.txt)
+  req_sec=$(echo "$result" | grep "^Requests/sec:" | awk '{print $2}')
+  latency_avg=$(echo "$result" | grep "^\s*Latency.*%" | awk '{print $2}' | ms)
+  latency_stddev=$(echo "$result" | grep "^\s*Latency.*%" | awk '{print $3}' | ms)
+  latency_50=$(echo "$result" | grep "^\s*50%" | awk '{print $2}' | ms)
+  latency_75=$(echo "$result" | grep "^\s*75%" | awk '{print $2}' | ms)
+  latency_90=$(echo "$result" | grep "^\s*90%" | awk '{print $2}' | ms)
+  latency_99=$(echo "$result" | grep "^\s*99%" | awk '{print $2}' | ms)
+
+  echo -e "$workers\t$threads\t$wrk_c\t$wrk_t\t$req_sec\t$latency_avg\t$latency_stddev\t$latency_50\t$latency_75\t$latency_90\t$latency_99"
+}
+
+run_concurrency_tests() {
+  echo
+  echo -e "PUMA_W\tPUMA_T\tWRK_C\tWRK_T\tREQ_SEC\tL_AVG\tL_DEV\tL_50%\tL_75%\tL_90%\tL_99%"
+  for wrk_c in $(seq $MIN_CONCURRENT $MAX_CONCURRENT); do
+    wrk_t="$wrk_c"
+    eval "$@"
+    sleep 1
+  done
+  echo
+}
+
+with_puma() {
+  # start puma and wait for 10s for it to start
+  bundle exec bin/puma -w "$workers" -t "$threads" -b "tcp://$HOST" -C test/config/cpu_spin.rb &
+  local puma_pid=$!
+  trap "kill $puma_pid" EXIT
+
+  # wait for Puma to be up
+  if ! retry 10 1s curl --fail "$URL" &>/dev/null; then
+    echo "Failed to connect to $URL."
+    return 1
+  fi
+
+  # execute testing command
+  eval "$@"
+  kill "$puma_pid" || true
+  trap - EXIT
+  wait
+}
+
+for workers in $(seq $MIN_WORKERS $MAX_WORKERS); do
+  for threads in $(seq $MIN_THREADS $MAX_THREADS); do
+    with_puma \
+      run_concurrency_tests \
+      run_wrk "$URL"
+  done
+done

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -664,6 +664,18 @@ module Puma
       @options[:shutdown_debug] = val
     end
 
+    # Controls an injected delay (in seconds) before
+    # accepting new socket
+    # if we are already processing requests,
+    # it gives a time for less busy workers
+    # to pick workbefore us
+    #
+    # This only affects Ruby MRI implementation
+    # The best value is between 0.001 (1ms) to 0.010 (10ms)
+    def wait_for_less_busy_worker(val)
+      @options[:wait_for_less_busy_worker] = val.to_f
+    end
+
     # Control how the remote address of the connection is set. This
     # is configurable because to calculate the true socket peer address
     # a kernel syscall is required which for very fast rack handlers

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -283,6 +283,9 @@ module Puma
               else
                 begin
                   pool.wait_until_not_full
+                  pool.wait_for_less_busy_worker(
+                    @options[:wait_for_less_busy_worker].to_f)
+
                   if io = sock.accept_nonblock
                     client = Client.new io, @binder.env(sock)
                     if remote_addr_value

--- a/test/config/cpu_spin.rb
+++ b/test/config/cpu_spin.rb
@@ -1,0 +1,17 @@
+# call with "GET /cpu/<d> HTTP/1.1\r\n\r\n",
+# where <d> is the number of iterations
+
+require 'benchmark'
+
+# configure `wait_for_less_busy_workers` based on ENV, default `true`
+wait_for_less_busy_worker ENV.fetch('WAIT_FOR_LESS_BUSY_WORKERS', '0.005').to_f
+
+app do |env|
+  iterations = (env['REQUEST_PATH'][/\/cpu\/(\d.*)/,1] || '1000').to_i
+
+  duration = Benchmark.measure do
+    iterations.times { rand }
+  end
+
+  [200, {"Content-Type" => "text/plain"}, ["Run for #{duration.total} #{Process.pid}"]]
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -116,6 +116,7 @@ module TestSkips
       when :darwin  then "Skip unless darwin"  unless RUBY_PLATFORM[/darwin/]
       when :jruby   then "Skip unless JRuby"   unless Puma.jruby?
       when :windows then "Skip unless Windows" unless Puma.windows?
+      when :mri     then "Skip unless MRI"     unless Puma.mri?
       else false
     end
     skip skip_msg, bt if skip_msg

--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -1,0 +1,106 @@
+require_relative "helper"
+require "puma/events"
+
+class TestBusyWorker < Minitest::Test
+  parallelize_me!
+
+  def setup
+    @ios = []
+    @server = nil
+  end
+
+  def teardown
+    @server.stop(true) if @server
+    @ios.each {|i| i.close unless i.closed?}
+  end
+
+  def new_connection
+    TCPSocket.new('127.0.0.1', @server.connected_ports[0]).tap {|s| @ios << s}
+  rescue IOError
+    Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+    retry
+  end
+
+  def send_http(req)
+    new_connection << req
+  end
+
+  def send_http_and_read(req)
+    send_http(req).read
+  end
+
+  def with_server(**options, &app)
+    @requests_count = 0 # number of requests processed
+    @requests_running = 0 # current number of requests running
+    @requests_max_running = 0 # max number of requests running in parallel
+    @mutex = Mutex.new
+
+    request_handler = ->(env) do
+      @mutex.synchronize do
+        @requests_count += 1
+        @requests_running += 1
+        if @requests_running > @requests_max_running
+          @requests_max_running = @requests_running
+        end
+      end
+
+      begin
+        yield(env)
+      ensure
+        @mutex.synchronize do
+          @requests_running -= 1
+        end
+      end
+    end
+
+    @server = Puma::Server.new request_handler, Puma::Events.strings, **options
+    @server.min_threads = options[:min_threads] || 0
+    @server.max_threads = options[:max_threads] || 10
+    @server.add_tcp_listener '127.0.0.1', 0
+    @server.run
+  end
+
+  # Multiple concurrent requests are not processed
+  # sequentially as a small delay is introduced
+  def test_multiple_requests_waiting_on_less_busy_worker
+    skip_unless :mri
+
+    with_server(wait_for_less_busy_worker: 1.0) do |_|
+      sleep(0.1)
+
+      [200, {}, [""]]
+    end
+
+    n = 2
+
+    Array.new(n) do
+      Thread.new { send_http_and_read "GET / HTTP/1.0\r\n\r\n" }
+    end.each(&:join)
+
+    assert_equal n, @requests_count, "number of requests needs to match"
+    assert_equal 0, @requests_running, "none of requests needs to be running"
+    assert_equal 1, @requests_max_running, "maximum number of concurrent requests needs to be 1"
+  end
+
+  # Multiple concurrent requests are processed
+  # in parallel as a delay is disabled
+  def test_multiple_requests_processing_in_parallel
+    skip_unless :mri
+
+    with_server(wait_for_less_busy_worker: 0.0) do |_|
+      sleep(0.1)
+
+      [200, {}, [""]]
+    end
+
+    n = 4
+
+    Array.new(n) do
+      Thread.new { send_http_and_read "GET / HTTP/1.0\r\n\r\n" }
+    end.each(&:join)
+
+    assert_equal n, @requests_count, "number of requests needs to match"
+    assert_equal 0, @requests_running, "none of requests needs to be running"
+    assert_equal n, @requests_max_running, "maximum number of concurrent requests needs to match"
+  end
+end


### PR DESCRIPTION
**Describe the bug**

We at GitLab.com are production testing Puma with prepartions for switching to it.
However, we noticed a few oddness when running Puma vs Unicorn in mostly similar configurations.

An worker of Puma when running in Cluster mode has no knowledge about siblings and their utilisation. This results in some of the sockets to be accepted by sub-optimal workers, that are already processing requests. This does have a statistical significance as in my local testing, and GitLab.com testing in the above workload we see an increase of around 20-30% of durations on P60%. Which is a significant increase.

**Capacity of Puma**

Capacity of Puma web-server is defined by `workers * threads`. Each of these
form a slot that can accept a new request. It means that each slot can accept
a new request at random (effectively round-robin).

Now, what happens if we have 2 requests waiting to be processed and two workers,
and two threads:

1. Our total capacity is 4 (W2 * T2),
2. Each request can be assigned at random to any worker, even the worker that is
   processing currently request, as we do not control that,
3. It means that in ideal scenario if we have 2 requests, for the optimal performance
   they should be assigned to two separate workers,
4. Puma does not implement any mechanism for 3., rather it is first accepting, first wins.
   It does mean that it is plausible that the two requests will be assigned in sub-optimal
   way: to the single worker, but multiple threads.
5. If the two requests are being processed by the same worker, they do share CPU-time,
   it means that they processing time is increased by the noisy neighbor due to Ruby MRI GVL.

Interestingly, the same latency impact is present on `Sidekiq`, we just don't see it,
as we do not care about real-time aspect of background processing that much.

However, the scheduling changes can improve `Sidekiq` performance as well if we would
target `sidekiq` as well.

This is more described in detail here: https://gitlab.com/gitlab-com/gl-infra/infrastructure/issues/8334#note_247859173

**Our Configuration**

We do run Puma and Unicorn in the following configurations:

1. Puma runs in `W16/T2`, the `16` corresponds to 16 CPUs available, nodes do not process anything else,
2. Unicorn runs in `W30`, the `30` seems like some artificial factor taken to have some sort of node saturation,
3. The nodes are lightly utilised, peeking at around 45% of CPU usage,
4. We seem to process around 70-80rq/sec.

We did notice oddness in Puma scheduling, as it was sometimes hitting the workers that are already processing requests. This resulted in increase of latency and duration of requests processing, even though we had a ton of spare capacity on other workers that were simply idle.

The nodes are configured today like that, due to graceful restart/overwrite/shutdown of Unicorn, to have a spare capacity to handle as many as twice amount of regular `W30`. They are highly underutilized on average due to that, but this is something to change. 

**Data**

The exact data are presented here: https://gitlab.com/gitlab-com/gl-infra/infrastructure/issues/8334#note_247824814 with the description of what we are seeing.

**Expected behavior: Ideal-scheduling algorithm in multi-threaded scenario**

In ideal scenario we would always want to use our capacity efficiently:

1. Assign to free workers first, as they do offer the best latency,
1. Assign to workers with the least amount of other requests being processed, as they are the least busy,
1. Assign to workers that are close to finish the requests being processed, as they will have a free capacity in the future (this is hard to implement, as this becomes a quite complex heuristic to understand the request completion time).

Currently, Puma does nothing from that. For round-robin we pay around 20% of ~performance penalty due to sub-optimal request processing assignment.

It is expected that the closer we get to 100% CPU-usage the more expected is that the Puma-non-scheduling algorithm will not be a problem, due to node being saturated, and threads by balanced by the kernel.

### Workaround

We can insert very small delay for busy workers, by assuming that they are already busy doing other work, and even if we schedule requests on them it will not really make them process requests faster.

The value of `5ms` is tested to provide a compromise between throughput and a delay, as we don't really want to delay forever. There's a test that tries to test that value and provide a benchmark which shows when this delay makes a difference.

### Your checklist for this pull request

- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
