### PR TITLE
Fix-up test_refork, hot_restart_does_not_drop_connections [changelog skip]

### DIFF
--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -109,7 +109,7 @@ class TestIntegrationPumactl < TestIntegration
 
     cli_pumactl "stop", unix: true
 
-    _, status = Process.wait2(@pid)
+    _, _ = Process.wait2(@pid)
     @server = nil
   end
 

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -182,7 +182,7 @@ class TestPumaControlCli < TestConfigFileBase
     out, _ = capture_subprocess_io do
       begin
         cmd.run
-      rescue SystemExit => e
+      rescue SystemExit
       end
     end
     assert_match expected_out, out


### PR DESCRIPTION
### Description

**test_refork** - since refork is unlikely to be used with less than 3 workers, set workers to 3, previous value was 2.  Test sends 1k+ sockets, and will error if all do not receive a response.  Removed 'speed of light' client loop, as they can cause issues with CI.

**hot_restart_does_not_drop_connections** - fixed Windows error.  Removed 'speed of light' client loop.

**test/integration.rb** - added `fast_connect` which opens and sends a request without a read.  Uses `fast_write` (`syswrite`).  Moved `fast_write` to below `fast_connect`.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
