### PR TITLE
test_cli.rb - fix bind port (9292 port in use errors) [changelog skip]

### DIFF
--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -40,7 +40,8 @@ class TestCLI < Minitest::Test
     cntl = UniquePort.call
     url = "tcp://127.0.0.1:#{cntl}/"
 
-    cli = Puma::CLI.new [ "--control-url", url,
+    cli = Puma::CLI.new ["-b", "tcp://127.0.0.1:0",
+                         "--control-url", url,
                          "--control-token", "",
                          "test/rackup/lobster.ru"], @events
 
@@ -72,7 +73,8 @@ class TestCLI < Minitest::Test
     control_url = "ssl://#{control_host}:#{control_port}?#{ssl_query}"
     token = "token"
 
-    cli = Puma::CLI.new ["--control-url", control_url,
+    cli = Puma::CLI.new ["-b", "tcp://127.0.0.1:0",
+                         "--control-url", control_url,
                          "--control-token", token,
                          "test/rackup/lobster.ru"], @events
 


### PR DESCRIPTION
### Description

Noticed intermittent test failures re 'port already in use' on port 9292, which is the default.  Change two tests using it to use port 0, they aren't actually using as a client, but they are binding to it...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.