### PR TITLE
Add optional state file permissions

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@
   * Increases maximum URI path length from 2048 to 8196 bytes (#2167)
   * Force shutdown responses can be overridden by using the `lowlevel_error_handler` config (#2203)
   * Faster phased restart and worker timeout (#2121)
+  * New configuration option to set state file permissions (#2238)
 
 * Deprecations, Removals and Breaking API Changes
   * `Puma.stats` now returns a Hash instead of a JSON string (#2086)

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -399,6 +399,14 @@ module Puma
       @options[:state] = path.to_s
     end
 
+    # Use +permission+ to restrict permissions for the state file.
+    #
+    # @example
+    #   state_permission 0600
+    def state_permission(permission)
+      @options[:state_permission] = permission
+    end
+
     # How many worker processes to run.  Typically this is set to
     # the number of available cores.
     #

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -102,6 +102,7 @@ module Puma
       write_pid
 
       path = @options[:state]
+      permission = @options[:state_permission]
       return unless path
 
       require 'puma/state_file'
@@ -111,7 +112,7 @@ module Puma
       sf.control_url = @options[:control_url]
       sf.control_auth_token = @options[:control_auth_token]
 
-      sf.save path
+      sf.save path, permission
     end
 
     # Delete the configured pidfile

--- a/lib/puma/state_file.rb
+++ b/lib/puma/state_file.rb
@@ -8,8 +8,11 @@ module Puma
       @options = {}
     end
 
-    def save(path)
-      File.write path, YAML.dump(@options)
+    def save(path, permission = nil)
+      File.open(path, "w") do |file|
+        file.chmod(permission) if permission
+        file.write(YAML.dump(@options))
+      end
     end
 
     def load(path)

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -79,6 +79,57 @@ class TestLauncher < Minitest::Test
     File.unlink tmp_path
   end
 
+  def test_state_permission_0640
+    tmp_file = Tempfile.new("puma-test")
+    tmp_path = tmp_file.path
+    tmp_file.close!
+    tmp_permission = 0640
+
+    conf = Puma::Configuration.new do |c|
+      c.state_path tmp_path
+      c.state_permission tmp_permission
+    end
+
+    launcher(conf).write_state
+
+    assert File.stat(tmp_path).mode.to_s(8)[-4..-1], tmp_permission
+  ensure
+    File.unlink tmp_path
+  end
+
+  def test_state_permission_nil
+    tmp_file = Tempfile.new("puma-test")
+    tmp_path = tmp_file.path
+    tmp_file.close!
+
+    conf = Puma::Configuration.new do |c|
+      c.state_path tmp_path
+      c.state_permission nil
+    end
+
+    launcher(conf).write_state
+
+    assert File.exist?(tmp_path)
+  ensure
+    File.unlink tmp_path
+  end
+
+  def test_no_state_permission
+    tmp_file = Tempfile.new("puma-test")
+    tmp_path = tmp_file.path
+    tmp_file.close!
+
+    conf = Puma::Configuration.new do |c|
+      c.state_path tmp_path
+    end
+
+    launcher(conf).write_state
+
+    assert File.exist?(tmp_path)
+  ensure
+    File.unlink tmp_path
+  end
+
   def test_puma_stats
     conf = Puma::Configuration.new do |c|
       c.app -> {[200, {}, ['']]}


### PR DESCRIPTION
### Description
Before this commit, it was possible that the puma.state file would be world-readable which may not be desirable in production environments. This introduces a new optional configuration option to set desired state file permissions.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
```console
# bundle exec rake test:all
<snip>
# Running:
....................................................................................................................................S.....................S.....S.....S..........................................................................................................................................................S........

Fabulous run in 115.014845s, 2.8692 runs/s, 7.3643 assertions/s.

330 runs, 847 assertions, 0 failures, 0 errors, 5 skips

You have skipped tests. Run with --verbose for details.

------------------------------------------------------------ Debugging Info
TestIntegrationCluster#test_term_closes_listeners_tcp
    10 successes, 5 resets, 25 refused, failures 0
TestIntegrationCluster#test_term_closes_listeners_unix
    10 successes, 0 resets, 30 refused, failures 0
---------------------------------------------------------------------------

ruby test/shell/run.rb
curl: (7) Failed to connect to localhost port 10102: Connection refused
Puma starting in single mode...
* Version 4.3.3 (ruby 2.7.0-p0), codename: Mysterious Traveller
* Min threads: 0, max threads: 5
* Environment: development
* Listening on tcp://0.0.0.0:10102
Use Ctrl-C to stop
Hello Worldcurl: (7) Failed to connect to localhost port 10103: Connection refused
Puma starting in single mode...
* Version 4.3.3 (ruby 2.7.0-p0), codename: Mysterious Traveller
* Min threads: 0, max threads: 5
* Environment: development
* Listening on tcp://0.0.0.0:10103
Use Ctrl-C to stop
Hello WorldCommand stop sent success
[440153] Puma starting in cluster mode...
[440153] * Version 4.3.3 (ruby 2.7.0-p0), codename: Mysterious Traveller
[440153] * Min threads: 0, max threads: 5
[440153] * Environment: development
[440153] * Process workers: 3
[440153] * Phased restart available
[440153] * Listening on tcp://0.0.0.0:10102
[440153] Use Ctrl-C to stop
[440153] - Worker 0 (pid: 440155) booted, phase: 0
[440153] - Worker 1 (pid: 440156) booted, phase: 0
[440153] - Worker 2 (pid: 440158) booted, phase: 0
[440153] - Worker 2 (pid: 440178) booted, phase: 0
[440153] - Gracefully shutting down workers...
</snip>
```