### PR TITLE
Use $host instead of $http_host in nginx config [ci skip]

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -31,7 +31,7 @@ server {
 
   location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $host;
 
     # If the file exists as a static file serve it directly without
     # running all the other rewrite tests on it


### PR DESCRIPTION
### Description

`$http_host` is vulnerable to host spoofing. Use `$host` instead. See https://github.com/yandex/gixy/blob/f5a54ad161a8f956eed0237ff689d49f7ed3a3e2/docs/en/plugins/hostspoofing.md


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
