### PR TITLE
Fix hang on shutdown in test_refork [changelog skip]

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -479,7 +479,9 @@ module Puma
         rescue Errno::ECHILD
           begin
             Process.kill(0, w.pid)
-            false # child still alive, but has another parent
+            # child still alive but has another parent (e.g., using fork_worker)
+            w.term if w.term?
+            false
           rescue Errno::ESRCH, Errno::EPERM
             true # child is already terminated
           end

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -91,6 +91,7 @@ module Puma
 
         Signal.trap "SIGTERM" do
           @worker_write << "e#{Process.pid}\n" rescue nil
+          restart_server.clear
           server.stop
           restart_server << false
         end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1150,4 +1150,15 @@ EOF
       assert thread.join(1)
     end
   end
+
+  def test_command_ignored_before_run
+    @server.stop # ignored
+    @server.run
+    @server.halt
+    done = Queue.new
+    @server.events.register(:state) do |state|
+      done << @server.instance_variable_get(:@status) if state == :done
+    end
+    assert_equal :halt, done.pop
+  end
 end


### PR DESCRIPTION
### Description

This PR fixes a hang on shutdown that occurred intermittently in `test_refork` ([example](https://github.com/puma/puma/runs/1281242974#step:8:550)). I reproduced the hang more consistently running `test_refork` with an extra `sleep` after the `'b'` (boot) message and before it starts the server (e.g., line 106 below): https://github.com/puma/puma/blob/aae4d4d045e35e1ad79b2009e008f1a9cdd94d71/lib/puma/cluster/worker.rb#L99-L108

The PR contains two small fixes.

1. Prevent server from starting if worker receives `TERM` signal (0018edde2c36011b26a1930bbbeeadc02368635b). This handles some (but not 100% of all) edge cases where the `TERM` signal is received and calls `server.stop` before the server has started.
2. Send TERM to fork_worker child processes in Cluster#wait_workers (aae4d4d045e35e1ad79b2009e008f1a9cdd94d71) - When `fork_worker` is used, the call to `Process.wait` in `wait_workers` returns `ECHILD` for forked workers. This commit adds a call to `w.term` in the rescue clause, matching the behavior when `fork_worker` is not used and ensuring workers shut down properly. This should handle all other edge-cases where a worker receives `TERM` before the server starts.

Finally, note that this bug started occurring more frequently after #2435, because that PR changed behavior so that calling `#stop` before `#run` now has no effect. I've added `test_command_ignored_before_run` to clarify this new behavior in a unit test. I _think_ this is more intuitive and predictable behavior overall, but we can change it back if anyone disagrees or if the change continues to cause any other issues.