### PR TITLE
replace SOL_TCP with IPPROTO_TCP [changelog skip]

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -104,7 +104,6 @@ module Puma
         RbConfig::CONFIG['host_os'] =~ /linux/ &&
           Socket.const_defined?(:IPPROTO_TCP) &&
           Socket.const_defined?(:TCP_CORK) &&
-          Socket.const_defined?(:SOL_TCP) &&
           Socket.const_defined?(:TCP_INFO)
       end
       private :tcp_cork_supported?
@@ -140,7 +139,7 @@ module Puma
         return false unless @precheck_closing
 
         begin
-          tcp_info = socket.getsockopt(Socket::SOL_TCP, Socket::TCP_INFO)
+          tcp_info = socket.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_INFO)
         rescue IOError, SystemCallError
           Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
           @precheck_closing = false


### PR DESCRIPTION
### Description
I found there's an inconsistency
```socket.setsockopt(Socket::IPPROTO_TCP```
and
```socket.getsockopt(Socket::SOL_TCP```

https://students.mimuw.edu.pl/SO/Linux/Kod/include/linux/socket.h.html
https://linux.die.net/man/7/tcp
* Setsockoptions(2) level. Thanks to BSD these must match IPPROTO_xxx

*To set or get a TCP socket option, call getsockopt(2) to read or setsockopt(2) to write the option with the option level argument set to IPPROTO_TCP. In addition, most IPPROTO_IP socket options are valid on TCP sockets. For more information see ip(7). 

```SOL_``` constants except for ```SOL_SOCKET``` are Linux specific and pretty unreliable even on CRuby. JRuby doesn't define them at all.

so why not just choose ```IPPROTO_TCP``` for both?

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
