### PR TITLE
Change parse error to output a single line log [changelog skip]

### DIFF
--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -95,8 +95,7 @@ module Puma
     def parse_error(server, env, error)
       @stderr.puts "#{Time.now}: HTTP parse error, malformed request " \
         "(#{env[HTTP_X_FORWARDED_FOR] || env[REMOTE_ADDR]}#{env[REQUEST_PATH]}): " \
-        "#{error.inspect}" \
-        "\n---\n"
+        "#{error.inspect}"
     end
 
     # An SSL error has occurred.


### PR DESCRIPTION
### Description

This changes the error when an HTTP parse error is encountered so it outputs a single line to the error log. Our logging system (Loggly) expects a single line per error, and it doesn't support filtering the second line (`---`) as it contains special characters. As discussed in #986 we experience these errors often on AWS, so is causing a lot of noise for us.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
