### PR TITLE
Add test case for response header [changelog skip]

### DIFF
--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -1,0 +1,140 @@
+require_relative "helper"
+require "puma/events"
+require "net/http"
+
+class TestResponseHeader < Minitest::Test
+  parallelize_me!
+
+  def setup
+    @host = "127.0.0.1"
+
+    @ios = []
+
+    @app = ->(env) { [200, {}, [env['rack.url_scheme']]] }
+
+    @events = Puma::Events.strings
+    @server = Puma::Server.new @app, @events
+  end
+
+  def teardown
+    @server.stop(true)
+    @ios.each { |io| io.close if io && !io.closed? }
+  end
+
+  def server_run(app: @app, early_hints: false)
+    @server.app = app
+    @port = (@server.add_tcp_listener @host, 0).addr[1]
+    @server.early_hints = true if early_hints
+    @server.run
+  end
+
+  def send_http_and_read(req)
+    send_http(req).read
+  end
+
+  def send_http(req)
+    new_connection << req
+  end
+
+  def new_connection
+    TCPSocket.new(@host, @port).tap {|sock| @ios << sock}
+  end
+
+  # The header keys must be Strings
+  def test_integer_key
+    server_run app: ->(env) { [200, { 1 => 'Boo'}, []] }
+    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+
+    assert_match(/HTTP\/1.1 500 Internal Server Error/, data)
+  end
+
+  # The header must respond to each
+  def test_nil_header
+    server_run app: ->(env) { [200, nil, []] }
+    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+
+    assert_match(/HTTP\/1.1 500 Internal Server Error/, data)
+  end
+
+  # The values of the header must be Strings
+  def test_integer_value
+    server_run app: ->(env) { [200, {'Content-Length' => 500}, []] }
+    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+
+    assert_match(/HTTP\/1.0 200 OK\r\nContent-Length: 500\r\n\r\n/, data)
+  end
+
+  def assert_ignore_header(name, value, opts={})
+    header = { name => value }
+
+    if opts[:early_hints]
+      app = ->(env) do
+        env['rack.early_hints'].call(header)
+        [200, {}, ['Hello']]
+      end
+    else
+      app = -> (env) { [200, header, ['hello']]}
+    end
+
+    server_run(app: app, early_hints: opts[:early_hints])
+    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+
+    refute_match("#{name}: #{value}", data)
+  end
+
+  # The header must not contain a Status key.
+  def test_status_key
+    skip 'implement later'
+
+    assert_ignore_header("Status", "500")
+  end
+
+  # Special headers starting “rack.” are for communicating with the server, and must not be sent back to the client.
+  def test_rack_key
+    skip 'implement later'
+
+    assert_ignore_header("rack.command_to_server_only", "work")
+  end
+
+
+  # testing header key must conform rfc token specification
+  # i.e. cannot contain non-printable ASCII, DQUOTE or “(),/:;<=>?@[]{}”.
+  # Header keys will be set through two ways: Regular and early hints.
+
+  def test_illegal_character_in_key
+    skip 'implement later'
+    assert_ignore_header("\"F\u0000o\u0025(@o}", "Boo")
+  end
+
+  def test_illegal_character_in_key_when_early_hints
+    skip 'implement later'
+    assert_ignore_header("\"F\u0000o\u0025(@o}", "Boo", early_hints: true)
+  end
+
+  # testing header value can be separated by \n into line, and each line must not contain characters below 037
+  # Header values can be set through three ways: Regular, early hints and a special case for overriding content-length
+
+  def test_illegal_character_in_value
+    skip 'implement later'
+    assert_ignore_header("X-header", "First \000Lin\037e")
+  end
+
+  def test_illegal_character_in_value_when_early_hints
+    skip 'implement later'
+    assert_ignore_header("X-header", "First \000Lin\037e", early_hints: true)
+  end
+
+  def test_illegal_character_in_value_when_override_content_length
+    skip 'implement later'
+    assert_ignore_header("Content-Length", "\037")
+  end
+
+  def test_illegal_character_in_value_when_newline
+    skip 'implement later'
+
+    server_run app: ->(env) { [200, {'X-header' => "First\000 line\nSecond Lin\037e"}, ["Hello"]] }
+    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+
+    refute_match("X-header: First\000 line\r\nX-header: Second Lin\037e\r\n", data)
+  end
+end


### PR DESCRIPTION
### Description
This PR tends to solve issue #2137 , adding more test for the response header, and follow the requirement mentioned in the rack doc.

Test include:
1. The header keys must be Strings. 
2. Special headers starting “rack.” are for communicating with the server, and must not be sent back to the client. 
3. The header must not contain a Status key. 
4. The header must conform to RFC7230 token specification, i.e. cannot contain non-printable ASCII, DQUOTE or “(),/:;<=>?@[]{}”. 
5. The values of the header must be Strings, consisting of lines (for multiple header values, e.g. multiple Set-Cookie values) separated by “\n”. The lines must not contain characters below 037.

If my test case is correct, I have found most features mentioned above did not cover yet (so the most tests should fail anyway) and would like to do so after some feedback. I am a newbie btw, so let me know anything if I can make things better. Thanks! 

> Double check https://github.com/rack/rack/blob/master/SPEC.rdoc#the-headers- for test coverage, and add where necessary.


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
