### PR TITLE
Bug: Fix Events#fire_on_stopped! double call [changelog skip]

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -139,7 +139,6 @@ module Puma
 
     # Begin async shutdown of the server gracefully
     def stop
-      @events.fire_on_stopped!
       @status = :stop
       @runner.stop
     end


### PR DESCRIPTION
### Description

Currently, `Events#fire_on_stopped!` is called in both `Launcher#stop` and `Launcher#graceful_stop`

Launcher#graceful_stop is called later in Launcher#run, remove the call from `Launcher#stop`.


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
