### PR TITLE
Fix for spawning subprocesses with fork_worker option

### DIFF
--- a/History.md
+++ b/History.md
@@ -45,6 +45,7 @@
   * Fix `UserFileDefaultOptions#fetch` to properly use `default` (#2233)
   * Improvements to `out_of_band` hook (#2234)
   * Prefer the rackup file specified by the CLI (#2225)
+  * Fix for spawning subprocesses with fork_worker option (#2267)
 
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -168,6 +168,20 @@ RUBY
     refute_includes pids, get_worker_pids(1, WORKERS - 1)
   end
 
+  def test_fork_worker_spawn
+    cli_server '', config: <<RUBY
+workers 1
+fork_worker 0
+app do |_|
+  pid = spawn('ls', [:out, :err]=>'/dev/null')
+  sleep 0.01
+  exitstatus = Process.detach(pid).value.exitstatus
+  [200, {}, [exitstatus.to_s]]
+end
+RUBY
+    assert_equal '0', read_body(connect)
+  end
+
   def test_nakayoshi
     cli_server "-w #{WORKERS} test/rackup/hello.ru", config: <<RUBY
     nakayoshi_fork true


### PR DESCRIPTION
### Description
This fixes a bug in `fork_worker` mode (#2099) where an application that spawns subprocesses can sometimes get `nil` instead of an expected `Process::Status` object when waiting on the child (see https://github.com/puma/puma/pull/2099#discussion_r425927136). `test_fork_worker_spawn` demonstrates the regression and currently fails on `master`: https://github.com/puma/puma/blob/2d9b72ecc1e5ae214a964b7d6b692f1740c584a3/test/test_integration_cluster.rb#L171-L183

This PR is one of two approaches for a fix- it stores the list of forked worker pids and the `SIGCHLD` handler calls non-blocking `Process.wait` on each of them, removing the pids that have exited. This is similar to `#wait_workers`.

Worth noting that this approach results in a `wait` syscall for every worker for every subprocess spawned by worker 0's application, which might cause some performance impact for applications which spawn lots of subprocesses and/or have a large number of workers. (I haven't benchmarked in detail so I don't know if it really matters or how big an impact it might be.)

An alternative approach (aacd629575a06eb5c381f57dd39e07b50b337eb2) avoids a `SIGCHLD` handler and instead spawns a separate thread for each forked worker that calls blocking `Process.wait`, to automatically clean up each process as it exits. This is similar to `Process.detach`- it avoids the extra syscall per worker * subprocess, at the cost of an extra thread per worker. That approach was discouraged in https://github.com/puma/puma/pull/2099#discussion_r377972777 but I thought worth mentioning in any case.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
