### PR TITLE
Allow configuring query string max length

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,6 +7,7 @@
   * Adds max_fast_inline as a configuration option for the Server object ([#2406])
   * You can now fork workers from worker 0 using SIGURG w/o fork_worker enabled [#2449]
   * Add option to bind to systemd activated sockets ([#2362])
+  * Add compile option to change the `QUERY_STRING` max length ([#2485])
 
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)

--- a/docs/compile_options.md
+++ b/docs/compile_options.md
@@ -1,0 +1,19 @@
+# Compile Options
+
+There provide some `cflags` to change Puma's default configuration for C.
+
+## Query String
+
+By default, the max length of `QUERY_STRING` is `1024 * 10`. But you may want to adjust it to allow accept large queries in the GET requests.
+
+For manual install
+
+```
+gem install puma -- --with-cflags="-D PUMA_QUERY_STRING_MAX_LENGTH=64000"
+```
+
+For bundler config
+
+```
+bundle config build.puma --with-cflags="-D PUMA_QUERY_STRING_MAX_LENGTH=64000"
+```

--- a/ext/puma_http11/http11_parser.c
+++ b/ext/puma_http11/http11_parser.c
@@ -33,12 +33,12 @@ static void snake_upcase_char(char *c)
 /** Machine **/
 
 
-#line 79 "ext/puma_http11/http11_parser.rl"
+#line 81 "ext/puma_http11/http11_parser.rl"
 
 
 /** Data **/
 
-#line 40 "ext/puma_http11/http11_parser.c"
+#line 42 "ext/puma_http11/http11_parser.c"
 static const int puma_parser_start = 1;
 static const int puma_parser_first_final = 46;
 static const int puma_parser_error = 0;
@@ -46,17 +46,17 @@ static const int puma_parser_error = 0;
 static const int puma_parser_en_main = 1;
 
 
-#line 83 "ext/puma_http11/http11_parser.rl"
+#line 85 "ext/puma_http11/http11_parser.rl"
 
 int puma_parser_init(puma_parser *parser)  {
   int cs = 0;
   
-#line 53 "ext/puma_http11/http11_parser.c"
+#line 55 "ext/puma_http11/http11_parser.c"
 	{
 	cs = puma_parser_start;
 	}
 
-#line 87 "ext/puma_http11/http11_parser.rl"
+#line 89 "ext/puma_http11/http11_parser.rl"
   parser->cs = cs;
   parser->body_start = 0;
   parser->content_len = 0;
@@ -85,7 +85,7 @@ size_t puma_parser_execute(puma_parser *parser, const char *buffer, size_t len, 
   assert((size_t) (pe - p) == len - off && "pointers aren't same distance");
 
   
-#line 87 "ext/puma_http11/http11_parser.c"
+#line 89 "ext/puma_http11/http11_parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -109,14 +109,14 @@ st0:
 cs = 0;
 	goto _out;
 tr0:
-#line 35 "ext/puma_http11/http11_parser.rl"
+#line 37 "ext/puma_http11/http11_parser.rl"
 	{ MARK(mark, p); }
 	goto st2;
 st2:
 	if ( ++p == pe )
 		goto _test_eof2;
 case 2:
-#line 118 "ext/puma_http11/http11_parser.c"
+#line 120 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr2;
 		case 36: goto st27;
@@ -132,7 +132,7 @@ case 2:
 		goto st27;
 	goto st0;
 tr2:
-#line 48 "ext/puma_http11/http11_parser.rl"
+#line 50 "ext/puma_http11/http11_parser.rl"
 	{
     parser->request_method(parser, PTR_TO(mark), LEN(mark, p));
   }
@@ -141,7 +141,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 143 "ext/puma_http11/http11_parser.c"
+#line 145 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 42: goto tr4;
 		case 43: goto tr5;
@@ -158,67 +158,67 @@ case 3:
 		goto tr5;
 	goto st0;
 tr4:
-#line 35 "ext/puma_http11/http11_parser.rl"
+#line 37 "ext/puma_http11/http11_parser.rl"
 	{ MARK(mark, p); }
 	goto st4;
 st4:
 	if ( ++p == pe )
 		goto _test_eof4;
 case 4:
-#line 167 "ext/puma_http11/http11_parser.c"
+#line 169 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr8;
 		case 35: goto tr9;
 	}
 	goto st0;
 tr8:
-#line 51 "ext/puma_http11/http11_parser.rl"
+#line 53 "ext/puma_http11/http11_parser.rl"
 	{
     parser->request_uri(parser, PTR_TO(mark), LEN(mark, p));
   }
 	goto st5;
 tr31:
-#line 35 "ext/puma_http11/http11_parser.rl"
+#line 37 "ext/puma_http11/http11_parser.rl"
 	{ MARK(mark, p); }
-#line 54 "ext/puma_http11/http11_parser.rl"
+#line 56 "ext/puma_http11/http11_parser.rl"
 	{
     parser->fragment(parser, PTR_TO(mark), LEN(mark, p));
   }
 	goto st5;
 tr33:
-#line 54 "ext/puma_http11/http11_parser.rl"
+#line 56 "ext/puma_http11/http11_parser.rl"
 	{
     parser->fragment(parser, PTR_TO(mark), LEN(mark, p));
   }
 	goto st5;
 tr37:
-#line 67 "ext/puma_http11/http11_parser.rl"
+#line 69 "ext/puma_http11/http11_parser.rl"
 	{
     parser->request_path(parser, PTR_TO(mark), LEN(mark,p));
   }
-#line 51 "ext/puma_http11/http11_parser.rl"
+#line 53 "ext/puma_http11/http11_parser.rl"
 	{
     parser->request_uri(parser, PTR_TO(mark), LEN(mark, p));
   }
 	goto st5;
 tr41:
-#line 58 "ext/puma_http11/http11_parser.rl"
+#line 60 "ext/puma_http11/http11_parser.rl"
 	{ MARK(query_start, p); }
-#line 59 "ext/puma_http11/http11_parser.rl"
+#line 61 "ext/puma_http11/http11_parser.rl"
 	{
     parser->query_string(parser, PTR_TO(query_start), LEN(query_start, p));
   }
-#line 51 "ext/puma_http11/http11_parser.rl"
+#line 53 "ext/puma_http11/http11_parser.rl"
 	{
     parser->request_uri(parser, PTR_TO(mark), LEN(mark, p));
   }
 	goto st5;
 tr44:
-#line 59 "ext/puma_http11/http11_parser.rl"
+#line 61 "ext/puma_http11/http11_parser.rl"
 	{
     parser->query_string(parser, PTR_TO(query_start), LEN(query_start, p));
   }
-#line 51 "ext/puma_http11/http11_parser.rl"
+#line 53 "ext/puma_http11/http11_parser.rl"
 	{
     parser->request_uri(parser, PTR_TO(mark), LEN(mark, p));
   }
@@ -227,19 +227,19 @@ st5:
 	if ( ++p == pe )
 		goto _test_eof5;
 case 5:
-#line 229 "ext/puma_http11/http11_parser.c"
+#line 231 "ext/puma_http11/http11_parser.c"
 	if ( (*p) == 72 )
 		goto tr10;
 	goto st0;
 tr10:
-#line 35 "ext/puma_http11/http11_parser.rl"
+#line 37 "ext/puma_http11/http11_parser.rl"
 	{ MARK(mark, p); }
 	goto st6;
 st6:
 	if ( ++p == pe )
 		goto _test_eof6;
 case 6:
-#line 241 "ext/puma_http11/http11_parser.c"
+#line 243 "ext/puma_http11/http11_parser.c"
 	if ( (*p) == 84 )
 		goto st7;
 	goto st0;
@@ -297,21 +297,21 @@ case 13:
 		goto st13;
 	goto st0;
 tr18:
-#line 63 "ext/puma_http11/http11_parser.rl"
+#line 65 "ext/puma_http11/http11_parser.rl"
 	{
     parser->http_version(parser, PTR_TO(mark), LEN(mark, p));
   }
 	goto st14;
 tr26:
-#line 44 "ext/puma_http11/http11_parser.rl"
+#line 46 "ext/puma_http11/http11_parser.rl"
 	{ MARK(mark, p); }
-#line 45 "ext/puma_http11/http11_parser.rl"
+#line 47 "ext/puma_http11/http11_parser.rl"
 	{
     parser->http_field(parser, PTR_TO(field_start), parser->field_len, PTR_TO(mark), LEN(mark, p));
   }
 	goto st14;
 tr29:
-#line 45 "ext/puma_http11/http11_parser.rl"
+#line 47 "ext/puma_http11/http11_parser.rl"
 	{
     parser->http_field(parser, PTR_TO(field_start), parser->field_len, PTR_TO(mark), LEN(mark, p));
   }
@@ -320,7 +320,7 @@ st14:
 	if ( ++p == pe )
 		goto _test_eof14;
 case 14:
-#line 322 "ext/puma_http11/http11_parser.c"
+#line 324 "ext/puma_http11/http11_parser.c"
 	if ( (*p) == 10 )
 		goto st15;
 	goto st0;
@@ -360,7 +360,7 @@ case 16:
 		goto tr22;
 	goto st0;
 tr22:
-#line 71 "ext/puma_http11/http11_parser.rl"
+#line 73 "ext/puma_http11/http11_parser.rl"
 	{
     parser->body_start = p - buffer + 1;
     parser->header_done(parser, p + 1, pe - p - 1);
@@ -371,23 +371,23 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 373 "ext/puma_http11/http11_parser.c"
+#line 375 "ext/puma_http11/http11_parser.c"
 	goto st0;
 tr21:
-#line 38 "ext/puma_http11/http11_parser.rl"
+#line 40 "ext/puma_http11/http11_parser.rl"
 	{ MARK(field_start, p); }
-#line 39 "ext/puma_http11/http11_parser.rl"
+#line 41 "ext/puma_http11/http11_parser.rl"
 	{ snake_upcase_char((char *)p); }
 	goto st17;
 tr23:
-#line 39 "ext/puma_http11/http11_parser.rl"
+#line 41 "ext/puma_http11/http11_parser.rl"
 	{ snake_upcase_char((char *)p); }
 	goto st17;
 st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 389 "ext/puma_http11/http11_parser.c"
+#line 391 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 33: goto tr23;
 		case 58: goto tr24;
@@ -413,71 +413,71 @@ case 17:
 		goto tr23;
 	goto st0;
 tr24:
-#line 40 "ext/puma_http11/http11_parser.rl"
+#line 42 "ext/puma_http11/http11_parser.rl"
 	{
     parser->field_len = LEN(field_start, p);
   }
 	goto st18;
 tr27:
-#line 44 "ext/puma_http11/http11_parser.rl"
+#line 46 "ext/puma_http11/http11_parser.rl"
 	{ MARK(mark, p); }
 	goto st18;
 st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 428 "ext/puma_http11/http11_parser.c"
+#line 430 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 13: goto tr26;
 		case 32: goto tr27;
 	}
 	goto tr25;
 tr25:
-#line 44 "ext/puma_http11/http11_parser.rl"
+#line 46 "ext/puma_http11/http11_parser.rl"
 	{ MARK(mark, p); }
 	goto st19;
 st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 442 "ext/puma_http11/http11_parser.c"
+#line 444 "ext/puma_http11/http11_parser.c"
 	if ( (*p) == 13 )
 		goto tr29;
 	goto st19;
 tr9:
-#line 51 "ext/puma_http11/http11_parser.rl"
+#line 53 "ext/puma_http11/http11_parser.rl"
 	{
     parser->request_uri(parser, PTR_TO(mark), LEN(mark, p));
   }
 	goto st20;
 tr38:
-#line 67 "ext/puma_http11/http11_parser.rl"
+#line 69 "ext/puma_http11/http11_parser.rl"
 	{
     parser->request_path(parser, PTR_TO(mark), LEN(mark,p));
   }
-#line 51 "ext/puma_http11/http11_parser.rl"
+#line 53 "ext/puma_http11/http11_parser.rl"
 	{
     parser->request_uri(parser, PTR_TO(mark), LEN(mark, p));
   }
 	goto st20;
 tr42:
-#line 58 "ext/puma_http11/http11_parser.rl"
+#line 60 "ext/puma_http11/http11_parser.rl"
 	{ MARK(query_start, p); }
-#line 59 "ext/puma_http11/http11_parser.rl"
+#line 61 "ext/puma_http11/http11_parser.rl"
 	{
     parser->query_string(parser, PTR_TO(query_start), LEN(query_start, p));
   }
-#line 51 "ext/puma_http11/http11_parser.rl"
+#line 53 "ext/puma_http11/http11_parser.rl"
 	{
     parser->request_uri(parser, PTR_TO(mark), LEN(mark, p));
   }
 	goto st20;
 tr45:
-#line 59 "ext/puma_http11/http11_parser.rl"
+#line 61 "ext/puma_http11/http11_parser.rl"
 	{
     parser->query_string(parser, PTR_TO(query_start), LEN(query_start, p));
   }
-#line 51 "ext/puma_http11/http11_parser.rl"
+#line 53 "ext/puma_http11/http11_parser.rl"
 	{
     parser->request_uri(parser, PTR_TO(mark), LEN(mark, p));
   }
@@ -486,7 +486,7 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 488 "ext/puma_http11/http11_parser.c"
+#line 490 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr31;
 		case 60: goto st0;
@@ -500,14 +500,14 @@ case 20:
 		goto st0;
 	goto tr30;
 tr30:
-#line 35 "ext/puma_http11/http11_parser.rl"
+#line 37 "ext/puma_http11/http11_parser.rl"
 	{ MARK(mark, p); }
 	goto st21;
 st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 509 "ext/puma_http11/http11_parser.c"
+#line 511 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr33;
 		case 60: goto st0;
@@ -521,14 +521,14 @@ case 21:
 		goto st0;
 	goto st21;
 tr5:
-#line 35 "ext/puma_http11/http11_parser.rl"
+#line 37 "ext/puma_http11/http11_parser.rl"
 	{ MARK(mark, p); }
 	goto st22;
 st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 530 "ext/puma_http11/http11_parser.c"
+#line 532 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 43: goto st22;
 		case 58: goto st23;
@@ -546,14 +546,14 @@ case 22:
 		goto st22;
 	goto st0;
 tr7:
-#line 35 "ext/puma_http11/http11_parser.rl"
+#line 37 "ext/puma_http11/http11_parser.rl"
 	{ MARK(mark, p); }
 	goto st23;
 st23:
 	if ( ++p == pe )
 		goto _test_eof23;
 case 23:
-#line 555 "ext/puma_http11/http11_parser.c"
+#line 557 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr8;
 		case 34: goto st0;
@@ -566,14 +566,14 @@ case 23:
 		goto st0;
 	goto st23;
 tr6:
-#line 35 "ext/puma_http11/http11_parser.rl"
+#line 37 "ext/puma_http11/http11_parser.rl"
 	{ MARK(mark, p); }
 	goto st24;
 st24:
 	if ( ++p == pe )
 		goto _test_eof24;
 case 24:
-#line 575 "ext/puma_http11/http11_parser.c"
+#line 577 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr37;
 		case 34: goto st0;
@@ -587,7 +587,7 @@ case 24:
 		goto st0;
 	goto st24;
 tr39:
-#line 67 "ext/puma_http11/http11_parser.rl"
+#line 69 "ext/puma_http11/http11_parser.rl"
 	{
     parser->request_path(parser, PTR_TO(mark), LEN(mark,p));
   }
@@ -596,7 +596,7 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 598 "ext/puma_http11/http11_parser.c"
+#line 600 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr41;
 		case 34: goto st0;
@@ -609,14 +609,14 @@ case 25:
 		goto st0;
 	goto tr40;
 tr40:
-#line 58 "ext/puma_http11/http11_parser.rl"
+#line 60 "ext/puma_http11/http11_parser.rl"
 	{ MARK(query_start, p); }
 	goto st26;
 st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 618 "ext/puma_http11/http11_parser.c"
+#line 620 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr44;
 		case 34: goto st0;
@@ -1010,7 +1010,7 @@ case 45:
 	_out: {}
 	}
 
-#line 115 "ext/puma_http11/http11_parser.rl"
+#line 117 "ext/puma_http11/http11_parser.rl"
 
   if (!puma_parser_has_error(parser))
     parser->cs = cs;

--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -40,7 +40,9 @@ static VALUE global_http_version;
 static VALUE global_request_path;
 
 /** Defines common length and error messages for input length validation. */
-#define DEF_MAX_LENGTH(N,length) const size_t MAX_##N##_LENGTH = length; const char *MAX_##N##_LENGTH_ERR = "HTTP element " # N  " is longer than the " # length " allowed length (was %d)"
+#define QUOTE(s) #s
+#define EXPLAND_MAX_LENGHT_VALUE(s) QUOTE(s)
+#define DEF_MAX_LENGTH(N,length) const size_t MAX_##N##_LENGTH = length; const char *MAX_##N##_LENGTH_ERR = "HTTP element " # N  " is longer than the " EXPLAND_MAX_LENGHT_VALUE(length) " allowed length (was %d)"
 
 /** Validates the max length of given input and throws an HttpParserError exception if over. */
 #define VALIDATE_MAX_LENGTH(len, N) if(len > MAX_##N##_LENGTH) { rb_raise(eHttpParserError, MAX_##N##_LENGTH_ERR, len); }

--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -50,12 +50,16 @@ static VALUE global_request_path;
 
 
 /* Defines the maximum allowed lengths for various input elements.*/
+#ifndef PUMA_QUERY_STRING_MAX_LENGTH
+#define PUMA_QUERY_STRING_MAX_LENGTH (1024 * 10)
+#endif
+
 DEF_MAX_LENGTH(FIELD_NAME, 256);
 DEF_MAX_LENGTH(FIELD_VALUE, 80 * 1024);
 DEF_MAX_LENGTH(REQUEST_URI, 1024 * 12);
 DEF_MAX_LENGTH(FRAGMENT, 1024); /* Don't know if this length is specified somewhere or not */
 DEF_MAX_LENGTH(REQUEST_PATH, 8192);
-DEF_MAX_LENGTH(QUERY_STRING, (1024 * 10));
+DEF_MAX_LENGTH(QUERY_STRING, PUMA_QUERY_STRING_MAX_LENGTH);
 DEF_MAX_LENGTH(HEADER, (1024 * (80 + 32)));
 
 struct common_field {


### PR DESCRIPTION
### Description
Please describe your pull request. Thank you for contributing! You're the best.

According to #2273 discussion, I add an optional cflags to configure query string max length when we compile puma.

This change is reference @maleksiuk version (https://github.com/maleksiuk/puma/commit/1c56e5f9ae9760b838d4ed8ce972f615a942e55b) to keep source code clean, but I didn't put the environment variable detect part which I think isn't necessary when we have `--cflags` options.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
