### PR TITLE
Log binding on http:// for TCP bindings to make it clickable

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@
   * Changed #connected_port to #connected_ports (#2076)
   * `--control` has been removed. Use `--control-url` (#1487)
   * `worker_directory` has been removed. Use `directory`
+  * Log binding on http:// for TCP bindings to make it clickable
 
 * Bugfixes
   * Windows update extconf.rb for use with ssp and varied Ruby/MSYS2 combinations (#2069)

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -115,7 +115,7 @@ module Puma
                 i.local_address.ip_unpack.join(':')
               end
 
-              logger.log "* #{log_msg} on tcp://#{addr}"
+              logger.log "* #{log_msg} on http://#{addr}"
             end
           end
 

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -64,7 +64,7 @@ class TestBinder < TestBinderBase
   def test_correct_zero_port
     @binder.parse ["tcp://localhost:0"], @events
 
-    m = %r!tcp://127.0.0.1:(\d+)!.match(@events.stdout.string)
+    m = %r!http://127.0.0.1:(\d+)!.match(@events.stdout.string)
     port = m[1].to_i
 
     refute_equal 0, port
@@ -84,9 +84,9 @@ class TestBinder < TestBinderBase
   def test_logs_all_localhost_bindings
     @binder.parse ["tcp://localhost:0"], @events
 
-    assert_match %r!tcp://127.0.0.1:(\d+)!, @events.stdout.string
+    assert_match %r!http://127.0.0.1:(\d+)!, @events.stdout.string
     if Socket.ip_address_list.any? {|i| i.ipv6_loopback? }
-      assert_match %r!tcp://\[::1\]:(\d+)!, @events.stdout.string
+      assert_match %r!http://\[::1\]:(\d+)!, @events.stdout.string
     end
   end
 
@@ -271,7 +271,7 @@ class TestBinder < TestBinderBase
 
     prepared_paths = {
         ssl: "ssl://127.0.0.1:#{UniquePort.call}?#{ssl_query}",
-        tcp: "tcp://127.0.0.1:#{UniquePort.call}",
+        tcp: "http://127.0.0.1:#{UniquePort.call}",
         unix: "unix://test/#{name}_server.sock"
       }
 


### PR DESCRIPTION
### Description
> since TCP mode is on the way out, how do you feel about (independently, and right away) changing the console message from * Listening on tcp://0.0.0.0:9292 to http:// instead? That would make it possible to cmd-double-click on the message Puma prints to open it immediately in a browser, which I miss a lot.

Fix https://github.com/puma/puma/issues/2166


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
