### PR TITLE
Fix the CI [changelog skip]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,6 +28,7 @@ jobs:
         uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: 1
           apt-get: ragel
           brew: ragel
 

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -87,7 +87,7 @@ class TestThreadPool < Minitest::Test
   end
 
   def test_trim_leaves_min
-    skip_on :truffleruby # Undiagnose thread race. TODO fix
+    skip_on :jruby, :truffleruby # Undiagnose thread race. TODO fix
     pool = new_pool(1, 2) do |work|
       @work_mutex.synchronize do
         @work_done.signal


### PR DESCRIPTION
### Description
See https://github.com/puma/puma/runs/553627446 and https://github.com/oracle/truffleruby/issues/1984

The CI fails recently due to `ruby/setup-ruby` defaulting to latest Bundler (= 2) by default.

The failures are rather unclear so I suggest to stick to Bundler 1 to keep CI green, and then investigate what goes wrong with Bundler 2.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
