### PR TITLE
Rescue IO::WaitReadable instead of EAGAIN for blocking read

### DIFF
--- a/History.md
+++ b/History.md
@@ -13,6 +13,7 @@
   * Windows update extconf.rb for use with ssp and varied Ruby/MSYS2 combinations (#2069)
   * Preserve `BUNDLE_GEMFILE` env var when using `prune_bundler` (#1893)
   * Send 408 request timeout even when queue requests is disabled (#2119)
+  * Rescue IO::WaitReadable instead of EAGAIN for blocking read (#2121)
 
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -153,7 +153,7 @@ module Puma
 
       begin
         data = @io.read_nonblock(CHUNK_SIZE)
-      rescue Errno::EAGAIN
+      rescue IO::WaitReadable
         return false
       rescue SystemCallError, IOError, EOFError
         raise ConnectionError, "Connection error detected during read"
@@ -349,7 +349,7 @@ module Puma
 
       begin
         chunk = @io.read_nonblock(want)
-      rescue Errno::EAGAIN
+      rescue IO::WaitReadable
         return false
       rescue SystemCallError, IOError
         raise ConnectionError, "Connection error detected during read"

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -754,4 +754,17 @@ EOF
     # it is set to a reasonable number.
     assert_operator request_body_wait, :>=, 900
   end
+
+  def test_open_connection_wait
+    server_run app: ->(_) { [200, {}, ["Hello"]] }
+    s = send_http nil
+    sleep 0.1
+    s << "GET / HTTP/1.0\r\n\r\n"
+    assert_equal 'Hello', s.readlines.last
+  end
+
+  def test_open_connection_wait_no_queue
+    @server = Puma::Server.new @app, @events, queue_requests: false
+    test_open_connection_wait
+  end
 end


### PR DESCRIPTION
### Description

Rescue `IO::WaitReadable` instead of `EAGAIN` on calls to `read_nonblock` when a blocking read would occur.

On Windows, `read_nonblock` raises `Errno::EWOULDBLOCK`, which is a different value on this platform from `Errno::EAGAIN`. Both of these errors are extended by `IO::WaitReadable`, which is Ruby's recommended exception class for retrying `read_nonblock`.

I've included a test `test_open_connection_wait_no_queue` which [fails on windows](https://github.com/wjordan/puma/runs/458869490) without this PR applied.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
