### PR TITLE
Add customizable error messages on thread shutdown

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,6 +7,7 @@
   * `GC.compact` is called before fork if available (#2093)
   * Add `requests_count` to workers stats. (#2106)
   * Increases maximum URI path length from 2048 to 8196 bytes (#2167)
+  * Added `force_shutdown_error_response` to override the force shutdown response to clients. (#2182)
 
 * Deprecations, Removals and Breaking API Changes
   * `Puma.stats` now returns a Hash instead of a JSON string (#2086)

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -13,6 +13,8 @@ module Puma
     DefaultTCPPort = 9292
     DefaultWorkerTimeout = 60
     DefaultWorkerShutdownTimeout = 30
+
+    DefaultThreadShutdownResponse = [503, {}, ["Request was internally terminated early\n"]].freeze
   end
 
   # A class used for storing "leveled" configuration options.
@@ -186,7 +188,8 @@ module Puma
         :logger => STDOUT,
         :persistent_timeout => Const::PERSISTENT_TIMEOUT,
         :first_data_timeout => Const::FIRST_DATA_TIMEOUT,
-        :raise_exception_on_sigterm => true
+        :raise_exception_on_sigterm => true,
+        :force_shutdown_error_response => DefaultThreadShutdownResponse,
       }
     end
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -539,6 +539,22 @@ module Puma
       @options[:lowlevel_error_handler] = obj
     end
 
+    # When force_shutdown_after is set, this allows you to control the message returned
+    # on a force shutdown to the client.
+    #
+    # @example
+    #   force_shutdown_error_response(500, {"Content-Type" => "application/json"}, [JSON.generate({message: "Server shutdown."})])
+    def force_shutdown_error_response(status, headers, response)
+      raise "Headers must be a hash" unless headers.is_a?(Hash)
+      raise "Response must be enumerable" unless response.is_a?(Enumerable)
+
+      @options[:force_shutdown_error_response] = [
+        Integer(status),
+        headers,
+        response
+      ]
+    end
+
     # This option is used to allow your app and its gems to be
     # properly reloaded when not using preload.
     #

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -545,8 +545,8 @@ module Puma
     # @example
     #   force_shutdown_error_response(500, {"Content-Type" => "application/json"}, [JSON.generate({message: "Server shutdown."})])
     def force_shutdown_error_response(status, headers, response)
-      raise "Headers must be a hash" unless headers.is_a?(Hash)
-      raise "Response must be enumerable" unless response.is_a?(Enumerable)
+      raise "Not a Rack-compatible header (must respond to each)" unless headers.respond_to?(:each)
+      raise "Not a Rack-compatible response (must respond to each)" unless response.respond_to?(:each)
 
       @options[:force_shutdown_error_response] = [
         Integer(status),

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -593,9 +593,13 @@ module Puma
           @events.log "Detected force shutdown of a thread, returning 503"
           @events.unknown_error self, e, "Rack app"
 
-          status = 503
-          headers = {}
-          res_body = ["Request was internally terminated early\n"]
+          if @options[:force_shutdown_error_response]
+            status, headers, res_body = @options[:force_shutdown_error_response]
+          else
+            status = 503
+            headers = {}
+            res_body = ["Request was internally terminated early\n"]
+          end
 
         rescue Exception => e
           @events.unknown_error self, e, "Rack app", env

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -593,14 +593,7 @@ module Puma
           @events.log "Detected force shutdown of a thread, returning 503"
           @events.unknown_error self, e, "Rack app"
 
-          if @options[:force_shutdown_error_response]
-            status, headers, res_body = @options[:force_shutdown_error_response]
-          else
-            status = 503
-            headers = {}
-            res_body = ["Request was internally terminated early\n"]
-          end
-
+          status, headers, res_body = @options[:force_shutdown_error_response]
         rescue Exception => e
           @events.unknown_error self, e, "Rack app", env
 

--- a/test/config/app.rb
+++ b/test/config/app.rb
@@ -7,3 +7,9 @@ end
 lowlevel_error_handler do |err|
   [200, {}, ["error page"]]
 end
+
+force_shutdown_error_response(
+  500,
+  {"Content-Type" => "application/json"},
+  ["{}"]
+)

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -114,6 +114,15 @@ class TestConfigFile < TestConfigFileBase
     assert_equal [200, {}, ["error page"]], app.call({})
   end
 
+  def test_force_shutdown_error_response_DSL
+    conf = Puma::Configuration.new do |c|
+      c.load "test/config/app.rb"
+    end
+    conf.load
+
+    assert_equal [500, {"Content-Type" => "application/json"}, ["{}"]], conf.options[:force_shutdown_error_response]
+  end
+
   def test_allow_users_to_override_default_options
     conf = Puma::Configuration.new(restart_cmd: 'bin/rails server')
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -278,7 +278,7 @@ EOF
   end
 
   def test_force_shutdown_error_default
-    @server = Puma::Server.new @app, @events, {:force_shutdown_after => 2}
+    @server = Puma::Server.new @app, @events, {:force_shutdown_after => 2, :force_shutdown_error_response => Puma::ConfigDefault::DefaultThreadShutdownResponse}
 
     server_run app: ->(env) do
       @server.stop


### PR DESCRIPTION
### Description
When threads are forced to shutdown, the response is static and cannot be configured. For our use case, we want to always guarantee a JSON response is returned on the rare case this comes up.

I didn't make this a proc like `lowlevel_error_handler`, since the intent is to be shutting down quickly, a static response felt more appropriate. While I was here, I also added a test for the base case (default message) as I couldn't find any tests which exercised that.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
