### PR TITLE
Add hot_restart_does_not_drop_connections tests [changelog skip]

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -11,7 +11,6 @@ class TestIntegration < Minitest::Test
   DARWIN = !!RUBY_PLATFORM[/darwin/]
   HOST  = "127.0.0.1"
   TOKEN = "xxyyzz"
-  WORKERS = 2
 
   BASE = defined?(Bundler) ? "bundle exec #{Gem.ruby} -Ilib" :
     "#{Gem.ruby} -Ilib"
@@ -129,7 +128,7 @@ class TestIntegration < Minitest::Test
   end
 
   # gets worker pids from @server output
-  def get_worker_pids(phase = 0, size = WORKERS)
+  def get_worker_pids(phase = 0, size = workers)
     pids = []
     re = /pid: (\d+)\) booted, phase: #{phase}/
     while pids.size < size
@@ -138,5 +137,173 @@ class TestIntegration < Minitest::Test
       end
     end
     pids.map(&:to_i)
+  end
+
+  # used to define correct 'refused' errors
+  def thread_run_refused(unix: false)
+    if unix
+      [Errno::ENOENT, IOError]
+    else
+      DARWIN ? [Errno::ECONNREFUSED, Errno::EPIPE, EOFError] :
+        [Errno::ECONNREFUSED]
+    end
+  end
+
+  def cli_pumactl(argv, unix: false)
+    if unix
+      pumactl = IO.popen("#{BASE} bin/pumactl -C unix://#{@control_path} -T #{TOKEN} #{argv}", "r")
+    else
+      pumactl = IO.popen("#{BASE} bin/pumactl -C tcp://#{HOST}:#{@control_tcp_port} -T #{TOKEN} #{argv}", "r")
+    end
+    @ios_to_close << pumactl
+    Process.wait pumactl.pid
+    pumactl
+  end
+
+  def hot_restart_does_not_drop_connections(num_threads: 1, total_requests: 500)
+    skipped = true
+    skip_on :jruby, suffix: <<-MSG
+ - file descriptors are not preserved on exec on JRuby; connection reset errors are expected during restarts
+    MSG
+    skip_on :truffleruby, suffix: ' - Undiagnosed failures on TruffleRuby'
+    skip "Undiagnosed failures on Ruby 2.2" if RUBY_VERSION < '2.3'
+
+    args = "-w #{workers} -t 0:5 -q test/rackup/hello_with_delay.ru"
+    if Puma.windows?
+      @control_tcp_port = UniquePort.call
+      cli_server "#{args} --control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN}"
+    else
+      cli_server args
+    end
+
+    skipped = false
+    replies = Hash.new 0
+    refused = thread_run_refused unix: false
+    message = 'A' * 16_256  # 2^14 - 128
+
+    mutex = Mutex.new
+    restart_count = 0
+    client_threads = []
+
+    num_requests = (total_requests/num_threads).to_i
+
+    num_threads.times do |thread|
+      client_threads << Thread.new do
+        num_requests.times do
+          begin
+            socket = TCPSocket.new HOST, @tcp_port
+            fast_write socket, "POST / HTTP/1.1\r\nContent-Length: #{message.bytesize}\r\n\r\n#{message}"
+            true until socket.gets == "\r\n"
+            body = read_body(socket, 10)
+            if body == "Hello World"
+              mutex.synchronize {
+                replies[:success] += 1
+                replies[:restart] += 1 if restart_count > 0
+              }
+            else
+              mutex.synchronize { replies[:unexpected_response] += 1 }
+            end
+          rescue Errno::ECONNRESET, Errno::EBADF
+            # connection was accepted but then closed
+            # client would see an empty response
+            # Errno::EBADF Windows may not be able to make a connection
+            mutex.synchronize { replies[:reset] += 1 }
+          rescue *refused
+            mutex.synchronize { replies[:refused] += 1 }
+          rescue ::Timeout::Error
+            mutex.synchronize { replies[:read_timeout] += 1 }
+          ensure
+            if socket.is_a?(IO) && !socket.closed?
+              begin
+                socket.close
+              rescue Errno::EBADF
+              end
+            end
+          end
+        end
+#        STDOUT.puts "#{thread} #{replies[:success]}"
+      end
+    end
+
+    run = true
+
+    restart_thread = Thread.new do
+      sleep 0.30  # let some connections in before 1st restart
+      while run
+        if Puma.windows?
+          cli_pumactl 'restart'
+        else
+          Process.kill :USR2, @pid
+        end
+        wait_for_server_to_boot
+        restart_count += 1
+        sleep 1
+      end
+    end
+
+    client_threads.each(&:join)
+    run = false
+    restart_thread.join
+    if Puma.windows?
+      cli_pumactl 'stop'
+      Process.wait @server.pid
+      @server = nil
+    end
+
+    msg = ("   %4d unexpected_response\n"   % replies.fetch(:unexpected_response,0)).dup
+    msg << "   %4d refused\n"               % replies.fetch(:refused,0)
+    msg << "   %4d read timeout\n"          % replies.fetch(:read_timeout,0)
+    msg << "   %4d reset\n"                 % replies.fetch(:reset,0)
+    msg << "   %4d success\n"               % replies.fetch(:success,0)
+    msg << "   %4d success after restart\n" % replies.fetch(:restart,0)
+    msg << "   %4d restart count\n"         % restart_count
+
+    reset = replies[:reset]
+
+    if Puma.windows?
+      # 5 is default thread count in Puma?
+      reset_max = num_threads > 1 ? restart_count * 5 : 5
+      assert_operator reset_max, :>=, reset, "#{msg}Expected reset_max >= reset errors"
+    else
+      assert_equal 0, reset, "#{msg}Expected no reset errors"
+    end
+    assert_equal 0, replies[:unexpected_response], "#{msg}Unexpected response"
+    assert_equal 0, replies[:refused], "#{msg}Expected no refused connections"
+    assert_equal 0, replies[:read_timeout], "#{msg}Expected no read timeouts"
+
+    if Puma.windows?
+      assert_equal (num_threads * num_requests) - reset, replies[:success]
+    else
+      assert_equal (num_threads * num_requests), replies[:success]
+    end
+
+  ensure
+    return if skipped
+    if passed?
+      msg = "   restart_count #{restart_count}, reset #{reset}, success after restart #{replies[:restart]}"
+      $debugging_info << "#{full_name}\n#{msg}\n"
+    else
+      $debugging_info << "#{full_name}\n#{msg}\n"
+    end
+  end
+
+  def fast_write(io, str)
+    n = 0
+    while true
+      begin
+        n = io.syswrite str
+      rescue Errno::EAGAIN, Errno::EWOULDBLOCK => e
+        if !IO.select(nil, [io], nil, 5)
+          raise e
+        end
+
+        retry
+      rescue Errno::EPIPE, SystemCallError, IOError => e
+        raise e
+      end
+
+      return if n == str.bytesize
+      str = str.byteslice(n..-1)
+    end
   end
 end

--- a/test/rackup/hello_with_delay.ru
+++ b/test/rackup/hello_with_delay.ru
@@ -1,0 +1,4 @@
+run lambda { |env|
+  sleep 0.001
+  [200, {"Content-Type" => "text/plain"}, ["Hello World"]]
+}

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -4,6 +4,16 @@ require_relative "helpers/integration"
 class TestIntegrationSingle < TestIntegration
   parallelize_me!
 
+  def workers ; 0 ; end
+
+  def test_hot_restart_does_not_drop_connections_threads
+    hot_restart_does_not_drop_connections num_threads: 5, total_requests: 1_000
+  end
+
+  def test_hot_restart_does_not_drop_connections
+    hot_restart_does_not_drop_connections
+  end
+
   def test_usr2_restart
     skip_unless_signal_exist? :USR2
     _, new_reply = restart_server_and_listen("-q test/rackup/hello.ru")


### PR DESCRIPTION
### Description

Building on PR #2417, this adds testing for whether restart/USR2 drops connections.

#### Tests

1. Adds `hot_restart_does_not_drop_connections` to `helpers/integration.rb`.  The method is used in both `test_integration_cluster.rb` and `test_integration_single.rb` tests.  Each file runs the test two ways, first, with all connections created in one thread, and a second test with connections created in five threads.

2. Currently the test is adding output to the bottom 'debug' section, showing resets, restart count, and connections competed after the the first restart.

3. A file `rackup/hello_with_delay.ru` has been added and used in the test.  A normal 'Hello World' app, with a delay of 0.001 before the return.  The time can be increased to whatever is appropriate.

4. Not sure about whether the test could also be used to test rolling-restart/USR1.

#### Integration Tests Misc

5. Moved `cli_pumactl` from `test_integration_pumactl.rb` to `helpers/integration.rb`.  This was done so it can be used in other integrations tests when signals aren't supported (Windows).

6. Moved `thread_run_refused` from `test_integration_cluster.rb` to `helpers/integration.rb`.  It's being used by ``hot_restart_does_not_drop_connections`` in both 'single' and 'cluster'.

7. Added `if ::Process.respond_to?(:fork)` to the end of `test_integration_cluster.rb`.  This omits the skips shown for the tests on platforms that do not support `fork`.  Tired of looking thru them on non-MRI failures...

8. Small changes to integration tests as to how 'worker' is used when starting Puma.  The was needed to allow `hot_restart_does_not_drop_connections` to work in both 'single and 'cluster' tests.

9. Added a method `fast_write` to `helpers/integration.rb`.  It's essentially `Puma::Request##fast_write` with different error handling.  It uses `syswrite` instead of `write`, which is probably only beneficial with tests that write a large numbers sockets, as in hundreds or more.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
