### PR TITLE
Better error handling during force shutdown

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@
 
 * Bugfixes
   * Prevent connections from entering Reactor after shutdown begins (#2377)
+  * Better error handling during force shutdown (#2271)
 
 * Refactor
   * Change Events#ssl_error signature from (error, peeraddr, peercert) to (error, ssl_socket) (#2375)

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -222,8 +222,10 @@ class TestThreadPool < Minitest::Test
 
     pool = mutex_pool(0, 1) do
       begin
-        pool.signal
-        sleep
+        pool.with_force_shutdown do
+          pool.signal
+          sleep
+        end
       rescue Puma::ThreadPool::ForceShutdown
         rescued = true
       end
@@ -248,8 +250,10 @@ class TestThreadPool < Minitest::Test
     rescued = []
     pool = mutex_pool(2, 2) do
       begin
-        pool.signal
-        sleep
+        pool.with_force_shutdown do
+          pool.signal
+          sleep
+        end
       rescue Puma::ThreadPool::ForceShutdown
         rescued << Thread.current
         sleep


### PR DESCRIPTION
### Description

Refactors tests covering shutdown behavior to be less flaky (the current tests depend on fragile `sleep` timing that isn't 100% deterministic), and also fixes a couple of subtle timing edge-cases around force-shutdown behavior:

- Only allow `ForceShutdown` to be raised in a thread during specific areas of the connection-processing cycle (marked by `with_force_shutdown` blocks), to ensure that the raised error is always rescued and handled cleanly. (This fixes an issue where the `force_shutdown_after: 0` option throws uncaught exceptions from the threadpool on shutdown)
- ~Add `@queue_mutex` and helper methods `if_queue_requests` and `queue_client` to `Server` to handle an edge case where the reactor shuts down while a thread is concurrently queuing a client. (#2337)~ A fix for this issue was merged in #2377.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
