### PR TITLE
Log the configuration if an env variable is provided

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 * Features
   * Your feature goes here <Most recent on the top, like GitHub> (#Github Number)
+  * Prints the loaded configuration if the environment variable `PUMA_LOG_CONFIG` is present ([#2472])
   * Integrate with systemd's watchdog and notification features ([#2438])
   * Adds max_fast_inline as a configuration option for the Server object ([#2406])
   * You can now fork workers from worker 0 using SIGURG w/o fork_worker enabled [#2449]

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ Puma provides numerous options. Consult `puma -h` (or `puma --help`) for a full 
 You can also find several configuration examples as part of the
 [test](https://github.com/puma/puma/tree/master/test/config) suite.
 
+For debugging purposes, you can set the environment variable `PUMA_LOG_CONFIG` with a value
+and the loaded configuration will be printed as part of the boot process.
+
 ### Thread Pool
 
 Puma uses a thread pool. You can set the minimum and maximum number of threads that are available in the pool with the `-t` (or `--threads`) flag:

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -92,6 +92,12 @@ module Puma
         end
       end
     end
+
+    def final_options
+      default_options
+        .merge(file_options)
+        .merge(user_options)
+    end
   end
 
   # The main configuration class of Puma.
@@ -288,6 +294,10 @@ module Puma
           events.debug e.backtrace.join("\n")
         end
       end
+    end
+
+    def final_options
+      @options.final_options
     end
 
     def self.temp_path

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -87,6 +87,8 @@ module Puma
       Puma.stats_object = @runner
 
       @status = :run
+
+      log_config if ENV['PUMA_LOG_CONFIG']
     end
 
     attr_reader :binder, :events, :config, :options, :restart_dir
@@ -520,6 +522,15 @@ module Puma
       else
         Bundler.with_unbundled_env { yield }
       end
+    end
+
+    def log_config
+      log "Configuration:"
+
+      @config.final_options
+        .each { |config_key, value| log "- #{config_key}: #{value}" }
+
+      log "\n"
     end
   end
 end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -265,6 +265,13 @@ class TestConfigFile < TestConfigFileBase
     assert_equal 0, Puma::Configuration.new.options.default_options[:workers]
   end
 
+  def test_final_options_returns_merged_options
+    conf = Puma::Configuration.new({ min_threads: 1, max_threads: 2 }, { min_threads: 2 })
+
+    assert_equal 1, conf.final_options[:min_threads]
+    assert_equal 2, conf.final_options[:max_threads]
+  end
+
   private
 
   def assert_run_hooks(hook_name, options = {})

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -158,6 +158,22 @@ class TestLauncher < Minitest::Test
     launcher.run
   end
 
+  def test_log_config_enabled
+    ENV['PUMA_LOG_CONFIG'] = "1"
+
+    assert_match(/Configuration:/, launcher.events.stdout.string)
+
+    launcher.config.final_options.each do |config_key, _value|
+      assert_match(/#{config_key}/, launcher.events.stdout.string)
+    end
+
+    ENV.delete('PUMA_LOG_CONFIG')
+  end
+
+  def test_log_config_disabled
+    refute_match /Configuration:/, launcher.events.stdout.string
+  end
+
   private
 
   def events


### PR DESCRIPTION
### Description
This PR adds support for printing the puma config if an env variable is provided as agreed in #2414 
I'm aware am missing several things including the tests but I just want early feedback if possible, this is my first contribution to the project :) 
Closes #2414 

Here is an example of the output:
<img width="683" alt="image" src="https://user-images.githubusercontent.com/1001834/97638098-28cfd080-1a3c-11eb-98ee-70ad9c7941af.png">


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
