### PR TITLE
Simplify Runner#start_control URL parsing

### DIFF
--- a/History.md
+++ b/History.md
@@ -13,6 +13,7 @@
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)
   * Simplify `Configuration.random_token` and remove insecure fallback (#2102)
+  * Simplify `Runner#start_control` URL parsing (#2111)
 
 ## 4.3.1 and 3.12.2 / 2019-12-05
 

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -86,7 +86,7 @@ module Puma
       end
     end
 
-    def parse(binds, logger)
+    def parse(binds, logger, log_msg = 'Listening')
       binds.each do |str|
         uri = URI.parse str
         case uri.scheme
@@ -113,7 +113,7 @@ module Puma
                 i.local_address.ip_unpack.join(':')
               end
 
-              logger.log "* Listening on tcp://#{addr}"
+              logger.log "* #{log_msg} on tcp://#{addr}"
             end
           end
 
@@ -149,7 +149,7 @@ module Puma
             end
 
             io = add_unix_listener path, umask, mode, backlog
-            logger.log "* Listening on #{str}"
+            logger.log "* #{log_msg} on #{str}"
           end
 
           @listeners << [str, io]

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -62,7 +62,7 @@ module Puma
       control.min_threads = 0
       control.max_threads = 1
 
-      control.binder.parse [str], self
+      control.binder.parse [str], self, 'Starting control server'
 
       control.run
       @control = control

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -52,8 +52,6 @@ module Puma
 
       require 'puma/app/status'
 
-      uri = URI.parse str
-
       if token = @options[:control_auth_token]
         token = nil if token.empty? || token == 'none'
       end
@@ -64,25 +62,7 @@ module Puma
       control.min_threads = 0
       control.max_threads = 1
 
-      case uri.scheme
-      when "ssl"
-          log "* Starting control server on #{str}"
-          params = Util.parse_query uri.query
-          ctx = MiniSSL::ContextBuilder.new(params, @events).context
-
-          control.add_ssl_listener uri.host, uri.port, ctx
-      when "tcp"
-        log "* Starting control server on #{str}"
-        control.add_tcp_listener uri.host, uri.port
-      when "unix"
-        log "* Starting control server on #{str}"
-        path = "#{uri.host}#{uri.path}"
-        mask = @options[:control_url_umask]
-
-        control.add_unix_listener path, mask
-      else
-        error "Invalid control URI: #{str}"
-      end
+      control.binder.parse [str], self
 
       control.run
       @control = control


### PR DESCRIPTION
### Description
Simplifies some code in `Runner#start_control` by reusing similar logic from `Binder#parse`.

~Besides simplifying code, this fixes a bug/issue where a Unix socket created for a control server (e.g., `--control-url unix://control.sock`) was not being properly removed on server shutdown.~
~This is because `Binder#parse` additionally adds its urls to `@listeners`, which allows them to be automatically cleaned up by `Binder#close_listeners` when the server shuts down.~

(Properly fixing the control-socket cleanup issue requires additional code changes not in this PR, but this simplification makes the fix easier to apply.)

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
