### PR TITLE
Pass queued requests to thread pool on server shutdown

### DIFF
--- a/History.md
+++ b/History.md
@@ -28,6 +28,7 @@
   * Rescue and log exceptions in hooks defined by users (on_worker_boot, after_worker_fork etc) (#1551)
   * Read directly from the socket in #read_and_drop to avoid raising further SSL errors (#2198)
   * Set `Connection: closed` header when queue requests is disabled (#2216)
+  * Pass queued requests to thread pool on server shutdown (#2122)
 
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -278,15 +278,16 @@ module Puma
       @peerip ||= @io.peeraddr.last
     end
 
-    # Returns true if the connection is idle and may be closed.
-    #
-    # From RFC 2616 section 8.1.4:
-    # Servers SHOULD always respond to at least one request per connection,
-    # if at all possible. Servers SHOULD NOT close a connection in the
-    # middle of transmitting a response, unless a network or client failure
-    # is suspected.
-    def idle?
-      @requests_served > 0 && !in_data_phase
+    # Returns true if the persistent connection can be closed immediately
+    # without waiting for the configured idle/shutdown timeout.
+    def can_close?
+      # Allow connection to close if it's received at least one full request
+      # and hasn't received any data for a future request.
+      #
+      # From RFC 2616 section 8.1.4:
+      # Servers SHOULD always respond to at least one request per connection,
+      # if at all possible.
+      @requests_served > 0 && @parsed_bytes == 0
     end
 
     private

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -273,6 +273,17 @@ module Puma
       @peerip ||= @io.peeraddr.last
     end
 
+    # Returns true if the connection is idle and may be closed.
+    #
+    # From RFC 2616 section 8.1.4:
+    # Servers SHOULD always respond to at least one request per connection,
+    # if at all possible. Servers SHOULD NOT close a connection in the
+    # middle of transmitting a response, unless a network or client failure
+    # is suspected.
+    def idle?
+      @requests_served > 0 && !in_data_phase
+    end
+
     private
 
     def setup_body

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -246,7 +246,12 @@ module Puma
     def finish(timeout)
       return true if @ready
       until try_to_finish
-        unless IO.select([@to_io], nil, nil, timeout)
+        can_read = begin
+          IO.select([@to_io], nil, nil, timeout)
+        rescue ThreadPool::ForceShutdown
+          nil
+        end
+        unless can_read
           write_error(408) if in_data_phase
           raise ConnectionError
         end

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -189,7 +189,12 @@ module Puma
                     if submon.value == @ready
                       false
                     else
-                      submon.value.close
+                      if submon.value.idle?
+                        submon.value.close
+                      else
+                        # Pass non-idle client connections to the thread pool.
+                        @app_pool << submon.value
+                      end
                       begin
                         selector.deregister submon.value
                       rescue IOError

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -189,10 +189,10 @@ module Puma
                     if submon.value == @ready
                       false
                     else
-                      if submon.value.idle?
+                      if submon.value.can_close?
                         submon.value.close
                       else
-                        # Pass non-idle client connections to the thread pool.
+                        # Pass remaining open client connections to the thread pool.
                         @app_pool << submon.value
                       end
                       begin


### PR DESCRIPTION
### Description

Fixes a concurrency bug during server shutdown when `queue_requests` is enabled (the default), which can can be minimally reproduced by the following sequence:

- s1 and s2 both open client connections
- s1 sends a request
- server shutdown is triggered (but does not complete while s1's request is still in process)
- s2 sends a request

Expected: s2 receives a successful response
Actual: s2 receives a 500 response

Here is the test implementation, currently failing on `master`: https://github.com/puma/puma/blob/17af6cfa8a2fa245b2153479448f54505e7b5de4/test/test_puma_server.rb#L771-L788


The underlying issue is that in a 'graceful' shutdown, the server stops accepting connections and the thread pool stops accepting new work while it waits up to `force_shutdown_after` seconds to finish processing currently active requests. However, a client request queued in the reactor will be rejected if it gets received after the thread pool stops accepting new work.

To fix, this PR makes a small change to shut down the reactor _before_ the thread pool, and to disable `queue_requests` and pass along any remaining non-'idle' client connections to the thread pool when the reactor shuts down. This allows graceful shutdown to behave properly without prematurely aborting any requests it shouldn't.

The logic for determining 'idle' clients that can be closed immediately follows guidance from [RFC 2616 section 8.1.4](https://tools.ietf.org/html/rfc2616#section-8.1.4):

> Servers SHOULD always respond to at least one request per connection,
> if at all possible.

The added test depends on the small fix in #2121 to pass properly on Windows, so this branch currently includes that commit as well.

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
