### PR TITLE
Timeout unit tests on teardown [changelog skip]

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -58,7 +58,7 @@ module TimeoutEveryTestCase
   class TestTookTooLong < Timeout::Error
   end
 
-  def run(*)
+  def capture_exceptions(*)
     ::Timeout.timeout(RUBY_ENGINE == 'ruby' ? 60 : 120, TestTookTooLong) { super }
   end
 end


### PR DESCRIPTION
This change tries to prevent hangs in the CI test runner caused by `teardown` hanging after a test times out by adding separate `Timeout.timeout` calls for the teardown hook.

Recent examples of tests that (I think) have failed in this way:

- [`TestIntegrationSingle#test_int_refuse`](https://github.com/puma/puma/runs/687729920?check_suite_focus=true#step:7:496) ([2](https://github.com/puma/puma/runs/682781346?check_suite_focus=true#step:7:247))
- [`TestIntegrationPumactl#test_halt_unix`](https://github.com/puma/puma/runs/683526520?check_suite_focus=true#step:7:161) ([2](https://github.com/puma/puma/runs/683526529?check_suite_focus=true#step:7:381), [3](https://github.com/puma/puma/runs/683526591?check_suite_focus=true#step:7:303))

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
