### PR TITLE
eregon/use-ruby-action moved to ruby/setup-ruby

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,8 +24,7 @@ jobs:
     - name: repo checkout
       uses: actions/checkout@v2
 
-    - name: load ruby
-      uses: eregon/use-ruby-action@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
 


### PR DESCRIPTION
* See https://github.com/ruby/setup-ruby/releases/tag/v1.13.0

Follow-up of https://github.com/puma/puma/pull/2103