### PR TITLE
Improve MiniSSL for users without OpenSSL available

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 ### Master
 * Bugfixes
   * Resolve issue with threadpool waiting counter decrement when thread is killed
+  * Fix Puma::MiniSSL when OpenSSL is not available (#2303)
 
 ## 5.0.0
 
@@ -63,7 +64,7 @@
   * JSON parse cluster worker stats instead of regex (#2124)
   * Support parallel tests in verbose progress reporting (#2223)
   * Refactor error handling in server accept loop (#2239)
-  
+
 ## 4.3.4/4.3.5 and 3.12.5/3.12.6 / 2020-05-22
 
 Each patchlevel release contains a separate security fix. We recommend simply upgrading to 4.3.5/3.12.6.

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -13,7 +13,7 @@ module Puma
 
     # define constant at runtime, as it's easy to determine at built time,
     # but Puma could (it shouldn't) be loaded with an older OpenSSL version
-    HAS_TLS1_3 = !IS_JRUBY &&
+    HAS_TLS1_3 = !IS_JRUBY && defined?(OPENSSL_VERSION) &&
       (OPENSSL_VERSION[/ \d+\.\d+\.\d+/].split('.').map(&:to_i) <=> [1,1,1]) != -1 &&
       (OPENSSL_LIBRARY_VERSION[/ \d+\.\d+\.\d+/].split('.').map(&:to_i) <=> [1,1,1]) !=-1
 


### PR DESCRIPTION
### Description

SSL constants removed in https://github.com/puma/puma/commit/3a127f7d407eb2abea94b6e15e35863446899abb. And for people who did not install from OpenSSL extension, this [change](https://github.com/puma/puma/commit/ee8596237fb25cbc3a908586f4100e37ff4d77c6) will end up here. https://github.com/puma/puma/blob/91e57f4e173343746e122e8bb850b0244f508484/ext/puma_http11/mini_ssl.c#L12 which `HAVE_OPENSSL_BIO_H` is false, then arrived at this code path https://github.com/puma/puma/blob/91e57f4e173343746e122e8bb850b0244f508484/ext/puma_http11/mini_ssl.c#L555-L562

resulted in `SSLError`.

Check if the `OPENSSL_VERSION` constant is defined to fix this.


### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
