### PR TITLE
[changelog skip] Resolves rubocop offence: Prefer String#tr over String#gsub

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -586,7 +586,7 @@ module Puma
             to_add = {}
           end
 
-          to_add[k.gsub(",", "_")] = v
+          to_add[k.tr(",", "_")] = v
         end
       end
 


### PR DESCRIPTION
### Description
This PR fixes rubocop offence by using `String#tr` instead of `String#gsub`
[CI failure](https://github.com/puma/puma/runs/697908887)

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
