### PR TITLE
Consolidate fast_write calls in Server, extract early_hints assembly

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,6 +7,7 @@
   * Cleanup daemonization in rc.d script (#2409)
 
 * Refactor
+  * Consolidate fast_write calls in Server, extract early_hints assembly (#2405)
   * Remove upstart from docs (#2408)
   * Consolidate option handling in Server, Server small refactors, doc changes (#2389)
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -595,20 +595,7 @@ module Puma
       if @early_hints
         env[EARLY_HINTS] = lambda { |headers|
           begin
-            fast_write client, "HTTP/1.1 103 Early Hints\r\n".freeze
-
-            headers.each_pair do |k, vs|
-              if vs.respond_to?(:to_s) && !vs.to_s.empty?
-                vs.to_s.split(NEWLINE).each do |v|
-                  next if possible_header_injection?(v)
-                  fast_write client, "#{k}: #{v}\r\n"
-                end
-              else
-                fast_write client, "#{k}: #{vs}\r\n"
-              end
-            end
-
-            fast_write client, "\r\n".freeze
+            fast_write client, str_early_hints(headers)
           rescue ConnectionError => e
             @events.debug_error e
             # noop, if we lost the socket we just won't send the early hints
@@ -797,14 +784,11 @@ module Puma
           res_body.each do |part|
             next if part.bytesize.zero?
             if chunked
-              fast_write client, part.bytesize.to_s(16)
-              fast_write client, line_ending
-              fast_write client, part
-              fast_write client, line_ending
+              str = part.bytesize.to_s(16) << line_ending << part << line_ending
+              fast_write client, str
             else
               fast_write client, part
             end
-
             client.flush
           end
 
@@ -1037,5 +1021,21 @@ module Puma
     def stats
       STAT_METHODS.map {|name| [name, send(name) || 0]}.to_h
     end
+
+    def str_early_hints(headers)
+      eh_str = "HTTP/1.1 103 Early Hints\r\n".dup
+      headers.each_pair do |k, vs|
+        if vs.respond_to?(:to_s) && !vs.to_s.empty?
+          vs.to_s.split(NEWLINE).each do |v|
+            next if possible_header_injection?(v)
+            eh_str << "#{k}: #{v}\r\n"
+          end
+        else
+          eh_str << "#{k}: #{vs}\r\n"
+        end
+      end
+      "#{eh_str}\r\n".freeze
+    end
+    private :str_early_hints
   end
 end


### PR DESCRIPTION
### Description

`Server#handle_request` is a very long method, and also has many `#fast_write` calls.  `#fast_write` calls, which involve `rescue` clauses, when done with a reasonably defined string in terms of length, should be minimized.

Also, extract code to assemble the 'early hints' string into `#str_early_hints`.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.