### PR TITLE
HTTP Injection - fix bug + 1 more vectors

### DIFF
--- a/History.md
+++ b/History.md
@@ -23,6 +23,13 @@
   * Simplify `Runner#start_control` URL parsing (#2111)
   * Removed the IOBuffer extension and replaced with Ruby (#1980)
 
+
+## 4.3.3 and 3.12.4 / 2020-02-28
+  * Bugfixes
+    * Fix: Fixes a problem where we weren't splitting headers correctly on newlines (#2132)
+  * Security
+    * Fix: Prevent HTTP Response splitting via CR in early hints.
+
 ## 4.3.2 and 3.12.3 / 2020-02-27
 
 * Security

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -228,7 +228,7 @@ module Puma
     COLON = ": ".freeze
 
     NEWLINE = "\n".freeze
-    CRLF_REGEX = /[\r\n]/.freeze
+    HTTP_INJECTION_REGEX = /[\r\n]/.freeze
 
     HIJACK_P = "rack.hijack?".freeze
     HIJACK = "rack.hijack".freeze

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -663,6 +663,7 @@ module Puma
             headers.each_pair do |k, vs|
               if vs.respond_to?(:to_s) && !vs.to_s.empty?
                 vs.to_s.split(NEWLINE).each do |v|
+                  next if possible_header_injection?(v)
                   fast_write client, "#{k}: #{v}\r\n"
                 end
               else
@@ -687,8 +688,6 @@ module Puma
           status, headers, res_body = @app.call(env)
 
           return :async if req.hijacked
-          # Checking to see if an attacker is trying to inject headers into the response
-          headers.reject! { |_k, v| CRLF_REGEX =~ v.to_s }
 
           status = status.to_i
 
@@ -766,6 +765,7 @@ module Puma
         headers.each do |k, vs|
           case k.downcase
           when CONTENT_LENGTH2
+            next if possible_header_injection?(vs)
             content_length = vs
             next
           when TRANSFER_ENCODING
@@ -778,6 +778,7 @@ module Puma
 
           if vs.respond_to?(:to_s) && !vs.to_s.empty?
             vs.to_s.split(NEWLINE).each do |v|
+              next if possible_header_injection?(v)
               lines.append k, colon, v, line_ending
             end
           else
@@ -1048,5 +1049,10 @@ module Puma
     def shutting_down?
       @status == :stop || @status == :restart
     end
+
+    def possible_header_injection?(header_value)
+      HTTP_INJECTION_REGEX =~ header_value.to_s
+    end
+    private :possible_header_injection?
   end
 end


### PR DESCRIPTION
+ Fixes a problem in 4.3.2/3.12.3 where we were not splitting newlines in headers according to Rack spec
+ Fixes another vector for HTTP injection - early hints

Closes #2132 