### PR TITLE
Handle thread shutdown responses via low level error messages

### DIFF
--- a/History.md
+++ b/History.md
@@ -9,6 +9,7 @@
   * Add `requests_count` to workers stats. (#2106)
   * Increases maximum URI path length from 2048 to 8196 bytes (#2167)
   * Sending SIGWINCH to any Puma worker now prints currently active threads and their backtraces (#2195)
+  * Force shutdown responses can be overridden by using the `lowlevel_error_handler` config (#2203)
 
 * Deprecations, Removals and Breaking API Changes
   * `Puma.stats` now returns a Hash instead of a JSON string (#2086)

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -589,17 +589,15 @@ module Puma
 
             return :async
           end
+        rescue ThreadPool::ForceShutdown => e
+          @events.unknown_error self, e, "Rack app", env
+          @events.log "Detected force shutdown of a thread"
+
+          status, headers, res_body = lowlevel_error(e, env, 503)
         rescue Exception => e
           @events.unknown_error self, e, "Rack app", env
 
-          status = 500
-          if e.is_a?(ThreadPool::ForceShutdown)
-            status = 503
-
-            @events.log "Detected force shutdown of a thread, returning 503"
-          end
-
-          status, headers, res_body = lowlevel_error(e, env, status)
+          status, headers, res_body = lowlevel_error(e, env, 500)
         end
 
         content_length = nil

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -267,7 +267,7 @@ EOF
 
     server_run app: ->(env) do
       @server.stop
-      sleep 10
+      sleep 5
     end
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
@@ -282,7 +282,7 @@ EOF
 
     server_run app: ->(env) do
       @server.stop
-      sleep 10
+      sleep 5
     end
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"


### PR DESCRIPTION
### Description
Please describe your pull request. Thank you for contributing! You're the best.

This is a follow on from the suggestions in https://github.com/puma/puma/pull/2182#issuecomment-603638985. I did not make the change around `DefaultLowlevelErrorHandler`, because:

https://github.com/puma/puma/blob/0b737cce42746d8226701520f35685e0624e061b/lib/puma/server.rb#L819-L823

The `leak_stack_on_error` option is stored on the server instance and not options, which leaves no way of getting that data into the handler. I wasn't a fan of passing that through, and reorganizing how `leak_stack_on_error` works also felt out of scope.

Functionality wise, there's no changes besides thread shutdown now goes through lowlevel error handler and we pass `status` to the handler based on arity. If `leak_stack_on_error` is set, we include the stack, if not we show the generic error messages. 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
