### PR TITLE
Remove nio from status server

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
   * Fix compiler warnings, but skipped warnings related to ragel state machine generated code ([#1953])
+  * Fix phased restart errors related to nio4r gem when using the Puma control server (#2516)
 
 
 ## 5.1.1 / 2020-12-10

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -55,7 +55,7 @@ module Puma
       app = Puma::App::Status.new @launcher, token
 
       control = Puma::Server.new app, @launcher.events,
-        { min_threads: 0, max_threads: 1 }
+        { min_threads: 0, max_threads: 1, queue_requests: false }
 
       control.binder.parse [str], self, 'Starting control server'
 

--- a/test/config/prune_bundler_print_nio_defined.rb
+++ b/test/config/prune_bundler_print_nio_defined.rb
@@ -1,0 +1,4 @@
+prune_bundler true
+before_fork do
+  puts "defined?(::NIO): #{defined?(::NIO).inspect}"
+end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -283,6 +283,25 @@ RUBY
     assert_match(/defined\?\(::JSON\): nil/, line)
   end
 
+  def test_nio4r_gem_not_required_in_master_process
+    cli_server "-w #{workers} -C test/config/prune_bundler_print_nio_defined.rb test/rackup/hello.ru"
+
+    line = @server.gets
+    assert_match(/defined\?\(::NIO\): nil/, line)
+  end
+
+  def test_nio4r_gem_not_required_in_master_process_when_using_control_server
+    @control_tcp_port = UniquePort.call
+    control_opts = "--control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN}"
+    cli_server "-w #{workers} #{control_opts} -C test/config/prune_bundler_print_nio_defined.rb test/rackup/hello.ru"
+
+    line = @server.gets
+    assert_match(/Starting control server/, line)
+
+    line = @server.gets
+    assert_match(/defined\?\(::NIO\): nil/, line)
+  end
+
   def test_application_is_loaded_exactly_once_if_using_preload_app
     cli_server "-w #{workers} --preload test/rackup/write_to_stdout_on_boot.ru"
 


### PR DESCRIPTION
### Description

There's a bug related to https://github.com/puma/puma/issues/2018. Essentially, if the `nio4r` gem is ever loaded into the puma master process, it makes it impossible to do things like upgrade `nio4r` during a phased restart and also makes it impossible to remove the gems from disk without breaking phased restarts. Those problems were addressed mostly by my own https://github.com/puma/puma/pull/2427. 

In PR #2427, I was pretty sure I made it so that if you're running a puma cluster with `--prune-bundler`, the puma master process would never load `nio4r`. It turns out that actually, if you enable the status server, the puma master process ends up loading `nio4r` -- the status server is launched in a _thread_ in the master process. Since the status server just uses its own instance of `Puma::Server`, that ends up using a Reactor, which, in turn requires the `nio4r` gem.

The user impact is that if you're using the status server,
1. you can't upgrade nio4r in a phased restart
2. you can't safely delete the specific version of the nio4r native extensions from disk from previous releases
3. worker processes unexpectedly double-load the `nio4r` gem. I don't know what the implications are for this last one, but in general, it's probably not good to double-load any gem.

There are a bunch of different creative solutions to this problem, but I think the easiest is probably to just disable `queue_requests` for the `Puma::Server` that serves the status server. Disabling that setting _probably_ doesn't introduce a DOS vector since you probably shouldn't have your puma status server exposed to the public anyway--only trusted clients should have access.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [X] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [X] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
