### PR TITLE
Remove unused file_log_requests_config variable [changelog skip]

### DIFF
--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -227,6 +227,13 @@ class TestUserSuppliedOptionsIsNotPresent < Minitest::Test
     end
   end
 
+  def test_default_log_request_when_no_config_file
+    conf = Rack::Handler::Puma.config(->{}, @options)
+    conf.load
+
+    assert_equal false, conf.options[:log_requests]
+  end
+
   def test_file_log_requests_wins_over_default_config
     file_log_requests_config = true
 
@@ -240,9 +247,7 @@ class TestUserSuppliedOptionsIsNotPresent < Minitest::Test
     assert_equal file_log_requests_config, conf.options[:log_requests]
   end
 
-
   def test_user_log_requests_wins_over_file_config
-    file_log_requests_config = true
     user_log_requests_config = false
 
     @options[:log_requests] = user_log_requests_config


### PR DESCRIPTION
### Description
A file_log_requests_config variable was assigned but not used, resulting in a warning.
The variable has been removed.
An extra test has been added to show the default log_request config when no file
is present.

Closes #2135 
### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
