### PR TITLE
Refactor error handling in server accept loop

### DIFF
--- a/History.md
+++ b/History.md
@@ -54,6 +54,7 @@
   * ThreadPool concurrency refactoring (#2220)
   * JSON parse cluster worker stats instead of regex (#2124)
   * Support parallel tests in verbose progress reporting (#2223)
+  * Refactor error handling in server accept loop (#2239)
 
 ## 4.3.3 and 3.12.4 / 2020-02-28
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -41,19 +41,16 @@ class TestPumaServer < Minitest::Test
   end
 
   def send_http_and_read(req)
-    port = @server.connected_ports[0]
-    sock = TCPSocket.new @host, port
-    @ios << sock
-    sock << req
-    sock.read
+    send_http(req).read
   end
 
   def send_http(req)
+    new_connection << req
+  end
+
+  def new_connection
     port = @server.connected_ports[0]
-    sock = TCPSocket.new @host, port
-    @ios << sock
-    sock << req
-    sock
+    TCPSocket.new(@host, port).tap {|sock| @ios << sock}
   end
 
   def test_proper_stringio_body
@@ -983,5 +980,34 @@ EOF
     sock = send_http "GET / HTTP/1.0\r\n\r\n"
     assert_equal ["HTTP/1.0 200 OK", "Content-Length: 0"], header(sock)
     sock.close
+  end
+
+  def stub_accept_nonblock(error)
+    @server.add_tcp_listener @host, @port
+    io = @server.binder.ios.last
+    accept_old = io.method(:accept_nonblock)
+    accept_stub = -> do
+      accept_old.call.close
+      raise error
+    end
+    io.stub(:accept_nonblock, accept_stub) do
+      @server.run
+      new_connection
+      sleep 0.01
+    end
+  end
+
+  # System-resource errors such as EMFILE should not be silently swallowed by accept loop.
+  def test_accept_emfile
+    stub_accept_nonblock Errno::EMFILE.new('accept(2)')
+    refute_empty @events.stderr.string, "Expected EMFILE error not logged"
+  end
+
+  # Retryable errors such as ECONNABORTED should be silently swallowed by accept loop.
+  def test_accept_econnaborted
+    # Match Ruby #accept_nonblock implementation, ECONNABORTED error is extended by IO::WaitReadable.
+    error = Errno::ECONNABORTED.new('accept(2) would block').tap {|e| e.extend IO::WaitReadable}
+    stub_accept_nonblock(error)
+    assert_empty @events.stderr.string
   end
 end


### PR DESCRIPTION
### Description

The server accept loop currently has two `rescue` clauses: https://github.com/puma/puma/blob/5a4e744e8a96cbdfd10d5a5c1fe04f479bdd7f88/lib/puma/server.rb#L293-L302

- The `SystemCallError` clause is overly broad, since it would swallow any system failures that would be useful to log as errors (e.g., `EMFILE` which is thrown when the process can't create another file-descriptor);
- The `Errno::ECONNABORTED` clause is unreachable, because it's a subclass of `SystemCallError`. Even if it were reachable, `io.close` is the wrong handler (because `ECONNABORTED` would only ever be thrown by `accept_nonblock` so `io` would always be `nil`).

This PR refactors this code to rescue `IO::WaitReadable` narrowly around the call to `accept_nonblock`, which should be more accurate and more readable as well:

https://github.com/puma/puma/blob/96f191af95b82e70319d83b7ef70ddf75cca9233/lib/puma/server.rb#L281-L285

Two tests to `test_puma_server` add a bit of coverage around the `accept_nonblock` call, ensuring that any `EMFILE` errors thrown by the system call are logged (this test would currently fail on `master`) while `ECONNABORTED` errors are still silently ignored.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
