### PR TITLE
test_integration_pumactl.rb - adjust test_phased_restart_cluster [changelog skip]

### DIFF
--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -58,9 +58,9 @@ class TestIntegrationPumactl < TestIntegration
 
   def test_phased_restart_cluster
     skip NO_FORK_MSG unless HAS_FORK
-    start = Time.now
-
     cli_server "-q -w #{WORKERS} test/rackup/sleep.ru --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}", unix: true
+
+    start = Time.now
 
     s = UNIXSocket.new @bind_path
     @ios_to_close << s


### PR DESCRIPTION
### Description

This test fails intermittently on macOS.  `test_phased_restart_cluster` asserts for a time interval to restart.  Currently the time mark for the start is before the server is started.  This PR moves the mark to after the server is started.

macOS CI intermittently fails, times were ~ 6.5 to 8.0 sec, see:
https://github.com/puma/puma/runs/1083927456#step:7:435

Another failure, times ~ 9.5 to 11.5 sec:
https://github.com/puma/puma/runs/1068237128#step:7:474

Hopefully, the server is taking a while to start.  If the test continues to fail, it may need the time limit to be set conditionally...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.