### PR TITLE
Fix JRuby ssl_cipher_list, add Puma::DSL.ssl_bind_str method

### DIFF
--- a/History.md
+++ b/History.md
@@ -11,6 +11,7 @@
 
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
+  * Fix JRuby handling in Puma::DSL#ssl_bind (#2489)
   * control_cli.rb - all normal output should be to @stdout (#2487)
   * Catch 'Error in reactor loop escaped: mode not supported for this object: r' (#2477)
   * Ignore Rails' reaper thread (and any thread marked forksafe) for warning ([#2475])

--- a/test/helpers/ssl.rb
+++ b/test/helpers/ssl.rb
@@ -10,4 +10,18 @@ module SSLHelper
       "key=#{@key}&cert=#{@cert}"
     end
   end
+
+  # sets and returns an opts hash for use with Puma::DSL.ssl_bind_str
+  def ssl_opts
+    @ssl_opts ||= if Puma.jruby?
+      @ssl_opts = {}
+      @ssl_opts[:keystore] = File.expand_path '../../examples/puma/keystore.jks', __dir__
+      @ssl_opts[:keystore_pass] = 'jruby_puma'
+      @ssl_opts[:ssl_cipher_list] = 'TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256'
+    else
+      @ssl_opts = {}
+      @ssl_opts[:cert] = File.expand_path '../../examples/puma/cert_puma.pem', __dir__
+      @ssl_opts[:key]  = File.expand_path '../../examples/puma/puma_keypair.pem', __dir__
+    end
+  end
 end


### PR DESCRIPTION
### Description

Fixes up Puma::DSL#ssl_bind, which did not handle JRuby `ssl_cipher_list`.

Adds a class method to Puma::DSL that creates the ssl bind string.  The method should be used in CI for generating bind strings.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.