### PR TITLE
Avoid mutating $stdout and $stderr

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 * Features
   * Your feature goes here <Most recent on the top, like GitHub> (#Github Number)
+  * Uses `flush` after writing messages to avoid mutating $stdout and $stderr using `sync=true` ([#2486])
   * Prints the loaded configuration if the environment variable `PUMA_LOG_CONFIG` is present ([#2472])
   * Integrate with systemd's watchdog and notification features ([#2438])
   * Adds max_fast_inline as a configuration option for the Server object ([#2406])

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -237,6 +237,7 @@ module Puma
 
         if sig.nil?
           @stdout.puts "'#{@command}' not available via pid only"
+          @stdout.flush unless @stdout.sync
           return
         elsif sig.start_with? 'SIG'
           Process.kill sig, @pid
@@ -244,6 +245,7 @@ module Puma
           begin
             Process.kill 0, @pid
             @stdout.puts 'Puma is started'
+            @stdout.flush unless @stdout.sync
           rescue Errno::ESRCH
             raise 'Puma is not running'
           end

--- a/lib/puma/error_logger.rb
+++ b/lib/puma/error_logger.rb
@@ -15,7 +15,6 @@ module Puma
 
     def initialize(ioerr)
       @ioerr = ioerr
-      @ioerr.sync = true
 
       @debug = ENV.key? 'PUMA_DEBUG'
     end
@@ -32,7 +31,7 @@ module Puma
     #   and before all remaining info.
     #
     def info(options={})
-      ioerr.puts title(options)
+      log title(options)
     end
 
     # Print occured error details only if
@@ -54,7 +53,7 @@ module Puma
       string_block << request_dump(req) if request_parsed?(req)
       string_block << error.backtrace if error
 
-      ioerr.puts string_block.join("\n")
+      log string_block.join("\n")
     end
 
     def title(options={})
@@ -92,6 +91,14 @@ module Puma
 
     def request_parsed?(req)
       req && req.env[REQUEST_METHOD]
+    end
+
+    private
+
+    def log(str)
+      ioerr.puts str
+
+      ioerr.flush unless ioerr.sync
     end
   end
 end

--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -30,9 +30,6 @@ module Puma
       @stdout = stdout
       @stderr = stderr
 
-      @stdout.sync = true
-      @stderr.sync = true
-
       @debug = ENV.key? 'PUMA_DEBUG'
       @error_logger = ErrorLogger.new(@stderr)
 
@@ -66,6 +63,8 @@ module Puma
     #
     def log(str)
       @stdout.puts format(str) if @stdout.respond_to? :puts
+
+      @stdout.flush unless @stdout.sync
     rescue Errno::EPIPE
     end
 

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -106,8 +106,8 @@ module Puma
         end
 
         STDOUT.reopen stdout, (append ? "a" : "w")
-        STDOUT.sync = true
         STDOUT.puts "=== puma startup: #{Time.now} ==="
+        STDOUT.flush unless STDOUT.sync
       end
 
       if stderr
@@ -116,8 +116,8 @@ module Puma
         end
 
         STDERR.reopen stderr, (append ? "a" : "w")
-        STDERR.sync = true
         STDERR.puts "=== puma startup: #{Time.now} ==="
+        STDERR.flush unless STDERR.sync
       end
     end
 

--- a/test/test_error_logger.rb
+++ b/test/test_error_logger.rb
@@ -10,6 +10,14 @@ class TestErrorLogger < Minitest::Test
     assert_equal STDERR, error_logger.ioerr
   end
 
+
+  def test_stdio_respects_sync
+    error_logger = Puma::ErrorLogger.stdio
+
+    assert_equal STDERR.sync, error_logger.ioerr.sync
+    assert_equal STDERR, error_logger.ioerr
+  end
+
   def test_info_with_only_error
     _, err = capture_io do
       Puma::ErrorLogger.stdio.info(error: StandardError.new('ready'))

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -24,6 +24,15 @@ class TestEvents < Minitest::Test
     assert_equal STDERR, events.stderr
   end
 
+  def test_stdio_respects_sync
+    events = Puma::Events.stdio
+
+    assert_equal STDOUT.sync, events.stdout.sync
+    assert_equal STDERR.sync, events.stderr.sync
+    assert_equal STDOUT, events.stdout
+    assert_equal STDERR, events.stderr
+  end
+
   def test_register_callback_with_block
     res = false
 


### PR DESCRIPTION
### Description

Closes #1948 

Uses `flush` after writing to stdout and stderr so we don't need to use `sync=true`


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
