### PR TITLE
JRuby - Add Puma::MiniSSL::Engine#init? and #teardown methods, run all SSL tests

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,7 @@
 ### Master
 * Bugfixes
+  * JRuby - Add Puma::MiniSSL::Engine#init? and #teardown methods, run all SSL tests (#2317)
+  * Improve shutdown reliability (#2312)
   * Resolve issue with threadpool waiting counter decrement when thread is killed
   * Constrain rake-compiler version to 0.9.4 to fix `ClassNotFound` exception when using MiniSSL with Java8.
   * Ensure that TCP_CORK is usable

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -197,6 +197,9 @@ module Puma
     end
 
     if IS_JRUBY
+      OPENSSL_NO_SSL3 = false
+      OPENSSL_NO_TLS1 = false
+
       class SSLError < StandardError
         # Define this for jruby even though it isn't used.
       end

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -23,10 +23,17 @@ DISABLE_SSL = begin
               Puma::MiniSSL.check
               # net/http (loaded in helper) does not necessarily load OpenSSL
               require "openssl" unless Object.const_defined? :OpenSSL
-              puts "", RUBY_DESCRIPTION, "RUBYOPT: #{ENV['RUBYOPT']}",
-                   "                         Puma::MiniSSL                   OpenSSL",
-                   "OPENSSL_LIBRARY_VERSION: #{Puma::MiniSSL::OPENSSL_LIBRARY_VERSION.ljust 32}#{OpenSSL::OPENSSL_LIBRARY_VERSION}",
-                   "        OPENSSL_VERSION: #{Puma::MiniSSL::OPENSSL_VERSION.ljust 32}#{OpenSSL::OPENSSL_VERSION}", ""
+              if Puma::IS_JRUBY
+                puts "", RUBY_DESCRIPTION, "RUBYOPT: #{ENV['RUBYOPT']}",
+                  "                         OpenSSL",
+                  "OPENSSL_LIBRARY_VERSION: #{OpenSSL::OPENSSL_LIBRARY_VERSION}",
+                  "        OPENSSL_VERSION: #{OpenSSL::OPENSSL_VERSION}", ""
+              else
+                puts "", RUBY_DESCRIPTION, "RUBYOPT: #{ENV['RUBYOPT']}",
+                  "                         Puma::MiniSSL                   OpenSSL",
+                  "OPENSSL_LIBRARY_VERSION: #{Puma::MiniSSL::OPENSSL_LIBRARY_VERSION.ljust 32}#{OpenSSL::OPENSSL_LIBRARY_VERSION}",
+                  "        OPENSSL_VERSION: #{Puma::MiniSSL::OPENSSL_VERSION.ljust 32}#{OpenSSL::OPENSSL_VERSION}", ""
+              end
             rescue
               true
             else


### PR DESCRIPTION
### Description

JRuby implementation has always lacked Puma::MiniSSL::Engine#init? and #teardown methods, which are needed for use with SSL.  Added methods and set all SSL tests to run with JRuby.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
