### PR TITLE
Fix warnings for !HAS_FORK [changelog skip]

### DIFF
--- a/test/test_preserve_bundler_env.rb
+++ b/test/test_preserve_bundler_env.rb
@@ -8,6 +8,7 @@ class TestPreserveBundlerEnv < TestIntegration
   end
 
   def teardown
+    return if skipped?
     FileUtils.rm current_release_symlink, force: true
     super
   end

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -1,6 +1,8 @@
 require_relative "helper"
 require "puma/minissl"
 require "puma/puma_http11"
+require "puma/events"
+require "net/http"
 
 #———————————————————————————————————————————————————————————————————————————————
 #             NOTE: ALL TESTS BYPASSED IF DISABLE_SSL IS TRUE


### PR DESCRIPTION
Skip teardown if setup was skipped in test_preserve_bundler_env

* Otherwise we get
puma/test/helpers/integration.rb:27: warning: instance variable @ios_to_close not initialized
puma/test/helpers/integration.rb:34: warning: instance variable @bind_path not initialized
See https://travis-ci.org/github/puma/puma/jobs/662767158#L469
* Same pattern as in test/test_integration_cluster.rb.