### PR TITLE
resolve waiting counter problem

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+### Master
+* Bugfixes
+  * Resolve issue with threadpool waiting counter decrement when thread is killed
+
 ## 5.0.0
 
 * Features

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -122,8 +122,11 @@ module Puma
                 @out_of_band_pending = false
               end
               not_full.signal
-              not_empty.wait mutex
-              @waiting -= 1
+              begin
+                not_empty.wait mutex
+              ensure
+                @waiting -= 1
+              end
             end
 
             work = todo.shift

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -266,4 +266,24 @@ class TestThreadPool < Minitest::Test
     assert_equal 2, rescued.length
     refute rescued.compact.any?(&:alive?)
   end
+
+  def test_correct_waiting_count_for_killed_threads
+    pool = new_pool(1, 1) { |_| }
+
+    pause
+
+    # simulate our waiting worker thread getting killed for whatever reason
+    pool.instance_eval { @workers[0].kill }
+
+    pause
+
+    pool.reap
+
+    pause
+
+    pool << 0
+
+    pause
+    assert_equal 0, pool.backlog
+  end
 end

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -269,21 +269,16 @@ class TestThreadPool < Minitest::Test
 
   def test_correct_waiting_count_for_killed_threads
     pool = new_pool(1, 1) { |_| }
-
-    pause
+    sleep 1
 
     # simulate our waiting worker thread getting killed for whatever reason
     pool.instance_eval { @workers[0].kill }
-
-    pause
-
+    sleep 1
     pool.reap
-
-    pause
+    sleep 1
 
     pool << 0
-
-    pause
+    sleep 1
     assert_equal 0, pool.backlog
   end
 end


### PR DESCRIPTION
if a thread is in the wait state, but transitions into
a killed state the waiting counter will not be decremented
leaving the pool to believe there is a thread available
and waiting to complete work when that is not the case.
Introduce a begin..ensure block so that any thread exception
raised while in the wait state properly balances the
waiting counter.

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
