### PR TITLE
ext_help.h, minissl.c, puma_http11.c - change macros Data_ -> TypedData_ [changelog skip]

### DIFF
--- a/ext/puma_http11/ext_help.h
+++ b/ext/puma_http11/ext_help.h
@@ -2,7 +2,7 @@
 #define ext_help_h
 
 #define RAISE_NOT_NULL(T) if(T == NULL) rb_raise(rb_eArgError, "%s", "NULL found for " # T " when shouldn't be.");
-#define DATA_GET(from,type,name) Data_Get_Struct(from,type,name); RAISE_NOT_NULL(name);
+#define DATA_GET(from,type,data_type,name) TypedData_Get_Struct(from,type,data_type,name); RAISE_NOT_NULL(name);
 #define REQUIRE_TYPE(V, T) if(TYPE(V) != T) rb_raise(rb_eTypeError, "%s", "Wrong argument type for " # V " required " # T);
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof(x[0]))
 


### PR DESCRIPTION
### Description

'Data_' macros have been 'deprecated' since Ruby 2.3 or earlier, but are still supported.

Update c source to use the 'TypedData_' macros.

Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.