### PR TITLE
Allow Puma to compile when built without SSL, load SSL files on demand

### DIFF
--- a/.github/workflows/puma-no-ssl.yml
+++ b/.github/workflows/puma-no-ssl.yml
@@ -1,0 +1,51 @@
+name: No SSL
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: >-
+      ${{ matrix.os }} ${{ matrix.ruby }}
+    env:
+      CI: true
+      TESTOPTS: -v
+      DISABLE_SSL: no_ssl
+
+    runs-on: ${{ matrix.os }}
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]')
+        || contains(github.event.head_commit.message, '[ci skip]')
+        || contains(github.event.head_commit.message, '[skip ci]'))
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-20.04, ruby: 2.7   }
+          - { os: ubuntu-20.04, ruby: jruby }
+          - { os: windows-2019, ruby: 2.7   }
+
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v2
+
+      - name: load ruby, ragel
+        uses: MSP-Greg/setup-ruby-pkgs@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          apt-get: ragel
+          brew: ragel
+          mingw: _upgrade_ openssl ragel
+
+      # won't run on Ruby 2.2, see puma.yml
+      - name:  bundle install
+        shell: pwsh
+        run: bundle install --jobs 4 --retry 3
+
+      - name: compile
+        run:  bundle exec rake compile
+
+      - name: test
+        id: test
+        timeout-minutes: 10
+        run: bundle exec rake test:all

--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 ## 5.0.0
 
 * Features
+  * Allow compiling without OpenSSL and dynamically load files needed for SSL, add 'no ssl' CI (#2305)
   * EXPERIMENTAL: Add `fork_worker` option and `refork` command for reduced memory usage by forking from a worker process instead of the master process. (#2099)
   * EXPERIMENTAL: Added `wait_for_less_busy_worker` config. This may reduce latency on MRI through inserting a small delay before re-listening on the socket if worker is busy (#2079).
   * EXPERIMENTAL: Added `nakayoshi_fork` option. Reduce memory usage in preloaded cluster-mode apps by GCing before fork and compacting, where available. (#2093, #2256)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ $ puma
 Without arguments, puma will look for a rackup (.ru) file in
 working directory called `config.ru`.
 
+## SSL Connection Support
+
+Puma will install/compile with support for ssl sockets, assuming OpenSSL
+development files are installed on the system.
+
+If the system does not have OpenSSL development files installed, Puma will
+install/compile, but it will not allow ssl connections.
+
+If the system has OpenSSL development files installed, but you don't want Puma
+to use ssl connections, set ENV['DISABLE_SSL'] to any value before installing
+Puma.
+
 ## Frameworks
 
 ### Rails

--- a/Rakefile
+++ b/Rakefile
@@ -47,6 +47,29 @@ if !Puma.jruby?
   end
 else
   # Java (JRuby)
+  # ::Rake::JavaExtensionTask.source_files supplies the list of files to
+  # compile.  At present, it only works with a glob prefixed with @ext_dir.
+  # override it so we can select the files
+  class ::Rake::JavaExtensionTask
+    def source_files
+      if ENV["DISABLE_SSL"]
+        # uses no_ssl/PumaHttp11Service.java, removes MiniSSL.java
+        FileList[
+          File.join(@ext_dir, "no_ssl/PumaHttp11Service.java"),
+          File.join(@ext_dir, "org/jruby/puma/Http11.java"),
+          File.join(@ext_dir, "org/jruby/puma/Http11Parser.java")
+        ]
+      else
+        FileList[
+          File.join(@ext_dir, "PumaHttp11Service.java"),
+          File.join(@ext_dir, "org/jruby/puma/Http11.java"),
+          File.join(@ext_dir, "org/jruby/puma/Http11Parser.java"),
+          File.join(@ext_dir, "org/jruby/puma/MiniSSL.java")
+        ]
+      end
+    end
+  end
+
   Rake::JavaExtensionTask.new("puma_http11", gemspec) do |ext|
     ext.lib_dir = "lib/puma"
   end

--- a/ext/puma_http11/no_ssl/PumaHttp11Service.java
+++ b/ext/puma_http11/no_ssl/PumaHttp11Service.java
@@ -1,0 +1,15 @@
+package puma;
+
+import java.io.IOException;
+
+import org.jruby.Ruby;
+import org.jruby.runtime.load.BasicLibraryService;
+
+import org.jruby.puma.Http11;
+
+public class PumaHttp11Service implements BasicLibraryService {
+    public boolean basicLoad(final Ruby runtime) throws IOException {
+        Http11.createHttp11(runtime);
+        return true;
+    }
+}

--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -434,7 +434,9 @@ VALUE HttpParser_body(VALUE self) {
   return http->body;
 }
 
+#ifdef HAVE_OPENSSL_BIO_H
 void Init_mini_ssl(VALUE mod);
+#endif
 
 void Init_puma_http11()
 {
@@ -463,5 +465,7 @@ void Init_puma_http11()
   rb_define_method(cHttpParser, "body", HttpParser_body, 0);
   init_common_fields();
 
+#ifdef HAVE_OPENSSL_BIO_H
   Init_mini_ssl(mPuma);
+#endif
 }

--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -10,6 +10,9 @@ require 'stringio'
 
 require 'thread'
 
+require_relative 'puma/puma_http11'
+require_relative 'puma/detect'
+
 module Puma
   autoload :Const, 'puma/const'
   autoload :Server, 'puma/server'
@@ -32,5 +35,13 @@ module Puma
   def self.set_thread_name(name)
     return unless Thread.current.respond_to?(:name=)
     Thread.current.name = "puma #{name}"
+  end
+
+  unless HAS_SSL
+    module MiniSSL
+      # this class is defined so that it exists when Puma is compiled
+      # without ssl support, as Server and Reactor use it in rescue statements.
+      class SSLError < StandardError ; end
+    end
   end
 end

--- a/lib/puma/detect.rb
+++ b/lib/puma/detect.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 module Puma
+  # at present, MiniSSL::Engine is only defined in extension code, not in minissl.rb
+  HAS_SSL = const_defined?(:MiniSSL, false) && MiniSSL.const_defined?(:Engine, false)
+
+  def self.ssl?
+    HAS_SSL
+  end
+
   IS_JRUBY = defined?(JRUBY_VERSION)
 
   def self.jruby?

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -10,7 +10,6 @@ require 'puma/puma_http11'
 
 module Puma
   module MiniSSL
-
     # define constant at runtime, as it's easy to determine at built time,
     # but Puma could (it shouldn't) be loaded with an older OpenSSL version
     HAS_TLS1_3 = !IS_JRUBY &&
@@ -203,8 +202,6 @@ module Puma
       class SSLError < StandardError
         # Define this for jruby even though it isn't used.
       end
-
-      def self.check; end
     end
 
     class Context

--- a/lib/puma/minissl/context_builder.rb
+++ b/lib/puma/minissl/context_builder.rb
@@ -2,9 +2,6 @@ module Puma
   module MiniSSL
     class ContextBuilder
       def initialize(params, events)
-        require 'puma/minissl'
-        MiniSSL.check
-
         @params = params
         @events = events
       end

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'puma/util'
-require 'puma/minissl'
+require 'puma/minissl' if ::Puma::HAS_SSL
 
 require 'nio'
 

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -2,7 +2,6 @@
 
 require 'puma/server'
 require 'puma/const'
-require 'puma/minissl/context_builder'
 
 module Puma
   # Generic class that is used by `Puma::Cluster` and `Puma::Single` to

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -9,11 +9,8 @@ require 'puma/null_io'
 require 'puma/reactor'
 require 'puma/client'
 require 'puma/binder'
-require 'puma/accept_nonblock'
 require 'puma/util'
 require 'puma/io_buffer'
-
-require 'puma/puma_http11'
 
 require 'socket'
 require 'forwardable'

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -1,12 +1,12 @@
 require_relative "helper"
-require_relative "helpers/ssl"
+require_relative "helpers/ssl" if ::Puma::HAS_SSL
 require_relative "helpers/tmp_path"
 
 require "puma/cli"
 require "json"
 
 class TestCLI < Minitest::Test
-  include SSLHelper
+  include SSLHelper if ::Puma::HAS_SSL
   include TmpPath
 
   def setup
@@ -67,6 +67,8 @@ class TestCLI < Minitest::Test
   end
 
   def test_control_for_ssl
+    skip 'No ssl support' unless ::Puma::HAS_SSL
+
     require "net/http"
     control_port = UniquePort.call
     control_host = "127.0.0.1"

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -44,6 +44,7 @@ class TestConfigFile < TestConfigFileBase
   end
 
   def test_ssl_configuration_from_DSL
+    skip 'No ssl support' unless ::Puma::HAS_SSL
     conf = Puma::Configuration.new do |config|
       config.load "test/config/ssl_config.rb"
     end
@@ -61,6 +62,7 @@ class TestConfigFile < TestConfigFileBase
 
   def test_ssl_bind
     skip_on :jruby
+    skip 'No ssl support' unless ::Puma::HAS_SSL
 
     conf = Puma::Configuration.new do |c|
       c.ssl_bind "0.0.0.0", "9292", {
@@ -78,6 +80,7 @@ class TestConfigFile < TestConfigFileBase
 
   def test_ssl_bind_with_cipher_filter
     skip_on :jruby
+    skip 'No ssl support' unless ::Puma::HAS_SSL
 
     cipher_filter = "!aNULL:AES+SHA"
     conf = Puma::Configuration.new do |c|
@@ -95,6 +98,7 @@ class TestConfigFile < TestConfigFileBase
   end
 
   def test_ssl_bind_with_ca
+    skip 'No ssl support' unless ::Puma::HAS_SSL
     conf = Puma::Configuration.new do |c|
       c.ssl_bind "0.0.0.0", "9292", {
         cert: "/path/to/cert",

--- a/test/test_minissl.rb
+++ b/test/test_minissl.rb
@@ -1,6 +1,6 @@
 require_relative "helper"
 
-require "puma/minissl"
+require "puma/minissl" if ::Puma::HAS_SSL
 
 class TestMiniSSL < Minitest::Test
 
@@ -26,4 +26,4 @@ class TestMiniSSL < Minitest::Test
       assert_equal("No such cert file '/no/such/cert'", exception.message)
     end
   end
-end
+end if ::Puma::HAS_SSL

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -1,44 +1,38 @@
+# Nothing in this file runs if Puma isn't compiled with ssl support
+#
+# helper is required first since it loads Puma, which needs to be
+# loaded so HAS_SSL is defined
 require_relative "helper"
-require "puma/minissl"
-require "puma/puma_http11"
-require "puma/events"
-require "net/http"
 
-#———————————————————————————————————————————————————————————————————————————————
-#             NOTE: ALL TESTS BYPASSED IF DISABLE_SSL IS TRUE
-#———————————————————————————————————————————————————————————————————————————————
+if ::Puma::HAS_SSL
+  require "puma/minissl"
+  require "puma/events"
+  require "net/http"
 
-class SSLEventsHelper < ::Puma::Events
-  attr_accessor :addr, :cert, :error
+  class SSLEventsHelper < ::Puma::Events
+    attr_accessor :addr, :cert, :error
 
-  def ssl_error(error, peeraddr, peercert)
-    self.error = error
-    self.addr = peeraddr
-    self.cert = peercert
+    def ssl_error(error, peeraddr, peercert)
+      self.error = error
+      self.addr = peeraddr
+      self.cert = peercert
+    end
+  end
+
+  # net/http (loaded in helper) does not necessarily load OpenSSL
+  require "openssl" unless Object.const_defined? :OpenSSL
+  if Puma::IS_JRUBY
+    puts "", RUBY_DESCRIPTION, "RUBYOPT: #{ENV['RUBYOPT']}",
+      "                         OpenSSL",
+      "OPENSSL_LIBRARY_VERSION: #{OpenSSL::OPENSSL_LIBRARY_VERSION}",
+      "        OPENSSL_VERSION: #{OpenSSL::OPENSSL_VERSION}", ""
+  else
+    puts "", RUBY_DESCRIPTION, "RUBYOPT: #{ENV['RUBYOPT']}",
+      "                         Puma::MiniSSL                   OpenSSL",
+      "OPENSSL_LIBRARY_VERSION: #{Puma::MiniSSL::OPENSSL_LIBRARY_VERSION.ljust 32}#{OpenSSL::OPENSSL_LIBRARY_VERSION}",
+      "        OPENSSL_VERSION: #{Puma::MiniSSL::OPENSSL_VERSION.ljust 32}#{OpenSSL::OPENSSL_VERSION}", ""
   end
 end
-
-DISABLE_SSL = begin
-              Puma::Server.class
-              Puma::MiniSSL.check
-              # net/http (loaded in helper) does not necessarily load OpenSSL
-              require "openssl" unless Object.const_defined? :OpenSSL
-              if Puma::IS_JRUBY
-                puts "", RUBY_DESCRIPTION, "RUBYOPT: #{ENV['RUBYOPT']}",
-                  "                         OpenSSL",
-                  "OPENSSL_LIBRARY_VERSION: #{OpenSSL::OPENSSL_LIBRARY_VERSION}",
-                  "        OPENSSL_VERSION: #{OpenSSL::OPENSSL_VERSION}", ""
-              else
-                puts "", RUBY_DESCRIPTION, "RUBYOPT: #{ENV['RUBYOPT']}",
-                  "                         Puma::MiniSSL                   OpenSSL",
-                  "OPENSSL_LIBRARY_VERSION: #{Puma::MiniSSL::OPENSSL_LIBRARY_VERSION.ljust 32}#{OpenSSL::OPENSSL_LIBRARY_VERSION}",
-                  "        OPENSSL_VERSION: #{Puma::MiniSSL::OPENSSL_VERSION.ljust 32}#{OpenSSL::OPENSSL_VERSION}", ""
-              end
-            rescue
-              true
-            else
-              false
-            end
 
 class TestPumaServerSSL < Minitest::Test
   parallelize_me!
@@ -247,7 +241,7 @@ class TestPumaServerSSL < Minitest::Test
 
     assert busy_threads.zero?, "Our connection is wasn't dropped"
   end
-end unless DISABLE_SSL
+end if ::Puma::HAS_SSL
 
 # client-side TLS authentication tests
 class TestPumaServerSSLClient < Minitest::Test
@@ -345,4 +339,4 @@ class TestPumaServerSSLClient < Minitest::Test
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     end
   end
-end unless DISABLE_SSL
+end if ::Puma::HAS_SSL

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -150,6 +150,8 @@ class TestPumaControlCli < TestConfigFileBase
   end
 
   def test_control_ssl
+    skip 'No ssl support' unless ::Puma::HAS_SSL
+
     host = "127.0.0.1"
     port = UniquePort.call
     url = "ssl://#{host}:#{port}?#{ssl_query}"


### PR DESCRIPTION
### Description

Currently, Puma will not function if built without SSL support.  Also, SSL related files are all loaded regardless, so make them load-on-demand.

#### Changes

1. Allows compiling without OpenSSL & runs 'no ssl' CI on a few jobs
2. SSL test (now `Puma::HAS_SSL` or `Puma.ssl?`) relies on classes that only exist in the compiled extension if properly compiled with OpenSSL.
3. If compiled with 'no ssl', don't load ssl related files in Puma.  Also, don't load Ruby MRI OpenSSL.  JRuby currently  requires it for some reason. (?)

****Commits**** (need to be squashed for bisect)

1. **'Adjust code for compiling without SSL (MRI & JRuby), add ssl detection'** -  Removes MiniSSL.check, replace with Puma::HAS_SSL or Puma.ssl?

2. **'Adjust test files for 'no ssl' compile'**

3. **'Actions - add 'no ssl' workflow, puma-no-ssl.yml'** - three jobs: Ubuntu-20.04 with 2.7 & JRuby, and Windows 2.7

4. **'Update History.md'**

5. **'README.md - add 'SSL Connection Support' section'**

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
