### PR TITLE
Do not quite when `pumactl` unexpectedly exits.

### DIFF
--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -178,7 +178,10 @@ class TestPumaControlCli < TestConfigFileBase
   def assert_command_cli_output(options, expected_out)
     cmd = Puma::ControlCLI.new(options)
     out, _ = capture_subprocess_io do
-      cmd.run
+      begin
+        cmd.run
+      rescue SystemExit => e
+      end
     end
     assert_match expected_out, out
   end


### PR DESCRIPTION
### Description
When `pumactl` encounters issue, it exits [[1]]. That way also the whole test suite unexpectedly exits. Rescuing `SystemExit` exception keeps the test suite finish.

Fixes #2329

[1]: https://github.com/puma/puma/blob/0f718d516b92cd8bc4120c543b06792b22ac20bb/lib/puma/control_cli.rb#L272
