### PR TITLE
Add no_tlsv1_3 to Puma::DSL#ssl_bindings and Puma::MiniSSL::Context

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 * Features
   * Your feature goes here <Most recent on the top, like GitHub> (#Github Number)
+  * Add no_tlsv1_3 to Puma::DSL#ssl_bindings and Puma::MiniSSL::Context (#2426)
 
 * Bugfixes
   * Cleanup daemonization in rc.d script (#2409)

--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -17,12 +17,11 @@ unless ENV["DISABLE_SSL"]
     have_header "openssl/bio.h"
 
     # below is  yes for 1.0.2 & later
-    have_func  "DTLS_method"                  , "openssl/ssl.h"
+    have_func  "DTLS_method"                           , "openssl/ssl.h"
 
-    # below are yes for 1.1.0 & later, may need to check func rather than macro
-    # with versions after 1.1.1
-    have_func  "TLS_server_method"            , "openssl/ssl.h"
-    have_macro "SSL_CTX_set_min_proto_version", "openssl/ssl.h"
+    # below are yes for 1.1.0 & later
+    have_func  "TLS_server_method"                     , "openssl/ssl.h"
+    have_func  "SSL_CTX_set_min_proto_version(NULL, 0)", "openssl/ssl.h"
   end
 end
 

--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -171,6 +171,9 @@ VALUE engine_init_server(VALUE self, VALUE mini_ssl_ctx) {
   ID sym_no_tlsv1_1 = rb_intern("no_tlsv1_1");
   VALUE no_tlsv1_1 = rb_funcall(mini_ssl_ctx, sym_no_tlsv1_1, 0);
 
+  ID sym_no_tlsv1_3 = rb_intern("no_tlsv1_3");
+  VALUE no_tlsv1_3 = rb_funcall(mini_ssl_ctx, sym_no_tlsv1_3, 0);
+
 #ifdef HAVE_TLS_SERVER_METHOD
   ctx = SSL_CTX_new(TLS_server_method());
 #else
@@ -198,11 +201,14 @@ VALUE engine_init_server(VALUE self, VALUE mini_ssl_ctx) {
   else {
     min = TLS1_VERSION;
   }
-  
+
   SSL_CTX_set_min_proto_version(ctx, min);
 
-  SSL_CTX_set_options(ctx, ssl_options);
+  if (RTEST(no_tlsv1_3)) {
+    SSL_CTX_set_max_proto_version(ctx, TLS1_2_VERSION);
+  }
 
+  SSL_CTX_set_options(ctx, ssl_options);
 #else
   /* As of 1.0.2f, SSL_OP_SINGLE_DH_USE key use is always on */
   ssl_options |= SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_SINGLE_DH_USE;
@@ -504,27 +510,27 @@ void Init_mini_ssl(VALUE puma) {
 #else
   rb_define_const(mod, "OPENSSL_LIBRARY_VERSION", rb_str_new2(SSLeay_version(SSLEAY_VERSION)));
 #endif
- 
-#if defined(OPENSSL_NO_SSL3) || defined(OPENSSL_NO_SSL3_METHOD) 
-  /* True if SSL3 is not available */ 
-  rb_define_const(mod, "OPENSSL_NO_SSL3", Qtrue); 
-#else 
-  rb_define_const(mod, "OPENSSL_NO_SSL3", Qfalse); 
-#endif 
 
-#if defined(OPENSSL_NO_TLS1) || defined(OPENSSL_NO_TLS1_METHOD) 
-  /* True if TLS1 is not available */ 
-  rb_define_const(mod, "OPENSSL_NO_TLS1", Qtrue); 
-#else 
-  rb_define_const(mod, "OPENSSL_NO_TLS1", Qfalse); 
-#endif 
+#if defined(OPENSSL_NO_SSL3) || defined(OPENSSL_NO_SSL3_METHOD)
+  /* True if SSL3 is not available */
+  rb_define_const(mod, "OPENSSL_NO_SSL3", Qtrue);
+#else
+  rb_define_const(mod, "OPENSSL_NO_SSL3", Qfalse);
+#endif
 
-#if defined(OPENSSL_NO_TLS1_1) || defined(OPENSSL_NO_TLS1_1_METHOD) 
-  /* True if TLS1_1 is not available */ 
-  rb_define_const(mod, "OPENSSL_NO_TLS1_1", Qtrue); 
-#else 
-  rb_define_const(mod, "OPENSSL_NO_TLS1_1", Qfalse); 
-#endif 
+#if defined(OPENSSL_NO_TLS1) || defined(OPENSSL_NO_TLS1_METHOD)
+  /* True if TLS1 is not available */
+  rb_define_const(mod, "OPENSSL_NO_TLS1", Qtrue);
+#else
+  rb_define_const(mod, "OPENSSL_NO_TLS1", Qfalse);
+#endif
+
+#if defined(OPENSSL_NO_TLS1_1) || defined(OPENSSL_NO_TLS1_1_METHOD)
+  /* True if TLS1_1 is not available */
+  rb_define_const(mod, "OPENSSL_NO_TLS1_1", Qtrue);
+#else
+  rb_define_const(mod, "OPENSSL_NO_TLS1_1", Qfalse);
+#endif
 
   rb_define_singleton_method(mod, "check", noop, 0);
 

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -217,11 +217,12 @@ module Puma
 
     class Context
       attr_accessor :verify_mode
-      attr_reader :no_tlsv1, :no_tlsv1_1
+      attr_reader :no_tlsv1, :no_tlsv1_1, :no_tlsv1_3
 
       def initialize
         @no_tlsv1   = false
         @no_tlsv1_1 = false
+        @no_tlsv1_3 = false
       end
 
       if IS_JRUBY
@@ -267,20 +268,26 @@ module Puma
         end
       end
 
-      # disables TLSv1
+      # Disables TLSv1
       # @!attribute [w] no_tlsv1=
       def no_tlsv1=(tlsv1)
         raise ArgumentError, "Invalid value of no_tlsv1=" unless ['true', 'false', true, false].include?(tlsv1)
         @no_tlsv1 = tlsv1
       end
 
-      # disables TLSv1 and TLSv1.1.  Overrides `#no_tlsv1=`
+      # Disables TLSv1 and TLSv1.1.  Overrides `#no_tlsv1=`
       # @!attribute [w] no_tlsv1_1=
       def no_tlsv1_1=(tlsv1_1)
         raise ArgumentError, "Invalid value of no_tlsv1_1=" unless ['true', 'false', true, false].include?(tlsv1_1)
         @no_tlsv1_1 = tlsv1_1
       end
 
+      # Disables TLSv1.3.
+      # @!attribute [w] no_tlsv1_3=
+      def no_tlsv1_3=(tlsv1_3)
+        raise ArgumentError, "Invalid value of no_tlsv1_3=" unless ['true', 'false', true, false].include?(tlsv1_3)
+        @no_tlsv1_3 = tlsv1_3 if HAS_TLS1_3
+      end
     end
 
     VERIFY_NONE = 0

--- a/lib/puma/minissl/context_builder.rb
+++ b/lib/puma/minissl/context_builder.rb
@@ -45,8 +45,9 @@ module Puma
           ctx.ssl_cipher_filter = params['ssl_cipher_filter'] if params['ssl_cipher_filter']
         end
 
-        ctx.no_tlsv1 = true if params['no_tlsv1'] == 'true'
+        ctx.no_tlsv1   = true if params['no_tlsv1']   == 'true'
         ctx.no_tlsv1_1 = true if params['no_tlsv1_1'] == 'true'
+        ctx.no_tlsv1_3 = true if params['no_tlsv1_3'] == 'true'
 
         if params['verify_mode']
           ctx.verify_mode = case params['verify_mode']

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -16,7 +16,6 @@ class TestConfigFile < TestConfigFileBase
     assert_equal max_threads, Puma::Configuration.new.default_max_threads
   end
 
-
   def test_app_from_rackup
     conf = Puma::Configuration.new do |c|
       c.rackup "test/rackup/hello-bind.ru"
@@ -74,7 +73,82 @@ class TestConfigFile < TestConfigFileBase
 
     conf.load
 
-    ssl_binding = "ssl://0.0.0.0:9292?cert=/path/to/cert&key=/path/to/key&verify_mode=the_verify_mode&no_tlsv1=false&no_tlsv1_1=false"
+    ssl_binding = "ssl://0.0.0.0:9292?cert=/path/to/cert&key=/path/to/key&verify_mode=the_verify_mode"
+    assert_equal [ssl_binding], conf.options[:binds]
+  end
+
+  def test_ssl_bind
+    skip_on :jruby
+    skip 'No ssl support' unless ::Puma::HAS_SSL
+
+    conf = Puma::Configuration.new do |c|
+      c.ssl_bind "0.0.0.0", "9292", {
+        cert: "/path/to/cert",
+        key: "/path/to/key",
+        verify_mode: "the_verify_mode",
+      }
+    end
+
+    conf.load
+
+    ssl_binding = "ssl://0.0.0.0:9292?cert=/path/to/cert&key=/path/to/key&verify_mode=the_verify_mode"
+    assert_equal [ssl_binding], conf.options[:binds]
+  end
+
+  def test_ssl_bind_no_tlsv1
+    skip_on :jruby
+    skip 'No ssl support' unless ::Puma::HAS_SSL
+
+    conf = Puma::Configuration.new do |c|
+      c.ssl_bind "0.0.0.0", "9292", {
+        cert: "/path/to/cert",
+        key: "/path/to/key",
+        verify_mode: "the_verify_mode",
+        no_tlsv1: true,
+      }
+    end
+
+    conf.load
+
+    ssl_binding = "ssl://0.0.0.0:9292?cert=/path/to/cert&key=/path/to/key&verify_mode=the_verify_mode&no_tlsv1=true"
+    assert_equal [ssl_binding], conf.options[:binds]
+  end
+
+  def test_ssl_bind_no_tlsv1_1
+    skip_on :jruby
+    skip 'No ssl support' unless ::Puma::HAS_SSL
+
+    conf = Puma::Configuration.new do |c|
+      c.ssl_bind "0.0.0.0", "9292", {
+        cert: "/path/to/cert",
+        key: "/path/to/key",
+        verify_mode: "the_verify_mode",
+        no_tlsv1_1: true,
+      }
+    end
+
+    conf.load
+
+    ssl_binding = "ssl://0.0.0.0:9292?cert=/path/to/cert&key=/path/to/key&verify_mode=the_verify_mode&no_tlsv1_1=true"
+    assert_equal [ssl_binding], conf.options[:binds]
+  end
+
+  def test_ssl_bind_no_tlsv1_3
+    skip_on :jruby
+    skip 'No ssl support' unless ::Puma::HAS_SSL
+
+    conf = Puma::Configuration.new do |c|
+      c.ssl_bind "0.0.0.0", "9292", {
+        cert: "/path/to/cert",
+        key: "/path/to/key",
+        verify_mode: "the_verify_mode",
+        no_tlsv1_3: true,
+      }
+    end
+
+    conf.load
+
+    ssl_binding = "ssl://0.0.0.0:9292?cert=/path/to/cert&key=/path/to/key&verify_mode=the_verify_mode&no_tlsv1_3=true"
     assert_equal [ssl_binding], conf.options[:binds]
   end
 


### PR DESCRIPTION
### Description

Disables TLSv1.3 when front-ends don't support it

Also:

1. Remove 'no_tls' false query parameters in bind string
2. Update minissl.c for no_tlsv1_3, whitespace
3. Add test_tls_v1_3_rejection to test_puma_server_ssl.rb
4. Add three protocol tests to test_config.rb
5. extconf.rb - 1.1.0 -> 1.1.1 change (macro to func)

See #1735

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
