### PR TITLE
Change Events#ssl_error signature from (error, peeraddr, peercert) to (error, ssl_socket)

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,9 @@
 * Bugfixes
   * Your bugfix goes here (#Github Number)
 
+* Refactor
+  * Change Events#ssl_error signature from (error, peeraddr, peercert) to (error, ssl_socket) (#2375)
+
 ## 5.0.0
 
 * Features

--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -106,10 +106,12 @@ module Puma
     end
 
     # An SSL error has occurred.
-    # +error+ an exception object, +peeraddr+ peer address,
-    # and +peercert+ any peer certificate (if present).
+    # @param error <Puma::MiniSSL::SSLError>
+    # @param ssl_socket <Puma::MiniSSL::Socket>
     #
-    def ssl_error(error, peeraddr, peercert)
+    def ssl_error(error, ssl_socket)
+      peeraddr = ssl_socket.peeraddr.last rescue "<unknown>"
+      peercert = ssl_socket.peercert
       subject = peercert ? peercert.subject : nil
       @error_logger.info(error: error, text: "SSL error, peer: #{peeraddr}, peer cert: #{subject}")
     end

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -237,22 +237,11 @@ module Puma
 
               # SSL handshake failure
               rescue MiniSSL::SSLError => e
-                @server.lowlevel_error(e, c.env)
-
-                ssl_socket = c.io
-                begin
-                  addr = ssl_socket.peeraddr.last
-                # EINVAL can happen when browser closes socket w/security exception
-                rescue IOError, Errno::EINVAL
-                  addr = "<unknown>"
-                end
-
-                cert = ssl_socket.peercert
+                @server.lowlevel_error e, c.env
+                @events.ssl_error e, c.io
 
                 c.close
                 clear_monitor mon
-
-                @events.ssl_error e, addr, cert
 
               # The client doesn't know HTTP well
               rescue HttpParserError => e

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -220,13 +220,9 @@ module Puma
             process_now = true
           end
         rescue MiniSSL::SSLError => e
-          ssl_socket = client.io
-          addr = ssl_socket.peeraddr.last
-          cert = ssl_socket.peercert
-
+          @events.ssl_error e, client.io
           client.close
 
-          @events.ssl_error e, addr, cert
         rescue HttpParserError => e
           client.write_error(400)
           client.close
@@ -423,15 +419,9 @@ module Puma
 
       # SSL handshake error
       rescue MiniSSL::SSLError => e
-        lowlevel_error(e, client.env)
-
-        ssl_socket = client.io
-        addr = ssl_socket.peeraddr.last
-        cert = ssl_socket.peercert
-
+        lowlevel_error e, client.env
+        @events.ssl_error e, client.io
         close_socket = true
-
-        @events.ssl_error e, addr, cert
 
       # The client doesn't know HTTP well
       rescue HttpParserError => e

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -12,10 +12,10 @@ if ::Puma::HAS_SSL
   class SSLEventsHelper < ::Puma::Events
     attr_accessor :addr, :cert, :error
 
-    def ssl_error(error, peeraddr, peercert)
+    def ssl_error(error, ssl_socket)
       self.error = error
-      self.addr = peeraddr
-      self.cert = peercert
+      self.addr = ssl_socket.peeraddr.last rescue "<unknown>"
+      self.cert = ssl_socket.peercert
     end
   end
 


### PR DESCRIPTION
### Description

The method signature should include the socket, so it determines what socket info is logged, and also so it can catch exceptions.

Closes #2365, closes #2367


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.