### PR TITLE
test_redirect_io.rb - fix teardown for skipped tests [changelog skip]

### DIFF
--- a/test/test_redirect_io.rb
+++ b/test/test_redirect_io.rb
@@ -17,7 +17,9 @@ class TestRedirectIO < TestIntegration
   def teardown
     super
 
-    paths = [@out_file_path, @err_file_path, @old_out_file_path, @old_err_file_path].compact
+    paths = (skipped? ? [@out_file_path, @err_file_path] :
+      [@out_file_path, @err_file_path, @old_out_file_path, @old_err_file_path]).compact
+
     File.unlink(*paths)
     @out_file = nil
     @err_file = nil


### PR DESCRIPTION
### Description

Fix teardown

Stops:
  warning: instance variable @old_err_file_path not initialized
  warning: instance variable @old_out_file_path not initialized

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.