### PR TITLE
Faster phased restart and worker timeout

### DIFF
--- a/History.md
+++ b/History.md
@@ -14,6 +14,7 @@
   * Preserve `BUNDLE_GEMFILE` env var when using `prune_bundler` (#1893)
   * Send 408 request timeout even when queue requests is disabled (#2119)
   * Rescue IO::WaitReadable instead of EAGAIN for blocking read (#2121)
+  * Pass queued requests to thread pool on server shutdown (#2122)
 
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)

--- a/History.md
+++ b/History.md
@@ -13,6 +13,7 @@
   * Windows update extconf.rb for use with ssp and varied Ruby/MSYS2 combinations (#2069)
   * Preserve `BUNDLE_GEMFILE` env var when using `prune_bundler` (#1893)
   * Send 408 request timeout even when queue requests is disabled (#2119)
+  * Rescue IO::WaitReadable instead of EAGAIN for blocking read (#2121)
 
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)

--- a/History.md
+++ b/History.md
@@ -7,6 +7,7 @@
   * `Puma.stats` now returns a Hash instead of a JSON string (#2086)
   * `GC.compact` is called before fork if available (#2093)
   * Add `requests_count` to workers stats. (#2106)
+  * Faster phased restart and worker timeout
 
 * Bugfixes
   * Your bugfix goes here (#Github Number)

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -153,7 +153,7 @@ module Puma
 
       begin
         data = @io.read_nonblock(CHUNK_SIZE)
-      rescue Errno::EAGAIN
+      rescue IO::WaitReadable
         return false
       rescue SystemCallError, IOError, EOFError
         raise ConnectionError, "Connection error detected during read"
@@ -349,7 +349,7 @@ module Puma
 
       begin
         chunk = @io.read_nonblock(want)
-      rescue Errno::EAGAIN
+      rescue IO::WaitReadable
         return false
       rescue SystemCallError, IOError
         raise ConnectionError, "Connection error detected during read"

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -273,6 +273,17 @@ module Puma
       @peerip ||= @io.peeraddr.last
     end
 
+    # Returns true if the connection is idle and may be closed.
+    #
+    # From RFC 2616 section 8.1.4:
+    # Servers SHOULD always respond to at least one request per connection,
+    # if at all possible. Servers SHOULD NOT close a connection in the
+    # middle of transmitting a response, unless a network or client failure
+    # is suspected.
+    def idle?
+      @requests_served > 0 && !in_data_phase
+    end
+
     private
 
     def setup_body

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -24,9 +24,8 @@ module Puma
 
       @phase = 0
       @workers = []
-      @next_check = nil
+      @next_check = Time.now
 
-      @phased_state = :idle
       @phased_restart = false
     end
 
@@ -101,8 +100,12 @@ module Puma
         end
       end
 
-      def ping_timeout?(which)
-        Time.now - @last_checkin > which
+      def ping_timeout
+        @last_checkin +
+          (booted? ?
+            @options[:worker_timeout] :
+            @options[:worker_boot_timeout]
+          )
       end
 
       def term
@@ -119,8 +122,8 @@ module Puma
       end
 
       def kill
-        Process.kill "KILL", @pid
-      rescue Errno::ESRCH
+        @signal = 'KILL'
+        term
       end
 
       def hup
@@ -151,10 +154,6 @@ module Puma
 
         @launcher.config.run_hooks :after_worker_fork, idx
       end
-
-      if diff > 0
-        @phased_state = :idle
-      end
     end
 
     def cull_workers
@@ -183,26 +182,12 @@ module Puma
       @workers.count { |w| !w.booted? } == 0
     end
 
-    def check_workers(force=false)
-      return if !force && @next_check && @next_check >= Time.now
+    def check_workers
+      return if @next_check >= Time.now
 
       @next_check = Time.now + Const::WORKER_CHECK_INTERVAL
 
-      any = false
-
-      @workers.each do |w|
-        next if !w.booted? && !w.ping_timeout?(@options[:worker_boot_timeout])
-        if w.ping_timeout?(@options[:worker_timeout])
-          log "! Terminating timed out worker: #{w.pid}"
-          w.kill
-          any = true
-        end
-      end
-
-      # If we killed any timed out workers, try to catch them
-      # during this loop by giving the kernel time to kill them.
-      sleep 1 if any
-
+      timeout_workers
       wait_workers
       cull_workers
       spawn_workers
@@ -215,21 +200,23 @@ module Puma
         w = @workers.find { |x| x.phase != @phase }
 
         if w
-          if @phased_state == :idle
-            @phased_state = :waiting
-            log "- Stopping #{w.pid} for phased upgrade..."
-          end
-
+          log "- Stopping #{w.pid} for phased upgrade..."
           unless w.term?
             w.term
             log "- #{w.signal} sent to #{w.pid}..."
           end
         end
       end
+
+      @next_check = [
+        @workers.reject(&:term?).map(&:ping_timeout).min,
+        @next_check
+      ].compact.min
     end
 
     def wakeup!
       return unless @wakeup
+      @next_check = Time.now
 
       begin
         @wakeup.write "!" unless @wakeup.closed?
@@ -498,8 +485,6 @@ module Puma
       @launcher.events.fire_on_booted!
 
       begin
-        force_check = false
-
         while @status == :run
           begin
             if @phased_restart
@@ -507,11 +492,9 @@ module Puma
               @phased_restart = false
             end
 
-            check_workers force_check
+            check_workers
 
-            force_check = false
-
-            res = IO.select([read], nil, nil, Const::WORKER_CHECK_INTERVAL)
+            res = IO.select([read], nil, nil, [0, @next_check - Time.now].max)
 
             if res
               req = read.read_nonblock(1)
@@ -526,13 +509,12 @@ module Puma
                 when "b"
                   w.boot!
                   log "- Worker #{w.index} (pid: #{pid}) booted, phase: #{w.phase}"
-                  force_check = true
+                  @next_check = Time.now
                 when "e"
                   # external term, see worker method, Signal.trap "SIGTERM"
                   w.instance_variable_set :@term, true
                 when "t"
                   w.term unless w.term?
-                  force_check = true
                 when "p"
                   w.ping!(result.sub(/^\d+/,'').chomp)
                 end
@@ -570,6 +552,15 @@ module Puma
           end
         rescue Errno::ECHILD
           true # child is already terminated
+        end
+      end
+    end
+
+    def timeout_workers
+      @workers.each do |w|
+        if !w.term? && w.ping_timeout <= Time.now
+          log "! Terminating timed out worker: #{w.pid}"
+          w.kill
         end
       end
     end

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -189,7 +189,12 @@ module Puma
                     if submon.value == @ready
                       false
                     else
-                      submon.value.close
+                      if submon.value.idle?
+                        submon.value.close
+                      else
+                        # Pass non-idle client connections to the thread pool.
+                        @app_pool << submon.value
+                      end
                       begin
                         selector.deregister submon.value
                       rescue IOError

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -293,8 +293,6 @@ module Puma
         return run_lopez_mode(background)
       end
 
-      queue_requests = @queue_requests
-
       @thread_pool = ThreadPool.new(@min_threads,
                                     @max_threads,
                                     IOBuffer) do |client, buffer|
@@ -305,7 +303,7 @@ module Puma
         process_now = false
 
         begin
-          if queue_requests
+          if @queue_requests
             process_now = client.eagerly_finish
           else
             client.finish(@first_data_timeout)
@@ -338,7 +336,7 @@ module Puma
 
       @thread_pool.clean_thread_locals = @options[:clean_thread_locals]
 
-      if queue_requests
+      if @queue_requests
         @reactor = Reactor.new self, @thread_pool
         @reactor.run_in_thread
       end
@@ -422,11 +420,12 @@ module Puma
 
         @events.fire :state, @status
 
-        graceful_shutdown if @status == :stop || @status == :restart
         if queue_requests
+          @queue_requests = false
           @reactor.clear!
           @reactor.shutdown
         end
+        graceful_shutdown if @status == :stop || @status == :restart
       rescue Exception => e
         STDERR.puts "Exception handling servers: #{e.message} (#{e.class})"
         STDERR.puts e.backtrace
@@ -497,6 +496,7 @@ module Puma
             end
 
             unless client.reset(check_for_more_data)
+              return unless @queue_requests
               close_socket = false
               client.set_timeout @persistent_timeout
               @reactor.add client

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -121,8 +121,6 @@ class TestIntegration < Minitest::Test
     while pids.size < size
       if pid = @server.gets[re, 1]
         pids << pid
-      else
-        sleep 2
       end
     end
     pids.map(&:to_i)

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -43,12 +43,13 @@ class TestIntegrationPumactl < TestIntegration
 
   def test_phased_restart_cluster
     skip NO_FORK_MSG unless HAS_FORK
+    start = Time.now
 
     cli_server "-q -w #{WORKERS} test/rackup/sleep.ru --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}", unix: true
 
     s = UNIXSocket.new @bind_path
     @ios_to_close << s
-    s << "GET /sleep5 HTTP/1.0\r\n\r\n"
+    s << "GET /sleep1 HTTP/1.0\r\n\r\n"
 
     # Get the PIDs of the phase 0 workers.
     phase0_worker_pids = get_worker_pids 0
@@ -71,7 +72,7 @@ class TestIntegrationPumactl < TestIntegration
 
     _, status = Process.wait2(@pid)
     assert_equal 0, status
-
+    assert_operator Time.now - start, :<, 5
     @server = nil
   end
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -767,4 +767,23 @@ EOF
     @server = Puma::Server.new @app, @events, queue_requests: false
     test_open_connection_wait
   end
+
+  def test_shutdown_queued_request
+    server_run app: ->(env) {
+      sleep 3
+      [204, {}, []]
+    }
+
+    s1 = send_http "GET / HTTP/1.1\r\n\r\n"
+    s2 = send_http "GET / HTTP/1.1\r\n"
+    sleep 1
+
+    @server.stop
+    sleep 1
+
+    s2 << "\r\n"
+
+    assert_match /204/, s1.gets
+    assert_match /204/, s2.gets
+  end
 end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -754,4 +754,17 @@ EOF
     # it is set to a reasonable number.
     assert_operator request_body_wait, :>=, 900
   end
+
+  def test_open_connection_wait
+    server_run app: ->(_) { [200, {}, ["Hello"]] }
+    s = send_http nil
+    sleep 0.1
+    s << "GET / HTTP/1.0\r\n\r\n"
+    assert_equal 'Hello', s.readlines.last
+  end
+
+  def test_open_connection_wait_no_queue
+    @server = Puma::Server.new @app, @events, queue_requests: false
+    test_open_connection_wait
+  end
 end


### PR DESCRIPTION
### Description

Refactors the cluster main thread's command-processing loop to sleep for more precise times, allowing phased restart and worker timeouts to be performed faster instead of around the 5-second check-worker interval.

I've included tests covering these timing-change improvements (worker timeouts were previously not tested at all).

Depends on #2122 to fix a bug that's triggered by the stricter timing changes happening as a result of this PR.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
