### PR TITLE
Support parallel tests in verbose progress reporting

### DIFF
--- a/History.md
+++ b/History.md
@@ -40,6 +40,7 @@
   * Update `Rack::Handler::Puma.run` to use `**options` (#2189)
   * ThreadPool concurrency refactoring (#2220)
   * JSON parse cluster worker stats instead of regex (#2124)
+  * Support parallel tests in verbose progress reporting (#2223)
 
 ## 4.3.3 and 3.12.4 / 2020-02-28
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,6 +11,8 @@ if %w(2.2.7 2.2.8 2.2.9 2.2.10 2.3.4 2.4.1).include? RUBY_VERSION
   end
 end
 
+$LOAD_PATH.unshift('test')
+
 require "minitest/autorun"
 require "minitest/pride"
 require "minitest/proveit"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,8 +11,7 @@ if %w(2.2.7 2.2.8 2.2.9 2.2.10 2.3.4 2.4.1).include? RUBY_VERSION
   end
 end
 
-$LOAD_PATH.unshift('test')
-
+require_relative "minitest/verbose"
 require "minitest/autorun"
 require "minitest/pride"
 require "minitest/proveit"

--- a/test/minitest/verbose.rb
+++ b/test/minitest/verbose.rb
@@ -1,0 +1,5 @@
+require "minitest"
+require_relative "verbose_progress_plugin"
+
+Minitest.load_plugins
+Minitest.extensions << 'verbose_progress' unless Minitest.extensions.include?('verbose_progress')

--- a/test/minitest/verbose_progress_plugin.rb
+++ b/test/minitest/verbose_progress_plugin.rb
@@ -1,0 +1,34 @@
+module Minitest
+  # Adds minimal support for parallel tests to the default verbose progress reporter.
+  def self.plugin_verbose_progress_init(options)
+    if options[:verbose]
+      self.reporter.reporters.
+        delete_if {|r| r.is_a?(ProgressReporter)}.
+        push(VerboseProgressReporter.new(options[:io], options))
+    end
+  end
+
+  # Verbose progress reporter that supports parallel test execution.
+  class VerboseProgressReporter < Reporter
+    def prerecord(klass, name)
+      @current ||= nil
+      @current = [klass.name, name].tap(&method(:print_start))
+    end
+
+    def record(result)
+      print_start [result.klass, result.name]
+      @current = nil
+      io.print "%.2f s = " % [result.time]
+      io.print result.result_code
+      io.puts
+    end
+
+    def print_start(test)
+      unless @current == test
+        io.puts '…' if @current
+        io.print "%s#%s = " % test
+        io.flush
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a Minitest plugin to fix verbose progress reporting when running parallel tests.

The default verbose progress reporter interleaves results when test are executed in parallel threads (e.g., in test classes containing `parallelize_me!`), making the printed results entirely useless because the duration/results printed no longer correspond to the correct test names. This made it impossible to debug slow/hanging tests in the CI output and has probably caused all sorts of confusion.

The plugin fixes this by printing `…` when another test starts in parallel, and re-prints the test name along with the result when the test finishes.

For example, [a CI failure on this PR](https://github.com/wjordan/puma/runs/586788575) had a test hang, causing the CI action to time out after 10 minutes. The test log shows that the culprit is `TestIntegrationSingle#test_siginfo_thread_print`, since the line `TestIntegrationSingle#test_siginfo_thread_print = …` showing the test started never had a matching line showing the test finished.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
