### PR TITLE
control_cli.rb - fix for OpenSSL 1.1.1e

### DIFF
--- a/History.md
+++ b/History.md
@@ -18,6 +18,7 @@
   * Changed #connected_port to #connected_ports (#2076)
 
 * Bugfixes
+  * Fix Puma::ControlCLI's use of the Ruby OpenSSL stdlib when using OpenSSL 1.1.1e (#2208)
   * Windows update extconf.rb for use with ssp and varied Ruby/MSYS2 combinations (#2069)
   * Ensure control server Unix socket is closed on shutdown (#2112)
   * Preserve `BUNDLE_GEMFILE` env var when using `prune_bundler` (#1893)

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -167,7 +167,15 @@ module Puma
 
         server << "GET #{url} HTTP/1.0\r\n\r\n"
 
-        unless data = server.read
+        data = ''.dup
+        begin
+          while (t = server.read 1) do
+            data << t
+          end
+        rescue EOFError, OpenSSL::SSL::SSLError
+        end
+
+        if data.empty?
           raise "Server closed connection before responding"
         end
 


### PR DESCRIPTION
### Description
Fix Puma::ControlCLI's use of the Ruby OpenSSL stdlib when using OpenSSL 1.1.1e

Closes #2205

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
