### PR TITLE
Create new worker processes in separate memory spaces from master process

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@
   * Your feature goes here <Most recent on the top, like GitHub> (#Github Number)
 
 * Bugfixes
+  * Fix errors related to phased restarts when using deployment strategies that delete gems for old releases ([#2407])
   * Cleanup daemonization in rc.d script (#2409)
 
 * Refactor

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -103,11 +103,6 @@ is unavailable would be nice as well. Here's how to do it:
 1. Don't use `preload!`. This dirties the master process and means it will have
 to shutdown all the workers and re-exec itself to get your new code. It is not compatible with phased-restart and `prune_bundler` as well.
 
-1. Use `prune_bundler`. This makes it so that the cluster master will detach itself
-from a Bundler context on start. This allows the cluster workers to load your app
-and start a brand new Bundler context within the worker only. This means your
-master remains pristine and can live on between new releases of your code.
-
 1. Use phased-restart (`SIGUSR1` or `pumactl phased-restart`). This tells the master
 to kill off one worker at a time and restart them in your new code. This minimizes
 downtime and staggers the restart nicely. **WARNING** This means that both your

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -199,7 +199,7 @@ module Puma
     end
 
     def phased_restart
-      return false if @options[:preload_app]
+      return false unless supports_phased_restart?
 
       @phased_restart = true
       wakeup!
@@ -459,6 +459,10 @@ module Puma
     end
 
     private
+
+    def supports_phased_restart?
+      !@options[:preload_app]
+    end
 
     # loops thru @workers, removing workers that exited, and calling
     # `#term` if needed

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -583,18 +583,12 @@ module Puma
       @options[:lowlevel_error_handler] = obj
     end
 
-    # This option is used to allow your app and its gems to be
-    # properly reloaded when not using preload.
+    # This option is a memory optimization for use in cluster mode.
     #
-    # When set, if Puma detects that it's been invoked in the
-    # context of Bundler, it will cleanup the environment and
-    # re-run itself outside the Bundler environment, but directly
-    # using the files that Bundler has setup.
-    #
-    # This means that Puma is now decoupled from your Bundler
-    # context and when each worker loads, it will be loading a
-    # new Bundler context and thus can float around as the release
-    # dictates.
+    # When set, if the Puma master process detects that it's been invoked in
+    # the context of Bundler, it will cleanup the environment and re-run itself
+    # outside the Bundler environment, but directly using the files that
+    # Bundler has setup. This has no effect on worker processes.
     #
     # @see extra_runtime_dependencies
     #

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -89,7 +89,7 @@ module Puma
       @status = :run
     end
 
-    attr_reader :binder, :events, :config, :options, :restart_dir
+    attr_reader :binder, :events, :config, :options, :restart_dir, :original_argv
 
     # Return stats about the server
     def stats

--- a/test/config/cluster_stats.rb
+++ b/test/config/cluster_stats.rb
@@ -1,0 +1,3 @@
+app -> {[200, {}, ['']]}
+workers 1
+clear_binds!

--- a/test/config/prune_bundler_with_deps.rb
+++ b/test/config/prune_bundler_with_deps.rb
@@ -1,2 +1,5 @@
 prune_bundler true
 extra_runtime_dependencies ["rdoc"]
+before_fork do
+  puts "Last LOAD_PATH: #{$LOAD_PATH[-1]}"
+end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -54,11 +54,12 @@ class TestIntegration < Minitest::Test
       config_file.close
       config = "-C #{config_file.path}"
     end
+    puma_path = File.expand_path '../../../bin/puma', __FILE__
     if unix
-      cmd = "#{BASE} bin/puma #{config} -b unix://#{@bind_path} #{argv}"
+      cmd = "#{BASE} #{puma_path} #{config} -b unix://#{@bind_path} #{argv}"
     else
       @tcp_port = UniquePort.call
-      cmd = "#{BASE} bin/puma #{config} -b tcp://#{HOST}:#{@tcp_port} #{argv}"
+      cmd = "#{BASE} #{puma_path} #{config} -b tcp://#{HOST}:#{@tcp_port} #{argv}"
     end
     @server = IO.popen(cmd, "r")
     wait_for_server_to_boot

--- a/test/rackup/hello-last-load-path.ru
+++ b/test/rackup/hello-last-load-path.ru
@@ -1,3 +1,0 @@
-run lambda { |env|
-  [200, {}, [$LOAD_PATH[-1]]]
-}

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -229,10 +229,10 @@ RUBY
   end
 
   def test_load_path_includes_extra_deps
-    cli_server "-w #{WORKERS} -C test/config/prune_bundler_with_deps.rb test/rackup/hello-last-load-path.ru"
-    last_load_path = read_body(connect)
+    cli_server "-w #{WORKERS} -C test/config/prune_bundler_with_deps.rb test/rackup/hello.ru"
 
-    assert_match(%r{gems/rdoc-[\d.]+/lib$}, last_load_path)
+    true while (line = @server.gets) !~ /^Last LOAD_PATH/
+    assert_match(%r{gems/rdoc-[\d.]+/lib$}, line)
   end
 
   private

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -3,6 +3,7 @@ require_relative "helpers/tmp_path"
 
 require "puma/configuration"
 require 'puma/events'
+require 'puma/cli'
 
 class TestLauncher < Minitest::Test
   include TmpPath
@@ -141,12 +142,8 @@ class TestLauncher < Minitest::Test
   def test_puma_stats_clustered
     skip NO_FORK_MSG unless HAS_FORK
 
-    conf = Puma::Configuration.new do |c|
-      c.app -> {[200, {}, ['']]}
-      c.workers 1
-      c.clear_binds!
-    end
-    launcher = launcher(conf)
+    cli = Puma::CLI.new ['--config', 'test/config/cluster_stats.rb']
+    launcher = cli.launcher
     Thread.new do
       sleep Puma::Const::WORKER_CHECK_INTERVAL + 1
       status = Puma.stats_hash[:worker_status].first[:last_status]

--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -1,0 +1,74 @@
+require_relative "helper"
+require_relative "helpers/integration"
+
+class TestWorkerGemIndependence < TestIntegration
+  def setup
+    skip NO_FORK_MSG unless HAS_FORK
+    super
+  end
+
+  def teardown
+    return if skipped?
+    FileUtils.rm current_release_symlink, force: true
+    super
+  end
+
+  def test_workers_can_use_different_versions_of_gems_used_by_puma_master_process
+    skip_unless_signal_exist? :USR1
+
+    set_release_symlink File.expand_path("worker_gem_independence_test/version1", __dir__)
+
+    Dir.chdir(current_release_symlink) do
+      bundle_install
+      cli_server '--prune-bundler -w 1'
+    end
+
+    connection = connect
+    initial_reply = read_body(connection)
+    expected_nio4r_version = '2.3.0'
+    assert_equal expected_nio4r_version, initial_reply
+
+    set_release_symlink File.expand_path("worker_gem_independence_test/version2", __dir__)
+    Dir.chdir(current_release_symlink) do
+      bundle_install
+    end
+    start_phased_restart
+
+    connection = connect
+    new_reply = read_body(connection)
+    new_expected_nio4r_version = '2.3.1'
+    assert_equal new_expected_nio4r_version, new_reply
+  end
+
+  private
+
+  def current_release_symlink
+    File.expand_path "worker_gem_independence_test/current", __dir__
+  end
+
+  def set_release_symlink(target_dir)
+    FileUtils.rm current_release_symlink, force: true
+    FileUtils.symlink target_dir, current_release_symlink, force: true
+  end
+
+  def start_phased_restart
+    Process.kill :USR1, @pid
+
+    true while @server.gets !~ /booted, phase: 1/
+  end
+
+  def with_unbundled_env
+    bundler_ver = Gem::Version.new(Bundler::VERSION)
+    if bundler_ver < Gem::Version.new('2.1.0')
+      Bundler.with_clean_env { yield }
+    else
+      Bundler.with_unbundled_env { yield }
+    end
+  end
+
+  def bundle_install
+    with_unbundled_env do
+      system("bundle install", out: File::NULL)
+    end
+  end
+end

--- a/test/worker_gem_independence_test/version1/Gemfile
+++ b/test/worker_gem_independence_test/version1/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'puma', path: '../../..'
+gem 'nio4r', '= 2.3.0'

--- a/test/worker_gem_independence_test/version1/config.ru
+++ b/test/worker_gem_independence_test/version1/config.ru
@@ -1,0 +1,1 @@
+run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [NIO::VERSION]] }

--- a/test/worker_gem_independence_test/version1/config/puma.rb
+++ b/test/worker_gem_independence_test/version1/config/puma.rb
@@ -1,0 +1,1 @@
+directory File.expand_path("../../current", __dir__)

--- a/test/worker_gem_independence_test/version2/Gemfile
+++ b/test/worker_gem_independence_test/version2/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'puma', path: '../../..'
+gem 'nio4r', '= 2.3.1'

--- a/test/worker_gem_independence_test/version2/config.ru
+++ b/test/worker_gem_independence_test/version2/config.ru
@@ -1,0 +1,1 @@
+run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [NIO::VERSION]] }

--- a/test/worker_gem_independence_test/version2/config/puma.rb
+++ b/test/worker_gem_independence_test/version2/config/puma.rb
@@ -1,0 +1,1 @@
+directory File.expand_path("../../current", __dir__)


### PR DESCRIPTION
### Description

Fixes #2018

A fairly common and reasonable deployment strategy has been broken since the introduction of `nio4r` in puma 4.0. Imagine that a user is using puma in cluster mode. In order to deploy a new version of an application, a user's deployment tool does this:

1. Add new version of the application's source to the server in a new directory
2. Update the "current release" symlink to point to the new release directory (the symlink is configured as puma's `directory` in the config file)
3. Issue a phased restart
4. After verifying that the release was successful, delete the old version of the application from disk

During the next deployment, workers will fail to start. They'll encounter the error `Could not find nio4r-2.5.1 in any of the sources (Bundler::GemNotFound)`. This is, in part, due to a quirk in Bundler where Bundler will raise this error if you're trying to activate a gem whose native extensions are no longer present on disk (even if the gem is already loaded into memory). However, this exception reveals a deeper problem related to the intimate relationship between the gems used by the puma master process and those used by the puma worker processes.

Users can, in part, separate the gems used in workers from those used in the puma master by turning on `prune_bundler`. That option will "eject" the puma master process from the full Bundler context, re-activating only the small number of gems used by the puma master process, including `puma`, `nio4r`, and gems added to `extra_runtime_dependencies`. The `GemNotFound` issue, however reveals that even `prune_bundler` isn't always sufficient in severing the relationship between gems used by the master and worker processes. In addition to being unable to delete gems from old releases, the existing `prune_bundler`-based solution doesn't allow a user to upgrade the version of `nio4r` or any gem in `extra_runtime_dependencies` with a phased restart.

The solution proposed in this PR is to place worker processes in a completely separate memory space. The proposed change uses `spawn` to spin up new workers (this is essentially a `fork` followed by an `exec` on Unix-like systems). Since workers use a separate memory space, the gems they load can be totally different than those loaded in the puma master process. The drawback, of course, is that this `spawn`-based stategy doesn't allow one to take advantage of COW memory between the puma master and the puma workers. For this reason, we still use the old `fork` method in two cases:

1) If `preload_app` is enabled, since if `preload_app` is enabled, phased restarts aren't supported anyway. This option behaves as it did before: it forgoes the ability to perform phased restarts in exchange for minimizing the amount of memory used by fully leveraging the benefit of COW memory.
2) When workers fork from other workers (when `fork_worker` is enabled). Similar to `preload_app`, the main benefit of this option is to reduce memory by leveraging COW memory. The new spawn-based strategy is used only when creating `worker 0`, the process from which other workers fork. Subsequent workers are `forked` in the traditional way from `worker 0`.

What does this mean for `prune_bundler`? Before this change, it was necessary to use `prune_bundler` if you wanted phased restarts and the ability to change gem versions between different releases of your application. After this change, `prune_bundler` won't be necessary in this case. `prune_bundler` will essentially just be a memory optimization for the puma master process since it'll shed some gems from the puma master.

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
