### PR TITLE
[ci skip] Allow changelog check to run on edit

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,6 +1,8 @@
 name: Check Changelog
 
-on: [pull_request]
+on:
+ pull_request:
+  types: [opened, reopened, edited, synchronize]
 
 jobs:
   build:


### PR DESCRIPTION
I did this on the rate limit throttle repo and it works https://github.com/zombocom/rate_throttle_client/blob/e9ecec60802d8a0d85904e61dc975c61e9f19de0/.github/workflows/check_changelog.yml#L2-L4