### PR TITLE
Add integration test to help prevent JSON loading regressions [changelog skip]

### DIFF
--- a/test/config/prune_bundler_print_json_defined.rb
+++ b/test/config/prune_bundler_print_json_defined.rb
@@ -1,0 +1,4 @@
+prune_bundler true
+before_fork do
+  puts "defined?(JSON): #{defined?(JSON).inspect}"
+end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -261,6 +261,13 @@ RUBY
     end
   end
 
+  def test_json_gem_not_required_in_master_process
+    cli_server "-w #{workers} -C test/config/prune_bundler_print_json_defined.rb test/rackup/hello.ru"
+
+    line = @server.gets
+    assert_match(/defined\?\(JSON\): nil/, line)
+  end
+
   private
 
   def worker_timeout(timeout, iterations, config)


### PR DESCRIPTION
### Description

This change adds an integration test for the changes in #2269, in order to prevent regressions similar to #1801.

It's important that in a puma cluster, that the master process doesn't `require`s the `json` gem, because doing to makes it not possible for users to upgrade or downgrade their application using a phased restart if they change the version of the `json` gem they're using.

### Your checklist for this pull request

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [X] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [X] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [X] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
