### PR TITLE
[changelog skip] Fix: Rubocop offence introduced in ad8197e

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -586,7 +586,7 @@ module Puma
             to_add = {}
           end
 
-          to_add[k.gsub(",", "_")] = v
+          to_add[k.tr(",", "_")] = v
         end
       end
 


### PR DESCRIPTION
### Description
Fix rubocop offence introduced in https://github.com/puma/puma/commit/ad8197e4d6e4fc9b11545f455387ff4739f24fdf

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
