### PR TITLE
Don't show "WARNING: Detected 1 Thread(s) started in app boot" for known connection reaper thread started by Active Record

### DIFF
--- a/History.md
+++ b/History.md
@@ -14,6 +14,9 @@
   * Remove upstart from docs (#2408)
   * Consolidate option handling in Server, Server small refactors, doc changes (#2389)
 
+* Other
+  * Don't show "WARNING: Detected 1 Thread(s) started in app boot" for known connection reaper thread started by Active Record ([#2422])
+
 ## 5.0.2 / 2020-09-28
 
 * Bugfixes 


### PR DESCRIPTION
Closes #2421

### Description

This PR ignores the known connection reaper thread started by Active Record by checking if the first line in the backtrace matches a regex:

```
%r{active_record/connection_adapters/abstract/connection_pool\.rb:\d+:.*sleep}
```

This prevents the following message from showing in the logs:

```
[12836] ! WARNING: Detected 1 Thread(s) started in app boot:
[12836] ! #<Thread:0x00007fd344792330 /Users/ndbroadbent/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/activerecord-6.0.3.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:333 sleep> - /Users/ndbroadbent/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/activerecord-6.0.3.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:336:in `sleep'
```

This message is always shown for a standard Rails 6.0.3.4 app with Puma 5.0.2 in cluster mode (>=2 workers.)

This is probably a bit too hacky/specific, so hopefully there's a better solution.

### Your checklist for this pull request

- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [X] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed, including Rubocop.
