### PR TITLE
Improve docs around preload_app! and phased restart

### DIFF
--- a/5.0-Upgrade.md
+++ b/5.0-Upgrade.md
@@ -84,12 +84,12 @@ To learn more about using `refork` and `fork_worker`, see ['Fork Worker'](docs/f
 
 ## Upgrade
 
-* Setting the `WEB_CONCURRENCY` environment variable will now configure the number of workers (processes) that Puma will boot.
+* Setting the `WEB_CONCURRENCY` environment variable will now configure the number of workers (processes) that Puma will boot and enable preloading of the application.
 * If you did not explicitly set `environment` before, Puma now checks `RAILS_ENV` and will use that, if available in addition to `RACK_ENV`.
 * If you have been using the `--control` CLI option, update your scripts to use `--control-url`.
 * If you are using `worker_directory` in your config file, change it to `directory`.
 * If you are running MRI, default thread count on Puma is now 5, not 16. This may change the amount of threads running in your threadpool. We believe 5 is a better default for most Ruby web applications on MRI. Higher settings increase latency by causing GVL contention.
-* If you are using a worker count of more than 1, Puma will now preload the application by default (disable with `preload_app! false`). We believe this is a better default, but may cause issues in non-Rails applications if you do not have the proper `before` and `after` fork hooks configured. See documentation for your framework. Rails users do not need to change anything. **Please note that it is not possible to use [the phased restart](docs/restart.md) with preloading.**
+* If you are using a worker count of more than 1, set using `WEB_CONCURRENCY`, Puma will now preload the application by default (disable with `preload_app! false`). We believe this is a better default, but may cause issues in non-Rails applications if you do not have the proper `before` and `after` fork hooks configured. See documentation for your framework. Rails users do not need to change anything. **Please note that it is not possible to use [the phased restart](docs/restart.md) with preloading.**
 * tcp mode and daemonization have been removed without replacement. For daemonization, please use a modern process management solution, such as systemd or monit.
 * `connected_port` was renamed to `connected_ports` and now returns an Array, not an Integer.
 

--- a/5.0-Upgrade.md
+++ b/5.0-Upgrade.md
@@ -89,7 +89,7 @@ To learn more about using `refork` and `fork_worker`, see ['Fork Worker'](docs/f
 * If you have been using the `--control` CLI option, update your scripts to use `--control-url`.
 * If you are using `worker_directory` in your config file, change it to `directory`.
 * If you are running MRI, default thread count on Puma is now 5, not 16. This may change the amount of threads running in your threadpool. We believe 5 is a better default for most Ruby web applications on MRI. Higher settings increase latency by causing GVL contention.
-* If you are using a worker count of more than 1 and you are not using phased_restart, Puma will now `preload` by default. We believe this is a better default, but may cause issues in non-Rails applications if you do not have the proper `before` and `after` fork hooks configured. See documentation for your framework. Rails users do not need to change anything.
+* If you are using a worker count of more than 1, Puma will now preload the application by default (disable with `preload_app! false`). We believe this is a better default, but may cause issues in non-Rails applications if you do not have the proper `before` and `after` fork hooks configured. See documentation for your framework. Rails users do not need to change anything. **Please note that it is not possible to use [the phased restart](docs/restart.md) with preloading.**
 * tcp mode and daemonization have been removed without replacement. For daemonization, please use a modern process management solution, such as systemd or monit.
 * `connected_port` was renamed to `connected_ports` and now returns an Array, not an Integer.
 

--- a/History.md
+++ b/History.md
@@ -81,7 +81,7 @@
   * min_threads now set by environment variables PUMA_MIN_THREADS and MIN_THREADS. ([#2143])
   * max_threads now set by environment variables PUMA_MAX_THREADS and MAX_THREADS. ([#2143])
   * max_threads default to 5 in MRI or 16 for all other interpreters. ([#2143])
-  * preload by default if workers > 1 ([#2143])
+  * `preload_app!` is on by default if number of workers > 1 and set via `WEB_CONCURRENCY` ([#2143])
   * Puma::Plugin.workers_supported? has been removed. Use Puma.forkable? instead. ([#2143])
   * `tcp_mode` has been removed without replacement. ([#2169])
   * Daemonization has been removed without replacement. ([#2170])

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ before_fork do
 end
 ```
 
-Preloading can’t be used with phased restart, since phased restart kills and restarts workers one-by-one, and preload_app copies the code of master into the workers.
+Preloading can’t be used with phased restart, since phased restart kills and restarts workers one-by-one, and `preload_app!` copies the code of master into the workers.
 
 ### Error handling
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ run Sinatra::Application
 You can then start your application using:
 
 ```
-$ bundle exec puma 
+$ bundle exec puma
 ```
 
 ## Configuration

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -561,7 +561,7 @@ module Puma
     end
 
     # Preload the application before starting the workers; this conflicts with
-    # phased restart feature. This is off by default.
+    # phased restart feature. On by default if your app uses more than 1 worker.
     #
     # @note Cluster mode only.
     # @example

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -343,7 +343,7 @@ class TestConfigEnvVariables < TestConfigFileBase
     end
   end
 
-  def test_config_does_not_preload_app_if_using_workers
+  def test_config_does_not_preload_app_if_not_using_workers
     with_env("WEB_CONCURRENCY" => "0") do
       conf = Puma::Configuration.new
       assert_equal false, conf.options.default_options[:preload_app]


### PR DESCRIPTION
### Description

As seen from the output below, by default, phased restart is only available with 1 worker 🤔 😆

```
$ WEB_CONCURRENCY=0 puma -C test/config/app.rb -p 0
Puma starting in single mode...
* Version 5.0.4 (ruby 2.7.1-p83), codename: Spoony Bard
* Min threads: 0, max threads: 5
* Environment: development
* Listening on http://0.0.0.0:49619
Use Ctrl-C to stop


$ WEB_CONCURRENCY=1 puma -C test/config/app.rb -p 0
[61446] Puma starting in cluster mode...
[61446] * Version 5.0.4 (ruby 2.7.1-p83), codename: Spoony Bard
[61446] * Min threads: 0, max threads: 5
[61446] * Environment: development
[61446] * Process workers: 1
[61446] * Phased restart available
[61446] * Listening on http://0.0.0.0:49621
[61446] Use Ctrl-C to stop
[61470] + Gemfile in context: /Users/dentarg/src/puma/Gemfile
[61446] - Worker 0 (pid: 61470) booted, phase: 0


$ WEB_CONCURRENCY=2 puma -C test/config/app.rb -p 0
[61702] Puma starting in cluster mode...
[61702] * Version 5.0.4 (ruby 2.7.1-p83), codename: Spoony Bard
[61702] * Min threads: 0, max threads: 5
[61702] * Environment: development
[61702] * Process workers: 2
[61702] * Preloading application
[61702] * Listening on http://0.0.0.0:49622
[61702] Use Ctrl-C to stop
[61704] + Gemfile in context: /Users/dentarg/src/puma/Gemfile
[61702] - Worker 0 (pid: 61704) booted, phase: 0
[61705] + Gemfile in context: /Users/dentarg/src/puma/Gemfile
[61702] - Worker 1 (pid: 61705) booted, phase: 0


$ WEB_CONCURRENCY=2 puma -C test/config/app_with_preload_off.rb -p 0
[5265] Puma starting in cluster mode...
[5265] * Version 5.0.4 (ruby 2.7.1-p83), codename: Spoony Bard
[5265] * Min threads: 0, max threads: 5
[5265] * Environment: development
[5265] * Process workers: 2
[5265] * Phased restart available
[5265] * Listening on http://0.0.0.0:49865
[5265] Use Ctrl-C to stop
[5267] + Gemfile in context: /Users/dentarg/src/puma/Gemfile
[5268] + Gemfile in context: /Users/dentarg/src/puma/Gemfile
[5265] - Worker 0 (pid: 5267) booted, phase: 0
[5265] - Worker 1 (pid: 5268) booted, phase: 0
```

(`app_with_preload_off.rb` is the same as `test/config/app.rb` in this repo + one line with `preload_app! false`)

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
