### PR TITLE
Add back timeout for teardown [changelog skip]

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -72,7 +72,10 @@ module TimeoutEveryTestCase
 
         Minitest::Test::TEARDOWN_METHODS.each do |hook|
           capture_exceptions do
-            self.send hook
+            # wrap timeout around teardown methods, remove when they're stable
+            ::Timeout.timeout(RUBY_ENGINE == 'ruby' ? 60 : 120, TestTookTooLong) {
+              self.send hook
+            }
           end
         end
       end


### PR DESCRIPTION
### Description

Minitest teardown code intermittently seems to freeze/lock up.

#2318 removed the timeout code for test teardown.  It should not be needed, but some CI jobs intermittently lock up.  Without it, we can't see which test(s) caused the lock up.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
