### PR TITLE
Server run thread safety fix [changelog skip]

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -248,6 +248,8 @@ module Puma
         @thread_pool.auto_trim!(@auto_trim_time)
       end
 
+      @check, @notify = Puma::Util.pipe unless @notify
+
       @events.fire :state, :running
 
       if background
@@ -300,7 +302,6 @@ module Puma
     end
 
     def handle_servers
-      @check, @notify = Puma::Util.pipe unless @notify
       begin
         check = @check
         sockets = [check] + @binder.ios
@@ -640,19 +641,16 @@ module Puma
     end
 
     def notify_safely(message)
-      @check, @notify = Puma::Util.pipe unless @notify
-      begin
-        @notify << message
-      rescue IOError, NoMethodError, Errno::EPIPE
-         # The server, in another thread, is shutting down
+      @notify << message
+    rescue IOError, NoMethodError, Errno::EPIPE
+      # The server, in another thread, is shutting down
+      Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+    rescue RuntimeError => e
+      # Temporary workaround for https://bugs.ruby-lang.org/issues/13239
+      if e.message.include?('IOError')
         Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
-      rescue RuntimeError => e
-        # Temporary workaround for https://bugs.ruby-lang.org/issues/13239
-        if e.message.include?('IOError')
-          Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
-        else
-          raise e
-        end
+      else
+        raise e
       end
     end
     private :notify_safely

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -50,12 +50,11 @@ module Puma
       start_control
 
       @server = server = start_server
-
+      server_thread = server.run
 
       log "Use Ctrl-C to stop"
       redirect_io
 
-      server_thread = server.run
       @launcher.events.fire_on_booted!
 
       begin

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1141,4 +1141,12 @@ EOF
     sleep 0.5
     assert_empty @events.stdout.string
   end
+
+  def test_run_stop_thread_safety
+    100.times do
+      thread = @server.run
+      @server.stop
+      assert thread.join(1)
+    end
+  end
 end


### PR DESCRIPTION
### Description
This PR fixes a race-condition creating the `@check, @notify` pipe in `Server`, which caused various intermittent test failures on JRuby.

The issue can be triggered by a call to `#run` (which calls `#handle_servers` in a background-thread) followed immediately by `#stop` (which calls `#notify_safely`). This can result in two separate `@check, @notify` pipes getting created concurrently, causing the signal sent by `#stop` to not get picked up by the listen-loop in `#handle_servers`, and therefore fail to exit as expected. This PR adds a test `test_run_stop_thread_safety` demonstrating the race condition that consistently fails on JRuby without this fix (see [this test run](https://github.com/wjordan/puma/actions/runs/314657885)).

The fix moves pipe-creation into `Server#run` (before the background thread is spawned), making the behavior more consistent that the server will stop as long as the call to `#stop` comes after the call to `#run` returns.

This PR includes a related timing change in `Single`, moving the `Use Ctrl-C to stop` log message after the call to `Server#run`. This is because the `wait_for_server_to_boot` integration-test helper uses this log message to determine when the server is 'booted', and some integration tests (e.g., `test_int_refuse`) send an `INT` signal (which calls `stop`) immediately after this log message is printed, causing intermittent failures if the `stop` call arrived before the `run` call finished. The change ensures that `stop` always occurs after `run`, avoiding intermittent failures in this test.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
