### PR TITLE
[changelog skip][ci skip] Fix 404 link, bug in htpps://puma.io/puma/index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ configure { set :server, :puma }
 Puma provides numerous options. Consult `puma -h` (or `puma --help`) for a full list of CLI options, or see [dsl.rb](https://github.com/puma/puma/blob/master/lib/puma/dsl.rb).
 
 You can also find several configuration examples as part of the
-[test](test/config) suite.
+[test](https://github.com/puma/puma/tree/master/test/config) suite.
 
 ### Thread Pool
 


### PR DESCRIPTION
### Description

In https://puma.io/puma/index.html#configuration, when you click to `test`, it's shows bad link (404 not found) same with attachment image. 

![README](https://user-images.githubusercontent.com/1505720/73998555-96ab0800-4994-11ea-992c-691511de3ebe.png)

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
