### PR TITLE
client.rb - remove JRuby specific 'finish' code

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,6 +7,7 @@
   * Cleanup daemonization in rc.d script (#2409)
 
 * Refactor
+  * client.rb - remove JRuby specific 'finish' code (#2412)
   * Consolidate fast_write calls in Server, extract early_hints assembly (#2405)
   * Remove upstart from docs (#2408)
   * Consolidate option handling in Server, Server small refactors, doc changes (#2389)

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -188,64 +188,11 @@ module Puma
       false
     end
 
-    if IS_JRUBY
-      def jruby_start_try_to_finish
-        return read_body unless @read_header
-
-        begin
-          data = @io.sysread_nonblock(CHUNK_SIZE)
-        rescue OpenSSL::SSL::SSLError => e
-          return false if e.kind_of? IO::WaitReadable
-          raise e
-        end
-
-        # No data means a closed socket
-        unless data
-          @buffer = nil
-          set_ready
-          raise EOFError
-        end
-
-        if @buffer
-          @buffer << data
-        else
-          @buffer = data
-        end
-
-        @parsed_bytes = @parser.execute(@env, @buffer, @parsed_bytes)
-
-        if @parser.finished?
-          return setup_body
-        elsif @parsed_bytes >= MAX_HEADER
-          raise HttpParserError,
-            "HEADER is longer than allowed, aborting client early."
-        end
-
-        false
-      end
-
-      def eagerly_finish
-        return true if @ready
-
-        if @io.kind_of? OpenSSL::SSL::SSLSocket
-          return true if jruby_start_try_to_finish
-        end
-
-        return false unless IO.select([@to_io], nil, nil, 0)
-        try_to_finish
-      end
-
-    else
-
-      def eagerly_finish
-        return true if @ready
-        return false unless IO.select([@to_io], nil, nil, 0)
-        try_to_finish
-      end
-
-      # For documentation, see https://github.com/puma/puma/issues/1754
-      send(:alias_method, :jruby_eagerly_finish, :eagerly_finish)
-    end # IS_JRUBY
+    def eagerly_finish
+      return true if @ready
+      return false unless IO.select([@to_io], nil, nil, 0)
+      try_to_finish
+    end
 
     def finish(timeout)
       return true if @ready


### PR DESCRIPTION
### Description

Remove JRuby specific methods:
 #jruby_start_try_to_finish
 #eagerly_finish

This is old code.  As shown below, `jruby_start_try_to_finish` is only called if the io is an `OpenSSL::SSL::SSLSocket`, but those aren't exposed in Puma, the io would only be a `Puma::MiniSSL::Socket`.  Hence, it's never called.

https://github.com/puma/puma/blob/b08976840ec70448b26b66b4a9134369ca3c3a61/lib/puma/client.rb#L227-L232

The MRI code and the JRuby code are identical when accounting for the above.  Most other repos dealing with sockets (EM, nio4r) don't have JRuby specific code for current JRuby (quick check, I've contributed to both).

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
