### PR TITLE
[doc] plugins: Add note about Heroku plugin sunset [ci skip]

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -8,7 +8,7 @@ operations.
 * [tmp\_restart](https://github.com/puma/puma/blob/master/lib/puma/plugin/tmp_restart.rb):
   Restarts the server if the file `tmp/restart.txt` is touched
 * [heroku](https://github.com/puma/puma-heroku/blob/master/lib/puma/plugin/heroku.rb):
-  Packages up the default configuration used by puma on Heroku
+  Packages up the default configuration used by puma on Heroku (being sunset with the release of Puma 5.0)
 
 Plugins are activated in a puma configuration file (such as `config/puma.rb'`)
 by adding `plugin "name"`, such as `plugin "heroku"`.


### PR DESCRIPTION


### Description

This PR adds a note to the Puma docs that heroku plugin is no longer a current need.

I didn't change more of the text, since the example plugin "heroku" was good at not being a built-in plugin, so the examples were better off keeping it, until a new non-built-in plugin has been added.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
