### PR TITLE
Add Client#io_ok?, check before Reactor#register

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,9 +5,11 @@
   *  Adds max_fast_inline as a configuration option for the Server object (#2406)
 
 * Bugfixes
+  * Fix hang on shutdown in refork (#2442)
+  * Fix `Bundler::GemNotFound` errors for `nio4r` gem during phased restarts (#2427, #2018)
+  * Server run thread safety fix (#2435) 
+  * Fire `on_booted` after server starts (#2431, #2212)
   * Cleanup daemonization in rc.d script (#2409)
-  * Fix `Bundler::GemNotFound` errors for `nio4r` gem during phased restarts (#2427)
-  * Fire `on_booted` after server starts
 
 * Refactor
   * Extract req/resp methods to new request.rb from server.rb (#2419)

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -85,6 +85,12 @@ module Puma
 
     def_delegators :@io, :closed?
 
+    # Test to see if io meets a bare minimum of functioning, @to_io needs to be
+    # used for MiniSSL::Socket
+    def io_ok?
+      @to_io.is_a?(::BasicSocket) && !closed?
+    end
+
     # @!attribute [r] inspect
     def inspect
       "#<Puma::Client:0x#{object_id.to_s(16)} @ready=#{@ready.inspect}>"

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -74,7 +74,10 @@ module Puma
           timed_out.each(&method(:wakeup!))
 
           unless @input.empty?
-            register(@input.pop) until @input.empty?
+            until @input.empty?
+              client = @input.pop
+              register(client) if client.io_ok?
+            end
             @timeouts.sort_by!(&:timeout_at)
           end
         end


### PR DESCRIPTION
### Description

The issue - how to make Puma respond gracefully when a io connection can misbehave/fail at any point in its handling?

This is a difficult thing to test in CI, especially with multiple VM's running on CI runners.

The are infrequent errors in Puma CI, one example below:
```
Error in reactor loop escaped: mode not supported for this object: r (ArgumentError)
org/nio4r/Selector.java:124:in `register'
/Users/runner/work/puma/puma/lib/puma/reactor.rb:93:in `register'
/Users/runner/work/puma/puma/lib/puma/reactor.rb:77:in `select_loop'
/Users/runner/work/puma/puma/lib/puma/reactor.rb:34:in `block in run'
```

The error `mode not supported for this object: r` implies that the socket is no longer valid in some way.

Does it represent a CI specific issue, or is it something that could occur in real use?

At present, there is a great deal of 'rescue handling' re sockets, and where and how exceptions are raised/caught can get messy.

So, is there a way to conditionally test the socket?  This PR is just a guess, using an `io_ok?` method in Client.

I believe @schneems has mentioned something similar somewhere.

Anyway, if people think it's valid, maybe a method needs to also be added somewhere that takes a socket as a parameter,  which `Client#io_ok?` could call.  I also haven't thought about logging, etc.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
