### PR TITLE
Pass preloaded application into new workers if available

### DIFF
--- a/History.md
+++ b/History.md
@@ -8,6 +8,7 @@
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
   * Ignore illegal (by Rack spec) response header (#2439)
+  * Pass preloaded application into new workers if available when using `preload_app` (#2461)
   
 ## 5.0.3 / 2020-10-26
 

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -186,10 +186,12 @@ module Puma
         pipes[:wakeup] = @wakeup
       end
 
+      server = start_server if preload?
       new_worker = Worker.new index: index,
                               master: master,
                               launcher: @launcher,
-                              pipes: pipes
+                              pipes: pipes,
+                              server: server
       new_worker.run
     end
 

--- a/test/rackup/write_to_stdout_on_boot.ru
+++ b/test/rackup/write_to_stdout_on_boot.ru
@@ -1,0 +1,2 @@
+puts "Loading app"
+run lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Hello World"]] }

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -283,6 +283,17 @@ RUBY
     assert_match(/defined\?\(JSON\): nil/, line)
   end
 
+  def test_application_is_loaded_exactly_once_if_using_preload_app
+    cli_server "-w #{workers} --preload test/rackup/write_to_stdout_on_boot.ru"
+
+    worker_load_count = 0
+    while (line = @server.gets) =~ /^Loading app/
+      worker_load_count += 1
+    end
+
+    assert_equal 0, worker_load_count
+  end
+
   private
 
   def worker_timeout(timeout, iterations, config)


### PR DESCRIPTION
### Description

Fixes #2454. A regression introduced in #2374 effectively broke `preload_app`. The puma master process would successfully preload the app before starting any workers, but fail to pass the preloaded app into the workers, who would then load their own version of the app, effectively defeating the point of preloading in the first place.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [X] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [X] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed, including Rubocop.
