### PR TITLE
Constrain rake-compiler version to 0.9.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rdoc"
-gem "rake-compiler"
+gem "rake-compiler", "~> 0.9.4"
 
 gem "nio4r", "~> 2.0"
 gem "rack", "~> 1.6"

--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 ### Master
 * Bugfixes
   * Resolve issue with threadpool waiting counter decrement when thread is killed
+  * Constrain rake-compiler version to 0.9.4 to fix `ClassNotFound` exception when using MiniSSL with Java8.
 
 ## 5.0.0
 


### PR DESCRIPTION
### Description
Constrain `rake-compiler` version to 0.9.4 to fix `ClassNotFound` exception when using MiniSSL with Java8.

Fixes: #2301

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>

---

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.