### PR TITLE
[ci skip] Improve quoting of bundle cflags

### DIFF
--- a/docs/compile_options.md
+++ b/docs/compile_options.md
@@ -15,5 +15,5 @@ gem install puma -- --with-cflags="-D PUMA_QUERY_STRING_MAX_LENGTH=64000"
 For Bundler, use its configuration system:
 
 ```
-bundle config build.puma --with-cflags="-D PUMA_QUERY_STRING_MAX_LENGTH=64000"
+bundle config build.puma "--with-cflags='-D PUMA_QUERY_STRING_MAX_LENGTH=64000'"
 ```


### PR DESCRIPTION
Ensure that the full cflags option is quoted when
using bundle install

Without this, compilation would fail with this error:

Installing puma 5.1.1 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/puma-5.1.1/ext/puma_http11
/usr/local/bin/ruby -I /usr/local/lib/ruby/2.7.0 -r
./siteconf20201214-9-1yhulk9.rb extconf.rb --with-cflags\=-D
PUMA_QUERY_STRING_MAX_LENGTH\=64000
checking for BIO_read() in -lcrypto... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
