### PR TITLE
[changelog skip] Add tests for ControlCLI when the supplied command is invalid or empty

### DIFF
--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -82,6 +82,15 @@ module Puma
 
       @command = argv.shift
 
+      # check presence of command
+      unless @command
+        raise "Available commands: #{COMMANDS.join(", ")}"
+      end
+
+      unless COMMANDS.include? @command
+        raise "Invalid command: #{@command}"
+      end
+
       unless @config_file == '-'
         environment = @environment || 'development'
 
@@ -100,16 +109,6 @@ module Puma
           @pidfile            ||= config.options[:pidfile]
         end
       end
-
-      # check present of command
-      unless @command
-        raise "Available commands: #{COMMANDS.join(", ")}"
-      end
-
-      unless COMMANDS.include? @command
-        raise "Invalid command: #{@command}"
-      end
-
     rescue => e
       @stdout.puts e.message
       exit 1

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -33,6 +33,14 @@ class TestPumaControlCli < TestConfigFileBase
     end
   end
 
+  def test_blank_command
+    assert_system_exit_with_cli_output [], "Available commands: #{Puma::ControlCLI::COMMANDS.join(", ")}"
+  end
+
+  def test_invalid_command
+    assert_system_exit_with_cli_output ['an-invalid-command'], 'Invalid command: an-invalid-command'
+  end
+
   def test_config_file
     control_cli = Puma::ControlCLI.new ["--config-file", "test/config/state_file_testing_config.rb", "halt"]
     assert_equal "t3-pid", control_cli.instance_variable_get("@pidfile")
@@ -173,6 +181,18 @@ class TestPumaControlCli < TestConfigFileBase
     out, _ = capture_subprocess_io do
       cmd.run
     end
+    assert_match expected_out, out
+  end
+
+  def assert_system_exit_with_cli_output(options, expected_out)
+    out, _ = capture_subprocess_io do
+      response = assert_raises(SystemExit) do
+        Puma::ControlCLI.new(options).run
+      end
+
+      assert_equal(response.status, 1)
+    end
+
     assert_match expected_out, out
   end
 end


### PR DESCRIPTION
### Description

This change adds tests for the scenario where the `ControlCLI` exits with an `exit(1)` when:

1. No command is issued to the `ControlCLI`.
2. An invalid command is issued to the `ControlCLI`.

Furthermore, while working on adding the tests, I realized that the CLI could do an early exit when the supplied command is empty/invalid, before waiting to load config and then issuing an `exit` (the loading of `config` options would eventually turn out to be an unnecessary step when the command is invalid or empty).

So I have moved the piece of code that issues the `exit(1)` to before the config is loaded.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
