### PR TITLE
Revert api change from #2086 introduce Puma.stats_hash api

### DIFF
--- a/History.md
+++ b/History.md
@@ -11,9 +11,9 @@
   * Force shutdown responses can be overridden by using the `lowlevel_error_handler` config (#2203)
   * Faster phased restart and worker timeout (#2121)
   * New configuration option to set state file permissions (#2238)
+  * `Puma.stats_hash` returns a stats in Hash instead of a JSON string (#2086, #2253)
 
 * Deprecations, Removals and Breaking API Changes
-  * `Puma.stats` now returns a Hash instead of a JSON string (#2086)
   * `--control` has been removed. Use `--control-url` (#1487)
   * `worker_directory` has been removed. Use `directory`.
   * min_threads now set by environment variables PUMA_MIN_THREADS and MIN_THREADS. (#2143)

--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -20,6 +20,10 @@ module Puma
   end
 
   def self.stats
+    @get_stats.stats.to_json
+  end
+
+  def self.stats_hash
     @get_stats.stats
   end
 

--- a/puma.gemspec
+++ b/puma.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -- bin docs ext lib tools`.split("\n") +
             %w[History.md LICENSE README.md]
   s.homepage = "http://puma.io"
-  
+
   if s.respond_to?(:metadata=)
     s.metadata = {
       "bug_tracker_uri" => "https://github.com/puma/puma/issues",
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
       "source_code_uri" => "https://github.com/puma/puma"
     }
   end
-  
+
   s.license = "BSD-3-Clause"
   s.required_ruby_version = Gem::Requirement.new(">= 2.2")
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -55,6 +55,8 @@ class TestCLI < Minitest::Test
     body = s.read
     s.close
 
+    assert_equal Puma.stats_hash, JSON.parse(Puma.stats, symbolize_names: true)
+
     dmt = Puma::Configuration.new.default_max_threads
     assert_match(/{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0}/, body.split(/\r?\n/).last)
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -162,9 +162,7 @@ RUBY
 
     pids = []
     Timeout.timeout(iterations * timeout + 1) do
-      while pids.size < WORKERS * iterations
-        (pids << @server.gets[/Terminating timed out worker: (\d+)/, 1]).compact!
-      end
+      (pids << @server.gets[/Terminating timed out worker: (\d+)/, 1]).compact! while pids.size < WORKERS * iterations
       pids.map!(&:to_i)
     end
 

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -139,7 +139,7 @@ class TestLauncher < Minitest::Test
     launcher.events.on_booted {launcher.stop}
     launcher.run
     Puma::Server::STAT_METHODS.each do |stat|
-      assert_includes Puma.stats, stat
+      assert_includes Puma.stats_hash, stat
     end
   end
 
@@ -154,7 +154,7 @@ class TestLauncher < Minitest::Test
     launcher = launcher(conf)
     Thread.new do
       sleep Puma::Const::WORKER_CHECK_INTERVAL + 1
-      status = Puma.stats[:worker_status].first[:last_status]
+      status = Puma.stats_hash[:worker_status].first[:last_status]
       Puma::Server::STAT_METHODS.each do |stat|
         assert_includes status, stat
       end


### PR DESCRIPTION
The change in #2086 is not backwards compatible with existing gems that parse the output of Puma.stats such as Barnes.

Releasing a version of puma with this change would break anyone using the Barnes app and only in production. I'm proposing to keep the existing interface and instead add a new API. This buys us all the features of #2086 without causing any production facing downtime by customers due to API incompatibilities.

Unfortunately, it requires that we serialize and then de-serialize the values. One prior benefit of returning json in a string was that it allowed an end-user to de-serialize using a faster json algorithm such as `oj` via the "multi json" gem. But the performance penalty will be better than a stability break.
