### PR TITLE
Remove master dependency on nio4r

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -260,11 +260,7 @@ module Puma
     def dependencies_and_files_to_require_after_prune
       puma = spec_for_gem("puma")
 
-      deps = puma.runtime_dependencies.map do |d|
-        "#{d.name}:#{spec_for_gem(d.name).version}"
-      end
-
-      [deps, require_paths_for_gem(puma) + extra_runtime_deps_directories]
+      [[], require_paths_for_gem(puma) + extra_runtime_deps_directories]
     end
 
     def extra_runtime_deps_directories

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -166,6 +166,8 @@ module Puma
     end
 
     def start_server
+      require 'puma/server'
+
       min_t = @options[:min_threads]
       max_t = @options[:max_threads]
 


### PR DESCRIPTION
### Description

Fixes #2018 by removing `nio4r` as a dependency of the puma master process when using `prune_bundler`.

Just opening this PR for now to get some discussion on this. If it seems like a good idea, I can clean it up and add tests and everything.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
