### PR TITLE
Fix SSL Context - minissl.c, minissl.rb, extconf.rb

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 * Features
   * Your feature goes here <Most recent on the top, like GitHub> (#Github Number)
+  * 10x latency improvement for MRI on ssl connections by reducing overhead (#2519)
   * Add option to specify the desired IO selector backend for libev ([#2522])
   * Add ability to set OpenSSL verification flags (MRI only) ([#2490])
   * Uses `flush` after writing messages to avoid mutating $stdout and $stderr using `sync=true` ([#2486])
@@ -16,6 +17,7 @@
   * Fix binding via Rack handler to IPv6 addresses (#2521)
 
 * Refactor
+  * Refactor MiniSSL::Context on MRI, fix MiniSSL::Socket#write (#2519)
   * Remove `Server#read_body` ([#2531])
   * Fail build if compiling extensions raises warnings on GH Actions, configurable via `MAKE_WARNINGS_INTO_ERRORS` ([#1953])
 

--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -22,6 +22,9 @@ unless ENV["DISABLE_SSL"]
     # below are yes for 1.1.0 & later
     have_func  "TLS_server_method"                     , "openssl/ssl.h"
     have_func  "SSL_CTX_set_min_proto_version(NULL, 0)", "openssl/ssl.h"
+
+    have_func  "X509_STORE_up_ref"
+    have_func("SSL_CTX_set_ecdh_auto(NULL, 0)", "openssl/ssl.h")
   end
 end
 


### PR DESCRIPTION
### Description

While working on an update to the test suite, client connections were slow with ssl tests.  

Currently, a new context is created for each accepted client connection.  A context also reads two files for the cert and key.

Refactored to use one context created in MiniSSL::Server.new.

Code is included in a `misc` folder that reports on the times needed to open the socket and write a simple request.  It logs the time of each client's GET request, each having about a 100k body, then sorts the times, and outputs percentile times.  See the socket_times.md in the misc folder for info.

Times for this PR (see 'test ssl connection times` step):

https://github.com/MSP-Greg/puma/actions/runs/453868127

Times for current master:

https://github.com/MSP-Greg/puma/actions/runs/453894649

The CI for the PR has an additional 'test tcp connection times' step, which helps tell the two apart.

Times for this PR are approx two to three times faster than master on both Ubuntu & macOS.

But, there are a few odd things:

1. Checking it locally with Windows WSL2/Ubuntu, I noticed a larger speed increase, but that may be specific to that implementation.  Oddly, the tcp times were almost the same as Actions CI.

2. The longest macOS times are really high with the PR, compared to master.  Not sure about what could be causing the issue.

I'd appreciate if anyone running *nix or macOS natively can check the results.

To run locally, compile Puma, then (from the Puma folder) run `misc/run_socket_times.sh`.  Save the misc folder in master, and the tests will also run there.  You may need to run the following:
```
chmod +x ./misc/run_ssl_socket_times.sh
```

For more info on running `misc/run_socket_times.sh`, see [`socket_times.md`](https://github.com/puma/puma/blob/4aa4d05a41ad/misc/socket_times.md)

Note that the last three commits may be removed for the PR...

Thanks, and Happy New Year, Greg

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
