### PR TITLE
Remove use of json gem from WorkerHandle#ping!

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
   * Ignore illegal (by Rack spec) response header ([#2439])
   * Close idle connections immediately on shutdown ([#2460])
+  * Fix some instances of phased restart errors related to the `json` gem (#2473)
 
 ## 5.0.4 / 2020-10-27
 

--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -42,8 +42,11 @@ module Puma
 
       def ping!(status)
         @last_checkin = Time.now
-        require 'json'
-        @last_status = JSON.parse(status, symbolize_names: true)
+        captures = status.match(/{ "backlog":(?<backlog>\d*), "running":(?<running>\d*), "pool_capacity":(?<pool_capacity>\d*), "max_threads": (?<max_threads>\d*), "requests_count": (?<requests_count>\d*) }/)
+        @last_status = captures.names.inject({}) do |hash, key|
+          hash[key.to_sym] = captures[key].to_i
+          hash
+        end
       end
 
       # @see Puma::Cluster#check_workers

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -53,11 +53,12 @@ class TestIntegration < Minitest::Test
       config_file.close
       config = "-C #{config_file.path}"
     end
+    puma_path = File.expand_path '../../../bin/puma', __FILE__
     if unix
-      cmd = "#{BASE} bin/puma #{config} -b unix://#{@bind_path} #{argv}"
+      cmd = "#{BASE} #{puma_path} #{config} -b unix://#{@bind_path} #{argv}"
     else
       @tcp_port = UniquePort.call
-      cmd = "#{BASE} bin/puma #{config} -b tcp://#{HOST}:#{@tcp_port} #{argv}"
+      cmd = "#{BASE} #{puma_path} #{config} -b tcp://#{HOST}:#{@tcp_port} #{argv}"
     end
     @server = IO.popen(cmd, "r")
     wait_for_server_to_boot

--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -1,0 +1,74 @@
+require_relative "helper"
+require_relative "helpers/integration"
+
+class TestWorkerGemIndependence < TestIntegration
+  def setup
+    skip NO_FORK_MSG unless HAS_FORK
+    super
+  end
+
+  def teardown
+    return if skipped?
+    FileUtils.rm current_release_symlink, force: true
+    super
+  end
+
+  def test_changing_nio4r_version_during_phased_restart
+    skip_unless_signal_exist? :USR1
+
+    set_release_symlink File.expand_path("worker_gem_independence_test/old_nio4r", __dir__)
+
+    Dir.chdir(current_release_symlink) do
+      bundle_install
+      cli_server '--prune-bundler -w 1'
+    end
+
+    connection = connect
+    initial_reply = read_body(connection)
+    expected_nio4r_version = '2.3.0'
+    assert_equal expected_nio4r_version, initial_reply
+
+    set_release_symlink File.expand_path("worker_gem_independence_test/new_nio4r", __dir__)
+    Dir.chdir(current_release_symlink) do
+      bundle_install
+    end
+    start_phased_restart
+
+    connection = connect
+    new_reply = read_body(connection)
+    new_expected_nio4r_version = '2.3.1'
+    assert_equal new_expected_nio4r_version, new_reply
+  end
+
+  private
+
+  def current_release_symlink
+    File.expand_path "worker_gem_independence_test/current", __dir__
+  end
+
+  def set_release_symlink(target_dir)
+    FileUtils.rm current_release_symlink, force: true
+    FileUtils.symlink target_dir, current_release_symlink, force: true
+  end
+
+  def start_phased_restart
+    Process.kill :USR1, @pid
+
+    true while @server.gets !~ /booted, phase: 1/
+  end
+
+  def with_unbundled_env
+    bundler_ver = Gem::Version.new(Bundler::VERSION)
+    if bundler_ver < Gem::Version.new('2.1.0')
+      Bundler.with_clean_env { yield }
+    else
+      Bundler.with_unbundled_env { yield }
+    end
+  end
+
+  def bundle_install
+    with_unbundled_env do
+      system("bundle install", out: File::NULL)
+    end
+  end
+end

--- a/test/worker_gem_independence_test/new_json/Gemfile
+++ b/test/worker_gem_independence_test/new_json/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'puma', path: '../../..'
+gem 'json', '= 2.3.0'

--- a/test/worker_gem_independence_test/new_json/config.ru
+++ b/test/worker_gem_independence_test/new_json/config.ru
@@ -1,0 +1,2 @@
+require 'json'
+run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [JSON::VERSION]] }

--- a/test/worker_gem_independence_test/new_json/config/puma.rb
+++ b/test/worker_gem_independence_test/new_json/config/puma.rb
@@ -1,0 +1,1 @@
+directory File.expand_path("../../current", __dir__)

--- a/test/worker_gem_independence_test/new_nio4r/Gemfile
+++ b/test/worker_gem_independence_test/new_nio4r/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'puma', path: '../../..'
+gem 'nio4r', '= 2.3.1'

--- a/test/worker_gem_independence_test/new_nio4r/config.ru
+++ b/test/worker_gem_independence_test/new_nio4r/config.ru
@@ -1,0 +1,1 @@
+run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [NIO::VERSION]] }

--- a/test/worker_gem_independence_test/new_nio4r/config/puma.rb
+++ b/test/worker_gem_independence_test/new_nio4r/config/puma.rb
@@ -1,0 +1,1 @@
+directory File.expand_path("../../current", __dir__)

--- a/test/worker_gem_independence_test/old_json/Gemfile
+++ b/test/worker_gem_independence_test/old_json/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'puma', path: '../../..'
+gem 'json', '= 2.3.1'

--- a/test/worker_gem_independence_test/old_json/config.ru
+++ b/test/worker_gem_independence_test/old_json/config.ru
@@ -1,0 +1,2 @@
+require 'json'
+run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [JSON::VERSION]] }

--- a/test/worker_gem_independence_test/old_json/config/puma.rb
+++ b/test/worker_gem_independence_test/old_json/config/puma.rb
@@ -1,0 +1,1 @@
+directory File.expand_path("../../current", __dir__)

--- a/test/worker_gem_independence_test/old_nio4r/Gemfile
+++ b/test/worker_gem_independence_test/old_nio4r/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'puma', path: '../../..'
+gem 'nio4r', '= 2.3.0'

--- a/test/worker_gem_independence_test/old_nio4r/config.ru
+++ b/test/worker_gem_independence_test/old_nio4r/config.ru
@@ -1,0 +1,1 @@
+run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [NIO::VERSION]] }

--- a/test/worker_gem_independence_test/old_nio4r/config/puma.rb
+++ b/test/worker_gem_independence_test/old_nio4r/config/puma.rb
@@ -1,0 +1,1 @@
+directory File.expand_path("../../current", __dir__)


### PR DESCRIPTION
### Description

This change is the first in a series meant to address phased restart errors related to the `json` gem described in #2471. The changes for this specific PR are described in a comment in the same issue: https://github.com/puma/puma/issues/2471#issuecomment-719834731

This PR essentially reverts the changes to the handling of puma worker stats introduced by #2124 in a way that intentionally avoids the use of the `json` gem.

I added an integration test to ensure that users can upgrade/downgrade the JSON gem as part of phased restart (it reliably reproduces the error reported in #2471). While I was in there, I added a similar integration test for upgrading/downgrading the nio4r gem. That test was effectively fixed by #2427.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [X] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed, including Rubocop.
