### PR TITLE
Use SIGWINCH to print thread backtraces

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,6 +7,7 @@
   * `GC.compact` is called before fork if available (#2093)
   * Add `requests_count` to workers stats. (#2106)
   * Increases maximum URI path length from 2048 to 8196 bytes (#2167)
+  * Sending SIGWINCH to any Puma worker now prints currently active threads and their backtraces (#2195)
 
 * Deprecations, Removals and Breaking API Changes
   * `Puma.stats` now returns a Hash instead of a JSON string (#2086)

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -40,7 +40,7 @@ Puma cluster responds to these signals:
 - `USR1` restart workers in phases, a rolling restart. This will not reload configuration file.
 - `HUP`  reopen log files defined in stdout_redirect configuration parameter. If there is no stdout_redirect option provided it will behave like `INT`
 - `INT` equivalent of sending Ctrl-C to cluster. Will attempt to finish then exit.
-- `CHLD`
+- `WINCH` (`INFO` on BSD-based systems) prints a thread backtrace. This is useful for debugging infinite loops or slow performance.
 
 ## Callbacks order in case of different signals
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -453,17 +453,29 @@ module Puma
       end
 
       begin
+        Signal.trap "SIGWINCH" do
+          log_backtrace
+        end
+      rescue Exception
+        log "*** SIGWINCH not implemented, signal based thread backtraces unavailable!"
+      end
+
+      begin
         unless Puma.jruby? # INFO in use by JVM already
           Signal.trap "SIGINFO" do
-            thread_status do |name, backtrace|
-              @events.log name
-              @events.log backtrace.map { |bt| "  #{bt}" }
-            end
+            log_backtrace
           end
         end
       rescue Exception
         # Not going to log this one, as SIGINFO is *BSD only and would be pretty annoying
         # to see this constantly on Linux.
+      end
+    end
+
+    def log_backtrace
+      thread_status do |name, backtrace|
+        @events.log name
+        @events.log backtrace.map { |bt| "  #{bt}" }
       end
     end
 


### PR DESCRIPTION
### Description

https://github.com/puma/puma/pull/1320 added support for using SIGINFO,
but this is only available on BSD-based systems. SIGWINCH is on Linux.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
