### PR TITLE
Move initialization of KeyManagerFactory, TrustManagerFactory to server

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 ### Master
 * Bugfixes
   * Resolve issue with threadpool waiting counter decrement when thread is killed
+  * Fix filehandle leak in MiniSSL (#2299)
 
 ## 5.0.0
 


### PR DESCRIPTION
Move initialization of KeyManagerFactory, TrustManagerFactory to server initialization.  This avoids reading the keystore file twice on every ssl request, and also fixes (https://github.com/puma/puma/issues/2299) a filehandle leak from reading the keystore file without closing it properly.
