### PR TITLE
Refactor: extract worker process into separate class [changelog skip]

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -4,6 +4,7 @@ require 'puma/runner'
 require 'puma/util'
 require 'puma/plugin'
 require 'puma/cluster/worker_handle'
+require 'puma/cluster/worker'
 
 require 'time'
 
@@ -11,10 +12,6 @@ module Puma
   # This class is instantiated by the `Puma::Launcher` and used
   # to boot and serve a Ruby application when puma "workers" are needed
   # i.e. when using multi-processes. For example `$ puma -w 5`
-  #
-  # At the core of this class is running an instance of `Puma::Server` which
-  # gets created via the `start_server` method from the `Puma::Runner` class
-  # that this inherits from.
   #
   # An instance of this class will spawn the number of processes passed in
   # via the `spawn_workers` method call. Each worker will have it's own
@@ -176,113 +173,24 @@ module Puma
     end
 
     def worker(index, master)
-      title  = "puma: cluster worker #{index}: #{master}"
-      title += " [#{@options[:tag]}]" if @options[:tag] && !@options[:tag].empty?
-      $0 = title
-
-      Signal.trap "SIGINT", "IGNORE"
-      Signal.trap "SIGCHLD", "DEFAULT"
-
-      fork_worker = @options[:fork_worker] && index == 0
-
       @workers = []
-      if !@options[:fork_worker] || fork_worker
-        @master_read.close
-        @suicide_pipe.close
-        @fork_writer.close
+
+      @master_read.close
+      @suicide_pipe.close
+      @fork_writer.close
+
+      pipes = { check_pipe: @check_pipe, worker_write: @worker_write }
+      if @options[:fork_worker]
+        pipes[:fork_pipe] = @fork_pipe
+        pipes[:wakeup] = @wakeup
       end
 
-      Thread.new do
-        Puma.set_thread_name "worker check pipe"
-        IO.select [@check_pipe]
-        log "! Detected parent died, dying"
-        exit! 1
-      end
-
-      # If we're not running under a Bundler context, then
-      # report the info about the context we will be using
-      if !ENV['BUNDLE_GEMFILE']
-        if File.exist?("Gemfile")
-          log "+ Gemfile in context: #{File.expand_path("Gemfile")}"
-        elsif File.exist?("gems.rb")
-          log "+ Gemfile in context: #{File.expand_path("gems.rb")}"
-        end
-      end
-
-      # Invoke any worker boot hooks so they can get
-      # things in shape before booting the app.
-      @launcher.config.run_hooks :before_worker_boot, index, @launcher.events
-
-      server = @server ||= start_server
-      restart_server = Queue.new << true << false
-
-      if fork_worker
-        restart_server.clear
-        worker_pids = []
-        Signal.trap "SIGCHLD" do
-          wakeup! if worker_pids.reject! do |p|
-            Process.wait(p, Process::WNOHANG) rescue true
-          end
-        end
-
-        Thread.new do
-          Puma.set_thread_name "worker fork pipe"
-          while (idx = @fork_pipe.gets)
-            idx = idx.to_i
-            if idx == -1 # stop server
-              if restart_server.length > 0
-                restart_server.clear
-                server.begin_restart(true)
-                @launcher.config.run_hooks :before_refork, nil, @launcher.events
-                nakayoshi_gc
-              end
-            elsif idx == 0 # restart server
-              restart_server << true << false
-            else # fork worker
-              worker_pids << pid = spawn_worker(idx, master)
-              @worker_write << "f#{pid}:#{idx}\n" rescue nil
-            end
-          end
-        end
-      end
-
-      Signal.trap "SIGTERM" do
-        @worker_write << "e#{Process.pid}\n" rescue nil
-        server.stop
-        restart_server << false
-      end
-
-      begin
-        @worker_write << "b#{Process.pid}:#{index}\n"
-      rescue SystemCallError, IOError
-        Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
-        STDERR.puts "Master seems to have exited, exiting."
-        return
-      end
-
-      Thread.new(@worker_write) do |io|
-        Puma.set_thread_name "stat payload"
-
-        while true
-          sleep Const::WORKER_CHECK_INTERVAL
-          begin
-            require 'json'
-            io << "p#{Process.pid}#{server.stats.to_json}\n"
-          rescue IOError
-            Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
-            break
-          end
-        end
-      end
-
-      server.run.join while restart_server.pop
-
-      # Invoke any worker shutdown hooks so they can prevent the worker
-      # exiting until any background operations are completed
-      @launcher.config.run_hooks :before_worker_shutdown, index, @launcher.events
-    ensure
-      @worker_write << "t#{Process.pid}\n" rescue nil
-      @worker_write.close
+      new_worker = Worker.new index: index,
+                              master: master,
+                              options: @options,
+                              launcher: @launcher,
+                              pipes: pipes
+      new_worker.run
     end
 
     def restart

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -61,7 +61,7 @@ module Puma
       @workers.each { |x| x.hup }
     end
 
-    class Worker
+    class WorkerHandle
       def initialize(idx, pid, phase, options)
         @index = idx
         @pid = pid
@@ -154,7 +154,7 @@ module Puma
         end
 
         debug "Spawned worker: #{pid}"
-        @workers << Worker.new(idx, pid, @phase, @options)
+        @workers << WorkerHandle.new(idx, pid, @phase, @options)
       end
 
       if @options[:fork_worker] &&

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -187,7 +187,6 @@ module Puma
 
       new_worker = Worker.new index: index,
                               master: master,
-                              options: @options,
                               launcher: @launcher,
                               pipes: pipes
       new_worker.run

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -386,7 +386,7 @@ module Puma
       @master_read, @worker_write = read, @wakeup
 
       @launcher.config.run_hooks :before_fork, nil, @launcher.events
-      nakayoshi_gc
+      Puma::Util.nakayoshi_gc @events if @options[:nakayoshi_fork]
 
       spawn_workers
 
@@ -490,18 +490,6 @@ module Puma
           w.kill
         end
       end
-    end
-
-    # @version 5.0.0
-    def nakayoshi_gc
-      return unless @options[:nakayoshi_fork]
-      log "! Promoting existing objects to old generation..."
-      4.times { GC.start(full_mark: false) }
-      if GC.respond_to?(:compact)
-        log "! Compacting..."
-        GC.compact
-      end
-      log "! Friendly fork preparation complete."
     end
   end
 end

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -3,6 +3,7 @@
 require 'puma/runner'
 require 'puma/util'
 require 'puma/plugin'
+require 'puma/cluster/worker_handle'
 
 require 'time'
 
@@ -59,79 +60,6 @@ module Puma
       super
 
       @workers.each { |x| x.hup }
-    end
-
-    class WorkerHandle
-      def initialize(idx, pid, phase, options)
-        @index = idx
-        @pid = pid
-        @phase = phase
-        @stage = :started
-        @signal = "TERM"
-        @options = options
-        @first_term_sent = nil
-        @started_at = Time.now
-        @last_checkin = Time.now
-        @last_status = {}
-        @term = false
-      end
-
-      attr_reader :index, :pid, :phase, :signal, :last_checkin, :last_status, :started_at
-
-      # @version 5.0.0
-      attr_writer :pid, :phase
-
-      def booted?
-        @stage == :booted
-      end
-
-      def boot!
-        @last_checkin = Time.now
-        @stage = :booted
-      end
-
-      def term?
-        @term
-      end
-
-      def ping!(status)
-        @last_checkin = Time.now
-        require 'json'
-        @last_status = JSON.parse(status, symbolize_names: true)
-      end
-
-      # @see Puma::Cluster#check_workers
-      # @version 5.0.0
-      def ping_timeout
-        @last_checkin +
-          (booted? ?
-            @options[:worker_timeout] :
-            @options[:worker_boot_timeout]
-          )
-      end
-
-      def term
-        begin
-          if @first_term_sent && (Time.now - @first_term_sent) > @options[:worker_shutdown_timeout]
-            @signal = "KILL"
-          else
-            @term ||= true
-            @first_term_sent ||= Time.now
-          end
-          Process.kill @signal, @pid if @pid
-        rescue Errno::ESRCH
-        end
-      end
-
-      def kill
-        @signal = 'KILL'
-        term
-      end
-
-      def hup
-        Process.kill "HUP", @pid
-      rescue Errno::ESRCH
-      end
     end
 
     def spawn_workers

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -11,13 +11,13 @@ module Puma
     class Worker < Puma::Runner
       attr_reader :index, :master
 
-      def initialize(index:, master:, options:, launcher:, pipes:, server: nil)
+      def initialize(index:, master:, launcher:, pipes:, server: nil)
         super launcher, launcher.events
 
         @index = index
         @master = master
-        @options = options
         @launcher = launcher
+        @options = launcher.options
         @check_pipe = pipes[:check_pipe]
         @worker_write = pipes[:worker_write]
         @fork_pipe = pipes[:fork_pipe]
@@ -136,7 +136,6 @@ module Puma
         pid = fork do
           new_worker = Worker.new index: idx,
                                   master: master,
-                                  options: @options,
                                   launcher: @launcher,
                                   pipes: { check_pipe: @check_pipe,
                                            worker_write: @worker_write },

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+module Puma
+  class Cluster < Puma::Runner
+    # This class is instantiated by the `Puma::Cluster` and represents a single
+    # worker process.
+    #
+    # At the core of this class is running an instance of `Puma::Server` which
+    # gets created via the `start_server` method from the `Puma::Runner` class
+    # that this inherits from.
+    class Worker < Puma::Runner
+      attr_reader :index, :master
+
+      def initialize(index:, master:, options:, launcher:, pipes:, server: nil)
+        super launcher, launcher.events
+
+        @index = index
+        @master = master
+        @options = options
+        @launcher = launcher
+        @check_pipe = pipes[:check_pipe]
+        @worker_write = pipes[:worker_write]
+        @fork_pipe = pipes[:fork_pipe]
+        @wakeup = pipes[:wakeup]
+        @server = server
+      end
+
+      def run
+        title  = "puma: cluster worker #{index}: #{master}"
+        title += " [#{@options[:tag]}]" if @options[:tag] && !@options[:tag].empty?
+        $0 = title
+
+        Signal.trap "SIGINT", "IGNORE"
+        Signal.trap "SIGCHLD", "DEFAULT"
+
+        Thread.new do
+          Puma.set_thread_name "worker check pipe"
+          IO.select [@check_pipe]
+          log "! Detected parent died, dying"
+          exit! 1
+        end
+
+        # If we're not running under a Bundler context, then
+        # report the info about the context we will be using
+        if !ENV['BUNDLE_GEMFILE']
+          if File.exist?("Gemfile")
+            log "+ Gemfile in context: #{File.expand_path("Gemfile")}"
+          elsif File.exist?("gems.rb")
+            log "+ Gemfile in context: #{File.expand_path("gems.rb")}"
+          end
+        end
+
+        # Invoke any worker boot hooks so they can get
+        # things in shape before booting the app.
+        @launcher.config.run_hooks :before_worker_boot, index, @launcher.events
+
+        server = @server ||= start_server
+        restart_server = Queue.new << true << false
+
+        fork_worker = @options[:fork_worker] && index == 0
+
+        if fork_worker
+          restart_server.clear
+          worker_pids = []
+          Signal.trap "SIGCHLD" do
+            wakeup! if worker_pids.reject! do |p|
+              Process.wait(p, Process::WNOHANG) rescue true
+            end
+          end
+
+          Thread.new do
+            Puma.set_thread_name "worker fork pipe"
+            while (idx = @fork_pipe.gets)
+              idx = idx.to_i
+              if idx == -1 # stop server
+                if restart_server.length > 0
+                  restart_server.clear
+                  server.begin_restart(true)
+                  @launcher.config.run_hooks :before_refork, nil, @launcher.events
+                  nakayoshi_gc
+                end
+              elsif idx == 0 # restart server
+                restart_server << true << false
+              else # fork worker
+                worker_pids << pid = spawn_worker(idx)
+                @worker_write << "f#{pid}:#{idx}\n" rescue nil
+              end
+            end
+          end
+        end
+
+        Signal.trap "SIGTERM" do
+          @worker_write << "e#{Process.pid}\n" rescue nil
+          server.stop
+          restart_server << false
+        end
+
+        begin
+          @worker_write << "b#{Process.pid}:#{index}\n"
+        rescue SystemCallError, IOError
+          Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+          STDERR.puts "Master seems to have exited, exiting."
+          return
+        end
+
+        Thread.new(@worker_write) do |io|
+          Puma.set_thread_name "stat payload"
+
+          while true
+            sleep Const::WORKER_CHECK_INTERVAL
+            begin
+              require 'json'
+              io << "p#{Process.pid}#{server.stats.to_json}\n"
+            rescue IOError
+              Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+              break
+            end
+          end
+        end
+
+        server.run.join while restart_server.pop
+
+        # Invoke any worker shutdown hooks so they can prevent the worker
+        # exiting until any background operations are completed
+        @launcher.config.run_hooks :before_worker_shutdown, index, @launcher.events
+      ensure
+        @worker_write << "t#{Process.pid}\n" rescue nil
+        @worker_write.close
+      end
+
+      private
+
+      def spawn_worker(idx)
+        @launcher.config.run_hooks :before_worker_fork, idx, @launcher.events
+
+        pid = fork do
+          new_worker = Worker.new index: idx,
+                                  master: master,
+                                  options: @options,
+                                  launcher: @launcher,
+                                  pipes: { check_pipe: @check_pipe,
+                                           worker_write: @worker_write },
+                                  server: @server
+          new_worker.run
+        end
+
+        if !pid
+          log "! Complete inability to spawn new workers detected"
+          log "! Seppuku is the only choice."
+          exit! 1
+        end
+
+        @launcher.config.run_hooks :after_worker_fork, idx, @launcher.events
+        pid
+      end
+
+      def wakeup!
+        return unless @wakeup
+
+        begin
+          @wakeup.write "!" unless @wakeup.closed?
+        rescue SystemCallError, IOError
+          Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+        end
+      end
+
+      def nakayoshi_gc
+        return unless @options[:nakayoshi_fork]
+        log "! Promoting existing objects to old generation..."
+        4.times { GC.start(full_mark: false) }
+        if GC.respond_to?(:compact)
+          log "! Compacting..."
+          GC.compact
+        end
+        log "! Friendly fork preparation complete."
+      end
+    end
+  end
+end

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -77,7 +77,7 @@ module Puma
                   restart_server.clear
                   server.begin_restart(true)
                   @launcher.config.run_hooks :before_refork, nil, @launcher.events
-                  nakayoshi_gc
+                  Puma::Util.nakayoshi_gc @events if @options[:nakayoshi_fork]
                 end
               elsif idx == 0 # restart server
                 restart_server << true << false
@@ -162,17 +162,6 @@ module Puma
         rescue SystemCallError, IOError
           Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
         end
-      end
-
-      def nakayoshi_gc
-        return unless @options[:nakayoshi_fork]
-        log "! Promoting existing objects to old generation..."
-        4.times { GC.start(full_mark: false) }
-        if GC.respond_to?(:compact)
-          log "! Compacting..."
-          GC.compact
-        end
-        log "! Friendly fork preparation complete."
       end
     end
   end

--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -2,6 +2,11 @@
 
 module Puma
   class Cluster < Runner
+    # This class represents a worker process from the perspective of the puma
+    # master process. It contains information about the process and its health
+    # and it exposes methods to control the process via IPC. It does not
+    # include the actual logic executed by the worker process itself. For that,
+    # see Puma::Cluster::Worker.
     class WorkerHandle
       def initialize(idx, pid, phase, options)
         @index = idx

--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Puma
+  class Cluster < Runner
+    class WorkerHandle
+      def initialize(idx, pid, phase, options)
+        @index = idx
+        @pid = pid
+        @phase = phase
+        @stage = :started
+        @signal = "TERM"
+        @options = options
+        @first_term_sent = nil
+        @started_at = Time.now
+        @last_checkin = Time.now
+        @last_status = {}
+        @term = false
+      end
+
+      attr_reader :index, :pid, :phase, :signal, :last_checkin, :last_status, :started_at
+
+      # @version 5.0.0
+      attr_writer :pid, :phase
+
+      def booted?
+        @stage == :booted
+      end
+
+      def boot!
+        @last_checkin = Time.now
+        @stage = :booted
+      end
+
+      def term?
+        @term
+      end
+
+      def ping!(status)
+        @last_checkin = Time.now
+        require 'json'
+        @last_status = JSON.parse(status, symbolize_names: true)
+      end
+
+      # @see Puma::Cluster#check_workers
+      # @version 5.0.0
+      def ping_timeout
+        @last_checkin +
+          (booted? ?
+            @options[:worker_timeout] :
+            @options[:worker_boot_timeout]
+          )
+      end
+
+      def term
+        begin
+          if @first_term_sent && (Time.now - @first_term_sent) > @options[:worker_shutdown_timeout]
+            @signal = "KILL"
+          else
+            @term ||= true
+            @first_term_sent ||= Time.now
+          end
+          Process.kill @signal, @pid if @pid
+        rescue Errno::ESRCH
+        end
+      end
+
+      def kill
+        @signal = 'KILL'
+        term
+      end
+
+      def hup
+        Process.kill "HUP", @pid
+      rescue Errno::ESRCH
+      end
+    end
+  end
+end

--- a/lib/puma/util.rb
+++ b/lib/puma/util.rb
@@ -23,6 +23,17 @@ module Puma
     end
     module_function :unescape
 
+    # @version 5.0.0
+    def nakayoshi_gc(events)
+      events.log "! Promoting existing objects to old generation..."
+      4.times { GC.start(full_mark: false) }
+      if GC.respond_to?(:compact)
+        events.log "! Compacting..."
+        GC.compact
+      end
+      events.log "! Friendly fork preparation complete."
+    end
+
     DEFAULT_SEP = /[&;] */n
 
     # Stolen from Mongrel, with some small modifications:


### PR DESCRIPTION
### Description

My original motivation for extracting code related to the worker processes is the change described in https://github.com/puma/puma/issues/1875#issuecomment-695143880. I want to be able to create the first worker process (assuming `fork_worker` is on) by first `fork`ing from the master, then immediately `exec`ing into a new process definition with a separate memory space. 

My proof-of-concept in that comment technically _works_ but it's messy because the logic used by the worker process is woven in together with the logic used by the puma master process in `Puma::Cluster`. Worker processes implicitly rely on several instance variables used in `Puma::Cluster`, so for the new process to spin up a new worker, it needs to first spin up a dummy instance of `Puma::Cluster`.

To make it a little bit cleaner, I pulled out the worker logic into a new `Puma::Cluster::Worker` class. The initializer lays out everything that's necessary to construct a new worker process. My hope is that it's clear that this refactor is worth having regardless of the original motivation for it because it makes dependencies of the worker process clear and lowers the cognitive overhead of having worker logic and cluster logic in the same class definition.

### Your checklist for this pull request

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
