### PR TITLE
Temp fix for Actions Windows CI [changelog skip]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows-latest ]
-        ruby: [ 2.3, 2.4, 2.5, 2.6, 2.7, ruby-head ]
+        ruby: [ 2.4, 2.5, 2.6, 2.7, ruby-head ]
 
     steps:
       - name: repo checkout
@@ -82,7 +82,7 @@ jobs:
         if:   startsWith(matrix.os, 'windows')
         uses: MSP-Greg/actions-ruby@v1
         with:
-          base:  update
+          # base:  update
           mingw: openssl ragel
           ruby-version: ${{ matrix.ruby }}
 
@@ -94,7 +94,7 @@ jobs:
         run:  bundle exec rake compile
 
       # Ruby 2.3 uses a OpenSSL package that is not MSYS2
-      - name: compile
+      - name: compile ruby 2.3
         if:   matrix.ruby == '2.3'
         run:  bundle exec rake compile -- --with-openssl-dir=C:/openssl-win
 


### PR DESCRIPTION
### Description

GitHub has not intentionally installed MSYS2/MinGW tools on their Windows images.  Hence, what they unintentionally installed is out of date.  The MSYS2 servers are having issues, possibly from the Actions CI traffic updating the out of date tools...

Temporary fix for Actions CI issues on Windows.  I'll revert when...

1. Removes updating MSYS2/MinGW gcc tools

2. Remove  Ruby 2.3, as it won't compile jaro-winkler (RuboCop dependency) without the updated gcc

3. Ruby 2.5 thru master still need to download the MSYS2/MinGW OpenSSL 1.1.1 package.  Hopefully, it will work...

This did pass in my fork twice...

### Your checklist for this pull request
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
