### PR TITLE
Catch 'Error in reactor loop escaped: mode not supported for this object: r'

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@
 
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
+  * Catch 'Error in reactor loop escaped: mode not supported for this object: r' (#2477)
   * Ignore Rails' reaper thread (and any thread marked forksafe) for warning ([#2475])
   * Ignore illegal (by Rack spec) response header ([#2439])
   * Close idle connections immediately on shutdown ([#2460])

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -95,6 +95,8 @@ module Puma
     def register(client)
       @selector.register(client.to_io, :r).value = client
       @timeouts << client
+    rescue ArgumentError
+      # unreadable clients raise error when processed by NIO
     end
 
     # 'Wake up' a monitored object by calling the provided block.


### PR DESCRIPTION
### Description

The following error happens intermittently in non MRI CI:
```
Error in reactor loop escaped: mode not supported for this object: r (ArgumentError)
```
PR adds a rescue in `Reactor#register.

Note that https://github.com/puma/puma/pull/2432 also attempted to catch this (without a rescue), but some errors still occur.  I tried to remove it, and doing so caused more intermittent errors...

Updated HISTORY.md

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.