### PR TITLE
[changelog skip] Backfill tests for stdout/stderr redirection on SIGHUP

### DIFF
--- a/test/test_redirect_io.rb
+++ b/test/test_redirect_io.rb
@@ -1,0 +1,103 @@
+require_relative "helper"
+require_relative "helpers/integration"
+
+class TestRedirectIO < TestIntegration
+  parallelize_me!
+
+  def setup
+    super
+
+    @out_file = Tempfile.new 'puma-out'
+    @out_file_path = @out_file.path
+    @err_file = Tempfile.new 'puma-err'
+    @err_file_path = @err_file.path
+  end
+
+  def teardown
+    super
+
+    @out_file.close
+    @err_file.close
+    File.unlink @out_file_path
+    File.unlink @err_file_path
+  end
+
+  def test_sighup_redirects_io_single
+    skip_unless_signal_exist? :HUP
+
+    cli_args = [
+      '--redirect-stdout', @out_file_path,
+      '--redirect-stderr', @err_file_path,
+      'test/rackup/hello.ru'
+    ]
+    cli_server cli_args.join ' '
+
+    wait_until_file_has_content @out_file
+    assert_match 'puma startup', @out_file.readline
+
+    wait_until_file_has_content @err_file
+    assert_match 'puma startup', @err_file.readline
+
+    log_rotate_output_files
+
+    Process.kill :HUP, @server.pid
+
+    wait_until_file_has_content @out_file
+    assert_match 'puma startup', @out_file.readline
+
+    wait_until_file_has_content @err_file
+    assert_match 'puma startup', @err_file.readline
+  end
+
+  def test_sighup_redirects_io_cluster
+    skip_unless_signal_exist? :HUP
+
+    cli_args = [
+      '-w', '1',
+      '--redirect-stdout', @out_file_path,
+      '--redirect-stderr', @err_file_path,
+      'test/rackup/hello.ru'
+    ]
+    cli_server cli_args.join ' '
+
+    wait_until_file_has_content @out_file
+    assert_match 'puma startup', @out_file.readline
+
+    wait_until_file_has_content @err_file
+    assert_match 'puma startup', @err_file.readline
+
+    log_rotate_output_files
+
+    Process.kill :HUP, @server.pid
+
+    wait_until_file_has_content @out_file
+    assert_match 'puma startup', @out_file.readline
+
+    wait_until_file_has_content @err_file
+    assert_match 'puma startup', @err_file.readline
+  end
+
+  private
+
+  def log_rotate_output_files
+    # rename both files to .old
+    old_out_file_path = "#{@out_file_path}.old"
+    old_err_file_path = "#{@err_file_path}.old"
+    File.rename @out_file_path, old_out_file_path
+    File.rename @err_file_path, old_err_file_path
+
+    # reload references to output files
+    @out_file.close
+    @err_file.close
+    @out_file = File.open @out_file_path, File::CREAT
+    @err_file = File.open @err_file_path, File::CREAT
+  end
+
+  def wait_until_file_has_content(file)
+    file.read_nonblock 1
+    file.seek 0
+  rescue EOFError
+    sleep 0.1
+    retry
+  end
+end


### PR DESCRIPTION
### Description

I noticed that there weren't any tests for what is supposed to happen when `puma` receives the `SIGHUP` signal. #561 was the PR that introduced the behavior. I didn't really understand what the use case was at first, but [an issue on a unrelated project](https://github.com/influxdata/telegraf/issues/5128) gave a good explanation for why this functionality is desirable.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
