### PR TITLE
Send 408 request timeout even when queue requests is disabled

### DIFF
--- a/History.md
+++ b/History.md
@@ -12,6 +12,7 @@
   * Your bugfix goes here (#Github Number)
   * Windows update extconf.rb for use with ssp and varied Ruby/MSYS2 combinations (#2069)
   * Preserve `BUNDLE_GEMFILE` env var when using `prune_bundler` (#1893)
+  * Send 408 request timeout even when queue requests is disabled (#2119)
 
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -243,10 +243,13 @@ module Puma
       send(:alias_method, :jruby_eagerly_finish, :eagerly_finish)
     end # IS_JRUBY
 
-    def finish
+    def finish(timeout)
       return true if @ready
       until try_to_finish
-        IO.select([@to_io], nil, nil)
+        unless IO.select([@to_io], nil, nil, timeout)
+          write_error(408) if in_data_phase
+          raise ConnectionError
+        end
       end
       true
     end

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -308,7 +308,7 @@ module Puma
           if queue_requests
             process_now = client.eagerly_finish
           else
-            client.finish
+            client.finish(@first_data_timeout)
             process_now = true
           end
         rescue MiniSSL::SSLError => e

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -336,6 +336,11 @@ EOF
     assert_equal "HTTP/1.1 408 Request Timeout\r\n", data
   end
 
+  def test_timeout_data_no_queue
+    @server = Puma::Server.new @app, @events, queue_requests: false
+    test_timeout_in_data_phase
+  end
+
   def test_http_11_keep_alive_with_body
     server_run app: ->(env) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 


### PR DESCRIPTION
### Description

Return a 408 Request Timeout response based on `first_data_timeout` when `queue_requests` is disabled, matching the behavior for when `queue_requests` is enabled (the default).

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
