### PR TITLE
Remove unused loader argument from Plugin initializer

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,9 @@
   * Your bugfix goes here (#Github Number)
   * Windows update extconf.rb for use with ssp and varied Ruby/MSYS2 combinations (#2069)
 
+* Refactor
+  * Remove unused loader argument from Plugin initializer (#2095)
+
 ## 4.3.1 and 3.12.2 / 2019-12-05
 
 * Security

--- a/lib/puma/plugin.rb
+++ b/lib/puma/plugin.rb
@@ -10,7 +10,7 @@ module Puma
 
     def create(name)
       if cls = Plugins.find(name)
-        plugin = cls.new(Plugin)
+        plugin = cls.new
         @instances << plugin
         return plugin
       end
@@ -102,10 +102,6 @@ module Puma
       cls.class_eval(&blk)
 
       Plugins.register name, cls
-    end
-
-    def initialize(loader)
-      @loader = loader
     end
 
     def in_background(&blk)


### PR DESCRIPTION
I've been working on adding Puma instrumentation to our internal metrics gem. By reading the plugin code I got it to work in a way we want (no configuration required to enable the plugin from the gem) but I noticed I had to pass a slightly confusing `loader` argument when initializing the plugin.

In the current version of the gem, strangely enough the `Plugin` class is passed as loader, while it happens inside the `PluginLoader` class:
https://github.com/puma/puma/blob/b646fc522337c3c506399e68c0dab034ab98d4fc/lib/puma/plugin.rb#L13

this seems to have been an error made during refactoring in 33e0fa9999de17e85ed7e064d5f8ede8dc009014 as the original implementation made more sense:
https://github.com/puma/puma/blob/663666c5b775fd8224e2acb51399b34d907d753e/lib/puma/plugin_loader.rb#L11

but even at that time, it seems the loader argument was never used, hence this PR removing it. 

While technically part of the plugins API: https://github.com/puma/puma/blob/6bb070bb47362b6688cd8ce3306e67c8768762ba/docs/plugins.md#L37-L38
this does not affect the documented `Puma::Plugin.create do ... end` way of doing things.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
