### PR TITLE
Prevent connections from entering Reactor after shutdown begins

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,7 +4,7 @@
   * Your feature goes here (#Github Number)
 
 * Bugfixes
-  * Your bugfix goes here (#Github Number)
+  * Prevent connections from entering Reactor after shutdown begins (#2377)
 
 ## 5.0.0
 


### PR DESCRIPTION
### Description

This change addresses one source of connection reset errors related to the shutdown process of `Puma::Sever`. Details about the particular problem are described in https://github.com/puma/puma/issues/2337#issuecomment-694549921 and in the commit messages.

#### Why does this PR not include tests?

The most straightforward way to test this change is to add an integration test that repeatedly fires off requests to a server that is restarting via hot restarts (`SIGUSR2`). The expectation is that no client connection experiences a connection reset error, or better, that every client request gets a successful response.

I've written such an integration test, but unfortunately, there are other sources of connection reset errors that make it so that the test does not pass reliably. I suggest we continue to document and catalog those errors in #2337.

My claim is that change demonstrably fixes one problem that causes connection reset errors and gets us closer to the point that puma reliably handles all client connections that it accepted before shutting down, even if the change doesn't fix every kind of problem. It is possible to use the reproduction steps in #2337 to verify that the error `Error reached top of thread-pool: closed stream (IOError)` is resolved by this PR.

### Your checklist for this pull request

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
