### PR TITLE
Show RUBYOPT in test 'header', use setup-ruby-pkgs in Actions CI [changelog skip]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,44 +21,32 @@ jobs:
       - name: repo checkout
         uses: actions/checkout@v2
 
-      - name: load ruby
-        uses: ruby/setup-ruby@v1
+      - name: load ruby, ragel
+        uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - name: ubuntu & macos - install ragel
-        if:   startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
-        run:  |
-          if [ "${{ matrix.os }}" == "macos" ]; then
-            brew install ragel
-          else
-            sudo apt-get -qy install ragel
-          fi
-
-      - name: Ruby 2.2 update RubyGems
-        if:   matrix.ruby < '2.3'
-        run:  |
-          gem update --system 2.7.10 --no-document
+          apt-get: ragel
+          brew: ragel
 
       - name: bundle install
-        run:  bundle install --jobs 4 --retry 3 --path=.bundle/puma
+        run:  |
+          # update RubyGems in Ruby 2.2, bundle install
+          if [[ "${{ matrix.ruby }}" < "2.3" ]]; then
+            gem update --system 2.7.10 --no-document
+          fi
+          bundle install --jobs 4 --retry 3 --path=.bundle/puma
+
       - name: compile
         run:  bundle exec rake compile
 
-      # two test steps due to pre-installed Bundler not working with
-      # frozen strings before 2.0
-
-      - name: test with frozen string
+      - name: test
         timeout-minutes: 10
-        env:
-          RUBYOPT: --enable-frozen-string-literal
-        if: matrix.ruby >= '2.6'
-        run:  bundle exec rake
-
-      - name: test without frozen string
-        timeout-minutes: 10
-        if: matrix.ruby < '2.6'
-        run:  bundle exec rake
+        run:  |
+          # RubyGems < 3, no frozen strings
+          if [[ "2.6" < "${{ matrix.ruby }}.0" ]]; then
+            export RUBYOPT="--enable=frozen-string-literal"
+          fi
+          bundle exec rake
 
   win32:
     name: >-
@@ -72,40 +60,35 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows-latest ]
-        ruby: [ 2.4, 2.5, 2.6, 2.7, ruby-head ]
+        ruby: [ 2.3, 2.4, 2.5, 2.6, 2.7, mingw ]
 
     steps:
       - name: repo checkout
         uses: actions/checkout@v2
 
-      - name: windows - update MSYS2, openssl, ragel
-        if:   startsWith(matrix.os, 'windows')
-        uses: MSP-Greg/actions-ruby@v1
+      - name: load ruby, ragel, openssl
+        uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
-          # base:  update
-          mingw: openssl ragel
           ruby-version: ${{ matrix.ruby }}
+          mingw: _upgrade_ openssl ragel
 
       - name: bundle install
         run:  bundle install --jobs 4 --retry 3 --path=.bundle/puma
 
       - name: compile
-        if:   matrix.ruby >= '2.4'
-        run:  bundle exec rake compile
+        run:  |
+          # Windows Ruby < 2.4 do not use MSYS2 OpenSSL
+          if ('${{ matrix.ruby }}' -lt '2.4') {
+            bundle exec rake compile -- --with-openssl-dir=C:/openssl-win
+          } else {
+            bundle exec rake compile
+          }
 
-      # Ruby 2.3 uses a OpenSSL package that is not MSYS2
-      - name: compile ruby 2.3
-        if:   matrix.ruby == '2.3'
-        run:  bundle exec rake compile -- --with-openssl-dir=C:/openssl-win
-
-      - name: test with frozen string
+      - name: test
         timeout-minutes: 10
-        env:
-          RUBYOPT: --enable-frozen-string-literal
-        if: matrix.ruby >= '2.6'
-        run:  bundle exec rake
-
-      - name: test without frozen string
-        timeout-minutes: 10
-        if: matrix.ruby < '2.6'
-        run:  bundle exec rake
+        run:  |
+          # RubyGems < 3, no frozen strings
+          if ('${{ matrix.ruby }}' -ge '2.6') {
+            $env:RUBYOPT = '--enable=frozen-string-literal'
+          }
+          bundle exec rake

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -21,7 +21,7 @@ DISABLE_SSL = begin
               Puma::MiniSSL.check
               # net/http (loaded in helper) does not necessarily load OpenSSL
               require "openssl" unless Object.const_defined? :OpenSSL
-              puts "", RUBY_DESCRIPTION,
+              puts "", RUBY_DESCRIPTION, "RUBYOPT: #{ENV['RUBYOPT']}",
                    "                         Puma::MiniSSL                   OpenSSL",
                    "OPENSSL_LIBRARY_VERSION: #{Puma::MiniSSL::OPENSSL_LIBRARY_VERSION.ljust 32}#{OpenSSL::OPENSSL_LIBRARY_VERSION}",
                    "        OPENSSL_VERSION: #{Puma::MiniSSL::OPENSSL_VERSION.ljust 32}#{OpenSSL::OPENSSL_VERSION}", ""


### PR DESCRIPTION
### Description

1. Actions CI - Via a new action, Windows gcc is now being updated again.  This is the gcc that a typical new Windows install would have.  It also allows Ruby 2.3 to be added back into the CI, which was removed in PR https://github.com/puma/puma/pull/2157.  The new action pulls all the MSYS2 packages from a GitHub release, so the current server issues won't be a problem.

2. Actions CI - There were several pairs of conditional steps. Removed them by moving the logic into script.  The first line of script is a brief comment re the reason for the conditional, which appears in the step log.

3. Added `RUBYOPT` in the test 'header'.

As mentioned elsewhere, once GitHub adds MSYS2 to their Windows images, I'll update as needed...

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
