### PR TITLE
Explicitly include ctype.h to fix compilation warning

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,7 +1,7 @@
 ## Master
 
 * Bugfixes
-  * Explicitly include ctype.h to fix compilation warning and build error on MacOS Big Sur (#2304)
+  * Explicitly include ctype.h to fix compilation warning and build error on macOS with Xcode 12 (#2304)
 
 
 ## 4.3.3 and 3.12.4 / 2020-02-28

--- a/History.md
+++ b/History.md
@@ -1,10 +1,7 @@
 ## Master
 
-* Features
-  * Your feature goes here (#Github Number)
-
 * Bugfixes
-  * Your bugfix goes here (#Github Number)
+  * Explicitly include ctype.h to fix compilation warning and build error on MacOS Big Sur (#2304)
 
 
 ## 4.3.3 and 3.12.4 / 2020-02-28

--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -10,6 +10,7 @@
 #include "ext_help.h"
 #include <assert.h>
 #include <string.h>
+#include <ctype.h>
 #include "http11_parser.h"
 
 #ifndef MANAGED_STRINGS


### PR DESCRIPTION
### Description

This simply adds `#include <ctype.h>` to puma_http11.c

On the 4.x branch, we get the following warning during compilation:
```
warning: implicitly declaring library function 'isspace' with type 'int (int)'
```

On MacOS Big Sur, this results in a build failure with:

```
include the header <ctype.h> or explicitly provide a declaration for 'isspace' 
1 error generated.
```

This change has already been applied to 5.0.0.beta / master as part of https://github.com/puma/puma/commit/befe00a86447ffaedfad8b94eb5c4f2208f8bf7a

Closes #2304 

This PR is going to the 4.3.5 branch -- unsure if that's where you'd like it merged.


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.



