### PR TITLE
Fix LoadError in CentOS 8 - 'require_relative' should not be necessar…

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,7 @@
 * Bugfixes
   * Prevent connections from entering Reactor after shutdown begins (#2377)
   * Better error handling during force shutdown (#2271)
+  * Fix LoadError in CentOS 8 (#2381)
 
 * Refactor
   * Change Events#ssl_error signature from (error, peeraddr, peercert) to (error, ssl_socket) (#2375)

--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -10,8 +10,8 @@ require 'stringio'
 
 require 'thread'
 
-require_relative 'puma/puma_http11'
-require_relative 'puma/detect'
+require 'puma/puma_http11'
+require 'puma/detect'
 
 module Puma
   autoload :Const, 'puma/const'


### PR DESCRIPTION
…y with recent version of rubygems

### Description
The pull request fixes compatibility with CentOS 8: Even for manual installs CentOS 8 separates architecture dependent files from independent ones. Therefore the shared library `puma_http11.so` ends up in a different directory from `puma.rb`, which results in the `require_relative 'puma/puma_http11'` to fail.

Replacing `require_relative` by `require` does not change the behavior in case `puma_http11.so` ends up in the same directory. Apart from that I also consider it best practice in a gem to avoid `require_relative` altogether. Therefore I also replaced the other 
 `require_relative` by `require`.

### Steps to reproduce
Executing the following steps inside a `centos:8` docker container:
```
dnf -y module enable ruby:2.6
dnf -y install ruby ruby-devel gcc make redhat-rpm-config
gem install puma -v5.0.0
puma --version
```
results in
```
Traceback (most recent call last):
	9: from /usr/local/bin/puma:23:in `<main>'
	8: from /usr/local/bin/puma:23:in `load'
	7: from /usr/local/share/gems/gems/puma-5.0.0/bin/puma:6:in `<top (required)>'
	6: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	5: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	4: from /usr/local/share/gems/gems/puma-5.0.0/lib/puma/cli.rb:6:in `<top (required)>'
	3: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	2: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
	1: from /usr/local/share/gems/gems/puma-5.0.0/lib/puma.rb:13:in `<top (required)>'
/usr/local/share/gems/gems/puma-5.0.0/lib/puma.rb:13:in `require_relative': cannot load such file -- /usr/local/share/gems/gems/puma-5.0.0/lib/puma/puma_http11 (LoadError)
```
The paths to the relevant files are
- `/usr/local/share/gems/gems/puma-5.0.0/lib/puma.rb`
- `/usr/local/lib64/gems/ruby/puma-5.0.0/puma/puma_http11.so`

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
