### PR TITLE
run regular GC if compact not available

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,7 +5,7 @@
   * Add pumactl `thread-backtraces` command to print thread backtraces (#2053)
   * Configuration: `environment` is read from `RAILS_ENV`, if `RACK_ENV` can't be found (#2022)
   * Do not set user_config to quiet by default to allow for file config (#2074)
-  * `GC.compact` is called before fork if available (#2093)
+  * `GC.compact` is called before fork if available (#2093), otherwise GC.start is called
   * Add `requests_count` to workers stats. (#2106)
   * Increases maximum URI path length from 2048 to 8196 bytes (#2167)
   * Force shutdown responses can be overridden by using the `lowlevel_error_handler` config (#2203)

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -459,7 +459,11 @@ module Puma
       @master_read, @worker_write = read, @wakeup
 
       @launcher.config.run_hooks :before_fork, nil, @launcher.events
-      GC.compact if GC.respond_to?(:compact)
+      if GC.respond_to?(:compact)
+        GC.compact
+      else
+        GC.start
+      end
 
       spawn_workers
 


### PR DESCRIPTION
### Description

While doing some simple experiments with GC.compact in ruby 2.7 I noticed that
GC.start also had some benefits in the pre_fork phase. Since the master process won't be
growing (as much? at all?) as the forked processes, it might not ever get an organic GC, so this
is perhaps a good time to get in a manual one to save a meg or three.

(I actually don't know if the garbage collection done by GC.start reduces forked memory and/or CoW effeciency — if so, an even better idea to do it for all ruby versions).

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed, including Rubocop. **i did not run tests because i was unable to install ragel**
