### PR TITLE
Fix out_of_band hook never executed when multiple worker threads (clo…

### DIFF
--- a/History.md
+++ b/History.md
@@ -24,6 +24,7 @@
   * Rescue IO::WaitReadable instead of EAGAIN for blocking read (#2121)
   * Ensure `BUNDLE_GEMFILE` is unspecified in workers if unspecified in master when using `prune_bundler` (#2154)
   * Rescue and log exceptions in hooks defined by users (on_worker_boot, after_worker_fork etc) (#1551)
+  * Fix `out_of_band` hook never executed if the number of worker threads is > 1 (#2177)
   
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -291,7 +291,7 @@ module Puma
 
                     pool << client
                     busy_threads = pool.wait_until_not_full
-                    if busy_threads == 0
+                    if busy_threads < @max_threads
                       @options[:out_of_band].each(&:call) if @options[:out_of_band]
                     end
                   end


### PR DESCRIPTION
### Description

**Alternative solution** to this PR: https://github.com/puma/puma/pull/2180
I believe this one should be merged and https://github.com/puma/puma/pull/2180 should be discarded but the maintainers are probably wiser than me on Puma!

#### Issue description
C.F. https://github.com/puma/puma/issues/2177

#### Fix description
Before this patch, the `out_of_band` hook was executed only when *all* worker threads were free:
```ruby
pool << client
busy_threads = pool.wait_until_not_full
if busy_threads == 0
  @options[:out_of_band].each(&:call) if @options[:out_of_band]
end
```

In addition, due to how the function `wait_until_not_full` (in lib/puma/thread_pool.rb) works, namely:
* If not all threads are busy, return the number of busy threads
* Otherwise, wait (loop) for the condition above

The condition `if busy_threads == 0` could never be satisfied if the number of worker threads was > 1.

EDIT: it could be satisfied if the worker finished its job before the call to `wait_until_not_full`, which is *very unlikely* because this function is called right after adding the client to the pool. 

I believe that the `out_of_band` hook should be allowed to run if there is *at least 1* available worker thread. It seems reasonable to me and provides an easy fix for this bug.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
