### PR TITLE
[changelog skip] Fix error backtrace debug logging && Don't log not parsed request

### DIFF
--- a/lib/puma/error_logger.rb
+++ b/lib/puma/error_logger.rb
@@ -51,8 +51,8 @@ module Puma
 
       string_block = []
       string_block << title(options)
-      string_block << request_dump(req) if req
-      string_block << error_backtrace(options) if error
+      string_block << request_dump(req) if request_parsed?(req)
+      string_block << error.backtrace if error
 
       ioerr.puts string_block.join("\n")
     end

--- a/test/test_error_logger.rb
+++ b/test/test_error_logger.rb
@@ -59,6 +59,23 @@ class TestErrorLogger < Minitest::Test
     end
   end
 
+  def test_debug_backtrace_logging
+    with_debug_mode do
+      def dummy_error
+        raise StandardError.new('non-blank')
+      rescue => e
+        Puma::ErrorLogger.stdio.debug(error: e)
+      end
+
+      _, err = capture_io do
+        dummy_error
+      end
+
+      assert_match %r!non-blank!, err
+      assert_match %r!:in `dummy_error'!, err
+    end
+  end
+
   private
 
   def with_debug_mode


### PR DESCRIPTION
### Description
I've found a couple of mistakes in the new error logging class.
- We don't have to parse the dump of the request if it wasn't parsed
- It failed on error backtrace logging in `#debug` because of a typo

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
