### PR TITLE
Add option to bind to systemd activated sockets

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,7 @@
   * Integrate with systemd's watchdog and notification features ([#2438])
   * Adds max_fast_inline as a configuration option for the Server object ([#2406])
   * You can now fork workers from worker 0 using SIGURG w/o fork_worker enabled [#2449]
+  * Add option to bind to systemd activated sockets ([#2362])
 
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -129,6 +129,21 @@ Puma will detect the release path socket as different than the one provided by
 systemd and attempt to bind it again, resulting in the exception
  `There is already a server bound to:`.
 
+### Binding
+
+By default you need to configure puma to have binds matching with all
+ListenStream statements. Any mismatched systemd ListenStreams will be closed by
+puma.
+
+To automatically bind to all activated sockets, the option
+`--bind-to-activated-sockets` can be used. This matches the config DSL
+`bind_to_activated_sockets` statement. This will cause puma to create a bind
+automatically for any activated socket. When systemd socket activation is not
+enabled, this option does nothing.
+
+This also accepts an optional argument `only` (DSL: `'only'`) to discard any
+binds that's not socket activated.
+
 ## Usage
 
 Without socket activation, use `systemctl` as root (e.g. via `sudo`) as

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -104,6 +104,10 @@ module Puma
             user_config.bind arg
           end
 
+          o.on "--bind-to-activated-sockets [only]", "Bind to all activated sockets" do |arg|
+            user_config.bind_to_activated_sockets(arg || true)
+          end
+
           o.on "-C", "--config PATH", "Load PATH as a config file" do |arg|
             file_config.load arg
           end

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -191,6 +191,32 @@ module Puma
       @options[:binds] = []
     end
 
+    # Bind to (systemd) activated sockets, regardless of configured binds.
+    #
+    # Systemd can present sockets as file descriptors that are already opened.
+    # By default Puma will use these but only if it was explicitly told to bind
+    # to the socket. If not, it will close the activated sockets. This means
+    # all configuration is duplicated.
+    #
+    # Binds can contain additional configuration, but only SSL config is really
+    # relevant since the unix and TCP socket options are ignored.
+    #
+    # This means there is a lot of duplicated configuration for no additional
+    # value in most setups. This method tells the launcher to bind to all
+    # activated sockets, regardless of existing bind.
+    #
+    # To clear configured binds, the value only can be passed. This will clear
+    # out any binds that may have been configured.
+    #
+    # @example Use any systemd activated sockets as well as configured binds
+    #   bind_to_activated_sockets
+    #
+    # @example Only bind to systemd activated sockets, ignoring other binds
+    #   bind_to_activated_sockets 'only'
+    def bind_to_activated_sockets(bind=true)
+      @options[:bind_to_activated_sockets] = bind
+    end
+
     # Define the TCP port to bind to. Use +bind+ for more advanced options.
     #
     # @example

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -58,6 +58,13 @@ module Puma
 
       @config.load
 
+      if @config.options[:bind_to_activated_sockets]
+        @config.options[:binds] = @binder.synthesize_binds_from_activated_fs(
+          @config.options[:binds],
+          @config.options[:bind_to_activated_sockets] == 'only'
+        )
+      end
+
       @options = @config.options
       @config.clamp
 


### PR DESCRIPTION
Currently still a draft, based on https://github.com/puma/puma/issues/1360#issuecomment-689548650. Having it as a PR allows me to refer to this work. That's why the checklist is not filled in yet.

### Description
Systemd can present sockets as file descriptors that are already opened.  By default Puma will use these but only if it was explicitly told to bind to the socket. If not, it will close the activated sockets. This means all configuration is duplicated.

Binds can contain additional configuration, but only SSL config is really relevant since the unix and TCP socket options are ignored.

This means there is a lot of duplicated configuration for no additional value in most setups. This option tells the launcher to bind to all activated sockets, regardless of existing binds.

Note it does not clear configured binds. That means it's still possible to bind to an additional socket not configured as an activated socket.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.