### PR TITLE
Gemfile - update rake-compiler to 1.1.1 [changelog skip]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rdoc"
-gem "rake-compiler", "~> 0.9.4"
+gem "rake-compiler", "~> 1.1.1"
 
 gem "nio4r", "~> 2.0"
 gem "rack", "~> 1.6"


### PR DESCRIPTION
### Description

Current Gemfile uses rake-compiler with constraint `"~> 0.9.4"`, current release is `1.1.1`.

Includes JRuby fix mentioned in https://github.com/puma/puma/pull/2302#issuecomment-655732965

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.