### PR TITLE
Refactor control_cli.rb - add CMD_PATH_SIG_MAP [changelog skip]

### DIFF
--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -34,7 +34,7 @@ class TestPumaControlCli < TestConfigFileBase
   end
 
   def test_blank_command
-    assert_system_exit_with_cli_output [], "Available commands: #{Puma::ControlCLI::COMMANDS.join(", ")}"
+    assert_system_exit_with_cli_output [], "Available commands: #{Puma::ControlCLI::CMD_PATH_SIG_MAP.keys.join(", ")}"
   end
 
   def test_invalid_command


### PR DESCRIPTION
### Description

Main change is to replace COMMANDS, an array of command names with CMD_PATH_SIG_MAP, a Hash with keys of command names and values of the signal.

COMMANDS remains for API compatibility

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
