### PR TITLE
Do not run the check changelog workflow if skipped [skip ci]

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -5,9 +5,14 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: |
+      !(   contains(github.event.pull_request.title, '[changelog skip]')
+        || contains(github.event.pull_request.title, '[skip changelog]')
+        || contains(github.event.pull_request.title, '[ci skip]')
+        || contains(github.event.pull_request.title, '[skip ci]'))
 
     steps:
     - uses: actions/checkout@v1
-    - name: Check that CHANGELOG is touched or PR is [ci skip]-d
+    - name: Check that CHANGELOG is touched
       run: |
-        cat $GITHUB_EVENT_PATH | jq .pull_request.title | grep -i '\[\(\(changelog skip\)\|\(skip changelog\)\|\(ci skip\)\|\(skip ci\)\)\]' ||  git diff remotes/origin/${{ github.base_ref }} --name-only | grep History.md
+        git diff remotes/origin/${{ github.base_ref }} --name-only | grep History.md

--- a/.github/workflows/puma.yml
+++ b/.github/workflows/puma.yml
@@ -12,8 +12,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}-latest
     if: |
-      !(contains(github.event.pull_request.title, '[ci skip]')
-        || contains(github.event.head_commit.message, '[ci skip]'))
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]')
+        || contains(github.event.head_commit.message, '[ci skip]')
+        || contains(github.event.head_commit.message, '[skip ci]'))
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Should make the experience looking at the checks more consistent  (noticed this from https://github.com/puma/puma/pull/2227#issuecomment-616841613)

The [contains method] is documented as case insensitive so this should be equivalent to what we had.

Add support for skipping the tests with `[skip ci]`.

[contains method]: https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contains

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
