### PR TITLE
Add #string method to Puma::NullIO

### DIFF
--- a/History.md
+++ b/History.md
@@ -11,13 +11,13 @@
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
   * Fix compiler warnings, but skipped warnings related to ragel state machine generated code ([#1953])
   * Fix phased restart errors related to nio4r gem when using the Puma control server (#2516)
-
+  * Add `#string` method to `Puma::NullIO` ([#2520])
 
 ## 5.1.1 / 2020-12-10
 
-* Bugfixes 
+* Bugfixes
   * Fix over eager matching against banned header names ([#2510])
-  
+
 ## 5.1.0 / 2020-11-30
 
 * Features
@@ -1687,6 +1687,7 @@ be added back in a future date when a java Puma::MiniSSL is added.
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
 
+[#2520]:https://github.com/puma/puma/pull/2520     "PR by @dentarg"
 [#2510]:https://github.com/puma/puma/pull/2510     "PR by @micke"
 [#2472]:https://github.com/puma/puma/pull/2472     "PR by @ccverak, merged 2020-11-02"
 [#2438]:https://github.com/puma/puma/pull/2438     "PR by @ekohl, merged 2020-10-26"

--- a/lib/puma/null_io.rb
+++ b/lib/puma/null_io.rb
@@ -9,6 +9,10 @@ module Puma
       nil
     end
 
+    def string
+      ""
+    end
+
     def each
     end
 

--- a/test/test_null_io.rb
+++ b/test/test_null_io.rb
@@ -21,6 +21,10 @@ class TestNullIO < Minitest::Test
     assert_nil nio.gets
   end
 
+  def test_string_returns_empty_string
+    assert_equal "", nio.string
+  end
+
   def test_each_never_yields
     nio.instance_variable_set(:@foo, :baz)
     nio.each { @foo = :bar }


### PR DESCRIPTION
### Description

Makes Puma::NullIO more similar to [StringIO].

[StringIO]: https://docs.ruby-lang.org/en/2.5.0/StringIO.html#method-i-string

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
