### PR TITLE
Split ruby.yml, revise Actions, all OS's test from 2.3 thru master/head [changelog skip]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: >-
-      ${{ matrix.os }}  Ruby: ${{ matrix.ruby }}
+      ${{ matrix.os }}, ${{ matrix.ruby }}
     env:
       CI: true
       TESTOPTS: -v
@@ -14,45 +14,93 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, macos, windows-latest ]
-        ruby: [ 2.3, 2.4, 2.5, 2.6, 2.7 ]
-        exclude:
-          - os: windows-latest
-            ruby: 2.3
+        os: [ ubuntu-18.04, macos ]
+        ruby: [ 2.3, 2.4, 2.5, 2.6, 2.7, ruby-head ]
 
     steps:
-    - name: repo checkout
-      uses: actions/checkout@v2
+      - name: repo checkout
+        uses: actions/checkout@v2
 
-    - name: load ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
+      - name: load ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
 
-    - name: ubuntu & macos - install ragel
-      if:   startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
-      run:  |
-        if [ "${{ matrix.os }}" == "macos" ]; then
-          brew install ragel
-        else
-          sudo apt-get -qy install ragel
-        fi
+      - name: ubuntu & macos - install ragel
+        if:   startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+        run:  |
+          if [ "${{ matrix.os }}" == "macos" ]; then
+            brew install ragel
+          else
+            sudo apt-get -qy install ragel
+          fi
 
-    - name: windows - update MSYS2, openssl, ragel
-      if:   startsWith(matrix.os, 'windows')
-      uses: MSP-Greg/msys2-action@master
-      with:
-        base:  update
-        mingw: openssl ragel
+      - name: bundle install
+        run:  bundle install --jobs 4 --retry 3
+      - name: compile
+        run:  bundle exec rake compile
 
-    - name: RubyGems, Bundler Update
-      run:  gem update --system --no-document --conservative
-    - name: bundle install
-      run:  bundle install --jobs 4 --retry 3
-    - name: compile
-      run:  bundle exec rake compile
-    - name: test
-      run:  bundle exec rake
-      env:
-        RUBYOPT: --enable-frozen-string-literal
-      timeout-minutes: 10
+      # two test steps due to pre-installed Bundler not working with
+      # frozen strings before 2.0
+
+      - name: test with frozen string
+        timeout-minutes: 10
+        env:
+          RUBYOPT: --enable-frozen-string-literal
+        if: matrix.ruby >= '2.6'
+        run:  bundle exec rake
+
+      - name: test without frozen string
+        timeout-minutes: 10
+        if: matrix.ruby < '2.6'
+        run:  bundle exec rake
+
+  win32:
+    name: >-
+      ${{ matrix.os }}, ${{ matrix.ruby }}
+    env:
+      CI: true
+      TESTOPTS: -v
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest ]
+        ruby: [ 2.3, 2.4, 2.5, 2.6, 2.7, ruby-head ]
+
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v2
+
+      - name: windows - update MSYS2, openssl, ragel
+        if:   startsWith(matrix.os, 'windows')
+        uses: MSP-Greg/actions-ruby@v1
+        with:
+          base:  update
+          mingw: openssl ragel
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: bundle install
+        run:  bundle install --jobs 4 --retry 3
+
+      - name: compile
+        if:   matrix.ruby >= '2.4'
+        run:  bundle exec rake compile
+
+      # Ruby 2.3 uses a OpenSSL package that is not MSYS2
+      - name: compile
+        if:   matrix.ruby == '2.3'
+        run:  bundle exec rake compile -- --with-openssl-dir=C:/openssl-win
+
+      - name: test with frozen string
+        timeout-minutes: 10
+        env:
+          RUBYOPT: --enable-frozen-string-literal
+        if: matrix.ruby >= '2.6'
+        run:  bundle exec rake
+
+      - name: test without frozen string
+        timeout-minutes: 10
+        if: matrix.ruby < '2.6'
+        run:  bundle exec rake


### PR DESCRIPTION
### Description

Revisions to Actions workflows.

1. All OS's test on Ruby 2.3 thru master/head.  Previously, many master/head builds were not fully tested.  As currently set up, all are fully tested.

2. Bundler is pre-installed on all builds, so it is no longer installed/updated.  Because of that, 'frozen string' does not work in older Rubies.  Added conditional steps to only add 'frozen string' where it will pass.

3. There are several places in the GitHub UI where lists of jobs appear.  I reformatted the string shown to hopefully make it not truncated in any of those places...

4. All OS's (including Windows) can have Ruby 2.2 added, but it is currently failing.  Not sure if it's code or tests.  Another PR can fix that.

5. Puma does compile and test successfully with a Windows mswin build, but changes are needed for it, as jaro_winkler won't compile on it, and it's a dependency for RuboCop.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
