### PR TITLE
Update Rack::Handler::Puma.run method options param

### DIFF
--- a/History.md
+++ b/History.md
@@ -30,6 +30,7 @@
   * Simplify `Configuration.random_token` and remove insecure fallback (#2102)
   * Simplify `Runner#start_control` URL parsing (#2111)
   * Removed the IOBuffer extension and replaced with Ruby (#1980)
+  * Update `Rack::Handler::Puma.run` to use `**options` (#2189)
 
 ## 4.3.3 and 3.12.4 / 2020-02-28
 

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -59,7 +59,7 @@ module Rack
         conf
       end
 
-      def self.run(app, options = {})
+      def self.run(app, **options)
         conf   = self.config(app, options)
 
         events = options.delete(:Silent) ? ::Puma::Events.strings : ::Puma::Events.stdio

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -26,7 +26,7 @@ class TestPathHandler < Minitest::Test
 
     @launcher = nil
     thread = Thread.new do
-      Rack::Handler::Puma.run(app, options) do |s, p|
+      Rack::Handler::Puma.run(app, **options) do |s, p|
         @launcher = s
       end
     end


### PR DESCRIPTION
Rack has opted to use the double splat operator for options.

See: https://github.com/rack/rack/commit/871c82f0ffa269d7e2e237d3ade9a1eac26418fe


