### PR TITLE
cluster.rb - rearrange SIGURG & fork_worker code, small test fix [changelog skip]

### DIFF
--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -213,7 +213,7 @@ RUBY
 
     socks.each { |s| read_body s }
 
-    refute_includes pids, get_worker_pids(1, wrkrs - 1)
+    get_worker_pids(1, wrkrs - 1).each { |pid| refute_includes pids, pid }
   end
 
   def test_fork_worker_spawn


### PR DESCRIPTION
### Description

`fork_worker` and `SIGURG` should be independent.  Rearrange code for that.  Small test fix.

@wjordan - agree?  I was working on some refactoring, wanted to add an 'http' based 'refork' command in ControlCLI, and noticed it...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.