### PR TITLE
CI: Use jruby-9.2.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       env:
         - OS="Trusty 14.04 OpenSSL 1.0.1"
         - RUBYOPT=""
-    - rvm: jruby-9.2.10.0
+    - rvm: jruby-9.2.11.0
       env:
         - JRUBY_OPTS="--debug"
         - JAVA_OPTS="--add-opens java.base/sun.nio.ch=org.jruby.dist --add-opens java.base/java.io=org.jruby.dist --add-opens java.base/java.util.zip=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.security.cert=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED"
@@ -44,7 +44,7 @@ matrix:
     - rvm: truffleruby
 
   allow_failures:
-    - rvm: jruby-9.2.10.0
+    - rvm: jruby-9.2.11.0
     - rvm: jruby-head
     - rvm: truffleruby
 


### PR DESCRIPTION


### Description


This PR updates the CI matrix to use latest JRuby, **9.2.11.0**.

[JRuby 9.2.11.0 release blog post](https://www.jruby.org/2020/03/02/jruby-9-2-11-0.html)

