### PR TITLE
Unskip two jruby ssl tests that were hanging [changelog skip]

### DIFF
--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -173,7 +173,7 @@ public class MiniSSL extends RubyObject {
     engine.setEnabledProtocols(protocols);
     engine.setUseClientMode(false);
 
-    long verify_mode = miniSSLContext.callMethod(threadContext, "verify_mode").convertToInteger().getLongValue();
+    long verify_mode = miniSSLContext.callMethod(threadContext, "verify_mode").convertToInteger("to_i").getLongValue();
     if ((verify_mode & 0x1) != 0) { // 'peer'
         engine.setWantClientAuth(true);
     }

--- a/test/helpers/ssl.rb
+++ b/test/helpers/ssl.rb
@@ -2,8 +2,8 @@ module SSLHelper
   def ssl_query
     @ssl_query ||= if Puma.jruby?
       @keystore = File.expand_path "../../../examples/puma/keystore.jks", __FILE__
-      @ssl_cipher_list = "TLS_DHE_RSA_WITH_DES_CBC_SHA,TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA"
-      "keystore=#{@keystore}&keystore-pass=pswd&ssl_cipher_list=#{@ssl_cipher_list}"
+      @ssl_cipher_list = "TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+      "keystore=#{@keystore}&keystore-pass=blahblah&ssl_cipher_list=#{@ssl_cipher_list}"
     else
       @cert = File.expand_path "../../../examples/puma/cert_puma.pem", __FILE__
       @key  = File.expand_path "../../../examples/puma/puma_keypair.pem", __FILE__

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -367,7 +367,7 @@ end
 class TestBinderJRuby < TestBinderBase
   def test_binder_parses_jruby_ssl_options
     keystore = File.expand_path "../../examples/puma/keystore.jks", __FILE__
-    ssl_cipher_list = "TLS_DHE_RSA_WITH_DES_CBC_SHA,TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA"
+    ssl_cipher_list = "TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
 
     @binder.parse ["ssl://0.0.0.0:8080?#{ssl_query}"], @events
 

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -66,7 +66,6 @@ class TestCLI < Minitest::Test
   end
 
   def test_control_for_ssl
-    skip_on :jruby # Hangs on CI, TODO fix
     require "net/http"
     control_port = UniquePort.call
     control_host = "127.0.0.1"

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -150,7 +150,6 @@ class TestPumaControlCli < TestConfigFileBase
   end
 
   def test_control_ssl
-    skip_on :jruby # Hanging on JRuby, TODO fix
     host = "127.0.0.1"
     port = UniquePort.call
     url = "ssl://#{host}:#{port}?#{ssl_query}"


### PR DESCRIPTION
### Description
This fixes two JRuby tests that were skipped. It therefore fixes part of issue #2183.

The only production code change is to handle a nil `verify_mode` properly in `MiniSSL.java`. The previous code was throwing an exception 'no implicit conversion of nil into Integer'. Now a nil `verify_mode` will be converted to 0 and behave the same as if 'none' is specified.

The other changes are in the test setup. The keystore password was incorrect and the cipher suites specified are not ones that appear in the list returned by calling `getSupportedCipherSuites()` on the SSLEngine.

New error messages are spat out during the running of these tests, but that's an existing problem. `Puma::MiniSSL::Socket` is calling methods that are only defined by the C engine, such as `init?` and `shutdown`.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
