### PR TITLE
Catch exceptions in hooks defined by users

### DIFF
--- a/History.md
+++ b/History.md
@@ -17,7 +17,7 @@
   * Preserve `BUNDLE_GEMFILE` env var when using `prune_bundler` (#1893)
   * Send 408 request timeout even when queue requests is disabled (#2119)
   * Rescue IO::WaitReadable instead of EAGAIN for blocking read (#2121)
-  * Rescue exceptions in hooks defined by users (on_worker_boot, after_worker_fork etc) (#1551)
+  * Rescue and log exceptions in hooks defined by users (on_worker_boot, after_worker_fork etc) (#1551)
 
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)

--- a/History.md
+++ b/History.md
@@ -17,6 +17,7 @@
   * Preserve `BUNDLE_GEMFILE` env var when using `prune_bundler` (#1893)
   * Send 408 request timeout even when queue requests is disabled (#2119)
   * Rescue IO::WaitReadable instead of EAGAIN for blocking read (#2121)
+  * Rescue exceptions in hooks defined by users (on_worker_boot, after_worker_fork etc) (#1551)
 
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -137,7 +137,7 @@ module Puma
 
       diff.times do
         idx = next_worker_index
-        @launcher.config.run_hooks :before_worker_fork, idx
+        @launcher.config.run_hooks :before_worker_fork, idx, @launcher.events
 
         pid = fork { worker(idx, master) }
         if !pid
@@ -149,7 +149,7 @@ module Puma
         debug "Spawned worker: #{pid}"
         @workers << Worker.new(idx, pid, @phase, @options)
 
-        @launcher.config.run_hooks :after_worker_fork, idx
+        @launcher.config.run_hooks :after_worker_fork, idx, @launcher.events
       end
 
       if diff > 0
@@ -268,7 +268,7 @@ module Puma
 
       # Invoke any worker boot hooks so they can get
       # things in shape before booting the app.
-      @launcher.config.run_hooks :before_worker_boot, index
+      @launcher.config.run_hooks :before_worker_boot, index, @launcher.events
 
       server = start_server
 
@@ -310,7 +310,7 @@ module Puma
 
       # Invoke any worker shutdown hooks so they can prevent the worker
       # exiting until any background operations are completed
-      @launcher.config.run_hooks :before_worker_shutdown, index
+      @launcher.config.run_hooks :before_worker_shutdown, index, @launcher.events
     ensure
       @worker_write << "t#{Process.pid}\n" rescue nil
       @worker_write.close
@@ -486,7 +486,7 @@ module Puma
 
       @master_read, @worker_write = read, @wakeup
 
-      @launcher.config.run_hooks :before_fork, nil
+      @launcher.config.run_hooks :before_fork, nil, @launcher.events
       GC.compact if GC.respond_to?(:compact)
 
       spawn_workers

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -275,8 +275,15 @@ module Puma
       @plugins.create name
     end
 
-    def run_hooks(key, arg)
-      @options.all_of(key).each { |b| b.call arg }
+    def run_hooks(key, arg, events)
+      @options.all_of(key).each do |b|
+        begin
+          b.call arg
+        rescue => e
+          events.log "WARNING hook #{key} failed with exception (#{e.class}) #{e.message}"
+          events.debug e.backtrace.join("\n")
+        end
+      end
     end
 
     def self.temp_path

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -237,7 +237,7 @@ module Puma
     end
 
     def restart!
-      @config.run_hooks :on_restart, self
+      @config.run_hooks :on_restart, self, @events
 
       if Puma.jruby?
         close_binder_listeners

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -198,6 +198,96 @@ class TestConfigFile < TestConfigFileBase
     assert_equal conf.options[:raise_exception_on_sigterm], true
   end
 
+  def test_run_hooks_on_restart_hook
+    require 'puma/events'
+
+    messages = []
+    conf = Puma::Configuration.new do |c|
+      c.on_restart do |a|
+        messages << "on_restart is called with #{a}"
+      end
+    end
+    conf.load
+
+    conf.run_hooks :on_restart, 'ARG', Puma::Events.strings
+    assert_equal messages, ['on_restart is called with ARG']
+  end
+
+  def test_run_hooks_before_worker_fork
+    require 'puma/events'
+
+    messages = []
+    conf = Puma::Configuration.new do |c|
+      c.on_worker_fork do |a|
+        messages << "before_worker_fork is called with #{a}"
+      end
+    end
+    conf.load
+
+    conf.run_hooks :before_worker_fork, 'ARG', Puma::Events.strings
+    assert_equal messages, ['before_worker_fork is called with ARG']
+  end
+
+  def test_run_hooks_after_worker_fork
+    require 'puma/events'
+
+    messages = []
+    conf = Puma::Configuration.new do |c|
+      c.after_worker_fork do |a|
+        messages << "after_worker_fork is called with #{a}"
+      end
+    end
+    conf.load
+
+    conf.run_hooks :after_worker_fork, 'ARG', Puma::Events.strings
+    assert_equal messages, ['after_worker_fork is called with ARG']
+  end
+
+  def test_run_hooks_before_worker_boot
+    require 'puma/events'
+
+    messages = []
+    conf = Puma::Configuration.new do |c|
+      c.on_worker_boot do |a|
+        messages << "before_worker_boot is called with #{a}"
+      end
+    end
+    conf.load
+
+    conf.run_hooks :before_worker_boot, 'ARG', Puma::Events.strings
+    assert_equal messages, ['before_worker_boot is called with ARG']
+  end
+
+  def test_run_hooks_before_worker_shutdown
+    require 'puma/events'
+
+    messages = []
+    conf = Puma::Configuration.new do |c|
+      c.on_worker_shutdown do |a|
+        messages << "before_worker_shutdown is called with #{a}"
+      end
+    end
+    conf.load
+
+    conf.run_hooks :before_worker_shutdown, 'ARG', Puma::Events.strings
+    assert_equal messages, ['before_worker_shutdown is called with ARG']
+  end
+
+  def test_run_hooks_before_fork
+    require 'puma/events'
+
+    messages = []
+    conf = Puma::Configuration.new do |c|
+      c.before_fork do |a|
+        messages << "before_fork is called with #{a}"
+      end
+    end
+    conf.load
+
+    conf.run_hooks :before_fork, 'ARG', Puma::Events.strings
+    assert_equal messages, ['before_fork is called with ARG']
+  end
+
   def test_run_hooks_and_exception
     require 'puma/events'
 


### PR DESCRIPTION
### Description

Suppress exceptions in user defined hooks (like `on_worker_boot`). We have just to rescue and log them.

Example of logged message:

```
WARNING hook on_restart failed with exception (RuntimeError) Error from hook
% Traceback (most recent call last):
	14: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/minitest-5.14.0/lib/minitest/parallel.rb:33:in `block (2 levels) in start'
	13: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/minitest-5.14.0/lib/minitest.rb:1026:in `run_one_method'
	12: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/minitest-5.14.0/lib/minitest/test.rb:93:in `run'
	11: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/minitest-5.14.0/lib/minitest/test.rb:211:in `with_info_handler'
	10: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/minitest-5.14.0/lib/minitest.rb:365:in `on_signal'
	 9: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/minitest-5.14.0/lib/minitest/test.rb:94:in `block in run'
	 8: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/minitest-5.14.0/lib/minitest.rb:270:in `time_it'
	 7: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/minitest-5.14.0/lib/minitest/test.rb:95:in `block (2 levels) in run'
	 6: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/minitest-5.14.0/lib/minitest/test.rb:195:in `capture_exceptions'
	 5: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/minitest-5.14.0/lib/minitest/test.rb:98:in `block (3 levels) in run'
	 4: from /Users/andrykonchin/projects/puma/test/test_config.rb:226:in `test_run_hooks_and_exception'
	 3: from /Users/andrykonchin/projects/puma/lib/puma/configuration.rb:279:in `run_hooks'
	 2: from /Users/andrykonchin/projects/puma/lib/puma/configuration.rb:279:in `each'
	 1: from /Users/andrykonchin/projects/puma/lib/puma/configuration.rb:281:in `block in run_hooks'
/Users/andrykonchin/projects/puma/test/test_config.rb:220:in `block (2 levels) in test_run_hooks_and_exception': Error from hook (RuntimeError)
```

Closes #1551

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
