### PR TITLE
Test Suite - convert client writes to syswrite [changelog skip]

### DIFF
--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -22,7 +22,7 @@ class TestBusyWorker < Minitest::Test
   end
 
   def send_http(req)
-    new_connection << req
+    new_connection.tap { |s| s.syswrite req }
   end
 
   def send_http_and_read(req)

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -21,7 +21,7 @@ class TestCLI < Minitest::Test
     @wait, @ready = IO.pipe
 
     @events = Puma::Events.strings
-    @events.on_booted { @ready << "!" }
+    @events.on_booted { @ready.syswrite "!" }
   end
 
   def wait_booted
@@ -52,7 +52,7 @@ class TestCLI < Minitest::Test
     wait_booted
 
     s = TCPSocket.new "127.0.0.1", cntl
-    s << "GET /stats HTTP/1.0\r\n\r\n"
+    s.syswrite "GET /stats HTTP/1.0\r\n\r\n"
     body = s.read
     s.close
 
@@ -124,7 +124,7 @@ class TestCLI < Minitest::Test
     wait_booted
 
     s = UNIXSocket.new @tmp_path
-    s << "GET /stats HTTP/1.0\r\n\r\n"
+    s.syswrite "GET /stats HTTP/1.0\r\n\r\n"
     body = s.read
     s.close
 
@@ -136,7 +136,7 @@ class TestCLI < Minitest::Test
     # wait until the first status ping has come through
     sleep 6
     s = UNIXSocket.new @tmp_path
-    s << "GET /stats HTTP/1.0\r\n\r\n"
+    s.syswrite "GET /stats HTTP/1.0\r\n\r\n"
     body = s.read
     s.close
 
@@ -171,7 +171,7 @@ class TestCLI < Minitest::Test
     wait_booted
 
     s = UNIXSocket.new @tmp_path
-    s << "GET /stats HTTP/1.0\r\n\r\n"
+    s.syswrite "GET /stats HTTP/1.0\r\n\r\n"
     body = s.read
     s.close
 
@@ -198,7 +198,7 @@ class TestCLI < Minitest::Test
     wait_booted
 
     s = UNIXSocket.new @tmp_path
-    s << "GET /stop HTTP/1.0\r\n\r\n"
+    s.syswrite "GET /stop HTTP/1.0\r\n\r\n"
     body = s.read
     s.close
 
@@ -224,7 +224,7 @@ class TestCLI < Minitest::Test
     wait_booted
 
     s = TCPSocket.new "127.0.0.1", cntl
-    s << "GET /stats HTTP/1.0\r\n\r\n"
+    s.syswrite "GET /stats HTTP/1.0\r\n\r\n"
     body = s.read
     s.close
 
@@ -233,13 +233,13 @@ class TestCLI < Minitest::Test
     # send real requests to server
     3.times do
       s = TCPSocket.new "127.0.0.1", tcp
-      s << "GET / HTTP/1.0\r\n\r\n"
+      s.syswrite "GET / HTTP/1.0\r\n\r\n"
       body = s.read
       s.close
     end
 
     s = TCPSocket.new "127.0.0.1", cntl
-    s << "GET /stats HTTP/1.0\r\n\r\n"
+    s.syswrite "GET /stats HTTP/1.0\r\n\r\n"
     body = s.read
     s.close
 
@@ -263,7 +263,7 @@ class TestCLI < Minitest::Test
     wait_booted
 
     s = UNIXSocket.new @tmp_path
-    s << "GET /thread-backtraces HTTP/1.0\r\n\r\n"
+    s.syswrite "GET /thread-backtraces HTTP/1.0\r\n\r\n"
     body = s.read
     s.close
 
@@ -286,7 +286,7 @@ class TestCLI < Minitest::Test
     wait_booted
 
     s = yield
-    s << "GET /gc-stats HTTP/1.0\r\n\r\n"
+    s.syswrite "GET /gc-stats HTTP/1.0\r\n\r\n"
     body = s.read
     s.close
 
@@ -301,12 +301,12 @@ class TestCLI < Minitest::Test
     gc_count_before = gc_stats["count"].to_i
 
     s = yield
-    s << "GET /gc HTTP/1.0\r\n\r\n"
+    s.syswrite "GET /gc HTTP/1.0\r\n\r\n"
     body = s.read # Ignored
     s.close
 
     s = yield
-    s << "GET /gc-stats HTTP/1.0\r\n\r\n"
+    s.syswrite "GET /gc-stats HTTP/1.0\r\n\r\n"
     body = s.read
     s.close
 

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -174,7 +174,7 @@ class TestEvents < Minitest::Test
     path = "/"
     params = "a"*1024*10
 
-    sock << "GET #{path}?a=#{params} HTTP/1.1\r\nConnection: close\r\n\r\n"
+    sock.syswrite "GET #{path}?a=#{params} HTTP/1.1\r\nConnection: close\r\n\r\n"
     sock.read
     sleep 0.1 # important so that the previous data is sent as a packet
     assert_match %r!HTTP parse error, malformed request!, events.stderr.string

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -64,7 +64,7 @@ class TestIntegrationPumactl < TestIntegration
 
     s = UNIXSocket.new @bind_path
     @ios_to_close << s
-    s << "GET /sleep1 HTTP/1.0\r\n\r\n"
+    s.syswrite "GET /sleep1 HTTP/1.0\r\n\r\n"
 
     # Get the PIDs of the phase 0 workers.
     phase0_worker_pids = get_worker_pids 0
@@ -98,7 +98,7 @@ class TestIntegrationPumactl < TestIntegration
 
     s = UNIXSocket.new @bind_path
     @ios_to_close << s
-    s << "GET / HTTP/1.0\r\n\r\n"
+    s.syswrite "GET / HTTP/1.0\r\n\r\n"
 
     body = s.read
 

--- a/test/test_out_of_band_server.rb
+++ b/test/test_out_of_band_server.rb
@@ -26,7 +26,7 @@ class TestOutOfBandServer < Minitest::Test
   end
 
   def send_http(req)
-    new_connection << req
+    new_connection.tap { |s| s.syswrite req }
   end
 
   def send_http_and_read(req)
@@ -108,7 +108,7 @@ class TestOutOfBandServer < Minitest::Test
       @oob_finished.wait(@mutex) # enter OOB
 
       # Send Req2
-      req2 << "GET / HTTP/1.0\r\n\r\n"
+      req2.syswrite "GET / HTTP/1.0\r\n\r\n"
       # If Req2 is processed now it raises 'OOB Conflict' in the response.
       sleep 0.01
 

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -45,7 +45,7 @@ class TestPersistent < Minitest::Test
   end
 
   def test_one_with_content_length
-    @client << @valid_request
+    @client.syswrite @valid_request
     sz = @body[0].size.to_s
 
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
@@ -53,13 +53,13 @@ class TestPersistent < Minitest::Test
   end
 
   def test_two_back_to_back
-    @client << @valid_request
+    @client.syswrite @valid_request
     sz = @body[0].size.to_s
 
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
     assert_equal "Hello", @client.read(5)
 
-    @client << @valid_request
+    @client.syswrite @valid_request
     sz = @body[0].size.to_s
 
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
@@ -67,13 +67,13 @@ class TestPersistent < Minitest::Test
   end
 
   def test_post_then_get
-    @client << @valid_post
+    @client.syswrite @valid_post
     sz = @body[0].size.to_s
 
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
     assert_equal "Hello", @client.read(5)
 
-    @client << @valid_request
+    @client.syswrite @valid_request
     sz = @body[0].size.to_s
 
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
@@ -81,10 +81,10 @@ class TestPersistent < Minitest::Test
   end
 
   def test_no_body_then_get
-    @client << @valid_no_body
+    @client.syswrite @valid_no_body
     assert_equal "HTTP/1.1 204 No Content\r\nX-Header: Works\r\n\r\n", lines(3)
 
-    @client << @valid_request
+    @client.syswrite @valid_request
     sz = @body[0].size.to_s
 
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
@@ -94,7 +94,7 @@ class TestPersistent < Minitest::Test
   def test_chunked
     @body << "Chunked"
 
-    @client << @valid_request
+    @client.syswrite @valid_request
 
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n7\r\nChunked\r\n0\r\n\r\n", lines(10)
   end
@@ -103,7 +103,7 @@ class TestPersistent < Minitest::Test
     @body << ""
     @body << "Chunked"
 
-    @client << @valid_request
+    @client.syswrite @valid_request
 
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n7\r\nChunked\r\n0\r\n\r\n", lines(10)
   end
@@ -111,7 +111,7 @@ class TestPersistent < Minitest::Test
   def test_no_chunked_in_http10
     @body << "Chunked"
 
-    @client << @http10_request
+    @client.syswrite @http10_request
 
     assert_equal "HTTP/1.0 200 OK\r\nX-Header: Works\r\n\r\n", lines(3)
     assert_equal "HelloChunked", @client.read
@@ -121,14 +121,14 @@ class TestPersistent < Minitest::Test
     str = "This is longer and will be in hex"
     @body << str
 
-    @client << @valid_request
+    @client.syswrite @valid_request
 
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n#{str.size.to_s(16)}\r\n#{str}\r\n0\r\n\r\n", lines(10)
 
   end
 
   def test_client11_close
-    @client << @close_request
+    @client.syswrite @close_request
     sz = @body[0].size.to_s
 
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nConnection: close\r\nContent-Length: #{sz}\r\n\r\n", lines(5)
@@ -136,7 +136,7 @@ class TestPersistent < Minitest::Test
   end
 
   def test_client10_close
-    @client << @http10_request
+    @client.syswrite @http10_request
     sz = @body[0].size.to_s
 
     assert_equal "HTTP/1.0 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
@@ -144,7 +144,7 @@ class TestPersistent < Minitest::Test
   end
 
   def test_one_with_keep_alive_header
-    @client << @keep_request
+    @client.syswrite @keep_request
     sz = @body[0].size.to_s
 
     assert_equal "HTTP/1.0 200 OK\r\nX-Header: Works\r\nConnection: Keep-Alive\r\nContent-Length: #{sz}\r\n\r\n", lines(5)
@@ -153,7 +153,7 @@ class TestPersistent < Minitest::Test
 
   def test_persistent_timeout
     @server.persistent_timeout = 1
-    @client << @valid_request
+    @client.syswrite @valid_request
     sz = @body[0].size.to_s
 
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
@@ -170,7 +170,7 @@ class TestPersistent < Minitest::Test
     @body = ["hello", " world"]
     @headers['Content-Length'] = "11"
 
-    @client << @valid_request
+    @client.syswrite @valid_request
 
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: 11\r\n\r\n",
                  lines(4)
@@ -182,7 +182,7 @@ class TestPersistent < Minitest::Test
 
     @body = ["5\r\nhello\r\n0\r\n\r\n"]
 
-    @client << @valid_request
+    @client.syswrite @valid_request
 
     assert_equal "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n", lines(7)
   end
@@ -194,7 +194,7 @@ class TestPersistent < Minitest::Test
     req = @valid_request.to_s
     req += "GET /second HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
 
-    @client << req
+    @client.syswrite req
 
     sz = @body[0].size.to_s
 
@@ -211,7 +211,7 @@ class TestPersistent < Minitest::Test
     req = @valid_request.to_s
     req += "GET /second HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
 
-    @client << req
+    @client.syswrite req
 
     sz = @body[0].size.to_s
 
@@ -228,10 +228,10 @@ class TestPersistent < Minitest::Test
   def test_keepalive_doesnt_starve_clients
     sz = @body[0].size.to_s
 
-    @client << @valid_request
+    @client.syswrite @valid_request
 
     c2 = TCPSocket.new HOST, @port
-    c2 << @valid_request
+    c2.syswrite @valid_request
 
     out = IO.select([c2], nil, nil, 1)
 

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -138,7 +138,7 @@ class TestPumaControlCli < TestConfigFileBase
     wait_booted
 
     s = TCPSocket.new host, 9292
-    s << "GET / HTTP/1.0\r\n\r\n"
+    s.syswrite "GET / HTTP/1.0\r\n\r\n"
     body = s.read
     assert_match "200 OK", body
     assert_match "embedded app", body

--- a/test/test_unix_socket.rb
+++ b/test/test_unix_socket.rb
@@ -25,7 +25,7 @@ class TestPumaUnixSocket < Minitest::Test
     skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
     sock = UNIXSocket.new @tmp_socket_path
 
-    sock << "GET / HTTP/1.0\r\nHost: blah.com\r\n\r\n"
+    sock.syswrite "GET / HTTP/1.0\r\nHost: blah.com\r\n\r\n"
 
     expected = "HTTP/1.0 200 OK\r\nContent-Length: 5\r\n\r\nWorks"
 


### PR DESCRIPTION
### Description
Recently I was working with Puma, testing with both client sockets created in Ruby, and a browser.  The Ruby client socket blocked on a `#read` for several seconds, but the browser showed it instantly.  I changed the `#read` call to `#sysread`, and the Ruby client behaved as the browser.  I have also seen similar issues before with reads & writes.

In general, using `#sysread` can be messy, because so many apps need to use other, buffered read methods.  OTOH, using `#syswrite` is easier.

So, I decided to convert all `#write`'s in the test suite to `syswrite`'s, and see if it helped, escpecially with non MRI jobs.

This PR implements that. I think I converted most of the `#write`'s, but I may have missed some.  It does seem to improve non MRI CI, and jobs seem to complete, rather than time out.  There are still intermittent failures/errors.

Lastly, Puma uses both `#write`/`<<` and `#syswrite`.  If this helps stabilize CI, maybe all 'writes' should be converted to `#syswrite`?

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
