### PR TITLE
Run CI using the default version of Bundler [changelog skip]

### DIFF
--- a/.github/workflows/puma.yml
+++ b/.github/workflows/puma.yml
@@ -48,7 +48,7 @@ jobs:
           if ('${{ matrix.ruby }}' -lt '2.3') {
             gem update --system 2.7.10 --no-document
           }
-          bundle install --jobs 4 --retry 3 --path=.bundle/puma
+          bundle install --jobs 4 --retry 3
 
       - name: compile
         run:  bundle exec rake compile

--- a/.github/workflows/puma.yml
+++ b/.github/workflows/puma.yml
@@ -37,7 +37,6 @@ jobs:
         uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler: 1
           apt-get: ragel
           brew: ragel
           mingw: _upgrade_ openssl ragel


### PR DESCRIPTION
### Description

Run CI using the default version of Bundler
* Which is Bundler on Ruby 2.2 and Bundler 2 on Ruby 2.3+.

This used to fail on TruffleRuby (fixed in https://github.com/oracle/truffleruby/issues/1984) and on Ruby 2.3 (due to https://github.com/ruby/setup-ruby/issues/51, now fixed).

Do not set the --path for bundle install
* This is buggy with Ruby 2.3 + Bundler 2.1.4, see https://github.com/ruby/setup-ruby/issues/51

cc @MSP-Greg, I'm not sure why the `--path` was set but it doesn't seem needed.