### PR TITLE
Test adding connection to Reactor after shutdown [changelog skip]

### DIFF
--- a/lib/puma/queue_close.rb
+++ b/lib/puma/queue_close.rb
@@ -18,6 +18,7 @@ unless Queue.instance_methods.include?(:close)
         raise ClosedQueueError if @closed
         super
       end
+      alias << push
     end
     Queue.prepend QueueClose
   end

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -84,7 +84,7 @@ module Puma
         retry
       end
       # Wakeup all remaining objects on shutdown.
-      @timeouts.each(&@block.method(:call))
+      @timeouts.each(&@block)
       @selector.close
     end
 


### PR DESCRIPTION
### Description
Quick followup to #2279, this PR extends the `TestPumaServer#shutdown_requests` test-method to pause `Reactor#add` for  the second connection until after shutdown begins, to ensure this edge case is correctly handled.

This adds unit-test coverage for the fix introduced in #2377 and updated in #2279.

This added test revealed that the edge-case wasn't handled properly in Ruby 2.2, so that is fixed in commit 0f4e51f9a170b271b257917a3df841e98ae7a0d3 as well.

Finally, commit e5d04ebb2ffeb4637a985804ee678dfe404f9b4b is a small style-fix followup in the related `Reactor` code.

### Testing

Verified that this modified test fails on the following commits:
- de2f108fcb0a0b15076e2caac1ff8d4c32f2df27 (commit before #2279):
```
  1) Failure:
TestPumaServer#test_shutdown_requests [test/test_puma_server.rb:1016]:
Expected /204/ to match # encoding: ASCII-8BIT
#    valid: true
"HTTP/1.1 500 Internal Server Error\r\n".

  2) Failure:
TestPumaServer#test_force_shutdown [test/test_puma_server.rb:1018]:
Expected # encoding: ASCII-8BIT
#    valid: true
"HTTP/1.1 500 Internal Server Error\r\n" to be nil.
```

- e041d0739b060b99d6796d5293e239ae9217b4d9 (commit before #2377):

```
Error reached top of thread-pool: closed stream (IOError)

  1) Failure:
TestPumaServer#test_shutdown_requests [test/test_puma_server.rb:1007]:
timeout waiting for response

  2) Failure:
TestPumaServer#test_force_shutdown [test/test_puma_server.rb:1007]:
timeout waiting for response
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
