### PR TITLE
test_puma_server_ssl.rb - fix for JRuby OpenSSL::SSL::SSLContext bug [changelog skip]

### DIFF
--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -164,7 +164,7 @@ class TestPumaServerSSL < Minitest::Test
     skip("TLSv1 protocol is unavailable") if Puma::MiniSSL::OPENSSL_NO_TLS1
     start_server { |ctx| ctx.no_tlsv1 = true }
 
-    if @http.respond_to? :max_version=
+    if OpenSSL::SSL::SSLContext.private_instance_methods(false).include?(:set_minmax_proto_version)
       @http.max_version = :TLS1
     else
       @http.ssl_version = :TLSv1
@@ -184,7 +184,7 @@ class TestPumaServerSSL < Minitest::Test
   def test_tls_v1_1_rejection
     start_server { |ctx| ctx.no_tlsv1_1 = true }
 
-    if @http.respond_to? :max_version=
+    if OpenSSL::SSL::SSLContext.private_instance_methods(false).include?(:set_minmax_proto_version)
       @http.max_version = :TLS1_1
     else
       @http.ssl_version = :TLSv1_1


### PR DESCRIPTION
### Description

`OpenSSL::SSL::SSLContext#min_version=` and `OpenSSL::SSL::SSLContext#max_version=` are broken on JRuby.

The methods may be called in OpenSSL code or net/http code.  The test may call it in a client used for testing.

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
