### PR TITLE
Improve reliability of non-MRI CI [changelog skip]

### DIFF
--- a/.github/workflows/non_mri.yml
+++ b/.github/workflows/non_mri.yml
@@ -18,16 +18,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15 ]
+        os: [ ubuntu-20.04, macos-10.15 ]
         ruby: [ jruby, jruby-head, truffleruby-head ]
         no-ssl: ['']
         include:
-          #- { os: ubuntu-18.04 , ruby: jruby-head, allow-failure: true }
+          - { os: ubuntu-20.04 , ruby: jruby-head, allow-failure: true }
           - { os: ubuntu-20.04 , ruby: jruby, no-ssl: ' no SSL' }
         exclude:
-          - { os: ubuntu-20.04 , ruby: jruby }
-          - { os: ubuntu-20.04 , ruby: jruby-head }
-          - { os: ubuntu-20.04 , ruby: truffleruby-head }
           - { os: macos-10.15  , ruby: jruby-head }
 
     steps:
@@ -59,7 +56,7 @@ jobs:
 
       - name: test
         id: test
-        timeout-minutes: 20
+        timeout-minutes: 15
         continue-on-error: ${{ matrix.allow-failure || false }}
         if: success() # only run if previous steps have succeeded
         run: bundle exec rake test:all

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -108,6 +108,8 @@ module TestSkips
 
   SIGNAL_LIST = Signal.list.keys.map(&:to_sym) - (Puma.windows? ? [:INT, :TERM] : [])
 
+  JRUBY_HEAD = Puma::IS_JRUBY && RUBY_DESCRIPTION =~ /SNAPSHOT/
+
   # usage: skip_unless_signal_exist? :USR2
   def skip_unless_signal_exist?(sig, bt: caller)
     signal = sig.to_s.sub(/\ASIG/, '').to_sym

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -208,7 +208,8 @@ class TestIntegration < Minitest::Test
             # client would see an empty response
             # Errno::EBADF Windows may not be able to make a connection
             mutex.synchronize { replies[:reset] += 1 }
-          rescue *refused
+          rescue *refused, IOError
+            # IOError intermittently thrown by Ubuntu, add to allow retry
             mutex.synchronize { replies[:refused] += 1 }
           rescue ::Timeout::Error
             mutex.synchronize { replies[:read_timeout] += 1 }

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestIntegrationCluster < TestIntegration
-  parallelize_me!
+  parallelize_me! if ::Puma.mri?
 
   def workers ; 2 ; end
 

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -3,7 +3,7 @@ require_relative "helpers/integration"
 
 class TestIntegrationPumactl < TestIntegration
   include TmpPath
-  parallelize_me!
+  parallelize_me! if ::Puma.mri?
 
   def workers ; 2 ; end
 

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestIntegrationSingle < TestIntegration
-  parallelize_me!
+  parallelize_me! if ::Puma.mri?
 
   def workers ; 0 ; end
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -3,7 +3,7 @@ require "puma/events"
 require "net/http"
 
 class TestPumaServer < Minitest::Test
-  parallelize_me!
+  parallelize_me! unless JRUBY_HEAD
 
   def setup
     @host = "127.0.0.1"


### PR DESCRIPTION
### Description

Two commits:

#### A. 'Improve reliability of non-MRI CI'

Jobs still occasionally freeze/time-out in test step.

1. Allows jruby-head to fail (as done previously)

2. Actions - change all Ubuntu JRuby OS's to 20.04 (18.04 uses JDK-8, 20.04 uses JDK-11)

3. Integration tests (cluster, pumactl, single) - only run parallel on MRI Rubies

4. `helper.rb` - `TestSkips` - add `JRUBY_HEAD` constant for use with non-parallel conditionals and skips

5. `test_puma_server.rb` - jruby-head - run non-parallel

6. `test_puma_server_ssl.rb` - `TestPumaServerSSLClient` tests - non-parallel on JRuby, add `Errno::ECONNRESET` to client net/https rescue for TruffleRuby

7. `test_puma_server_ssl.rb` - `TestPumaServerSSL#test_http_rejection` - add `Net::ReadTimeout` to client net/https rescue for TruffleRuby

#### B. 'test/integration.rb - hot_restart_does_not_drop_connections - another rescue error'

Added another exception to rescue trapping.  As the test creates a lot of client connections in thread(s), any error not caught will often abort the CI.  Add an error that is intermittently raised on Ubuntu, it should trigger a retry.

#### Notes

PR only changes test file code and the Actions non_mri.yml workflow file.  From inspecting here and there, there aren't many repos testing on jruby-head.  It is 'allow failure'.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
