### PR TITLE
Simplify random_token and remove insecure fallback

### DIFF
--- a/History.md
+++ b/History.md
@@ -12,6 +12,7 @@
 
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)
+  * Simplify `Configuration.random_token` and remove insecure fallback (#2102)
 
 ## 4.3.1 and 3.12.2 / 2019-12-05
 

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -332,29 +332,9 @@ module Puma
     end
 
     def self.random_token
-      begin
-        require 'openssl'
-      rescue LoadError
-      end
+      require 'securerandom' unless defined?(SecureRandom)
 
-      count = 16
-
-      bytes = nil
-
-      if defined? OpenSSL::Random
-        bytes = OpenSSL::Random.random_bytes(count)
-      elsif File.exist?("/dev/urandom")
-        File.open('/dev/urandom') { |f| bytes = f.read(count) }
-      end
-
-      if bytes
-        token = "".dup
-        bytes.each_byte { |b| token << b.to_s(16) }
-      else
-        token = (0..count).to_a.map { rand(255).to_s(16) }.join
-      end
-
-      return token
+      SecureRandom.hex(16)
     end
   end
 end


### PR DESCRIPTION
The original implementation is 8 years old from commit 47f76712. I'm guessing it partially reimplemented Ruby's SecureRandom [from that time](https://github.com/ruby/ruby/blob/fb99416115e8e48e6ac8aefefa6221cf572024ad/lib/securerandom.rb) to provide the fallback to using `Kernel#rand` in case the CSPRNG is unavailable. I'm removing it since I don't believe this is very common and I don't think it is Puma's job to fix a broken system.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] All new and existing tests passed, including Rubocop.
