### PR TITLE
Bug: extconf.rb - fixup for 1.1.1 change from 1.1.0 [changelog skip]

### DIFF
--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -17,12 +17,11 @@ unless ENV["DISABLE_SSL"]
     have_header "openssl/bio.h"
 
     # below is  yes for 1.0.2 & later
-    have_func  "DTLS_method"                  , "openssl/ssl.h"
+    have_func  "DTLS_method"                           , "openssl/ssl.h"
 
-    # below are yes for 1.1.0 & later, may need to check func rather than macro
-    # with versions after 1.1.1
-    have_func  "TLS_server_method"            , "openssl/ssl.h"
-    have_macro "SSL_CTX_set_min_proto_version", "openssl/ssl.h"
+    # below are yes for 1.1.0 & later
+    have_func  "TLS_server_method"                     , "openssl/ssl.h"
+    have_func  "SSL_CTX_set_min_proto_version(NULL, 0)", "openssl/ssl.h"
   end
 end
 


### PR DESCRIPTION
### Description

extconf.rb - fixup for OpenSSL 1.1.1, change from 1.1.0.  Removes one compile warning when building on newer gcc versions.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
