### PR TITLE
Fix `UserFileDefaultOptions#fetch` to properly consume `default` value

### DIFF
--- a/History.md
+++ b/History.md
@@ -38,6 +38,7 @@
   * Fixed a few minor concurrency bugs in ThreadPool that may have affected non-GVL Rubies (#2220)
   * Fix `out_of_band` hook never executed if the number of worker threads is > 1 (#2177)
   * Fix ThreadPool#shutdown timeout accuracy (#2221)
+  * Fix `UserFileDefaultOptions#fetch` to properly use `default` (#2233)
 
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -54,9 +54,7 @@ module Puma
     attr_reader :user_options, :file_options, :default_options
 
     def [](key)
-      return user_options[key]    if user_options.key?(key)
-      return file_options[key]    if file_options.key?(key)
-      return default_options[key] if default_options.key?(key)
+      fetch(key)
     end
 
     def []=(key, value)
@@ -64,7 +62,11 @@ module Puma
     end
 
     def fetch(key, default_value = nil)
-      self[key] || default_value
+      return user_options[key]    if user_options.key?(key)
+      return file_options[key]    if file_options.key?(key)
+      return default_options[key] if default_options.key?(key)
+
+      default_value
     end
 
     def all_of(key)


### PR DESCRIPTION
### Description

The usage of `||` fetch is incorrect, as presence of `false` is the correct value.
This change uses `default` value, only if the value is nowhere else defined.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
