### PR TITLE
Fix errors on test_halt_unix [changelog skip]

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -172,12 +172,13 @@ module Puma
       case @status
       when :halt
         log "* Stopping immediately!"
+        @runner.stop_control
       when :run, :stop
         graceful_stop
       when :restart
         log "* Restarting..."
         ENV.replace(previous_env)
-        @runner.before_restart
+        @runner.stop_control
         restart!
       when :exit
         # nothing

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -30,7 +30,7 @@ module Puma
       @events.log str
     end
 
-    def before_restart
+    def stop_control
       @control.stop(true) if @control
     end
 

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -42,13 +42,16 @@ class TestIntegrationPumactl < TestIntegration
 
   def ctl_unix(signal='stop')
     skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
-    cli_server "-q test/rackup/sleep.ru --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}", unix: true
+    stderr = Tempfile.new(%w(stderr .log))
+    cli_server "-q test/rackup/sleep.ru --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}",
+      config: "stdout_redirect nil, '#{stderr.path}'",
+      unix: true
 
     cli_pumactl signal, unix: true
 
     _, status = Process.wait2(@pid)
     assert_equal 0, status
-
+    refute_match 'error', File.read(stderr.path)
     @server = nil
   end
 


### PR DESCRIPTION
This is an attempt to fix `IOError: closed stream` errors resulting from the `test_halt_unix` test (which sends the `halt` control command to a server listening on a unix socket). These errors seem to be particularly affecting JRuby, so this fix may relate to #2262.

See examples of these errors on JRuby: [1](https://github.com/puma/puma/runs/687729880?check_suite_focus=true#step:7:346), [2](https://github.com/puma/puma/runs/687729939?check_suite_focus=true#step:7:316), [3](https://github.com/puma/puma/runs/687729995?check_suite_focus=true#step:7:358)

Here are examples where `test_halt_unix` hangs on Ubuntu MRI: [1](https://github.com/puma/puma/runs/683526520?check_suite_focus=true#step:7:161), [2](https://github.com/puma/puma/runs/683526529?check_suite_focus=true#step:7:381)

Here's an example of `test_halt_unix` hanging on macos MRI and reporting `Errno::EBADF: Bad file descriptor` error: [1](https://github.com/puma/puma/runs/683526591?check_suite_focus=true#step:7:303)

The issue seems to be caused by the `halt` command closing the control-server's listener socket before the `halt` command finishes processing. The fix in this PR is to stop the control server _before_ the listeners are closed when the server is halted. (Also renamed `#before_restart` to `#stop_control` to keep the method descriptive with this change.)

Also added a test assertion to `test_halt_unix` to ensure `Listen loop error` is no longer found in the server's stderr output.

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
