### PR TITLE
Set `Connection: closed` when running without request queueing

### DIFF
--- a/History.md
+++ b/History.md
@@ -27,6 +27,7 @@
   * Ensure `BUNDLE_GEMFILE` is unspecified in workers if unspecified in master when using `prune_bundler` (#2154)
   * Rescue and log exceptions in hooks defined by users (on_worker_boot, after_worker_fork etc) (#1551)
   * Read directly from the socket in #read_and_drop to avoid raising further SSL errors (#2198)
+  * Set `Connection: closed` header when queue requests is disabled (#2216)
 
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -371,7 +371,6 @@ module Puma
             close_socket = false
             return
           when true
-            return unless @queue_requests
             buffer.reset
 
             ThreadPool.clean_thread_locals if clean_thread_locals
@@ -644,6 +643,10 @@ module Puma
             no_body ||= status < 200 || STATUS_WITH_NO_ENTITY_BODY[status]
           end
         end
+
+        # regardless of what the client wants, we always close the connection
+        # if running without request queueing
+        keep_alive &&= @queue_requests
 
         response_hijack = nil
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -882,4 +882,43 @@ EOF
       assert_does_not_allow_http_injection(app)
     end
   end
+
+  def test_http11_connection_header_queue
+    server_run app: ->(_) { [200, {}, [""]] }
+
+    sock = send_http "GET / HTTP/1.1\r\n\r\n"
+    assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], header(sock)
+
+    sock << "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
+    assert_equal ["HTTP/1.1 200 OK", "Connection: close", "Content-Length: 0"], header(sock)
+
+    sock.close
+  end
+
+  def test_http10_connection_header_queue
+    server_run app: ->(_) { [200, {}, [""]] }
+
+    sock = send_http "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n"
+    assert_equal ["HTTP/1.0 200 OK", "Connection: Keep-Alive", "Content-Length: 0"], header(sock)
+
+    sock << "GET / HTTP/1.0\r\n\r\n"
+    assert_equal ["HTTP/1.0 200 OK", "Content-Length: 0"], header(sock)
+    sock.close
+  end
+
+  def test_http11_connection_header_no_queue
+    @server = Puma::Server.new @app, @events, queue_requests: false
+    server_run app: ->(_) { [200, {}, [""]] }
+    sock = send_http "GET / HTTP/1.1\r\n\r\n"
+    assert_equal ["HTTP/1.1 200 OK", "Connection: close", "Content-Length: 0"], header(sock)
+    sock.close
+  end
+
+  def test_http10_connection_header_no_queue
+    @server = Puma::Server.new @app, @events, queue_requests: false
+    server_run app: ->(_) { [200, {}, [""]] }
+    sock = send_http "GET / HTTP/1.0\r\n\r\n"
+    assert_equal ["HTTP/1.0 200 OK", "Content-Length: 0"], header(sock)
+    sock.close
+  end
 end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1,4 +1,6 @@
 require_relative "helper"
+require "puma/events"
+require "net/http"
 
 class TestPumaServer < Minitest::Test
   parallelize_me!


### PR DESCRIPTION
### Description
When running with `queue_requests=false`, the server closes the connection after each request. However, the server would indicate via the `Connection` header that the connection would be persisted. This was happening because the headers got reported in `handle_request`, _before_ the check to `@queue_requests` in `process_client` forces the connection to be closed. This PR moves the check to be in `handle_request` - this ensures that what the server reports in the headers, and what it actually does with the connection can't get out of whack.

Specifically the behaviour that we want here is:
 - for HTTP/1.0, omit the `Connection` header
 - for HTTP/1.1, setting `Connection: closed`. This is required by https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html, specifically:
`HTTP/1.1 applications that do not support persistent connections MUST include the "close" connection option in every message.`

As part of doing this change, I've refactored the logic around setting the connection headers to make it easier to understand why the headers are set the way they are. I've pulled this into a separate commit (345e127, which is intended to purely be a refactor and to have no functional effect). In general, this PR is probably best reviewed commit-by-commit.

The motivation for making this change is that this could previously cause clients which looked at this header to attempt to reuse connections which the server had closed. Clients that do this would get sent a TCP RST packet for their troubles, and would raise an exception.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
