### PR TITLE
Stabilize CI testing? [changelog skip]

### DIFF
--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -15,6 +15,13 @@ class TestBinderBase < Minitest::Test
     @binder = Puma::Binder.new(@events)
   end
 
+  def teardown
+    @binder.ios.reject! { |io| Minitest::Mock === io || io.to_io.closed? }
+    @binder.close
+    @binder.unix_paths.select! { |path| File.exist? path }
+    @binder.close_listeners
+  end
+
   private
 
   def ssl_context_for_binder(binder = @binder)

--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -56,7 +56,7 @@ class TestBusyWorker < Minitest::Test
     @server = Puma::Server.new request_handler, Puma::Events.strings, **options
     @server.min_threads = options[:min_threads] || 0
     @server.max_threads = options[:max_threads] || 10
-    @server.add_tcp_listener '127.0.0.1', 0
+    @server.add_tcp_listener '127.0.0.1', UniquePort.call
     @server.run
   end
 

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -37,10 +37,12 @@ class TestCLI < Minitest::Test
   end
 
   def test_control_for_tcp
+    tcp  = UniquePort.call
     cntl = UniquePort.call
     url = "tcp://127.0.0.1:#{cntl}/"
 
-    cli = Puma::CLI.new [ "--control-url", url,
+    cli = Puma::CLI.new ["-b", "tcp://127.0.0.1:#{tcp}",
+                         "--control-url", url,
                          "--control-token", "",
                          "test/rackup/lobster.ru"], @events
 
@@ -68,12 +70,14 @@ class TestCLI < Minitest::Test
   def test_control_for_ssl
     skip_on :jruby # Hangs on CI, TODO fix
     require "net/http"
+    tcp = UniquePort.call
     control_port = UniquePort.call
     control_host = "127.0.0.1"
     control_url = "ssl://#{control_host}:#{control_port}?#{ssl_query}"
     token = "token"
 
-    cli = Puma::CLI.new ["--control-url", control_url,
+    cli = Puma::CLI.new ["-b", "tcp://127.0.0.1:#{tcp}",
+                         "--control-url", control_url,
                          "--control-token", token,
                          "test/rackup/lobster.ru"], @events
 

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -158,7 +158,7 @@ class TestEvents < Minitest::Test
   end
 
   def test_parse_error
-    port = 0
+    port = UniquePort.call
     host = "127.0.0.1"
     app = proc { |env| [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
     events = Puma::Events.strings
@@ -167,7 +167,6 @@ class TestEvents < Minitest::Test
     server.add_tcp_listener host, port
     server.run
 
-    port = server.connected_ports[0]
     sock = TCPSocket.new host, port
     path = "/"
     params = "a"*1024*10

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -70,7 +70,7 @@ class TestIntegrationSingle < TestIntegration
     _stdin, _stdout, rejected_curl_stderr, rejected_curl_wait_thread = Open3.popen3("curl #{HOST}:#{@tcp_port}")
 
     assert nil != Process.getpgid(@server.pid) # ensure server is still running
-    assert nil != Process.getpgid(rejected_curl_wait_thread[:pid]) # ensure first curl invokation still in progress
+    assert nil != Process.getpgid(curl_wait_thread[:pid]) # ensure first curl invocation still in progress
 
     curl_wait_thread.join
     rejected_curl_wait_thread.join

--- a/test/test_out_of_band_server.rb
+++ b/test/test_out_of_band_server.rb
@@ -62,7 +62,7 @@ class TestOutOfBandServer < Minitest::Test
     @server = Puma::Server.new app, Puma::Events.strings, out_of_band: [oob], **options
     @server.min_threads = options[:min_threads] || 1
     @server.max_threads = options[:max_threads] || 1
-    @server.add_tcp_listener '127.0.0.1', 0
+    @server.add_tcp_listener '127.0.0.1', UniquePort.call
     @server.run
   end
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -6,7 +6,7 @@ class TestPumaServer < Minitest::Test
   parallelize_me!
 
   def setup
-    @port = 0
+    @port = UniquePort.call
     @host = "127.0.0.1"
 
     @ios = []
@@ -49,8 +49,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def new_connection
-    port = @server.connected_ports[0]
-    TCPSocket.new(@host, port).tap {|sock| @ios << sock}
+    TCPSocket.new(@host, @port).tap {|sock| @ios << sock}
   end
 
   def test_proper_stringio_body
@@ -138,8 +137,7 @@ class TestPumaServer < Minitest::Test
     req = Net::HTTP::Get.new '/'
     req['HOST'] = 'example.com'
 
-    port = @server.connected_ports[0]
-    res = Net::HTTP.start @host, port do |http|
+    res = Net::HTTP.start @host, @port do |http|
       http.request(req)
     end
 
@@ -155,8 +153,7 @@ class TestPumaServer < Minitest::Test
     req['HOST'] = "example.com"
     req['X_FORWARDED_PROTO'] = "https,http"
 
-    port = @server.connected_ports[0]
-    res = Net::HTTP.start @host, port do |http|
+    res = Net::HTTP.start @host, @port do |http|
       http.request(req)
     end
 

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -215,7 +215,7 @@ class TestPumaServerSSL < Minitest::Test
 
     tcp = Thread.new do
       req_http = Net::HTTP::Get.new "/", {}
-      assert_raises(Errno::ECONNREFUSED, EOFError) do
+      assert_raises(Errno::ECONNREFUSED, EOFError, ::Net::ReadTimeout) do
         http.start.request(req_http) { |rep| body_http = rep.body }
       end
     end

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -21,7 +21,7 @@ class TestPathHandler < Minitest::Test
   end
 
   def in_handler(app, options = {})
-    options[:Port] ||= 0
+    options[:Port] ||= UniquePort.call
     options[:Silent] = true
 
     @launcher = nil

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -35,7 +35,7 @@ class TestRackServer < Minitest::Test
   def setup
     @simple = lambda { |env| [200, { "X-Header" => "Works" }, ["Hello"]] }
     @server = Puma::Server.new @simple
-    @server.add_tcp_listener "127.0.0.1", 0
+    @server.add_tcp_listener "127.0.0.1", UniquePort.call
 
     @stopped = false
   end

--- a/test/test_redirect_io.rb
+++ b/test/test_redirect_io.rb
@@ -17,7 +17,9 @@ class TestRedirectIO < TestIntegration
   def teardown
     super
 
-    paths = [@out_file_path, @err_file_path, @old_out_file_path, @old_err_file_path].compact
+    paths = (skipped? ? [@out_file_path, @err_file_path] :
+      [@out_file_path, @err_file_path, @old_out_file_path, @old_err_file_path]).compact
+
     File.unlink(*paths)
     @out_file = nil
     @err_file = nil

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -264,6 +264,6 @@ class TestThreadPool < Minitest::Test
     end
     assert_equal 0, pool.spawned
     assert_equal 2, rescued.length
-    refute rescued.any?(&:alive?)
+    refute rescued.compact.any?(&:alive?)
   end
 end

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -24,7 +24,7 @@ class WebServerTest < Minitest::Test
   def setup
     @tester = TestHandler.new
     @server = Puma::Server.new @tester, Puma::Events.strings
-    @server.add_tcp_listener "127.0.0.1", 0
+    @server.add_tcp_listener "127.0.0.1", UniquePort.call
 
     @server.run
   end


### PR DESCRIPTION
### Description
CI testing is unstable.

The first four commits are each for a single test file and fix small issues.

The fifth commit ('test/helper.rb - revise UniquePort.call, no port 0') always returns a unique port number.  The sixth commit removes the use of 'port 0' from several test files.

### General Info

Currently, 'port 0' is used to determine an open port.  That works fine for normal serial testing.  But, Puma CI is using parallel testing, and ports are opened in both threads and forked or spawned processes.  Combine this with the fact that the job runners are also running code, and the potential for an 'open' port be either opened or repeated exists.  These errors aren't repeatable by using `--seed` values.

### Actions

Yesterday GH Action had some issues.  Today, the CI seems stable, the only thing I've noticed is TruffleRuby failing in the 'test\shell' scripts after the test suite passed.

Let's see if this passes...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
