### PR TITLE
Minor: Add running_from to state_file

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -111,6 +111,7 @@ module Puma
       sf.pid = Process.pid
       sf.control_url = @options[:control_url]
       sf.control_auth_token = @options[:control_auth_token]
+      sf.running_from = File.expand_path('.')
 
       sf.save path, permission
     end

--- a/lib/puma/state_file.rb
+++ b/lib/puma/state_file.rb
@@ -19,7 +19,7 @@ module Puma
       @options = YAML.load File.read(path)
     end
 
-    FIELDS = %w!control_url control_auth_token pid!
+    FIELDS = %w!control_url control_auth_token pid running_from!
 
     FIELDS.each do |f|
       define_method f do


### PR DESCRIPTION
### Description
In https://github.com/ylecuyer/puma-status/issues/5 we got the problem where the control_url is a unix socket with a relative path. Just with the info within the state file, it is impossible to resolve the full path of the control server.

In this PR I added a `running_from` attribute to the state file which will allow to resolve such relative paths

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
