### PR TITLE
Bug: Fix regex warnings in const.rb & test_launcher.rb [changelog skip]

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -240,9 +240,10 @@ module Puma
 
     # Illegal character in the key or value of response header
     DQUOTE = "\"".freeze
-    HTTP_HEADER_DELIMITER = Regexp.escape("(),/:;<=>?@[]{}").freeze
-    ILLEGAL_HEADER_KEY_REGEX = /(\u0000-\u0025|#{DQUOTE}|#{HTTP_HEADER_DELIMITER})/.freeze
-    ILLEGAL_HEADER_VALUE_REGEX = /[\000-\037]/.freeze
+    HTTP_HEADER_DELIMITER = Regexp.escape("(),/:;<=>?@[]{}\\").freeze
+    ILLEGAL_HEADER_KEY_REGEX = /[\x00-\x20#{DQUOTE}#{HTTP_HEADER_DELIMITER}]/.freeze
+    # header values can contain HTAB?
+    ILLEGAL_HEADER_VALUE_REGEX = /[\x00-\x08\x0A-\x1F]/.freeze
 
     # Banned keys of response header
     BANNED_HEADER_KEY = /rack.|status/.freeze

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -171,7 +171,7 @@ class TestLauncher < Minitest::Test
   end
 
   def test_log_config_disabled
-    refute_match /Configuration:/, launcher.events.stdout.string
+    refute_match(/Configuration:/, launcher.events.stdout.string)
   end
 
   private


### PR DESCRIPTION
### Description

Fix `Puma::Const::ILLEGAL_HEADER_KEY_REGEX` overlap warning

Add backslash as illegal character for header field-name

See https://github.com/puma/puma/pull/2495 and https://github.com/puma/puma/pull/2439

Update `test_launcher.rb`, use parenthesis with regex parameters, removes warning

Re headers, see:

7320 Header Fields
https://tools.ietf.org/html/rfc7230#section-3.2

Tokens
https://tools.ietf.org/html/rfc7230#section-3.2.6
ABNF
https://tools.ietf.org/html/rfc7230#appendix-B
See table from below
http://www.bizcoder.com/everything-you-need-to-know-about-http-header-syntax-but-were-afraid-to-ask#footnote3

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
