### PR TITLE
Fix ThreadPool#shutdown timeout accuracy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "rack", "~> 1.6"
 gem "minitest", "~> 5.11"
 gem "minitest-retry"
 gem "minitest-proveit"
+gem "minitest-stub-const"
 
 gem "jruby-openssl", :platform => "jruby"
 

--- a/History.md
+++ b/History.md
@@ -32,6 +32,7 @@
   * Pass queued requests to thread pool on server shutdown (#2122)
   * Fixed a few minor concurrency bugs in ThreadPool that may have affected non-GVL Rubies (#2220)
   * Fix `out_of_band` hook never executed if the number of worker threads is > 1 (#2177)
+  * Fix ThreadPool#shutdown timeout accuracy (#2221)
 
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -243,7 +243,7 @@ module Puma
           when :immediately
             0
           else
-            Integer(val)
+            Float(val)
           end
 
       @options[:force_shutdown_after] = i

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -14,6 +14,7 @@ end
 require "minitest/autorun"
 require "minitest/pride"
 require "minitest/proveit"
+require "minitest/stub_const"
 require_relative "helpers/apps"
 
 Thread.abort_on_exception = true

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -934,16 +934,16 @@ EOF
 
   # Requests still pending after `force_shutdown_after` should have connection closed (408 w/pending POST body).
   def test_force_shutdown
-    shutdown_requests request_delay: 4, response: nil, force_shutdown_after: 1
-    shutdown_requests request_delay: 4, response: nil, force_shutdown_after: 1, queue_requests: false
-    shutdown_requests request_delay: 4, response: /408/, force_shutdown_after: 1, post: true
+    shutdown_requests request_delay: 4, response: nil, force_shutdown_after: 3
+    shutdown_requests request_delay: 4, response: nil, force_shutdown_after: 3, queue_requests: false
+    shutdown_requests request_delay: 4, response: /408/, force_shutdown_after: 3, post: true
   end
 
   # App-responses still pending during `force_shutdown_after` should return 503
   # (uncaught Puma::ThreadPool::ForceShutdown exception).
   def test_force_shutdown_app
-    shutdown_requests app_delay: 3, response: /503/, force_shutdown_after: 1
-    shutdown_requests app_delay: 3, response: /503/, force_shutdown_after: 1, queue_requests: false
+    shutdown_requests app_delay: 3, response: /503/, force_shutdown_after: 3
+    shutdown_requests app_delay: 3, response: /503/, force_shutdown_after: 3, queue_requests: false
   end
 
   def test_http11_connection_header_queue


### PR DESCRIPTION
### Description
Fixes up `ThreadPool#shutdown` so that the provided `timeout` value (which corresponds to the `force_shutdown_after` configuration option) is more accurate, and can be set as a float instead of just an integer value.

Previously, the shutdown timeout ran a loop `timeout.times`, which called `t.join 1` on each thread (one after another, not parallel), followed by a `sleep 1` each loop iteration, then `t.join SHUTDOWN_GRACE_TIME` on each thread after raising `ForceShutdown`. Instead of forcing shutdown in `timeout` (+ `SHUTDOWN_GRACE_TIME`) seconds, this forced a shutdown in `timeout * (n + 1)` (+ `n * SHUTDOWN_GRACE_TIME`) seconds (where `n` is the number of running threads). The updated code fixes this by joining a maximum of `timeout` seconds (followed by a maximum of `grace` seconds) across all threads.

I also added an extra step at the end that calls `kill` on any remaining threads still alive after the grace period, plus another short (1-second) join to wait for force-killed threads to (finally) exit, as an extra precaution that threads are fully cleaned up when shutdown returns. I thought this might be helpful, but could be removed as it's not strictly needed for the rest of this PR.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
