### PR TITLE
[ci skip] Improve pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ Please describe your pull request. Thank you for contributing! You're the best.
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
-- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` the pull request title.
+- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
 - [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
 - [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
 - [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.


### PR DESCRIPTION
Make it more clear that the changelog check is skipped if CI is skipped.

Useful when making doc fixes. 

(Having `[ci skip]` in the commit message wont stop the tests from running when you open a PR.)