### PR TITLE
puma.gemspec metadata["msys2_mingw_dependencies"]  [changelog skip]

### DIFF
--- a/puma.gemspec
+++ b/puma.gemspec
@@ -12,7 +12,9 @@ Gem::Specification.new do |s|
   s.executables = ["puma", "pumactl"]
   s.extensions = ["ext/puma_http11/extconf.rb"]
   s.add_runtime_dependency "nio4r", "~> 2.0"
-  s.metadata["msys2_mingw_dependencies"] = "openssl"
+  if RbConfig::CONFIG['ruby_version'] >= '2.5'
+    s.metadata["msys2_mingw_dependencies"] = "openssl"
+  end
   s.files = `git ls-files -- bin docs ext lib tools`.split("\n") +
             %w[History.md LICENSE README.md]
   s.homepage = "http://puma.io"


### PR DESCRIPTION
### Description

Standard Windows Rubies have a mechanism to load the OpenSSL package when installing Puma.  This is done via the gemspec's metadata["msys2_mingw_dependencies"] item.

The MSYS2 package manager only allows installation of the most recently released package, which is currently OpenSSL 1.1.1d.  Windows Ruby 2.4.x builds with OpenSSL 1.0.2.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.