### PR TITLE
ThreadPool concurrency refactoring

### DIFF
--- a/History.md
+++ b/History.md
@@ -36,6 +36,7 @@
   * Simplify `Runner#start_control` URL parsing (#2111)
   * Removed the IOBuffer extension and replaced with Ruby (#1980)
   * Update `Rack::Handler::Puma.run` to use `**options` (#2189)
+  * ThreadPool concurrency refactoring (#2220)
 
 ## 4.3.3 and 3.12.4 / 2020-02-28
 


### PR DESCRIPTION
### Description
This PR refactors some tricky concurrency parts of `TestThreadPool`, in order to make the unit tests more stable (all tests pass on jruby), faster (no more 1-second sleeps), and a bit more readable. Many of the tests now use a subclass of `ThreadPool` that overrides `#<<` to wait on the existing `@not_full` condition variable, to ensure work begins executing on a worker thread before continuing the test.

There are also some small changes to the `ThreadPool` class itself:
- Add `#with_mutex` to make it easier to chain multiple `@mutex.synchronize`-wrapped methods together, and to extend existing mutex-wrapped methods in unit tests.
- Wait for initially-spawned threads to enter the wait loop before returning from `#initialize`. This fixes a subtle edge-case concurrency bug mostly affecting unit-test reliability, demonstrated by the following simple test that fails on `master`: https://github.com/puma/puma/blob/8d610275f6ca0c6094e75e93a3529ea61732fd57/test/test_thread_pool.rb#L239-L242
- Fix a concurrency bug in `#trim` where a trim could still be requested even when enough work to utilize all threads has been queued but not yet picked up by workers (e.g., `waiting > 0` but `waiting - todo.size == 0`). (I believe this was the cause of some jruby test flakiness in some `trim` unit tests.)
- Refactor the main wait-loop in `spawn_thread` to make it a bit simpler and easier to read and reason about.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
