### PR TITLE
reactor.rb - register the io, not the client, rename parameters [changelog skip]

### DIFF
--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -38,11 +38,11 @@ module Puma
       end
     end
 
-    # Add a new IO object to monitor.
+    # Add a new client to monitor.
     # The object must respond to #timeout and #timeout_at.
     # Returns false if the reactor is already shut down.
-    def add(io)
-      @input << io
+    def add(client)
+      @input << client
       @selector.wakeup
       true
     rescue ClosedQueueError
@@ -92,17 +92,17 @@ module Puma
     end
 
     # Start monitoring the object.
-    def register(io)
-      @selector.register(io, :r).value = io
-      @timeouts << io
+    def register(client)
+      @selector.register(client.to_io, :r).value = client
+      @timeouts << client
     end
 
     # 'Wake up' a monitored object by calling the provided block.
     # Stop monitoring the object if the block returns `true`.
-    def wakeup!(io)
-      if @block.call(io)
-        @selector.deregister(io)
-        @timeouts.delete(io)
+    def wakeup!(client)
+      if @block.call client
+        @selector.deregister client.to_io
+        @timeouts.delete client
       end
     end
   end


### PR DESCRIPTION
### Description

1. NIO has c, ruby, and java implementations.  Normally, an io object is expected to be passed to NIO::Selector#register, but currently we are providing a Client.  Change to pass the actual Client io.  `NIO::Monitor`'s have a `#value` attribute, and the client is set to that, so changing to an io affects no other code.

2. Puma::Client is a container that contains an 'accepted' io, and also has methods for interacting with other Puma objects.  Several Puma::Reactor methods take a Client as a parameter, but are currently named `io`.  Change to `client`.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
