### PR TITLE
Improve worker shutdown reliability, CI fixes

### DIFF
--- a/History.md
+++ b/History.md
@@ -33,6 +33,7 @@
   * Log binding on http:// for TCP bindings to make it clickable
 
 * Bugfixes
+  * Improve shutdown reliability (#2312)
   * Close client http connections made to an ssl server with TLSv1.3 (#2116)
   * Do not set user_config to quiet by default to allow for file config (#2074)
   * Always close SSL connection in Puma::ControlCLI (#2211)

--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -65,7 +65,8 @@ module Puma
     # Write +str+ to +@stdout+
     #
     def log(str)
-      @stdout.puts format(str)
+      @stdout.puts format(str) if @stdout.respond_to? :puts
+    rescue Errno::EPIPE
     end
 
     def write(str)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -58,8 +58,11 @@ module TimeoutEveryTestCase
   class TestTookTooLong < Timeout::Error
   end
 
-  def capture_exceptions(*)
-    ::Timeout.timeout(RUBY_ENGINE == 'ruby' ? 60 : 120, TestTookTooLong) { super }
+  def time_it
+    t0 = Minitest.clock_time
+    ::Timeout.timeout(RUBY_ENGINE == 'ruby' ? 60 : 120, TestTookTooLong) { yield }
+  ensure
+    self.time = Minitest.clock_time - t0
   end
 end
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -387,7 +387,7 @@ RUBY
   # used with thread_run to define correct 'refused' errors
   def thread_run_refused(unix: false)
     if unix
-      DARWIN ? [Errno::ENOENT, IOError] : [Errno::ENOENT]
+      [Errno::ENOENT, IOError]
     else
       DARWIN ? [Errno::ECONNREFUSED, Errno::EPIPE, EOFError] :
         [Errno::ECONNREFUSED]


### PR DESCRIPTION
### Description

CI is unreliable, with random failures across all Ruby types.  Small changes to lib files for shutdown, minor test changes.

Note that incomplete JRuby SSL implementation (`Puma::MiniSSL::Engine` `#init?` & `#shutdown`) will still   intermittently cause CI failure.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x]  All new and existing tests passed, including Rubocop.