### PR TITLE
Detect linux properly across all Ruby impls

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -101,7 +101,7 @@ module Puma
     # On Linux, use TCP_CORK to better control how the TCP stack
     # packetizes our stream. This improves both latency and throughput.
     #
-    if RUBY_PLATFORM =~ /linux/
+    if RbConfig::CONFIG['host_os'] =~ /linux/
       UNPACK_TCP_STATE_FROM_TCP_INFO = "C".freeze
 
       # 6 == Socket::IPPROTO_TCP


### PR DESCRIPTION
JRuby has used "java" for RUBY_PLATFORM for 15 years, so the best way to detect the host OS is to use RbConfig's "host_os" value. This allows JRuby to support the TCP_CORK hack and fix benchmarks of very small request/response cycles.

See jruby/jruby#6366 for a more detailed discussion of TCP_CORK.

### Description

Detect Linux using RbConfig's "host_os" value rather than RUBY_PLATFORM, which is always "java" on JRuby.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
