### PR TITLE
Make illegal header matching more stringent

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
   * Fix compiler warnings, but skipped warnings related to ragel state machine generated code ([#1953])
+  * Fix over eager matching against banned header names ([#2510])
 
 ## 5.1.0 / 2020-11-30
 
@@ -1680,6 +1681,7 @@ be added back in a future date when a java Puma::MiniSSL is added.
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
 
+[#2510]:https://github.com/puma/puma/pull/2510     "PR by @micke"
 [#2472]:https://github.com/puma/puma/pull/2472     "PR by @ccverak, merged 2020-11-02"
 [#2438]:https://github.com/puma/puma/pull/2438     "PR by @ekohl, merged 2020-10-26"
 [#2406]:https://github.com/puma/puma/pull/2406     "PR by @fdel15, merged 2020-10-19"

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -246,6 +246,6 @@ module Puma
     ILLEGAL_HEADER_VALUE_REGEX = /[\x00-\x08\x0A-\x1F]/.freeze
 
     # Banned keys of response header
-    BANNED_HEADER_KEY = /rack.|status/.freeze
+    BANNED_HEADER_KEY = /\A(rack\.|status\z)/.freeze
   end
 end

--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -87,11 +87,26 @@ class TestResponseHeader < Minitest::Test
     assert_ignore_header("Status", "500")
   end
 
+  # The header key can contain the word status.
+  def test_key_containing_status
+    server_run app: ->(env) { [200, {'Teapot-Status' => 'Boiling'}, []] }
+    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+
+    assert_match(/HTTP\/1.0 200 OK\r\nTeapot-Status: Boiling\r\n\r\n/, data)
+  end
+
   # Special headers starting “rack.” are for communicating with the server, and must not be sent back to the client.
   def test_rack_key
     assert_ignore_header("rack.command_to_server_only", "work")
   end
 
+  # The header key can still start with the word rack
+  def test_racket_key
+    server_run app: ->(env) { [200, {'Racket' => 'Bouncy'}, []] }
+    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+
+    assert_match(/HTTP\/1.0 200 OK\r\nRacket: Bouncy\r\n\r\n/, data)
+  end
 
   # testing header key must conform rfc token specification
   # i.e. cannot contain non-printable ASCII, DQUOTE or “(),/:;<=>?@[]{}”.


### PR DESCRIPTION
### Description
This PR fixes some false positive matches that was introduced in https://github.com/puma/puma/pull/2439

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
