### PR TITLE
Implement separate tokens for control and status actions

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 * Features
   * Add pumactl `thread-backtraces` command to print thread backtraces (#2053)
   * Configuration: `environment` is read from `RAILS_ENV`, if `RACK_ENV` can't be found (#2022)
+  * Add `status-token` to implement separate tokens for control and status actions (#2081)
 
 * Bugfixes
   * Your bugfix goes here (#Github Number)

--- a/README.md
+++ b/README.md
@@ -196,13 +196,17 @@ $ puma -b 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert&no_tlsv1=true'
 
 ### Control/Status Server
 
-Puma has a built-in status and control app that can be used to query and control Puma.
+Puma has a built-in control and status app that can be used to manage and query Puma.
 
 ```
 $ puma --control-url tcp://127.0.0.1:9293 --control-token foo
 ```
 
-Puma will start the control server on localhost port 9293. All requests to the control server will need to include control token (in this case, `token=foo`) as a query parameter. This allows for simple authentication. Check out [status.rb](https://github.com/puma/puma/blob/master/lib/puma/app/status.rb) to see what the status app has available.
+Puma will start the control server on localhost port 9293.
+All requests to the control server will need to include control token (in this case, `token=foo`) as a query parameter.
+This allows for simple authentication. 
+
+Check out [status.rb](https://github.com/puma/puma/blob/master/lib/puma/app/status.rb) to see what actions are available.
 
 You can also interact with the control server via `pumactl`. This command will restart Puma:
 
@@ -211,6 +215,9 @@ $ pumactl --control-url 'tcp://127.0.0.1:9293' --control-token foo restart
 ```
 
 To see a list of `pumactl` options, use `pumactl --help`.
+
+Note: To specify separate tokens for control and status actions, define both `control-token` and `status-token`. 
+For backwards compatibility, the control token is authorized to provide access to both control and status actions.
 
 ### Configuration File
 

--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -9,37 +9,42 @@ module Puma
     class Status
       OK_STATUS = '{ "status": "ok" }'.freeze
 
-      def initialize(cli, token = nil)
+      def initialize(cli, control_auth_token = nil, status_auth_token = nil)
         @cli = cli
-        @auth_token = token
+        @control_token = control_auth_token
+        @status_token = status_auth_token
       end
 
       def call(env)
-        unless authenticate(env)
-          return rack_response(403, 'Invalid auth token', 'text/plain')
-        end
-
         case env['PATH_INFO']
+
+        # Actions requiring the control token, if specified.
+
         when /\/stop$/
+          return invalid_token('stop') unless authenticate_control(env)
           @cli.stop
           rack_response(200, OK_STATUS)
 
         when /\/halt$/
+          return invalid_token('halt') unless authenticate_control(env)
           @cli.halt
           rack_response(200, OK_STATUS)
 
         when /\/restart$/
+          return invalid_token('restart') unless authenticate_control(env)
           @cli.restart
           rack_response(200, OK_STATUS)
 
         when /\/phased-restart$/
+          return invalid_token('phased restart') unless authenticate_control(env)
           if !@cli.phased_restart
-            rack_response(404, '{ "error": "phased restart not available" }')
+            rack_response(404, '{ "error": "phased_restart not available" }')
           else
             rack_response(200, OK_STATUS)
           end
 
         when /\/reload-worker-directory$/
+          return invalid_token('reload worker directory') unless authenticate_control(env)
           if !@cli.send(:reload_worker_directory)
             rack_response(404, '{ "error": "reload_worker_directory not available" }')
           else
@@ -47,32 +52,57 @@ module Puma
           end
 
         when /\/gc$/
+          return invalid_token('gc') unless authenticate_control(env)
           GC.start
           rack_response(200, OK_STATUS)
 
+        # Actions requiring the control or status tokens, if specified.
+
         when /\/gc-stats$/
+          return invalid_token('access gc stats') unless authenticate_status(env)
           rack_response(200, GC.stat.to_json)
 
         when /\/stats$/
+          return invalid_token('access stats') unless authenticate_status(env)
           rack_response(200, @cli.stats)
 
         when /\/thread-backtraces$/
+          return invalid_token('access thread backtraces') unless authenticate_status(env)
           backtraces = []
           @cli.thread_status do |name, backtrace|
             backtraces << { name: name, backtrace: backtrace }
           end
-
           rack_response(200, backtraces.to_json)
+
+        # Require the control token, if specified, when responding to unsupported actions.
+
         else
+          return invalid_token unless authenticate_control(env)
           rack_response 404, "Unsupported action", 'text/plain'
         end
       end
 
       private
 
-      def authenticate(env)
-        return true unless @auth_token
-        env['QUERY_STRING'].to_s.split(/&;/).include?("token=#{@auth_token}")
+      def authenticate(env, token)
+        return true unless token
+        env['QUERY_STRING'].to_s.split(/&;/).include?("token=#{token}")
+      end
+
+      def authenticate_control(env)
+        authenticate(env, @control_token)
+      end
+
+      # The control token includes access to status actions.
+      # But when no status token is defined, no token is needed, so the control token is not checked.
+
+      def authenticate_status(env)
+        authenticate(env, @status_token) || authenticate(env, @control_token)
+      end
+
+      def invalid_token(action = '')
+        action = "to #{action}" if action
+        rack_response(403, "Invalid auth token#{action}", 'text/plain')
       end
 
       def rack_response(status, body, content_type='application/json')

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -119,7 +119,12 @@ module Puma
 
           o.on "--control-token TOKEN",
             "The token to use as authentication for the control server" do |arg|
-            @control_options[:auth_token] = arg
+            @control_options[:control_auth_token] = arg
+          end
+
+          o.on "--status-token TOKEN",
+            "The token to use as authentication for the status server" do |arg|
+            @control_options[:status_auth_token] = arg
           end
 
           o.on "-d", "--daemon", "Daemonize the server into the background" do

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -135,13 +135,18 @@ module Puma
         # symbols as option values.
         #
         # See: https://github.com/puma/puma/issues/1193#issuecomment-305995488
-        auth_token = 'none'
+        control_auth_token = 'none'
+        status_auth_token = 'none'
       else
-        auth_token = opts[:auth_token]
-        auth_token ||= Configuration.random_token
+        control_auth_token = opts[:control_auth_token]
+        control_auth_token ||= Configuration.random_token
+        status_auth_token = opts[:status_auth_token]
+        status_auth_token ||= Configuration.random_token
       end
 
-      @options[:control_auth_token] = auth_token
+      @options[:control_auth_token] = control_auth_token
+      @options[:status_auth_token] = status_auth_token
+
       @options[:control_url_umask] = opts[:umask] if opts[:umask]
     end
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -113,6 +113,7 @@ module Puma
       sf.pid = Process.pid
       sf.control_url = @options[:control_url]
       sf.control_auth_token = @options[:control_auth_token]
+      sf.status_auth_token = @options[:status_auth_token]
 
       sf.save path
     end

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -54,11 +54,15 @@ module Puma
 
       uri = URI.parse str
 
-      if token = @options[:control_auth_token]
-        token = nil if token.empty? || token == 'none'
+      if control_auth_token = @options[:control_auth_token]
+        control_auth_token = nil if control_auth_token.empty? || control_auth_token == 'none'
       end
 
-      app = Puma::App::Status.new @launcher, token
+      if status_auth_token = @options[:status_auth_token]
+        status_auth_token = nil if status_auth_token.empty? || status_auth_token == 'none'
+      end
+
+      app = Puma::App::Status.new @launcher, control_auth_token, status_auth_token
 
       control = Puma::Server.new app, @launcher.events
       control.min_threads = 0

--- a/lib/puma/state_file.rb
+++ b/lib/puma/state_file.rb
@@ -16,7 +16,7 @@ module Puma
       @options = YAML.load File.read(path)
     end
 
-    FIELDS = %w!control_url control_auth_token pid!
+    FIELDS = %w!control_url control_auth_token status_auth_token pid!
 
     FIELDS.each do |f|
       define_method f do


### PR DESCRIPTION
Implements https://github.com/puma/puma/issues/2081

Prior to this commit ...

Authentication for control and status actions is implemented via the same token.

With this commit ...

Puma implements a 'status-token' limited to status actions in Puma::App::Status.

If 'control-token' is defined, it is required for any action.
If 'control-token' is undefined, no token is required for any action.
If 'status-token' is undefined, no status token is required for status actions.

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
