### PR TITLE
Suppress Rack deprecation warning in specs [changelog skip]

### DIFF
--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -14,7 +14,11 @@ class TestConfigFile < TestConfigFileBase
     end
     conf.load
 
-    conf.app
+    # suppress deprecation warning of Rack (>= 2.2.0)
+    # > Parsing options from the first comment line is deprecated!\n
+    assert_output(nil, nil) do
+      conf.app
+    end
 
     assert_equal ["tcp://127.0.0.1:9292"], conf.options[:binds]
   end


### PR DESCRIPTION
### Description

Don't show a message 
```
Parsing options from the first comment line is deprecated!`
```
when run tests:

```shell
bundle exec m test/test_config.rb:11
Run options: -n "/^(test_app_from_rackup)$/" --seed 35517

# Running:

Parsing options from the first comment line is deprecated!
.

Fabulous run in 0.007740s, 129.1990 runs/s, 129.1990 assertions/s.
```

Closes #2158

### Notes

Since Rack 2.2.0 specifying options in magic comments in a rackup file is deprecated ([Changelog](https://github.com/rack/rack/blob/master/CHANGELOG.md#220---2020-02-08), https://github.com/rack/rack/pull/1574)

Not sure whether we need the `test_app_from_rackup` test at all. At least we can hide the deprecation message.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
