### PR TITLE
control_cli.rb - all normal output should be to @stdout

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@
 
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
+  * control_cli.rb - all normal output should be to @stdout (#2487)
   * Catch 'Error in reactor loop escaped: mode not supported for this object: r' (#2477)
   * Ignore Rails' reaper thread (and any thread marked forksafe) for warning ([#2475])
   * Ignore illegal (by Rack spec) response header ([#2439])

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -96,7 +96,7 @@ module Puma
         end
 
         o.on_tail("-V", "--version", "Show version") do
-          puts Const::PUMA_VERSION
+          @stdout.puts Const::PUMA_VERSION
           exit
         end
       end
@@ -236,14 +236,14 @@ module Puma
         sig = CMD_PATH_SIG_MAP[@command]
 
         if sig.nil?
-          puts "'#{@command}' not available via pid only"
+          @stdout.puts "'#{@command}' not available via pid only"
           return
         elsif sig.start_with? 'SIG'
           Process.kill sig, @pid
         elsif @command == 'status'
           begin
             Process.kill 0, @pid
-            puts 'Puma is started'
+            @stdout.puts 'Puma is started'
           rescue Errno::ESRCH
             raise 'Puma is not running'
           end


### PR DESCRIPTION
### Description

control_cli.rb (`Puma::ControlCLI.new`) takes a parameter to route output to (defaults to `STDOUT`).  Currently, all output is not routed to it.  Fixed.

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
