### PR TITLE
Add bind_workers option to bind separate listeners per worker

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -272,6 +272,12 @@ module Puma
 
       server = start_server
 
+      if (bind_workers = @options[:bind_workers])
+        binder = Binder.new(@launcher.events)
+        binder.parse(@options[:binds].map {|bind| bind_workers.call(bind, index)}, self)
+        server.inherit_binder(binder)
+      end
+
       Signal.trap "SIGTERM" do
         @worker_write << "e#{Process.pid}\n" rescue nil
         server.stop
@@ -455,7 +461,7 @@ module Puma
           exit 1
         end
 
-        @launcher.binder.parse @options[:binds], self
+        @launcher.binder.parse @options[:binds], self unless @options[:bind_workers]
       end
 
       read, @wakeup = Puma::Util.pipe

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -138,7 +138,7 @@ module Puma
         raise e
       end
 
-      @launcher.binder.parse @options[:binds], self
+      @launcher.binder.parse @options[:binds], self unless @options[:bind_workers]
     end
 
     def app

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -969,7 +969,11 @@ module Puma
       end
 
       if @status != :restart
-        @binder.close
+        if @options[:bind_workers]
+          @binder.close_listeners
+        else
+          @binder.close
+        end
       end
 
       if @thread_pool


### PR DESCRIPTION
### Description

Adds a `bind_workers` option which binds separate listener sockets on each individual worker process, bypassing Puma's internal mechanism for balancing requests across processes through a single shared listener socket. This can help optimize performance in systems that are already connecting Puma through an external load-balancing proxy such as nginx or haproxy, since it can take advantage of the the least-busy load balancing algorithms these proxies offer.

This PR can be compared against #1646/#1920, #2079, and #2092 as a request-balancing approach. However, this approach will probably need to remain an optional configuration (similar to `queue_requests: false`) because it depends on an external load-balancing proxy to serve requests.

#### Example proxy config (for 8 workers)

nginx:
```
user www-data;
worker_processes auto;
events {}
http {
  proxy_http_version 1.1;
  proxy_set_header Connection "";
  upstream puma {
    zone puma 4m;
    least_conn;
    server 127.0.0.1:9292;
    server 127.0.0.1:9293;
    server 127.0.0.1:9294;
    server 127.0.0.1:9295;
    server 127.0.0.1:9296;
    server 127.0.0.1:9297;
    server 127.0.0.1:9298;
    server 127.0.0.1:9299;
  }
  server {
    listen 9291;
    server_name puma;
    location / {
      proxy_pass http://puma;
    }
  }
}
```

haproxy:
```
global
  daemon
defaults
  mode http
frontend puma
  bind *:9291
  default_backend pumabackend
backend pumabackend
  http-reuse always
  balance leastconn
  server s1 127.0.0.1:9292
  server s2 127.0.0.1:9293
  server s3 127.0.0.1:9294
  server s4 127.0.0.1:9295
  server s5 127.0.0.1:9296
  server s6 127.0.0.1:9297
  server s7 127.0.0.1:9298
  server s8 127.0.0.1:9299
```

### Performance

[benchmarks/comparisons todo]

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
