### PR TITLE
queue_close.rb - refactor loading, move comment for docs

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@
   * Fire `on_booted` after server starts
 
 * Refactor
+  * queue_close.rb - refactor loading, move comment for docs
   * Extract req/resp methods to new request.rb from server.rb (#2419)
   * Refactor Reactor and Client request buffering (#2279)
   * client.rb - remove JRuby specific 'finish' code (#2412)

--- a/lib/puma/queue_close.rb
+++ b/lib/puma/queue_close.rb
@@ -1,25 +1,25 @@
-# Queue#close was added in Ruby 2.3.
-# Add a simple implementation for earlier Ruby versions.
-unless Queue.instance_methods.include?(:close)
-  class ClosedQueueError < StandardError; end
-  module Puma
-    module QueueClose
-      def initialize
-        @closed = false
-        super
-      end
-      def close
-        @closed = true
-      end
-      def closed?
-        @closed
-      end
-      def push(object)
-        raise ClosedQueueError if @closed
-        super
-      end
-      alias << push
+class ClosedQueueError < StandardError; end
+module Puma
+
+  # Queue#close was added in Ruby 2.3.
+  # Add a simple implementation for earlier Ruby versions.
+  #
+  module QueueClose
+    def initialize
+      @closed = false
+      super
     end
-    Queue.prepend QueueClose
+    def close
+      @closed = true
+    end
+    def closed?
+      @closed
+    end
+    def push(object)
+      raise ClosedQueueError if @closed
+      super
+    end
+    alias << push
   end
+  ::Queue.prepend QueueClose
 end

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'puma/queue_close' if RUBY_VERSION < '2.3'
+require 'puma/queue_close' unless ::Queue.instance_methods.include? :close
 
 module Puma
   # Monitors a collection of IO objects, calling a block whenever


### PR DESCRIPTION
### Description

Small refactor of queue_close.rb and its loading.  Move comment so it is attached to `QueueClose`.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
