### PR TITLE
Updates for non MRI CI stablity [changelog skip]

### DIFF
--- a/.github/workflows/mri.yml
+++ b/.github/workflows/mri.yml
@@ -26,6 +26,7 @@ jobs:
           - { os: windows-2019 , ruby: mingw }
           - { os: ubuntu-20.04 , ruby: 2.7   , no-ssl: ' no SSL' }
           - { os: windows-2019 , ruby: 2.7   , no-ssl: ' no SSL' }
+          - { os: macos-11.0   , ruby: 2.7  }
         exclude:
           - { os: ubuntu-20.04 , ruby: 2.2  }
           - { os: ubuntu-20.04 , ruby: 2.3  }

--- a/.github/workflows/non_mri.yml
+++ b/.github/workflows/non_mri.yml
@@ -18,14 +18,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-10.15 ]
-        ruby: [ jruby, jruby-head, truffleruby-head ]
-        no-ssl: ['']
         include:
-          - { os: ubuntu-20.04 , ruby: jruby-head, allow-failure: true }
+          - { os: ubuntu-20.04 , ruby: jruby }
           - { os: ubuntu-20.04 , ruby: jruby, no-ssl: ' no SSL' }
-        exclude:
-          - { os: macos-10.15  , ruby: jruby-head }
+          - { os: ubuntu-20.04 , ruby: jruby-head, allow-failure: true }
+          - { os: ubuntu-20.04 , ruby: truffleruby-head }
+          - { os: macos-11.0   , ruby: jruby }
+          - { os: macos-10.15  , ruby: jruby }
+          - { os: macos-10.15  , ruby: truffleruby-head }
 
     steps:
       - name: repo checkout
@@ -38,6 +38,12 @@ jobs:
           apt-get: ragel
           brew: ragel
           mingw: _upgrade_ openssl ragel
+
+      - name: set JAVA_HOME
+        if: startsWith(matrix.os, 'macos')
+        shell: bash
+        run:  |
+          echo JAVA_HOME=$JAVA_HOME_11_X64 >> $GITHUB_ENV
 
       - name: bundle install
         run:  bundle install --jobs 4 --retry 3
@@ -56,7 +62,7 @@ jobs:
 
       - name: test
         id: test
-        timeout-minutes: 15
+        timeout-minutes: 12
         continue-on-error: ${{ matrix.allow-failure || false }}
         if: success() # only run if previous steps have succeeded
         run: bundle exec rake test:all

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -62,20 +62,15 @@ module TimeoutEveryTestCase
     with_info_handler do
       time_it do
         capture_exceptions do
-          before_setup; setup; after_setup
-
-          # wrap timeout around test method only
-          ::Timeout.timeout(RUBY_ENGINE == 'ruby' ? 45 : 60, TestTookTooLong) {
+          ::Timeout.timeout(RUBY_ENGINE == 'ruby' ? 45 : 60, TestTookTooLong) do
+            before_setup; setup; after_setup
             self.send self.name
-          }
+          end
         end
 
-        Minitest::Test::TEARDOWN_METHODS.each do |hook|
-          capture_exceptions do
-            # wrap timeout around teardown methods, remove when they're stable
-            ::Timeout.timeout(RUBY_ENGINE == 'ruby' ? 45 : 60, TestTookTooLong) {
-              self.send hook
-            }
+        capture_exceptions do
+          ::Timeout.timeout(RUBY_ENGINE == 'ruby' ? 45 : 60, TestTookTooLong) do
+            Minitest::Test::TEARDOWN_METHODS.each { |hook| self.send hook }
           end
         end
         if respond_to? :clean_tmp_paths

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -94,6 +94,7 @@ class TestIntegrationSingle < TestIntegration
 
   def test_int_refuse
     skip_unless_signal_exist? :INT
+    skip_on :jruby  # seems to intermittently lockup JRuby CI
 
     cli_server 'test/rackup/hello.ru'
     begin

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -131,9 +131,12 @@ class TestLauncher < Minitest::Test
       c.clear_binds!
     end
     launcher = launcher(conf)
-    launcher.events.on_booted {launcher.stop}
+    launcher.events.on_booted {
+      sleep 1.1 unless Puma.mri?
+      launcher.stop
+    }
     launcher.run
-    sleep 2 unless Puma.mri?
+    sleep 1 unless Puma.mri?
     Puma::Server::STAT_METHODS.each do |stat|
       assert_includes Puma.stats_hash, stat
     end

--- a/test/test_out_of_band_server.rb
+++ b/test/test_out_of_band_server.rb
@@ -64,6 +64,7 @@ class TestOutOfBandServer < Minitest::Test
     @server.max_threads = options[:max_threads] || 1
     @port = (@server.add_tcp_listener '127.0.0.1', 0).addr[1]
     @server.run
+    sleep 0.15 if Puma.jruby?
   end
 
   # Sequential requests should trigger out_of_band after every request.

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -27,7 +27,7 @@ class TestPersistent < Minitest::Test
     @port = (@server.add_tcp_listener HOST, 0).addr[1]
     @server.max_threads = 1
     @server.run
-
+    sleep 0.15 if Puma.jruby?
     @client = TCPSocket.new HOST, @port
   end
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -26,6 +26,7 @@ class TestPumaServer < Minitest::Test
     @port = (@server.add_tcp_listener @host, 0).addr[1]
     @server.early_hints = true if early_hints
     @server.run
+    sleep 0.15 if Puma.jruby?
   end
 
   def header(sock)


### PR DESCRIPTION
### Description

This PR contains various updates to (hopefully) increase the stability of the non MRI CI.

I ran this fourteen times, and only two jobs failed (excepting jruby-head). TruffleRuby failed once in `bundle install`, and a JRuby job failed once in the manner shown in PR https://github.com/puma/puma/pull/2432.

#### Actions changes

1. Big Sur is available on Actions, added a single job in both MRI & non-MRI workflows.

2. Set all JRuby jobs to use JDK11.  Since the matrix is sparse, changed it to an 'include' only matrix.

#### Test Changes

3. `test/helper.rb

    * changed the `run` method prepended into `Minitest::Test`.  `setup` and the test method now run in the same `Timeout` thread.
    
    * Only run one `Timeout.timeout` for teardown methods.

4. `TestIntegrationSingle#test_int_refuse` appears to be the test that was intermittently locking up the JRuby CI.  Now skipped on JRuby.

5. `TestLauncher#test_puma_stats` timed out and failed intermittently, but only on jruby-head.  It still times out, but often passes on retry.

6. 'add small sleep after `Server#run`' is added in three files for JRuby only.  Possibly helps with timeout issues.  Again, these are intermittent.

5 & 6 are largely jruby-head issues, and since they are intermittent, it's hard to determine a true solution.  Or, the last four commits I could remove or squash ('jruby-head band-aids').  I think.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
