### PR TITLE
Fire on_booted after server starts

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@
 
 * Bugfixes
   * Cleanup daemonization in rc.d script (#2409)
+  * Fire `on_booted` after server starts
 
 * Refactor
   * Extract req/resp methods to new request.rb from server.rb (#2419)

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -395,9 +395,9 @@ module Puma
         stop
       end
 
-      @launcher.events.fire_on_booted!
-
       begin
+        booted = false
+
         while @status == :run
           begin
             if @phased_restart
@@ -438,6 +438,10 @@ module Puma
                 when "p"
                   w.ping!(result.sub(/^\d+/,'').chomp)
                   @launcher.events.fire(:ping!, w)
+                  if !booted && @workers.none? {|worker| worker.last_status.empty?}
+                    @launcher.events.fire_on_booted!
+                    booted = true
+                  end
                 end
               else
                 log "! Out-of-sync worker list, no #{pid} worker"

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -55,10 +55,11 @@ module Puma
       log "Use Ctrl-C to stop"
       redirect_io
 
+      server_thread = server.run
       @launcher.events.fire_on_booted!
 
       begin
-        server.run.join
+        server_thread.join
       rescue Interrupt
         # Swallow it
       end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -133,8 +133,6 @@ class TestCLI < Minitest::Test
 
     assert_equal 2, status["workers"]
 
-    # wait until the first status ping has come through
-    sleep 6
     s = UNIXSocket.new @tmp_path
     s << "GET /stats HTTP/1.0\r\n\r\n"
     body = s.read
@@ -144,6 +142,7 @@ class TestCLI < Minitest::Test
   ensure
     if UNIX_SKT_EXIST && HAS_FORK
       cli.launcher.stop
+      t.join
 
       done = nil
       until done
@@ -152,7 +151,6 @@ class TestCLI < Minitest::Test
         done = log[/ - Goodbye!/]
       end
 
-      t.join
       $debugging_hold = false
     end
   end


### PR DESCRIPTION
### Description

This PR slightly changes the timing behavior of the `on_booted` event, ensuring that the event is only fired after the server is running (that is, after `Server#run` has been called), so server stats are guaranteed to be available when this event fires.

In cluster mode, this is when the first stats 'ping' has been received from all worker processes. The timing of the 'ping' has also been updated to send the first one immediately, instead of after `Const::WORKER_CHECK_INTERVAL` (default 5) seconds have passed.

Fixes #2212.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
