### PR TITLE
Consolidate option handling in Server, Server small refactors, doc changes

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,9 @@
 * Bugfixes
   * Your bugfix goes here (#Github Number)
 
+* Refactor
+  * Remove unneeded attr_accessor statements from Server (#2373)
+
 ## 5.0.0
 
 * Features

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -54,9 +54,8 @@ module Puma
 
       app = Puma::App::Status.new @launcher, token
 
-      control = Puma::Server.new app, @launcher.events
-      control.min_threads = 0
-      control.max_threads = 1
+      control = Puma::Server.new app, @launcher.events,
+        { min_threads: 0, max_threads: 1 }
 
       control.binder.parse [str], self, 'Starting control server'
 
@@ -69,6 +68,7 @@ module Puma
       @control.binder.close_listeners if @control
     end
 
+    # @!attribute [r] ruby_engine
     def ruby_engine
       if !defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby"
         "ruby #{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
@@ -137,27 +137,14 @@ module Puma
       @launcher.binder.parse @options[:binds], self
     end
 
+    # @!attribute [r] app
     def app
       @app ||= @launcher.config.app
     end
 
     def start_server
-      min_t = @options[:min_threads]
-      max_t = @options[:max_threads]
-
       server = Puma::Server.new app, @launcher.events, @options
-      server.min_threads = min_t
-      server.max_threads = max_t
       server.inherit_binder @launcher.binder
-
-      if @options[:early_hints]
-        server.early_hints = true
-      end
-
-      unless development? || test?
-        server.leak_stack_on_error = false
-      end
-
       server
     end
   end

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -34,15 +34,21 @@ module Puma
 
     attr_reader :thread
     attr_reader :events
-    attr_reader :requests_count # @version 5.0.0
-    attr_accessor :app
+    attr_reader :min_threads, :max_threads  # for #stats
+    attr_reader :requests_count             # @version 5.0.0
 
-    attr_accessor :min_threads
-    attr_accessor :max_threads
-    attr_accessor :persistent_timeout
-    attr_accessor :auto_trim_time
-    attr_accessor :reaping_time
-    attr_accessor :first_data_timeout
+    # the following may be deprecated in the future
+    attr_reader :auto_trim_time
+    attr_reader :first_data_timeout
+    attr_reader :persistent_timeout
+    attr_reader :reaping_time
+
+    attr_accessor :app
+    attr_accessor :binder
+
+    def_delegators :@binder, :add_tcp_listener, :add_ssl_listener, :add_unix_listener, :connected_ports
+
+    ThreadLocalKey = :puma_server
 
     # Create a server for the rack app +app+.
     #
@@ -52,6 +58,10 @@ module Puma
     # Server#run returns a thread that you can join on to wait for the server
     # to do its work.
     #
+    # @note Several instance variables exist so they are available for testing,
+    #   and have default values set via +fetch+.  Normally the values are set via
+    #   `::Puma::Configuration.puma_default_options`.
+    #
     def initialize(app, events=Events.stdio, options={})
       @app = app
       @events = events
@@ -59,24 +69,24 @@ module Puma
       @check, @notify = nil
       @status = :stop
 
-      @min_threads = 0
-      @max_threads = 16
       @auto_trim_time = 30
       @reaping_time = 1
 
       @thread = nil
       @thread_pool = nil
-      @early_hints = nil
-
-      @persistent_timeout = options.fetch(:persistent_timeout, PERSISTENT_TIMEOUT)
-      @first_data_timeout = options.fetch(:first_data_timeout, FIRST_DATA_TIMEOUT)
-
-      @binder = Binder.new(events)
-
-      @leak_stack_on_error = true
 
       @options = options
-      @queue_requests = options[:queue_requests].nil? ? true : options[:queue_requests]
+
+      @early_hints        = options.fetch :early_hints, nil
+      @first_data_timeout = options.fetch :first_data_timeout, FIRST_DATA_TIMEOUT
+      @min_threads        = options.fetch :min_threads, 0
+      @max_threads        = options.fetch :max_threads , (Puma.mri? ? 5 : 16)
+      @persistent_timeout = options.fetch :persistent_timeout, PERSISTENT_TIMEOUT
+      @queue_requests     = options.fetch :queue_requests, true
+
+      @leak_stack_on_error = !!(@options[:environment] =~ /\A(development|test)\z/)
+
+      @binder = Binder.new(events)
 
       ENV['RACK_ENV'] ||= "development"
 
@@ -87,15 +97,16 @@ module Puma
       @requests_count = 0
     end
 
-    attr_accessor :binder, :leak_stack_on_error, :early_hints
-
-    def_delegators :@binder, :add_tcp_listener, :add_ssl_listener, :add_unix_listener, :connected_ports
-
     def inherit_binder(bind)
       @binder = bind
     end
 
     class << self
+      # @!attribute [r] current
+      def current
+        Thread.current[ThreadLocalKey]
+      end
+
       # :nodoc:
       # @version 5.0.0
       def tcp_cork_supported?
@@ -170,10 +181,12 @@ module Puma
       end
     end
 
+    # @!attribute [r] backlog
     def backlog
       @thread_pool and @thread_pool.backlog
     end
 
+    # @!attribute [r] running
     def running
       @thread_pool and @thread_pool.spawned
     end
@@ -186,6 +199,7 @@ module Puma
     # there are 5 threads sitting idle ready to take
     # a request. If one request comes in, then the
     # value would be 4 until it finishes processing.
+    # @!attribute [r] pool_capacity
     def pool_capacity
       @thread_pool and @thread_pool.pool_capacity
     end
@@ -989,12 +1003,6 @@ module Puma
     end
     private :fast_write
 
-    ThreadLocalKey = :puma_server
-
-    def self.current
-      Thread.current[ThreadLocalKey]
-    end
-
     def shutting_down?
       @status == :stop || @status == :restart
     end
@@ -1010,6 +1018,7 @@ module Puma
 
     # Returns a hash of stats about the running server for reporting purposes.
     # @version 5.0.0
+    # @!attribute [r] stats
     def stats
       STAT_METHODS.map {|name| [name, send(name) || 0]}.to_h
     end

--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -54,8 +54,8 @@ class TestBusyWorker < Minitest::Test
     end
 
     @server = Puma::Server.new request_handler, Puma::Events.strings, **options
-    @server.min_threads = options[:min_threads] || 0
-    @server.max_threads = options[:max_threads] || 10
+    @server.instance_variable_set :@min_threads, options[:min_threads] || 0
+    @server.instance_variable_set :@max_threads, options[:max_threads] || 10
     @port = (@server.add_tcp_listener '127.0.0.1', 0).addr[1]
     @server.run
   end

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -108,6 +108,7 @@ class TestIntegrationPumactl < TestIntegration
     cli_pumactl "stop", unix: true
 
     _, status = Process.wait2(@pid)
+    assert_equal 0, status
     @server = nil
   end
 

--- a/test/test_out_of_band_server.rb
+++ b/test/test_out_of_band_server.rb
@@ -60,8 +60,8 @@ class TestOutOfBandServer < Minitest::Test
     end
 
     @server = Puma::Server.new app, Puma::Events.strings, out_of_band: [oob], **options
-    @server.min_threads = options[:min_threads] || 1
-    @server.max_threads = options[:max_threads] || 1
+    @server.instance_variable_set :@min_threads, options[:min_threads] || 1
+    @server.instance_variable_set :@max_threads, options[:max_threads] || 1
     @port = (@server.add_tcp_listener '127.0.0.1', 0).addr[1]
     @server.run
   end

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -25,7 +25,7 @@ class TestPersistent < Minitest::Test
 
     @server = Puma::Server.new @simple
     @port = (@server.add_tcp_listener HOST, 0).addr[1]
-    @server.max_threads = 1
+    @server.instance_variable_set :@max_threads, 1
     @server.run
 
     @client = TCPSocket.new HOST, @port
@@ -152,7 +152,7 @@ class TestPersistent < Minitest::Test
   end
 
   def test_persistent_timeout
-    @server.persistent_timeout = 1
+    @server.instance_variable_set :@persistent_timeout, 1
     @client << @valid_request
     sz = @body[0].size.to_s
 
@@ -189,7 +189,7 @@ class TestPersistent < Minitest::Test
 
 
   def test_two_requests_in_one_chunk
-    @server.persistent_timeout = 3
+    @server.instance_variable_set :@persistent_timeout, 3
 
     req = @valid_request.to_s
     req += "GET /second HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
@@ -206,7 +206,7 @@ class TestPersistent < Minitest::Test
   end
 
   def test_second_request_not_in_first_req_body
-    @server.persistent_timeout = 3
+    @server.instance_variable_set :@persistent_timeout, 3
 
     req = @valid_request.to_s
     req += "GET /second HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -182,7 +182,7 @@ class TestPumaControlCli < TestConfigFileBase
     out, _ = capture_subprocess_io do
       begin
         cmd.run
-      rescue SystemExit => e
+      rescue SystemExit
       end
     end
     assert_match expected_out, out


### PR DESCRIPTION
### Description

In normal use, Server is passed an options hash in its initialize method.  Some code is outside of Server, using attr_accessors, some of which may have been created for CI, etc.  They also display in docs, which isn't needed.

1. server.rb - consolidate option handling, remove `attr_accessor` statements, change other lib files as needed.

2. server.rb - Server had a method defined in `class << self` (`tcp_cork_supported?`), and also a method defined as `self.current`.  Move current into `class << self` block.

3. runner.rb - `remove development?` & `test?`, which are only used to set a value based on options in Server.

4. Change test files to use `Server#instance_variable_get`

5. Add YARD `# @!attribute` tags to methods that are actually attributes (no parameters, getter, setter, or predicate)

For those interested in seeing Puma docs:
current gem https://puma.io/puma
master https://msp-greg.github.io/puma/


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [?] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
