### PR TITLE
Least-busy load balancing in cluster mode

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -187,7 +187,8 @@ module Puma
         :logger => STDOUT,
         :persistent_timeout => Const::PERSISTENT_TIMEOUT,
         :first_data_timeout => Const::FIRST_DATA_TIMEOUT,
-        :raise_exception_on_sigterm => true
+        :raise_exception_on_sigterm => true,
+        :load_balancing => :least_busy
       }
     end
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -736,5 +736,26 @@ module Puma
       end
     end
 
+    # Control the load-balancing algorithm used to route incoming connections
+    # to workers.
+
+    # Built-in symbol values:
+    #
+    # * :least_busy  - [default] Select worker with least number of busy threads,
+    #                  using the oldest last request as a tie-breaker.
+    # * :round_robin - Select worker with the oldest last request, which will
+    #                  distribute requests evenly among all workers.
+    # * :pile_up     - Select a worker with non-zero capacity that has the lowest index.
+    #                  This will cause requests to 'pile up' on workers until
+    #                  they reach capacity.
+    # * :random      - Select a random worker.
+    #
+    # You can also pass a Proc to specify your own custom routing algorithm. The proc is
+    # passed an Array[Worker] argument and expects a Worker return value.
+    #
+    # @note Cluster mode only.
+    def load_balancing(algorithm=:least_busy)
+      @options[:load_balancing] = algorithm
+    end
   end
 end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -140,7 +140,7 @@ class TestIntegrationCluster < TestIntegration
   def term_closes_listeners(unix: false)
     skip_unless_signal_exist? :TERM
 
-    cli_server "-w #{WORKERS} -t 0:6 -q test/rackup/sleep_step.ru", unix: unix
+    cli_server "-w #{WORKERS} -t 1:6 -q test/rackup/sleep_step.ru", unix: unix
     threads = []
     replies = []
     mutex = Mutex.new


### PR DESCRIPTION
### Description

Proof-of-concept HTTP request load-balancing using a 'least-busy' algorithm for cluster mode. Instead of having each worker-process run a select-loop concurrently on the listener and race to accept incoming connections, this PR runs a select-loop on the listener in the parent process and forwards individual client TCP connections to worker-processes by sending the file descriptor through a unix domain socket-pair unique to each worker. With this approach, the parent gets to pick which worker gets the connection using a specific routing algorithm.

In order to implement 'least busy' routing for the parent process to select the worker to send each client connection, each worker updates the parent with its current capacity whenever its threads start or finish processing, and the parent selects the worker with the highest capacity. (If two workers report the same capacity, it chooses the one with the oldest last-request.)

This PR was designed to solve #1254 / #2078 as an alternative approach to #1646, #1920 and #2079. The configuration of custom load-balancing algorithms via DSL could support other use-cases as well.

### Performance

Runs the benchmark noted in https://github.com/puma/puma/pull/2079#issuecomment-564809228 with **4013** requests/sec.

[todo - will put the results of some other micro-benchmarks/comparisons here]

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
