### PR TITLE
Add hot restart integration test [changelog skip]

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -139,4 +139,14 @@ class TestIntegration < Minitest::Test
     end
     pids.map(&:to_i)
   end
+
+  # used to define correct 'refused' errors
+  def thread_run_refused(unix: false)
+    if unix
+      [Errno::ENOENT, IOError]
+    else
+      DARWIN ? [Errno::ECONNREFUSED, Errno::EPIPE, EOFError] :
+        [Errno::ECONNREFUSED]
+    end
+  end
 end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -421,16 +421,6 @@ RUBY
     end.compact
   end
 
-  # used with thread_run to define correct 'refused' errors
-  def thread_run_refused(unix: false)
-    if unix
-      [Errno::ENOENT, IOError]
-    else
-      DARWIN ? [Errno::ECONNREFUSED, Errno::EPIPE, EOFError] :
-        [Errno::ECONNREFUSED]
-    end
-  end
-
   # used in loop to create several 'requests'
   def thread_run_pid(replies, delay, sleep_time, mutex, refused, unix: false)
     begin

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -10,6 +10,64 @@ class TestIntegrationSingle < TestIntegration
     assert_equal "Hello World", new_reply
   end
 
+  def test_hot_restart_does_not_drop_connections
+    skip_unless_signal_exist? :USR2
+    skip_on :jruby, suffix: <<-MSG
+ - file descriptors are not preserved on exec on JRuby; connection reset errors are expected during restarts
+    MSG
+    skip_on :truffleruby, suffix: ' - Undiagnosed failures on TruffleRuby'
+    skip "Undiagnosed failures on Ruby 2.2" if RUBY_VERSION < '2.3'
+
+    replies = Hash.new 0
+    num_requests = 500
+    refused = thread_run_refused unix: false
+    message = 'A' * 2**14
+
+    cli_server "-q test/rackup/hello.ru"
+
+    client_thread = Thread.new do
+      num_requests.times do
+        begin
+          socket = TCPSocket.new(HOST, @tcp_port)
+          @ios_to_close << socket
+          socket << "POST / HTTP/1.1\r\nContent-Length: #{message.bytesize}\r\n\r\n#{message}"
+          true until socket.gets == "\r\n"
+          body = read_body(socket, 20)
+          if body == "Hello World"
+            replies[:success] += 1
+          else
+            replies[:unexpected_response] += 1
+          end
+        rescue Errno::ECONNRESET
+          # connection was accepted but then closed
+          # client would see an empty response
+          replies[:reset] += 1
+        rescue *refused
+          replies[:refused] += 1
+        end
+      end
+    end
+
+    run = true
+
+    restart_thread = Thread.new do
+      while run
+        Process.kill :USR2, @pid
+        wait_for_server_to_boot
+        sleep 1
+      end
+    end
+
+    client_thread.join
+    run = false
+    restart_thread.join
+
+    assert_equal 0, replies[:unexpected_response], "Unexpected response"
+    assert_equal 0, replies[:reset], "Expected no reset errors"
+    assert_equal 0, replies[:refused], "Expected no refused connections"
+    assert_equal num_requests, replies[:success]
+  end
+
   # It does not share environments between multiple generations, which would break Dotenv
   def test_usr2_restart_restores_environment
     # jruby has a bug where setting `nil` into the ENV or `delete` do not change the


### PR DESCRIPTION
### Description

I created https://github.com/cjlarose/puma-phased-restart-errors as a way to demonstrate connection errors related to hot restarts, phased restarts, and shutdowns (documented in #2337). The project has been helpful in catching concurrency errors such as in https://github.com/puma/puma/pull/2279#issuecomment-702443610. It has been helpful, too, in verifying fixes like #2377 and #2122. 

This PR introduces an integration test that aims to serve a similar purpose. I hope that it'll help prevent regressions related to connection handling and concurrency, especially around hot restarts, phased restarts, and shutdowns. By putting it in the repo along with the normal test suite, we can identify failures more quickly and easily.

The test basically just hammers a puma single-mode cluster while concurrently performing a bunch of hot restarts. The expectation is that all clients receive successful responses (all accepted connections on the socket are responded to as expected).


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
