### PR TITLE
Experiment: Fork from existing worker process to optimize copy-on-write performance

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@
   * Increases maximum URI path length from 2048 to 8196 bytes (#2167)
   * Force shutdown responses can be overridden by using the `lowlevel_error_handler` config (#2203)
   * Faster phased restart and worker timeout (#2121)
+  * Add `fork_worker` option and `refork` command for improved copy-on-write performance (#2099)
 
 * Deprecations, Removals and Breaking API Changes
   * `Puma.stats` now returns a Hash instead of a JSON string (#2086)

--- a/docs/fork_worker.md
+++ b/docs/fork_worker.md
@@ -1,0 +1,31 @@
+# Fork-Worker Cluster Mode [Experimental]
+
+Puma 5 introduces an experimental new cluster-mode configuration option, `fork_worker` (`--fork-worker` from the CLI). This mode causes Puma to fork additional workers from worker 0, instead of directly from the master process:
+
+```
+10000   \_ puma 4.3.3 (tcp://0.0.0.0:9292) [puma]
+10001       \_ puma: cluster worker 0: 10000 [puma]
+10002           \_ puma: cluster worker 1: 10000 [puma]
+10003           \_ puma: cluster worker 2: 10000 [puma]
+10004           \_ puma: cluster worker 3: 10000 [puma]
+```
+
+Similar to the `preload_app!` option, the `fork_worker` option allows your application to be initialized only once for copy-on-write memory savings, and it has two additional advantages:
+
+1. **Compatible with phased restart.** Because the master process itself doesn't preload the application, this mode works with phased restart (`SIGUSR1` or `pumactl phased-restart`). When worker 0 reloads as part of a phased restart, it initializes a new copy of your application first, then the other workers reload by forking from this new worker already containing the new preloaded application.
+
+   This allows a phased restart to complete as quickly as a hot restart (`SIGUSR2` or `pumactl restart`), while still minimizing downtime by staggering the restart across cluster workers.
+
+2. **'Refork' for additional copy-on-write improvements in running applications.** Fork-worker mode introduces a new `refork` command that re-loads all nonzero workers by re-forking them from worker 0.
+
+   This command can potentially improve memory utilization in large or complex applications that don't fully pre-initialize on startup, because the re-forked workers can share copy-on-write memory with a worker that has been running for a while and serving requests.
+
+   You can trigger a refork by sending the cluster the `SIGURG` signal or running the `pumactl refork` command at any time. A refork will also automatically trigger once, after a certain number of requests have been processed by worker 0 (default 1000). To configure the number of requests before the auto-refork, pass a positive integer argument to `fork_workers` (e.g., `fork_workers 1000`), or `0` to disable.
+
+### Limitations
+
+- This mode is still very experimental so there may be bugs or edge-cases, particularly around expected behavior of existing hooks. Please open a [bug report](https://github.com/puma/puma/issues/new?template=bug_report.md) if you encounter any issues.
+
+- In order to fork new workers cleanly, worker 0 shuts down its server and stops serving requests so there are no open file descriptors or other kinds of shared global state between processes, and to maximize copy-on-write efficiency across the newly-forked workers. This may temporarily reduce total capacity of the cluster during a phased restart / refork.
+
+  In a cluster with `n` workers, a normal phased restart stops and restarts workers one by one while the application is loaded in each process, so `n-1` workers are available serving requests during the restart. In a phased restart in fork-worker mode, the application is first loaded in worker 0 while `n-1` workers are available, then worker 0 remains stopped while the rest of the workers are reloaded one by one, leaving only `n-2` workers to be available for a brief period of time. Reloading the rest of the workers should be quick because the application is preloaded at that point, but there may be situations where it can take longer (slow clients, long-running application code, slow worker-fork hooks, etc).

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -41,6 +41,7 @@ Puma cluster responds to these signals:
 - `HUP`  reopen log files defined in stdout_redirect configuration parameter. If there is no stdout_redirect option provided it will behave like `INT`
 - `INT` equivalent of sending Ctrl-C to cluster. Will attempt to finish then exit.
 - `CHLD`
+- `URG` refork workers in phases from worker 0, if `fork_workers` option is enabled.
 
 ## Callbacks order in case of different signals
 

--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -63,6 +63,11 @@ module Puma
           end
 
           rack_response(200, backtraces.to_json)
+
+        when /\/refork$/
+          Process.kill "SIGURG", $$
+          rack_response(200, OK_STATUS)
+
         else
           rack_response 404, "Unsupported action", 'text/plain'
         end

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -130,6 +130,12 @@ module Puma
             user_config.environment arg
           end
 
+          o.on "-f", "--fork-worker=[REQUESTS]", OptionParser::DecimalInteger,
+            "Fork new workers from existing worker. Cluster mode only",
+            "Auto-refork after REQUESTS (default 1000)" do |*args|
+            user_config.fork_worker *args.compact
+          end
+
           o.on "-I", "--include PATH", "Specify $LOAD_PATH directories" do |arg|
             $LOAD_PATH.unshift(*arg.split(':'))
           end

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -11,7 +11,7 @@ require 'socket'
 module Puma
   class ControlCLI
 
-    COMMANDS = %w{halt restart phased-restart start stats status stop reload-worker-directory gc gc-stats thread-backtraces}
+    COMMANDS = %w{halt restart phased-restart start stats status stop reload-worker-directory gc gc-stats thread-backtraces refork}
     PRINTABLE_COMMANDS = %w{gc-stats stats thread-backtraces}
 
     def initialize(argv, stdout=STDOUT, stderr=STDERR)
@@ -238,6 +238,9 @@ module Puma
           end
 
           return
+
+        when "refork"
+          Process.kill "SIGURG", @pid
 
         else
           return

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -492,6 +492,28 @@ module Puma
 
     alias_method :after_worker_boot, :after_worker_fork
 
+    # When `fork_worker` is enabled, code to run in Worker 0
+    # before all other workers are re-forked from this process,
+    # after the server has temporarily stopped serving requests
+    # (once per complete refork cycle).
+    #
+    # This can be used to trigger extra garbage-collection to maximize
+    # copy-on-write efficiency, or close any connections to remote servers
+    # (database, Redis, ...) that were opened while the server was running.
+    #
+    # This can be called multiple times to add several hooks.
+    #
+    # @note Cluster mode with `fork_worker` enabled only.
+    # @example
+    #   on_refork do
+    #     3.times {GC.start}
+    #   end
+
+    def on_refork(&block)
+      @options[:before_refork] ||= []
+      @options[:before_refork] << block
+    end
+
     # Code to run out-of-band when the worker is idle.
     # These hooks run immediately after a request has finished
     # processing and there are no busy threads on the worker.

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -705,5 +705,19 @@ module Puma
       end
     end
 
+    # When enabled, workers will be forked from worker 0 instead of from the master process.
+    # This option is similar to `preload_app` because the app is preloaded before forking,
+    # but it is compatible with phased restart.
+    #
+    # This option also enables the `refork` command (SIGURG), which optimizes copy-on-write performance
+    # in a running app.
+    #
+    # A refork will automatically trigger once after the specified number of requests
+    # (default 1000), or pass 0 to disable auto refork.
+    #
+    # @note Cluster mode only.
+    def fork_worker(after_requests=1000)
+      @options[:fork_worker] = Integer(after_requests)
+    end
   end
 end

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -59,6 +59,7 @@ module Puma
       @app = app
       @events = events
 
+      @check, @notify = nil
       @status = :stop
 
       @min_threads = 0

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -44,12 +44,18 @@ class TestIntegration < Minitest::Test
 
   private
 
-  def cli_server(argv, unix: false)
+  def cli_server(argv, unix: false, config: nil)
+    if config
+      config_file = Tempfile.new(%w(config .rb))
+      config_file.write config
+      config_file.close
+      config = "-C #{config_file.path}"
+    end
     if unix
-      cmd = "#{BASE} bin/puma -b unix://#{@bind_path} #{argv}"
+      cmd = "#{BASE} bin/puma #{config} -b unix://#{@bind_path} #{argv}"
     else
       @tcp_port = UniquePort.call
-      cmd = "#{BASE} bin/puma -b tcp://#{HOST}:#{@tcp_port} #{argv}"
+      cmd = "#{BASE} bin/puma #{config} -b tcp://#{HOST}:#{@tcp_port} #{argv}"
     end
     @server = IO.popen(cmd, "r")
     wait_for_server_to_boot

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -157,13 +157,21 @@ end
 RUBY
   end
 
+  def test_refork
+    refork = Tempfile.new('refork')
+    cli_server "-w #{WORKERS} test/rackup/sleep.ru", config: <<RUBY
+fork_worker 1
+on_refork {File.write('#{refork.path}', 'Reforked')}
+RUBY
+    pids = get_worker_pids
+    read_body(connect('sleep1')) until refork.read == 'Reforked'
+    refute_includes pids, get_worker_pids(1, WORKERS - 1)
+  end
+
   private
 
   def worker_timeout(timeout, iterations, config)
-    config_file = Tempfile.new(%w(worker_timeout .rb))
-    config_file.write config
-    config_file.close
-    cli_server "-w #{WORKERS} -t 1:1 -C #{config_file.path} test/rackup/hello.ru"
+    cli_server "-w #{WORKERS} -t 1:1 test/rackup/hello.ru", config: config
 
     pids = []
     Timeout.timeout(iterations * timeout + 1) do

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -75,6 +75,11 @@ class TestIntegrationCluster < TestIntegration
     usr1_all_respond unix: false
   end
 
+  def test_usr1_fork_worker
+    skip_unless_signal_exist? :USR1
+    usr1_all_respond config: '--fork-worker'
+  end
+
   def test_usr1_all_respond_unix
     skip_unless_signal_exist? :USR1
     usr1_all_respond unix: true
@@ -239,8 +244,8 @@ RUBY
 
   # Send requests 1 per second.  Send 1, then :USR1 server, then send another 24.
   # All should be responded to, and at least three workers should be used
-  def usr1_all_respond(unix: false)
-    cli_server "-w #{WORKERS} -t 0:5 -q test/rackup/sleep_pid.ru", unix: unix
+  def usr1_all_respond(unix: false, config: '')
+    cli_server "-w #{WORKERS} -t 0:5 -q test/rackup/sleep_pid.ru #{config}", unix: unix
     threads = []
     replies = []
     mutex = Mutex.new


### PR DESCRIPTION
This is still rather experimental, but I thought I'd share this work in progress to share preliminary results and spark discussion on whether this optimization seems at all interesting to anyone else to pursue further.

### Description

This PR adds a config option (`fork_worker`) to spawn new worker processes by forking an existing worker process instead of the master process. It also adds a `refork` command (currently implemented via a `URG` signal) which re-forks all processes in the cluster from this original worker.

Because the existing worker has been serving live requests, forking new workers from this fully-loaded process can potentially reduce memory usage by further optimizing copy-on-write performance across processes, as a step beyond what the `preload_app!` directive accomplishes at initialization.

#### Demonstration

The ideal use-case for this technique involves a Rack application that loads a lot of persistent (non-garbage-collected) content into memory at runtime, instead of at initialization-time where `preload_app!` is able to load it before the initial fork. (Think of dynamically generated data or code that loads only after particular user inputs, or an in-memory object cache, etc..)

Here's a minimal Rack application which demonstrates the optimization:

```ruby
# config.ru
run lambda { |_env|
  $big_object ||= Array.new(10_000_000) {Object.new}
  [200, {}, ["Hello world"]].tap{3.times{GC.start}}
}

# config/puma.rb
workers 8
state_path 'puma.state'
activate_control_app
daemonize
fork_worker
```

To test and measure 'real' memory usage, compare the total [pss](https://stackoverflow.com/a/9923021/2518355) across all workers with a good amount of request traffic, before and after re-forking cluster workers using the added `refork` command.

```
# Total pss of all workers
function pss() {
  bundle exec pumactl stats | ruby -rjson -e '
    puts JSON.parse(ARGF.readlines.last)["worker_status"].map {|w| w["pid"]}.
      sum{|p| File.read("/proc/#{p}/smaps_rollup").match(/Pss:\s+(\d+)/)[1].to_i}
  '
}

$ bundle exec puma
$ wrk http://localhost:9292 -d 20 -H "Connection: close"
$ pss
> 4933788
$ bundle exec pumactl refork
$ wrk http://localhost:9292 -d 20 -H "Connection: close"
$ pss
> 1053686
```

Memory usage in this (obviously very contrived) example is reduced from ~5GB to ~1GB, or an **~80%** reduction in total memory usage across 8 workers.

Obviously most real-world use-cases won't see such a dramatic difference, but this still might possibly be a useful optimization in some situations. I'll look forward to testing on some large Rack applications to see how useful this might be in practice.

#### Production demo

I ran a rough comparison test on a [production Rails app](https://github.com/code-dot-org/code-dot-org) running 40 workers on a single instance, measuring memory usage after serving traffic for 15 minutes after a restart (for 'Baseline'), then restarting workers and serving traffic for another 15 minutes (for 'Optimized'):

##### Baseline
Per-worker Usage (MB): 2170 Rss, 1530 Pss, 655 Shared

##### Optimized
Per-worker Usage (MB): 2168 Rss, 1177 Pss (**-23%**), 1041 Shared (**+59%**)

This demo shows a ~20% improvement in memory usage on this particular application. (Note this app is running Ruby 2.5, the compacting GC in Ruby 2.7 may enable even greater CoW efficiency.)