### PR TITLE
Add a jruby_-prefixed method alias to conditional method [changelog skip] [ci skip]

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -238,6 +238,9 @@ module Puma
         return false unless IO.select([@to_io], nil, nil, 0)
         try_to_finish
       end
+
+      # For documentation, see https://github.com/puma/puma/issues/1754
+      send(:alias_method, :jruby_eagerly_finish, :eagerly_finish)
     end # IS_JRUBY
 
     def finish


### PR DESCRIPTION
  - This is a documentation edge-case

### Description


#1754 mentions a docs edge-case where JRuby versions of methods are defined with the same name - and docs tools have a hard time with that.

Fixes #1754

I could not spy any other conditional JRuby-related methods that had the same name as Ruby ones.

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
