### PR TITLE
[ci skip] Cleanup daemonization in rc.d script

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,7 +4,7 @@
   * Your feature goes here <Most recent on the top, like GitHub> (#Github Number)
 
 * Bugfixes
-  * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
+  * Cleanup daemonization in rc.d script (#2409)
 
 * Refactor
   * Consolidate option handling in Server, Server small refactors, doc chang (#2389)

--- a/docs/jungle/rc.d/puma
+++ b/docs/jungle/rc.d/puma
@@ -23,7 +23,7 @@ puma_start()
 		rb_ver=$(/usr/local/bin/jq -r ".servers[$i].ruby_version" /usr/local/etc/puma.conf)
 		case $rb_env in
 			"rbenv")
-				su - $user -c "cd $dir && rbenv shell $rb_ver && bundle exec puma -C $dir/config/puma.rb -d"
+				cd $dir && rbenv shell $rb_ver && /usr/sbin/daemon -u $user bundle exec puma -C $dir/config/puma.rb
 				;;
 			*)
 				;;
@@ -48,7 +48,7 @@ puma_restart()
 		rb_ver=$(/usr/local/bin/jq -r ".servers[$i].ruby_version" /usr/local/etc/puma.conf)
 		case $rb_env in
 			"rbenv")
-				su - $user -c "cd $dir && pkill ruby && rbenv shell $ruby_version && bundle exec puma -C $dir/config/puma.rb -d"
+				cd $dir && rbenv shell $rb_ver && /usr/sbin/daemon -u $user bundle exec puma -C $dir/config/puma.rb
 				;;
 			*)
 				;;


### PR DESCRIPTION
Pull request https://github.com/puma/puma/pull/2170/files removed all daemonization code.
The `-d` in the rc.d scripts is a left over from this.
This is replaces by `daemon` (https://www.freebsd.org/cgi/man.cgi?query=daemon&sektion=8)
for daemonization of the process.
