### PR TITLE
Use SIGTTIN to trigger thread backtraces

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,7 +7,8 @@
   * `GC.compact` is called before fork if available (#2093)
   * Add `requests_count` to workers stats. (#2106)
   * Increases maximum URI path length from 2048 to 8196 bytes (#2167)
-  * Sending SIGWINCH to any Puma worker now prints currently active threads and their backtraces (#2195)
+  * Sending SIGTTIN to a Puma worker now prints currently active threads and their backtraces (#2202)
+    NOTE: SIGTTIN will only increment a worker by 1 if the signal is sent to the main process.
 
 * Deprecations, Removals and Breaking API Changes
   * `Puma.stats` now returns a Hash instead of a JSON string (#2086)

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -33,14 +33,19 @@ Now you will see via `ps` that there is no more `tail` process. Sometimes when r
 
 Puma cluster responds to these signals:
 
-- `TTIN` increment the worker count by 1
+- `TTIN` This behaves differently depending on whether the signal is
+  sent to the main process or a cluster worker. When sent to the main
+  process, this increments the worker count by 1.
+
+  Otherwise, it prints a thread backtrace. This is useful for debugging infinite loops or slow performance.
+
 - `TTOU` decrement the worker count by 1
 - `TERM` send `TERM` to worker. Worker will attempt to finish then exit.
 - `USR2` restart workers. This also reloads puma configuration file, if there is one.
 - `USR1` restart workers in phases, a rolling restart. This will not reload configuration file.
 - `HUP`  reopen log files defined in stdout_redirect configuration parameter. If there is no stdout_redirect option provided it will behave like `INT`
 - `INT` equivalent of sending Ctrl-C to cluster. Will attempt to finish then exit.
-- `WINCH` (`INFO` on BSD-based systems) prints a thread backtrace. This is useful for debugging infinite loops or slow performance.
+- `INFO` (on BSD-based systems) prints a thread backtrace. This is useful for debugging infinite loops or slow performance.
 
 ## Callbacks order in case of different signals
 

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -390,17 +390,21 @@ module Puma
         wakeup!
       end
 
+      master_pid = Process.pid
+
       Signal.trap "TTIN" do
-        @options[:workers] += 1
-        wakeup!
+        if Process.pid == master_pid
+          @options[:workers] += 1
+          wakeup!
+        else
+          @launcher.log_backtrace
+        end
       end
 
       Signal.trap "TTOU" do
         @options[:workers] -= 1 if @options[:workers] >= 2
         wakeup!
       end
-
-      master_pid = Process.pid
 
       Signal.trap "SIGTERM" do
         # The worker installs their own SIGTERM when booted.

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -203,6 +203,13 @@ module Puma
       @binder.close_listeners
     end
 
+    def log_backtrace
+      thread_status do |name, backtrace|
+        @events.log name
+        @events.log backtrace.map { |bt| "  #{bt}" }
+      end
+    end
+
     def thread_status
       Thread.list.each do |thread|
         name = "Thread: TID-#{thread.object_id.to_s(36)}"
@@ -453,11 +460,11 @@ module Puma
       end
 
       begin
-        Signal.trap "SIGWINCH" do
+        Signal.trap "SIGTTIN" do
           log_backtrace
         end
       rescue Exception
-        log "*** SIGWINCH not implemented, signal based thread backtraces unavailable!"
+        log "*** SIGTTIN not implemented, signal based thread backtraces unavailable!"
       end
 
       begin
@@ -469,13 +476,6 @@ module Puma
       rescue Exception
         # Not going to log this one, as SIGINFO is *BSD only and would be pretty annoying
         # to see this constantly on Linux.
-      end
-    end
-
-    def log_backtrace
-      thread_status do |name, backtrace|
-        @events.log name
-        @events.log backtrace.map { |bt| "  #{bt}" }
       end
     end
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -33,10 +33,10 @@ class TestIntegrationCluster < TestIntegration
     end
   end
 
-  def test_sigwinch_thread_print
-    skip_unless_signal_exist? :WINCH
+  def test_sigttin_thread_print
+    skip_unless_signal_exist? :TTIN
 
-    signal_thread_backtrace :WINCH
+    signal_thread_backtrace :TTIN
   end
 
   def test_siginfo_thread_print


### PR DESCRIPTION
Note that this signal behaves differently depending on whether the signal is
sent to the main process or a cluster worker. When sent to the main
process, this increments the worker count by 1.

Otherwise, it prints a thread backtrace. This is useful for debugging
infinite loops or slow performance.

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
