### PR TITLE
[close #2371] Don't report EOFError

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -155,7 +155,9 @@ module Puma
         data = @io.read_nonblock(CHUNK_SIZE)
       rescue IO::WaitReadable
         return false
-      rescue SystemCallError, IOError, EOFError
+      rescue EOFError
+        # Swallow it
+      rescue SystemCallError, IOError
         raise ConnectionError, "Connection error detected during read"
       end
 


### PR DESCRIPTION
I think this fixes #2371. But there are some bigger problems:

- I can comment out these lines and tests still pass for me locally:

```
      # rescue SystemCallError, IOError, EOFError
      #   raise ConnectionError, "Connection error detected during read"
```

- It doesn't look like we're triggering the behavior that would fire the #<ConnectionError> in the output. We should figure out how to get that into our output while testing, and then assert our fix, fixes it.

- It looks like the exception catching is extremely nested. From this backtrace:

```
/Users/rschneeman/Documents/projects/puma/lib/puma/client.rb:154:in `try_to_finish'
/Users/rschneeman/Documents/projects/puma/lib/puma/client.rb:134:in `reset'
/Users/rschneeman/Documents/projects/puma/lib/puma/server.rb:428:in `block in process_client'
/Users/rschneeman/Documents/projects/puma/lib/puma/thread_pool.rb:335:in `with_force_shutdown'
/Users/rschneeman/Documents/projects/puma/lib/puma/server.rb:427:in `process_client'
/Users/rschneeman/Documents/projects/puma/lib/puma/server.rb:260:in `block in run'
/Users/rschneeman/Documents/projects/puma/lib/puma/thread_pool.rb:143:in `block in spawn_thread'
```

The EOFError would be rescued in both `try_to_finish` and in `reset`. Maybe more. It's unclear, from a unit perspective which of these exception catching locations exist for what reason. Basically: Were they just tacked on or is there a valid reason they're there. Being able to delete/comment code and have tests still pass is not confidence-inspiring in this exception case.

## TODO

- Find what can trigger the #2371 output behavior from a test, assert this fixes it.
- Optionally write some other assertions for other exception catching logic.
