### PR TITLE
Fix out_of_band hook

### DIFF
--- a/History.md
+++ b/History.md
@@ -31,6 +31,7 @@
   * Set `Connection: closed` header when queue requests is disabled (#2216)
   * Pass queued requests to thread pool on server shutdown (#2122)
   * Fixed a few minor concurrency bugs in ThreadPool that may have affected non-GVL Rubies (#2220)
+  * Fix `out_of_band` hook never executed if the number of worker threads is > 1 (#2177)
 
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -186,7 +186,6 @@ module Puma
     STOP_COMMAND = "?".freeze
     HALT_COMMAND = "!".freeze
     RESTART_COMMAND = "R".freeze
-    OUT_OF_BAND_COMMAND = "O".freeze
 
     RACK_INPUT = "rack.input".freeze
     RACK_URL_SCHEME = "rack.url_scheme".freeze

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -186,6 +186,7 @@ module Puma
     STOP_COMMAND = "?".freeze
     HALT_COMMAND = "!".freeze
     RESTART_COMMAND = "R".freeze
+    OUT_OF_BAND_COMMAND = "O".freeze
 
     RACK_INPUT = "rack.input".freeze
     RACK_URL_SCHEME = "rack.url_scheme".freeze

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -989,13 +989,24 @@ EOF
     @request_count = 0
     @oob_count = 0
     @start = Time.now
+    in_oob = Mutex.new
+    @mutex = Mutex.new
     @oob_finished = ConditionVariable.new
-    oob = -> {@oob_count += 1; @oob_finished.signal}
+    oob_wait = options.delete(:oob_wait)
+    oob = -> do
+      in_oob.synchronize do
+        @mutex.synchronize do
+          @oob_count += 1
+          @oob_finished.signal
+          @oob_finished.wait(@mutex, 1) if oob_wait
+        end
+      end
+    end
     @server = Puma::Server.new @app, @events, out_of_band: [oob], **options
     @server.min_threads = 5
     @server.max_threads = 5
-    @mutex = Mutex.new
     server_run app: ->(_) do
+      raise 'OOB conflict' if in_oob.locked?
       @mutex.synchronize {@request_count += 1}
       [200, {}, [""]]
     end
@@ -1007,7 +1018,7 @@ EOF
     oob_server queue_requests: false
     n.times do
       @mutex.synchronize do
-        send_http "HEAD / HTTP/1.0\r\n\r\n"
+        send_http "GET / HTTP/1.0\r\n\r\n"
         @oob_finished.wait(@mutex, 1)
       end
     end
@@ -1021,7 +1032,7 @@ EOF
     n = 100
     threads = 10
     oob_server
-    req = "HEAD / HTTP/1.1\r\n"
+    req = "GET / HTTP/1.1\r\n"
     @mutex.synchronize do
       Array.new(threads) do
         Thread.new do
@@ -1032,5 +1043,26 @@ EOF
     end
     assert_equal n, @request_count
     assert_equal 1, @oob_count
+  end
+
+  def test_out_of_band_overlapping_requests
+    oob_server oob_wait: true
+    sock = nil
+    sock2 = nil
+    @mutex.synchronize do
+      sock2 = send_http "GET / HTTP/1.0\r\n"
+      sleep 0.01
+      sock = send_http "GET / HTTP/1.0\r\n\r\n"
+      # Request 1 processed
+      @oob_finished.wait(@mutex) # enter oob
+      sock2 << "\r\n"
+      sleep 0.01
+      @oob_finished.signal # exit oob
+      # Request 2 processed
+      @oob_finished.wait(@mutex) # enter oob
+      @oob_finished.signal # exit oob
+    end
+    assert_match(/200/, sock.read)
+    assert_match(/200/, sock2.read)
   end
 end


### PR DESCRIPTION
### Description
Fixes #2177. (Thanks @GuiTeK for tracking down this bug!)

Modifies the `out_of_band` hook implementation in the `Server` class to ensure that hooks are fired as expected when the server is configured with >1 max threads.

Compare to #2178, #2180. This implementation is pretty simple. It changes behavior slightly by executing the hooks on the same thread that finished processing the last request (instead of the main acceptor thread), so the server can continue accepting incoming requests if any arrive while the out-of-band hooks are still executing.

I've also added a couple of server tests to ensure out-of-band hooks fire as expected in two scenarios (sequential and parallel requests).

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
