### PR TITLE
make sure that TCP_CORK is supported

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 * Bugfixes
   * Resolve issue with threadpool waiting counter decrement when thread is killed
   * Constrain rake-compiler version to 0.9.4 to fix `ClassNotFound` exception when using MiniSSL with Java8.
+  * Ensure that TCP_CORK is usable
 
 ## 5.0.0
 


### PR DESCRIPTION
### Description
according to @dentarg feedback https://github.com/puma/puma/pull/2345, we shouldn't use TCP_CORK on JRuby until it's properly supported.

It could also break on very old Linux kernels (< 2.6). Let's just make sure that all Socket constants are usable.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
