### PR TITLE
Fix Bundler::GemNotFound errors for nio4r gem

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@
 
 * Bugfixes
   * Cleanup daemonization in rc.d script (#2409)
+  * Fix `Bundler::GemNotFound` errors for `nio4r` gem during phased restarts (#2427)
 
 * Refactor
   * Extract req/resp methods to new request.rb from server.rb (#2419)

--- a/bin/puma-wild
+++ b/bin/puma-wild
@@ -5,24 +5,18 @@
 
 require 'rubygems'
 
-gems = ARGV.shift
+cli_arg = ARGV.shift
 
 inc = ""
 
-if gems == "-I"
+if cli_arg == "-I"
   inc = ARGV.shift
   $LOAD_PATH.concat inc.split(":")
-  gems = ARGV.shift
-end
-
-gems.split(",").each do |s|
-  name, ver = s.split(":",2)
-  gem name, ver
 end
 
 module Puma; end
 
-Puma.const_set("WILD_ARGS", ["-I", inc, gems])
+Puma.const_set("WILD_ARGS", ["-I", inc])
 
 require 'puma/cli'
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -268,11 +268,7 @@ module Puma
     def dependencies_and_files_to_require_after_prune
       puma = spec_for_gem("puma")
 
-      deps = puma.runtime_dependencies.map do |d|
-        "#{d.name}:#{spec_for_gem(d.name).version}"
-      end
-
-      [deps, require_paths_for_gem(puma) + extra_runtime_deps_directories]
+      [[], require_paths_for_gem(puma) + extra_runtime_deps_directories]
     end
 
     # @!attribute [r] extra_runtime_deps_directories

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -264,11 +264,11 @@ module Puma
       end
     end
 
-    # @!attribute [r] dependencies_and_files_to_require_after_prune
-    def dependencies_and_files_to_require_after_prune
+    # @!attribute [r] files_to_require_after_prune
+    def files_to_require_after_prune
       puma = spec_for_gem("puma")
 
-      [[], require_paths_for_gem(puma) + extra_runtime_deps_directories]
+      require_paths_for_gem(puma) + extra_runtime_deps_directories
     end
 
     # @!attribute [r] extra_runtime_deps_directories
@@ -300,7 +300,7 @@ module Puma
         return
       end
 
-      deps, dirs = dependencies_and_files_to_require_after_prune
+      dirs = files_to_require_after_prune
 
       log '* Pruning Bundler environment'
       home = ENV['GEM_HOME']
@@ -309,7 +309,7 @@ module Puma
         ENV['GEM_HOME'] = home
         ENV['BUNDLE_GEMFILE'] = bundle_gemfile
         ENV['PUMA_BUNDLER_PRUNED'] = '1'
-        args = [Gem.ruby, puma_wild_location, '-I', dirs.join(':'), deps.join(',')] + @original_argv
+        args = [Gem.ruby, puma_wild_location, '-I', dirs.join(':')] + @original_argv
         # Ruby 2.0+ defaults to true which breaks socket activation
         args += [{:close_others => false}]
         Kernel.exec(*args)

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'nio'
 require 'puma/queue_close' if RUBY_VERSION < '2.3'
 
 module Puma
@@ -20,6 +19,7 @@ module Puma
     # The provided block will be invoked when an IO has data available to read,
     # its timeout elapses, or when the Reactor shuts down.
     def initialize(&block)
+      require 'nio'
       @selector = NIO::Selector.new
       @input = Queue.new
       @timeouts = []

--- a/test/config/prune_bundler_with_deps.rb
+++ b/test/config/prune_bundler_with_deps.rb
@@ -1,2 +1,7 @@
 prune_bundler true
 extra_runtime_dependencies ["rdoc"]
+before_fork do
+  $LOAD_PATH.each do |path|
+    puts "LOAD_PATH: #{path}"
+  end
+end

--- a/test/rackup/hello-last-load-path.ru
+++ b/test/rackup/hello-last-load-path.ru
@@ -1,3 +1,0 @@
-run lambda { |env|
-  [200, {}, [$LOAD_PATH[-1]]]
-}

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -239,10 +239,13 @@ RUBY
   end
 
   def test_load_path_includes_extra_deps
-    cli_server "-w #{workers} -C test/config/prune_bundler_with_deps.rb test/rackup/hello-last-load-path.ru"
-    last_load_path = read_body(connect)
+    cli_server "-w #{workers} -C test/config/prune_bundler_with_deps.rb test/rackup/hello.ru"
 
-    assert_match(%r{gems/rdoc-[\d.]+/lib$}, last_load_path)
+    load_path = []
+    while (line = @server.gets) =~ /^LOAD_PATH/
+      load_path << line.gsub(/^LOAD_PATH: /, '')
+    end
+    assert_match(%r{gems/rdoc-[\d.]+/lib$}, load_path.last)
   end
 
   private

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -248,6 +248,19 @@ RUBY
     assert_match(%r{gems/rdoc-[\d.]+/lib$}, load_path.last)
   end
 
+  def test_load_path_does_not_include_nio4r
+    cli_server "-w #{workers} -C test/config/prune_bundler_with_deps.rb test/rackup/hello.ru"
+
+    load_path = []
+    while (line = @server.gets) =~ /^LOAD_PATH/
+      load_path << line.gsub(/^LOAD_PATH: /, '')
+    end
+
+    load_path.each do |path|
+      refute_match(%r{gems/nio4r-[\d.]+/lib}, path)
+    end
+  end
+
   private
 
   def worker_timeout(timeout, iterations, config)

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -12,8 +12,7 @@ class TestLauncher < Minitest::Test
 
     deps, dirs = launcher.send(:dependencies_and_files_to_require_after_prune)
 
-    assert_equal(1, deps.length)
-    assert_match(%r{^nio4r:[\d.]+$}, deps.first)
+    assert_empty deps
     assert_equal(2, dirs.length)
     assert_match(%r{puma/lib$}, dirs[0]) # lib dir
     assert_match(%r{puma-#{Puma::Const::PUMA_VERSION}$}, dirs[1]) # native extension dir
@@ -28,8 +27,7 @@ class TestLauncher < Minitest::Test
 
     deps, dirs = launcher(conf).send(:dependencies_and_files_to_require_after_prune)
 
-    assert_equal(1, deps.length)
-    assert_match(%r{^nio4r:[\d.]+$}, deps.first)
+    assert_empty deps
     assert_equal(3, dirs.length)
     assert_match(%r{puma/lib$}, dirs[0]) # lib dir
     assert_match(%r{puma-#{Puma::Const::PUMA_VERSION}$}, dirs[1]) # native extension dir

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -7,27 +7,25 @@ require 'puma/events'
 class TestLauncher < Minitest::Test
   include TmpPath
 
-  def test_dependencies_and_files_to_require_after_prune_is_correctly_built_for_no_extra_deps
+  def test_files_to_require_after_prune_is_correctly_built_for_no_extra_deps
     skip_on :no_bundler
 
-    deps, dirs = launcher.send(:dependencies_and_files_to_require_after_prune)
+    dirs = launcher.send(:files_to_require_after_prune)
 
-    assert_empty deps
     assert_equal(2, dirs.length)
     assert_match(%r{puma/lib$}, dirs[0]) # lib dir
     assert_match(%r{puma-#{Puma::Const::PUMA_VERSION}$}, dirs[1]) # native extension dir
     refute_match(%r{gems/rdoc-[\d.]+/lib$}, dirs[2])
   end
 
-  def test_dependencies_and_files_to_require_after_prune_is_correctly_built_with_extra_deps
+  def test_files_to_require_after_prune_is_correctly_built_with_extra_deps
     skip_on :no_bundler
     conf = Puma::Configuration.new do |c|
       c.extra_runtime_dependencies ['rdoc']
     end
 
-    deps, dirs = launcher(conf).send(:dependencies_and_files_to_require_after_prune)
+    dirs = launcher(conf).send(:files_to_require_after_prune)
 
-    assert_empty deps
     assert_equal(3, dirs.length)
     assert_match(%r{puma/lib$}, dirs[0]) # lib dir
     assert_match(%r{puma-#{Puma::Const::PUMA_VERSION}$}, dirs[1]) # native extension dir


### PR DESCRIPTION
### Description

Fixes #2018 

A fairly common and reasonable deployment strategy has been broken since the introduction of `nio4r` in puma 4.0. Imagine that a user is using puma in cluster mode. In order to deploy a new version of an application, a user's deployment tool does this:

1. Add new version of the application's source to the server in a new directory
2. Update the "current release" symlink to point to the new release directory (the symlink is configured as puma's `directory` in the config file)
3. Issue a phased restart
4. After verifying that the release was successful, delete the old version of the application from disk

During the next deployment, workers will fail to start. They'll encounter the error `Could not find nio4r-2.5.1 in any of the sources (Bundler::GemNotFound)`. The root cause of the issue is described in rubygems/rubygems#4004. As of the time of writing, that issue is not yet addressed. This PR introduces a workaround into puma that essentially sidesteps the Bundler issue.

The proposed change essentially just removes `nio4r` from being activated in the puma master process for cluster-mode puma as long as you're using `prune_bundler` (which is basically required anyway if you want phased restarts). `nio4r` is used for doing async IO in `Puma::Reactor`, and since in cluster-mode puma the master process doesn't actually run an instance of `Puma::Reactor`, we can defer loading `nio4r` until we're in the worker process.

In addition to adding tests in puma itself for this change, I also verified that the repro in https://github.com/cjlarose/puma-phased-restart-could-not-find-gem-errors is fixed by the same change.

### Your checklist for this pull request

- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [X] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [X] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed, including Rubocop.
