### PR TITLE
JSON parse cluster worker stats instead of regex

### DIFF
--- a/History.md
+++ b/History.md
@@ -36,6 +36,7 @@
   * Simplify `Runner#start_control` URL parsing (#2111)
   * Removed the IOBuffer extension and replaced with Ruby (#1980)
   * Update `Rack::Handler::Puma.run` to use `**options` (#2189)
+  * JSON parse cluster worker stats instead of regex (#2124)
 
 ## 4.3.3 and 3.12.4 / 2020-02-28
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -949,5 +949,10 @@ module Puma
       HTTP_INJECTION_REGEX =~ header_value.to_s
     end
     private :possible_header_injection?
+
+    def stats
+      stat_names = %i(backlog running pool_capacity max_threads requests_count)
+      stat_names.map {|name| [name, send(name) || 0]}.to_h
+    end
   end
 end

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -950,9 +950,12 @@ module Puma
     end
     private :possible_header_injection?
 
+    # List of methods invoked by #stats.
+    STAT_METHODS = [:backlog, :running, :pool_capacity, :max_threads, :requests_count].freeze
+
+    # Returns a hash of stats about the running server for reporting purposes.
     def stats
-      stat_names = %i(backlog running pool_capacity max_threads requests_count)
-      stat_names.map {|name| [name, send(name) || 0]}.to_h
+      STAT_METHODS.map {|name| [name, send(name) || 0]}.to_h
     end
   end
 end

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -15,13 +15,8 @@ module Puma
   class Single < Runner
     def stats
       {
-        started_at: @started_at.utc.iso8601,
-        backlog: @server.backlog || 0,
-        running: @server.running || 0,
-        pool_capacity: @server.pool_capacity || 0,
-        max_threads: @server.max_threads || 0,
-        requests_count: @server.requests_count || 0,
-      }
+        started_at: @started_at.utc.iso8601
+      }.merge(@server.stats)
     end
 
     def restart

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -91,7 +91,7 @@ class TestCLI < Minitest::Test
 
     expected_stats = /{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":16,"max_threads":16,"requests_count":0}/
     assert_match(expected_stats, body.split(/\r?\n/).last)
-    assert_equal([:started_at, :backlog, :running, :pool_capacity, :max_threads, :requests_count], Puma.stats.keys)
+    assert_equal(JSON.parse(body.split(/\r?\n/).last, symbolize_names: true), Puma.stats)
 
   ensure
     cli.launcher.stop if cli
@@ -135,6 +135,7 @@ class TestCLI < Minitest::Test
     s.close
 
     assert_match(/\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","workers":2,"phase":0,"booted_workers":2,"old_workers":0,"worker_status":\[\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":0,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\},\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":1,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\}\]\}/, body.split("\r\n").last)
+    assert_equal(Puma.stats, JSON.parse(body.split("\r\n").last, symbolize_names: true))
   ensure
     if UNIX_SKT_EXIST && HAS_FORK
       cli.launcher.stop
@@ -221,7 +222,7 @@ class TestCLI < Minitest::Test
     body = s.read
     s.close
 
-    assert_match(/{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":\d+,"running":\d+,"pool_capacity":\d+,"max_threads":\d+,"requests_count":0}/, body.split(/\r?\n/).last)
+    assert_equal 0, JSON.parse(body.split(/\r?\n/).last)['requests_count']
 
     # send real requests to server
     3.times do
@@ -236,7 +237,7 @@ class TestCLI < Minitest::Test
     body = s.read
     s.close
 
-    assert_match(/{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":\d+,"running":\d+,"pool_capacity":\d+,"max_threads":\d+,"requests_count":3}/, body.split(/\r?\n/).last)
+    assert_equal 3, JSON.parse(body.split(/\r?\n/).last)['requests_count']
   ensure
     cli.launcher.stop
     t.join

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -91,7 +91,6 @@ class TestCLI < Minitest::Test
 
     expected_stats = /{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":16,"max_threads":16,"requests_count":0}/
     assert_match(expected_stats, body.split(/\r?\n/).last)
-    assert_equal(JSON.parse(body.split(/\r?\n/).last, symbolize_names: true), Puma.stats)
 
   ensure
     cli.launcher.stop if cli
@@ -135,7 +134,6 @@ class TestCLI < Minitest::Test
     s.close
 
     assert_match(/\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","workers":2,"phase":0,"booted_workers":2,"old_workers":0,"worker_status":\[\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":0,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\},\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":1,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\}\]\}/, body.split("\r\n").last)
-    assert_equal(Puma.stats, JSON.parse(body.split("\r\n").last, symbolize_names: true))
   ensure
     if UNIX_SKT_EXIST && HAS_FORK
       cli.launcher.stop


### PR DESCRIPTION
### Description

Refactoring PR to simplify the cluster worker stats code using `JSON.parse` and `.to_json` in place of regex-parsing and string interpolation.

Also includes refactoring of duplicated server-stats logic into a `Server#stats` method.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
