### PR TITLE
Implement authorization for control/status actions

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 * Features
   * Add pumactl `thread-backtraces` command to print thread backtraces (#2053)
   * Configuration: `environment` is read from `RAILS_ENV`, if `RACK_ENV` can't be found (#2022)
+  * Add `control_auth_actions` to authorize specific control and status actions (#2081)
 
 * Bugfixes
   * Your bugfix goes here (#Github Number)

--- a/README.md
+++ b/README.md
@@ -196,13 +196,25 @@ $ puma -b 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert&no_tlsv1=true'
 
 ### Control/Status Server
 
-Puma has a built-in status and control app that can be used to query and control Puma.
+Puma includes a built-in status app that can be used to control and query Puma.
 
 ```
 $ puma --control-url tcp://127.0.0.1:9293 --control-token foo
 ```
 
-Puma will start the control server on localhost port 9293. All requests to the control server will need to include control token (in this case, `token=foo`) as a query parameter. This allows for simple authentication. Check out [status.rb](https://github.com/puma/puma/blob/master/lib/puma/app/status.rb) to see what the status app has available.
+Puma will start the control server on localhost port 9293.
+All requests to the control server will need to include a control token (in this case, `token=foo`) as a query parameter.
+This allows for simple authentication.
+
+You can limit the actions authorized via this interface by specifying `control-auth-actions`.
+
+```
+$ puma --control-url tcp://127.0.0.1:9293 --control-token foo --control-auth-actions gc,stats
+```
+
+By default, all actions are authorized.
+
+Review [status.rb](https://github.com/puma/puma/blob/master/lib/puma/app/status.rb) to see all available actions.
 
 You can also interact with the control server via `pumactl`. This command will restart Puma:
 

--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -9,9 +9,10 @@ module Puma
     class Status
       OK_STATUS = '{ "status": "ok" }'.freeze
 
-      def initialize(cli, token = nil)
+      def initialize(cli, token = nil, actions = [])
         @cli = cli
         @auth_token = token
+        @auth_actions = actions
       end
 
       def call(env)
@@ -20,49 +21,67 @@ module Puma
         end
 
         case env['PATH_INFO']
-        when /\/stop$/
+        when /\/(stop)$/
+          action = $1
+          return not_authorized(action) unless authorized(action)
           @cli.stop
           rack_response(200, OK_STATUS)
 
-        when /\/halt$/
+        when /\/(halt)$/
+          action = $1
+          return not_authorized(action) unless authorized(action)
           @cli.halt
           rack_response(200, OK_STATUS)
 
-        when /\/restart$/
+        when /\/(restart)$/
+          action = $1
+          return not_authorized(action) unless authorized(action)
           @cli.restart
           rack_response(200, OK_STATUS)
 
-        when /\/phased-restart$/
+        when /\/(phased-restart)$/
+          action = $1
+          return not_authorized(action) unless authorized(action)
           if !@cli.phased_restart
             rack_response(404, '{ "error": "phased restart not available" }')
           else
             rack_response(200, OK_STATUS)
           end
 
-        when /\/reload-worker-directory$/
+        when /\/(reload-worker-directory)$/
+          action = $1
+          return not_authorized(action) unless authorized(action)
           if !@cli.send(:reload_worker_directory)
             rack_response(404, '{ "error": "reload_worker_directory not available" }')
           else
             rack_response(200, OK_STATUS)
           end
 
-        when /\/gc$/
+        when /\/(gc)$/
+          action = $1
+          return not_authorized(action) unless authorized(action)
           GC.start
           rack_response(200, OK_STATUS)
 
-        when /\/gc-stats$/
+        when /\/(gc-stats)$/
+          action = $1
+          return not_authorized(action) unless authorized(action)
           rack_response(200, GC.stat.to_json)
 
-        when /\/stats$/
+        when /\/(stats)$/
+          action = $1
+          return not_authorized(action) unless authorized(action)
           rack_response(200, @cli.stats)
 
-        when /\/thread-backtraces$/
+        when /\/(thread-backtraces)$/
+          action = $1
+          return not_authorized(action) unless authorized(action)
           backtraces = []
           @cli.thread_status do |name, backtrace|
             backtraces << { name: name, backtrace: backtrace }
           end
-
           rack_response(200, backtraces.to_json)
+
         else
           rack_response 404, "Unsupported action", 'text/plain'
         end
@@ -73,6 +92,15 @@ module Puma
       def authenticate(env)
         return true unless @auth_token
         env['QUERY_STRING'].to_s.split(/&;/).include?("token=#{@auth_token}")
+      end
+
+      def authorized(action)
+        return true if @auth_actions.empty?
+        @auth_actions.include? action
+      end
+
+      def not_authorized(action)
+        rack_response(401, "Action '#{action}' not authorized", 'text/plain')
       end
 
       def rack_response(status, body, content_type='application/json')

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -122,6 +122,11 @@ module Puma
             @control_options[:auth_token] = arg
           end
 
+          o.on "--control-auth-actions ACTIONS", Array,
+            "Comma-delimited list of authorized actions for the control server" do |list|
+            @control_options[:auth_actions] = list
+          end
+
           o.on "-d", "--daemon", "Daemonize the server into the background" do
             user_config.daemonize
             user_config.quiet

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -142,6 +142,7 @@ module Puma
       end
 
       @options[:control_auth_token] = auth_token
+      @options[:control_auth_actions] = opts[:auth_actions] || []
       @options[:control_url_umask] = opts[:umask] if opts[:umask]
     end
 

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -58,7 +58,9 @@ module Puma
         token = nil if token.empty? || token == 'none'
       end
 
-      app = Puma::App::Status.new @launcher, token
+      actions = @options[:control_auth_actions]
+
+      app = Puma::App::Status.new @launcher, token, actions
 
       control = Puma::Server.new app, @launcher.events
       control.min_threads = 0

--- a/test/test_app_status.rb
+++ b/test/test_app_status.rb
@@ -61,6 +61,30 @@ class TestAppStatus < Minitest::Test
     assert_equal 404, status
   end
 
+  def test_unauthorized_with_auth_actions
+    @app.instance_variable_set(:@auth_actions, ['stats'])
+
+    status, _, _ = lint('/stop')
+
+    assert_equal 401, status
+  end
+
+  def test_authorized_with_auth_actions
+    @app.instance_variable_set(:@auth_actions, ['stats'])
+
+    status, _, _ = lint('/stats')
+
+    assert_equal 200, status
+  end
+
+  def test_authorized_without_auth_actions
+    @app.instance_variable_set(:@auth_actions, [])
+
+    status, _, _ = lint('/stop')
+
+    assert_equal 200, status
+  end
+
   def test_stop
     status, _ , app = lint('/stop')
 


### PR DESCRIPTION
Prior to this commit ...

Puma allows access to all (control and status) actions in Puma::App::Status.

With this commit ...

Puma implements 'control_auth_actions' to authorize only specific actions.

If 'control_auth_actions' is undefined, Puma allows access to all actions.
This maintains the default behavior, for backward-compatibility.

Closes #2081

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
