### PR TITLE
Add pid to start-up log output, name control server thread 'control' [changelog skip]

### DIFF
--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -59,7 +59,7 @@ module Puma
 
       control.binder.parse [str], self, 'Starting control server'
 
-      control.run
+      control.run thread_name: 'control'
       @control = control
     end
 
@@ -85,10 +85,11 @@ module Puma
       min_t = @options[:min_threads]
       max_t = @options[:max_threads]
 
-      log "Puma starting in #{mode} mode..."
-      log "* Version #{Puma::Const::PUMA_VERSION} (#{ruby_engine}), codename: #{Puma::Const::CODE_NAME}"
-      log "* Min threads: #{min_t}, max threads: #{max_t}"
-      log "* Environment: #{ENV['RACK_ENV']}"
+      log "Puma starting in #{mode} mode...\n" \
+          "* Version #{Puma::Const::PUMA_VERSION} (#{ruby_engine}), codename: #{Puma::Const::CODE_NAME}\n" \
+          "* Min threads: #{min_t}, max threads: #{max_t}\n" \
+          "* Environment: #{ENV['RACK_ENV']}\n" \
+          "*         Pid: #{Process.pid}"
     end
 
     def redirected_io?

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -219,7 +219,7 @@ module Puma
     # up in the background to handle requests. Otherwise requests
     # are handled synchronously.
     #
-    def run(background=true)
+    def run(background=true, thread_name: 'server')
       BasicSocket.do_not_reverse_lookup = true
 
       @events.fire :state, :booting
@@ -255,7 +255,7 @@ module Puma
 
       if background
         @thread = Thread.new do
-          Puma.set_thread_name "server"
+          Puma.set_thread_name thread_name
           handle_servers
         end
         return @thread


### PR DESCRIPTION
### Description

Simple PR that does two things:

1. Add the master pid to Puma's startup log output.  All other information needed is already included.

2. Changes the name of the control server thread to 'control'.  Previously named 'server'.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
