### PR TITLE
test/helper.rb -TimeoutEveryTestCase - set all timeouts to 45 sec [changelog skip]

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -65,7 +65,7 @@ module TimeoutEveryTestCase
           before_setup; setup; after_setup
 
           # wrap timeout around test method only
-          ::Timeout.timeout(RUBY_ENGINE == 'ruby' ? 60 : 120, TestTookTooLong) {
+          ::Timeout.timeout(RUBY_ENGINE == 'ruby' ? 45 : 45, TestTookTooLong) {
             self.send self.name
           }
         end
@@ -73,7 +73,7 @@ module TimeoutEveryTestCase
         Minitest::Test::TEARDOWN_METHODS.each do |hook|
           capture_exceptions do
             # wrap timeout around teardown methods, remove when they're stable
-            ::Timeout.timeout(RUBY_ENGINE == 'ruby' ? 60 : 120, TestTookTooLong) {
+            ::Timeout.timeout(RUBY_ENGINE == 'ruby' ? 45 : 45, TestTookTooLong) {
               self.send hook
             }
           end


### PR DESCRIPTION
### Description

While working on another PR, I noticed one job ([ubuntu-18.04 truffleruby-head](https://github.com/MSP-Greg/puma/runs/1109525323?check_suite_focus=true#step:7:599)) where the log output showed all tests passing, but the job hit the time limit set in the Actions workflow file.

Inspecting the log, it showed three two minute 'pauses' in the log output, which is the current setting in test/helper.rb for non MRI jobs.

A brief look at CI logs seemed to show that the longest test takes approx 30 sec.

This PR changes the settings in TimeoutEveryTestCase to 45 sec for all jobs.  Hopefully, this will result in fewer jobs hitting the ten minute time limit, and hence, passing.

**Note:**  testing in my fork with this patch still had jobs timing out (only non MRI jobs).  So, there are still problems...

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
