### PR TITLE
Fix typo in local #define name [changelog skip]

### DIFF
--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -41,8 +41,8 @@ static VALUE global_request_path;
 
 /** Defines common length and error messages for input length validation. */
 #define QUOTE(s) #s
-#define EXPLAND_MAX_LENGHT_VALUE(s) QUOTE(s)
-#define DEF_MAX_LENGTH(N,length) const size_t MAX_##N##_LENGTH = length; const char *MAX_##N##_LENGTH_ERR = "HTTP element " # N  " is longer than the " EXPLAND_MAX_LENGHT_VALUE(length) " allowed length (was %d)"
+#define EXPLAIN_MAX_LENGTH_VALUE(s) QUOTE(s)
+#define DEF_MAX_LENGTH(N,length) const size_t MAX_##N##_LENGTH = length; const char *MAX_##N##_LENGTH_ERR = "HTTP element " # N  " is longer than the " EXPLAIN_MAX_LENGTH_VALUE(length) " allowed length (was %d)"
 
 /** Validates the max length of given input and throws an HttpParserError exception if over. */
 #define VALIDATE_MAX_LENGTH(len, N) if(len > MAX_##N##_LENGTH) { rb_raise(eHttpParserError, MAX_##N##_LENGTH_ERR, len); }


### PR DESCRIPTION
### Description

This PR changes the name of a locally-defined `#define`, used to quote an explanation.

The definition `EXPLAIN_MAX_LENGTH_VALUE` is only used right here, so this is not a functional change, just spelling. See #2485


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
