### PR TITLE
Small test fixes - helpers/tmp_path.rb, helper.rb & test_redirect_io.rb [changelog skip]

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -102,7 +102,7 @@ module Puma
 
     PUMA_VERSION = VERSION = "5.0.0.beta2".freeze
     CODE_NAME = "Spoony Bard".freeze
-    
+
     PUMA_SERVER_STRING = ['puma', PUMA_VERSION, CODE_NAME].join(' ').freeze
 
     FAST_TRACK_KA_TIMEOUT = 0.2

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -78,6 +78,9 @@ module TimeoutEveryTestCase
             }
           end
         end
+        if respond_to? :clean_tmp_paths
+          clean_tmp_paths
+        end
       end
     end
 
@@ -85,9 +88,8 @@ module TimeoutEveryTestCase
   end
 end
 
+Minitest::Test.prepend TimeoutEveryTestCase
 if ENV['CI']
-  Minitest::Test.prepend TimeoutEveryTestCase
-
   require 'minitest/retry'
   Minitest::Retry.use!
 end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -8,6 +8,7 @@ require_relative 'tmp_path'
 # have their own files, use those instead
 class TestIntegration < Minitest::Test
   include TmpPath
+  DARWIN = !!RUBY_PLATFORM[/darwin/]
   HOST  = "127.0.0.1"
   TOKEN = "xxyyzz"
   WORKERS = 2

--- a/test/helpers/tmp_path.rb
+++ b/test/helpers/tmp_path.rb
@@ -1,28 +1,20 @@
 module TmpPath
-  def capture_exceptions
-    super
-  ensure
-    clean_tmp_paths
+  def clean_tmp_paths
+    while path = tmp_paths.pop
+      delete_tmp_path(path)
+    end
   end
 
   private
 
   def tmp_path(extension=nil)
-    sock_file = Tempfile.new(['', extension])
-    path = sock_file.path
-    sock_file.close!
+    path = Tempfile.create(['', extension]) { |f| f.path }
     tmp_paths << path
     path
   end
 
   def tmp_paths
     @tmp_paths ||= []
-  end
-
-  def clean_tmp_paths
-    while path = tmp_paths.pop
-      delete_tmp_path(path)
-    end
   end
 
   def delete_tmp_path(path)

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -4,8 +4,6 @@ require_relative "helpers/integration"
 class TestIntegrationCluster < TestIntegration
   parallelize_me!
 
-  DARWIN = !!RUBY_PLATFORM[/darwin/]
-
   def setup
     skip NO_FORK_MSG unless HAS_FORK
     super

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -87,7 +87,7 @@ class TestIntegrationPumactl < TestIntegration
 
     _, status = Process.wait2(@pid)
     assert_equal 0, status
-    assert_operator Time.now - start, :<, 5
+    assert_operator Time.now - start, :<, (DARWIN ? 8 : 5)
     @server = nil
   end
 

--- a/test/test_redirect_io.rb
+++ b/test/test_redirect_io.rb
@@ -5,6 +5,7 @@ class TestRedirectIO < TestIntegration
   parallelize_me!
 
   def setup
+    skip_unless_signal_exist? :HUP
     super
 
     # Keep the Tempfile instances alive to avoid being GC'd
@@ -15,6 +16,7 @@ class TestRedirectIO < TestIntegration
   end
 
   def teardown
+    return if skipped?
     super
 
     paths = (skipped? ? [@out_file_path, @err_file_path] :
@@ -27,7 +29,6 @@ class TestRedirectIO < TestIntegration
 
   def test_sighup_redirects_io_single
     skip_on :jruby # Server isn't coming up in CI, TODO Fix
-    skip_unless_signal_exist? :HUP
 
     cli_args = [
       '--redirect-stdout', @out_file_path,
@@ -55,7 +56,6 @@ class TestRedirectIO < TestIntegration
 
   def test_sighup_redirects_io_cluster
     skip NO_FORK_MSG unless HAS_FORK
-    skip_unless_signal_exist? :HUP
 
     cli_args = [
       '-w', '1',


### PR DESCRIPTION
### Description

Currently, helpers/tmp_path.rb uses `#capture_exceptions` to run cleanup code, which is called several times for each test.
Adjusted code in it and test/helpers.rb to run once, after teardown.
This also allows asserts in teardown to work properly, see test_integration_pumactl.rb.

Also, `Tempfile.new` attaches finalizers to each object, which seemed to be intermittently bothering JRuby.
Changed to `Tempfile.create`

test_redirect_io.rb - small fix for setup and teardown.

helper.rb - removed `if ENV['CI']` conditional so that local and cloud CI both use TimeoutEveryTestCase.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
