### PR TITLE
Fail build if compiling extensions raises warnings (#1953)

### DIFF
--- a/.github/workflows/mri.yml
+++ b/.github/workflows/mri.yml
@@ -60,6 +60,10 @@ jobs:
         shell: bash
         run: echo 'DISABLE_SSL=true' >> $GITHUB_ENV
 
+      - name: set WERRORFLAG
+        shell: bash
+        run: echo 'MAKE_WARNINGS_INTO_ERRORS=true' >> $GITHUB_ENV
+
       - name: compile
         run:  bundle exec rake compile
 

--- a/.github/workflows/non_mri.yml
+++ b/.github/workflows/non_mri.yml
@@ -54,6 +54,10 @@ jobs:
         shell: bash
         run: echo 'DISABLE_SSL=true' >> $GITHUB_ENV
 
+      - name: set WERRORFLAG
+        shell: bash
+        run: echo 'MAKE_WARNINGS_INTO_ERRORS=true' >> $GITHUB_ENV
+
       - name: compile
         run:  bundle exec rake compile
 

--- a/History.md
+++ b/History.md
@@ -2,9 +2,11 @@
 
 * Features
   * Your feature goes here <Most recent on the top, like GitHub> (#Github Number)
+  * Fail build if compiling extensions raises warnings ([#1953])
 
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
+  * Fix all compiler warnings reported in mini_ssl source code ([#1953])
 
 ## 5.1.0 / 2020-11-30
 

--- a/History.md
+++ b/History.md
@@ -2,11 +2,12 @@
 
 * Features
   * Your feature goes here <Most recent on the top, like GitHub> (#Github Number)
-  * Fail build if compiling extensions raises warnings ([#1953])
+  * Fail build if compiling extensions raises warnings on GH Actions ([#1953])
+  * Add MAKE_WARNINGS_INTO_ERRORS environment variable to toggle whether a build should treat all warnings into errors or not ([#1953])
 
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
-  * Fix all compiler warnings reported in mini_ssl source code ([#1953])
+  * Fix compiler warnings, but skipped warnings related to ragel state machine generated code ([#1953])
 
 ## 5.1.0 / 2020-11-30
 

--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -27,10 +27,12 @@ end
 
 if ENV["MAKE_WARNINGS_INTO_ERRORS"]
   # Make all warnings into errors
+  # Except `implicit-fallthrough` since most failures comes from ragel state machine generated code
   if respond_to? :append_cflags
     append_cflags config_string 'WERRORFLAG'
+    append_cflags '-Wno-implicit-fallthrough'
   else
-    $CFLAGS += ' ' << (config_string 'WERRORFLAG')
+    $CFLAGS += ' ' << (config_string 'WERRORFLAG') << ' -Wno-implicit-fallthrough'
   end
 end
 

--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -3,7 +3,11 @@ require 'mkmf'
 dir_config("puma_http11")
 
 # Make all warnings into errors
-append_cflags config_string 'WERRORFLAG'
+if respond_to? :append_cflags
+  append_cflags config_string 'WERRORFLAG'
+else
+  $CFLAGS += ' ' << (config_string 'WERRORFLAG')
+end
 
 if $mingw && RUBY_VERSION >= '2.4'
   append_cflags  '-fstack-protector-strong -D_FORTIFY_SOURCE=2'

--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -2,13 +2,6 @@ require 'mkmf'
 
 dir_config("puma_http11")
 
-# Make all warnings into errors
-if respond_to? :append_cflags
-  append_cflags config_string 'WERRORFLAG'
-else
-  $CFLAGS += ' ' << (config_string 'WERRORFLAG')
-end
-
 if $mingw && RUBY_VERSION >= '2.4'
   append_cflags  '-fstack-protector-strong -D_FORTIFY_SOURCE=2'
   append_ldflags '-fstack-protector-strong -l:libssp.a'
@@ -29,6 +22,15 @@ unless ENV["DISABLE_SSL"]
     # below are yes for 1.1.0 & later
     have_func  "TLS_server_method"                     , "openssl/ssl.h"
     have_func  "SSL_CTX_set_min_proto_version(NULL, 0)", "openssl/ssl.h"
+  end
+end
+
+if ENV["MAKE_WARNINGS_INTO_ERRORS"]
+  # Make all warnings into errors
+  if respond_to? :append_cflags
+    append_cflags config_string 'WERRORFLAG'
+  else
+    $CFLAGS += ' ' << (config_string 'WERRORFLAG')
   end
 end
 

--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -2,6 +2,9 @@ require 'mkmf'
 
 dir_config("puma_http11")
 
+# Make all warnings into errors
+append_cflags config_string 'WERRORFLAG'
+
 if $mingw && RUBY_VERSION >= '2.4'
   append_cflags  '-fstack-protector-strong -D_FORTIFY_SOURCE=2'
   append_ldflags '-fstack-protector-strong -l:libssp.a'

--- a/ext/puma_http11/http11_parser.c
+++ b/ext/puma_http11/http11_parser.c
@@ -43,9 +43,6 @@ static const int puma_parser_start = 1;
 static const int puma_parser_first_final = 46;
 static const int puma_parser_error = 0;
 
-static const int puma_parser_en_main = 1;
-
-
 #line 85 "ext/puma_http11/http11_parser.rl"
 
 int puma_parser_init(puma_parser *parser)  {

--- a/ext/puma_http11/http11_parser.c
+++ b/ext/puma_http11/http11_parser.c
@@ -43,12 +43,13 @@ static const int puma_parser_start = 1;
 static const int puma_parser_first_final = 46;
 static const int puma_parser_error = 0;
 
+
 #line 85 "ext/puma_http11/http11_parser.rl"
 
 int puma_parser_init(puma_parser *parser)  {
   int cs = 0;
   
-#line 55 "ext/puma_http11/http11_parser.c"
+#line 53 "ext/puma_http11/http11_parser.c"
 	{
 	cs = puma_parser_start;
 	}
@@ -82,7 +83,7 @@ size_t puma_parser_execute(puma_parser *parser, const char *buffer, size_t len, 
   assert((size_t) (pe - p) == len - off && "pointers aren't same distance");
 
   
-#line 89 "ext/puma_http11/http11_parser.c"
+#line 87 "ext/puma_http11/http11_parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -113,7 +114,7 @@ st2:
 	if ( ++p == pe )
 		goto _test_eof2;
 case 2:
-#line 120 "ext/puma_http11/http11_parser.c"
+#line 118 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr2;
 		case 36: goto st27;
@@ -138,7 +139,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 145 "ext/puma_http11/http11_parser.c"
+#line 143 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 42: goto tr4;
 		case 43: goto tr5;
@@ -162,7 +163,7 @@ st4:
 	if ( ++p == pe )
 		goto _test_eof4;
 case 4:
-#line 169 "ext/puma_http11/http11_parser.c"
+#line 167 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr8;
 		case 35: goto tr9;
@@ -224,7 +225,7 @@ st5:
 	if ( ++p == pe )
 		goto _test_eof5;
 case 5:
-#line 231 "ext/puma_http11/http11_parser.c"
+#line 229 "ext/puma_http11/http11_parser.c"
 	if ( (*p) == 72 )
 		goto tr10;
 	goto st0;
@@ -236,7 +237,7 @@ st6:
 	if ( ++p == pe )
 		goto _test_eof6;
 case 6:
-#line 243 "ext/puma_http11/http11_parser.c"
+#line 241 "ext/puma_http11/http11_parser.c"
 	if ( (*p) == 84 )
 		goto st7;
 	goto st0;
@@ -317,7 +318,7 @@ st14:
 	if ( ++p == pe )
 		goto _test_eof14;
 case 14:
-#line 324 "ext/puma_http11/http11_parser.c"
+#line 322 "ext/puma_http11/http11_parser.c"
 	if ( (*p) == 10 )
 		goto st15;
 	goto st0;
@@ -368,7 +369,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 375 "ext/puma_http11/http11_parser.c"
+#line 373 "ext/puma_http11/http11_parser.c"
 	goto st0;
 tr21:
 #line 40 "ext/puma_http11/http11_parser.rl"
@@ -384,7 +385,7 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 391 "ext/puma_http11/http11_parser.c"
+#line 389 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 33: goto tr23;
 		case 58: goto tr24;
@@ -423,7 +424,7 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 430 "ext/puma_http11/http11_parser.c"
+#line 428 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 13: goto tr26;
 		case 32: goto tr27;
@@ -437,7 +438,7 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 444 "ext/puma_http11/http11_parser.c"
+#line 442 "ext/puma_http11/http11_parser.c"
 	if ( (*p) == 13 )
 		goto tr29;
 	goto st19;
@@ -483,7 +484,7 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 490 "ext/puma_http11/http11_parser.c"
+#line 488 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr31;
 		case 60: goto st0;
@@ -504,7 +505,7 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 511 "ext/puma_http11/http11_parser.c"
+#line 509 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr33;
 		case 60: goto st0;
@@ -525,7 +526,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 532 "ext/puma_http11/http11_parser.c"
+#line 530 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 43: goto st22;
 		case 58: goto st23;
@@ -550,7 +551,7 @@ st23:
 	if ( ++p == pe )
 		goto _test_eof23;
 case 23:
-#line 557 "ext/puma_http11/http11_parser.c"
+#line 555 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr8;
 		case 34: goto st0;
@@ -570,7 +571,7 @@ st24:
 	if ( ++p == pe )
 		goto _test_eof24;
 case 24:
-#line 577 "ext/puma_http11/http11_parser.c"
+#line 575 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr37;
 		case 34: goto st0;
@@ -593,7 +594,7 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 600 "ext/puma_http11/http11_parser.c"
+#line 598 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr41;
 		case 34: goto st0;
@@ -613,7 +614,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 620 "ext/puma_http11/http11_parser.c"
+#line 618 "ext/puma_http11/http11_parser.c"
 	switch( (*p) ) {
 		case 32: goto tr44;
 		case 34: goto st0;

--- a/ext/puma_http11/http11_parser.java.rl
+++ b/ext/puma_http11/http11_parser.java.rl
@@ -58,7 +58,7 @@ public class Http11Parser {
 }%%
 
 /** Data **/
-%% write data;
+%% write data noentry;
 
    public static interface ElementCB {
      public void call(Ruby runtime, RubyHash data, ByteList buffer, int at, int length);

--- a/ext/puma_http11/http11_parser.rl
+++ b/ext/puma_http11/http11_parser.rl
@@ -81,7 +81,7 @@ static void snake_upcase_char(char *c)
 }%%
 
 /** Data **/
-%% write data;
+%% write data noentry;
 
 int puma_parser_init(puma_parser *parser)  {
   int cs = 0;

--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -567,9 +567,10 @@ void Init_mini_ssl(VALUE puma) {
 
 #else
 
+NORETURN(VALUE raise_error(VALUE self));
+
 VALUE raise_error(VALUE self) {
   rb_raise(rb_eStandardError, "SSL not available in this build");
-  return Qnil;
 }
 
 void Init_mini_ssl(VALUE puma) {

--- a/ext/puma_http11/org/jruby/puma/Http11Parser.java
+++ b/ext/puma_http11/org/jruby/puma/Http11Parser.java
@@ -182,8 +182,6 @@ static final int puma_parser_start = 1;
 static final int puma_parser_first_final = 46;
 static final int puma_parser_error = 0;
 
-static final int puma_parser_en_main = 1;
-
 
 // line 62 "ext/puma_http11/http11_parser.java.rl"
 
@@ -212,12 +210,12 @@ static final int puma_parser_en_main = 1;
           cs = 0;
 
           
-// line 218 "ext/puma_http11/org/jruby/puma/Http11Parser.java"
+// line 214 "ext/puma_http11/org/jruby/puma/Http11Parser.java"
 	{
 	cs = puma_parser_start;
 	}
 
-// line 90 "ext/puma_http11/http11_parser.java.rl"
+// line 88 "ext/puma_http11/http11_parser.java.rl"
 
           body_start = 0;
           content_len = 0;
@@ -244,7 +242,7 @@ static final int puma_parser_en_main = 1;
      parser.buffer = buffer;
 
      
-// line 250 "ext/puma_http11/org/jruby/puma/Http11Parser.java"
+// line 246 "ext/puma_http11/org/jruby/puma/Http11Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -400,7 +398,7 @@ case 1:
     { p += 1; _goto_targ = 5; if (true)  continue _goto;}
   }
 	break;
-// line 406 "ext/puma_http11/org/jruby/puma/Http11Parser.java"
+// line 402 "ext/puma_http11/org/jruby/puma/Http11Parser.java"
 			}
 		}
 	}
@@ -420,7 +418,7 @@ case 5:
 	break; }
 	}
 
-// line 116 "ext/puma_http11/http11_parser.java.rl"
+// line 114 "ext/puma_http11/http11_parser.java.rl"
 
      parser.cs = cs;
      parser.nread += (p - off);


### PR DESCRIPTION
### Description
Added `append_cflags config_string 'WERRORFLAG'` into extconf to instruct compiler to consider warnings as errors. Also fixed all warnings reported by GCC with default configuration.

Closes #1953.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
