### PR TITLE
Rescue ENOTCONN

### DIFF
--- a/History.md
+++ b/History.md
@@ -68,6 +68,7 @@
   * Ensure that TCP_CORK is usable
   * Fix corner case when request body is chunked (#2326)
   * Fix filehandle leak in MiniSSL (#2299)
+  * Rescue ENOTCONN (#2335)
 
 * Refactor
   * Remove unused loader argument from Plugin initializer (#2095)

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -188,10 +188,14 @@ module Puma
         end
       end
 
-      def peeraddr
+      def peeraddr(swallow: false)
         @socket.peeraddr
-      rescue
-        ["<unknown>"]
+      rescue => e
+        if swallow
+          ["<unknown>"]
+        else
+          raise e
+        end
       end
 
       def peercert

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -190,6 +190,8 @@ module Puma
 
       def peeraddr
         @socket.peeraddr
+      rescue
+        ["<unknown>"]
       end
 
       def peercert

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -239,13 +239,7 @@ module Puma
               rescue MiniSSL::SSLError => e
                 @server.lowlevel_error(e, c.env)
                 ssl_socket = c.io
-                begin
-                  addr = ssl_socket.peeraddr.last
-                # EINVAL can happen when browser closes socket w/security exception
-                rescue IOError, Errno::EINVAL, Errno::ENOTCONN
-                  addr = "<unknown>"
-                end
-
+                addr = ssl_socket.peeraddr.last
                 cert = ssl_socket.peercert
 
                 c.close

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -238,12 +238,11 @@ module Puma
               # SSL handshake failure
               rescue MiniSSL::SSLError => e
                 @server.lowlevel_error(e, c.env)
-
                 ssl_socket = c.io
                 begin
                   addr = ssl_socket.peeraddr.last
                 # EINVAL can happen when browser closes socket w/security exception
-                rescue IOError, Errno::EINVAL
+                rescue IOError, Errno::EINVAL, Errno::ENOTCONN
                   addr = "<unknown>"
                 end
 

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -239,7 +239,7 @@ module Puma
               rescue MiniSSL::SSLError => e
                 @server.lowlevel_error(e, c.env)
                 ssl_socket = c.io
-                addr = ssl_socket.peeraddr.last
+                addr = ssl_socket.peeraddr(swallow: true).last
                 cert = ssl_socket.peercert
 
                 c.close

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -211,7 +211,7 @@ module Puma
           end
         rescue MiniSSL::SSLError => e
           ssl_socket = client.io
-          addr = ssl_socket.peeraddr.last
+          addr = ssl_socket.peeraddr(swallow: true).last
           cert = ssl_socket.peercert
 
           client.close
@@ -416,7 +416,7 @@ module Puma
         lowlevel_error(e, client.env)
 
         ssl_socket = client.io
-        addr = ssl_socket.peeraddr.last
+        addr = ssl_socket.peeraddr(swallow: true).last
         cert = ssl_socket.peercert
 
         close_socket = true


### PR DESCRIPTION
### Description
Rescue `Errno::ENOTCONN` since it doesn't have socket address

Closes: https://github.com/puma/puma/issues/2335


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
