### PR TITLE
GitHub Actions no longer have Ruby 2.3.x, checkout w/RVM [changelog skip]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,21 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-16.04', 'ubuntu-18.04', 'macos', 'windows-latest' ]
-        ruby: [ '2.3.x', '2.4.x', '2.5.x', '2.6.x' ]
-        exclude:
-        - os: ubuntu-16.04
-          ruby: 2.4.x
-        - os: ubuntu-16.04
-          ruby: 2.5.x
-        - os: ubuntu-16.04
-          ruby: 2.6.x
-        - os: ubuntu-18.04
-          ruby: 2.3.x
-        - os: macos
-          ruby: 2.3.x
-        - os: windows-latest
-          ruby: 2.3.x
+        os: [ 'ubuntu-18.04', 'macos', 'windows-latest' ]
+        ruby: [ '2.4.x', '2.5.x', '2.6.x' ]
     steps:
     - name: repo checkout
       uses: actions/checkout@v1
@@ -64,6 +51,52 @@ jobs:
       run:  bundle exec rake compile
     - name: test
       run:  bundle exec rake
+      timeout-minutes: 10
+      env:
+        CI: true
+        TESTOPTS: -v
+        RUBYOPT: --enable-frozen-string-literal
+
+  rvm:
+    name: >-
+      OS: ${{ matrix.os }}  Ruby: ${{ matrix.cfg.ruby }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-18.04' ]
+        cfg:
+          - { ruby: '2.3.8' , openssl: 'libssl1.0-dev' }
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up RVM
+      run: |
+        curl -sSL https://get.rvm.io | bash
+    - name: Set up Ruby
+      run: |
+        source $HOME/.rvm/scripts/rvm
+        rvm install ${{ matrix.cfg.ruby }} --binary --autolibs=disable
+        rvm --default use ${{ matrix.cfg.ruby }}
+
+    - name: install ragel, openssl
+      run: sudo apt-get --quiet --yes install ragel ${{ matrix.cfg.openssl }}
+
+    - name: RubyGems, Bundler Update
+      run:  |
+        source $HOME/.rvm/scripts/rvm
+        gem update --system --no-document --conservative
+    - name: bundle install
+      run:  |
+        source $HOME/.rvm/scripts/rvm
+        bundle install --jobs 4 --retry 3
+    - name: compile
+      run:  |
+        source $HOME/.rvm/scripts/rvm
+        bundle exec rake compile
+    - name: test
+      run:  |
+        source $HOME/.rvm/scripts/rvm
+        bundle exec rake
       timeout-minutes: 10
       env:
         CI: true


### PR DESCRIPTION
Using RVM to install 2.3.8 like RubyGems does: https://github.com/rubygems/rubygems/blob/v3.1.2/.github/workflows/ubuntu-rvm.yml

...with OpenSSL 1.0.2 like @MSP-Greg says: #2087 (comment)


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` to all commit messages.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
