### PR TITLE
[changelog skip] [ci skip] Clarify how to run puma in single mode

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,7 +20,10 @@ Welcome back!
 Puma was originally conceived as a thread-only webserver, but grew the ability to
 also use processes in version 2.
 
-Here are some rules of thumb:
+To run puma in single mode (e.g. for a development environment) you will need to
+set the number of workers to 0, anything above will run in cluster mode.
+
+Here are some rules of thumb for cluster mode:
 
 ### MRI
 


### PR DESCRIPTION
### Description
When starting to transition from Unicorn to Puma, I first tried out puma in development. I initially assumed from skimming the docs that the number of workers for single mode should be 1. This led to our developers sometimes not being able to kill their puma server properly in our dev environment via Ctrl+C since the master process would stick around and try to revive it.

Upon reading the docs more carefully and checking out the issues, I found [I wasn't alone][issue-on-single-mode]. While it's obvious that 1 worker implies the existence of a master process, when you're just starting out it might take you a little while before you get your head around single mode versus cluster mode and having the configuration clearly stated helps with that imo.

So to make it blatantly obvious how to run puma in single mode, I've added a line to the docs to explain it.

[issue-on-single-mode]: https://github.com/puma/puma/issues/1364

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
