### PR TITLE
Build proper url instead of interpolating in `Puma::DSL#port`

### DIFF
--- a/History.md
+++ b/History.md
@@ -12,6 +12,7 @@
   * Fix compiler warnings, but skipped warnings related to ragel state machine generated code ([#1953])
   * Fix phased restart errors related to nio4r gem when using the Puma control server (#2516)
   * Add `#string` method to `Puma::NullIO` ([#2520])
+  * Fix binding via Rack handler to IPv6 addresses (#2521)
 
 ## 5.1.1 / 2020-12-10
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -257,7 +257,7 @@ module Puma
     #   port 9292
     def port(port, host=nil)
       host ||= default_host
-      bind "tcp://#{host}:#{port}"
+      bind URI::Generic.build(scheme: 'tcp', host: host, port: Integer(port)).to_s
     end
 
     # Define how long persistent connections can be idle before Puma closes them.

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -95,6 +95,14 @@ class TestUserSuppliedOptionsHostIsSet < Minitest::Test
 
     assert_equal ["tcp://#{user_host}:#{user_port}"], conf.options[:binds]
   end
+
+  def test_ipv6_host_supplied_port_default
+    @options[:Host] = "::1"
+    conf = Rack::Handler::Puma.config(->{}, @options)
+    conf.load
+
+    assert_equal ["tcp://[::1]:9292"], conf.options[:binds]
+  end
 end
 
 class TestUserSuppliedOptionsIsEmpty < Minitest::Test


### PR DESCRIPTION

### Description
Fixes the issue with running puma handler with `Host: '::1'`, right now we have a backtrace, since `[::1]` should be used as a hostname in URIs.
```
$ bundle exec rails s -u puma -b '::1'
=> Booting Puma
=> Rails 6.0.3.4 application starting in development
=> Run `rails server --help` for more startup options
Puma starting in single mode...
* Puma version: 5.1.1 (ruby 2.7.2-p137) ("At Your Service")
*  Min threads: 5
*  Max threads: 5
*  Environment: development
*          PID: 9014
Exiting
Traceback (most recent call last):
…
	10: from /home/ojab/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/server.rb:327:in `start'
	 9: from /home/ojab/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/puma-5.1.1/lib/rack/handler/puma.rb:71:in `run'
	 8: from /home/ojab/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/puma-5.1.1/lib/puma/launcher.rb:182:in `run'
	 7: from /home/ojab/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/puma-5.1.1/lib/puma/single.rb:44:in `run'
	 6: from /home/ojab/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/puma-5.1.1/lib/puma/runner.rb:144:in `load_and_bind'
	 5: from /home/ojab/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/puma-5.1.1/lib/puma/binder.rb:152:in `parse'
	 4: from /home/ojab/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/puma-5.1.1/lib/puma/binder.rb:152:in `each'
	 3: from /home/ojab/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/puma-5.1.1/lib/puma/binder.rb:153:in `block in parse'
	 2: from /home/ojab/.rbenv/versions/2.7.2/lib/ruby/2.7.0/uri/common.rb:234:in `parse'
	 1: from /home/ojab/.rbenv/versions/2.7.2/lib/ruby/2.7.0/uri/rfc3986_parser.rb:73:in `parse'
/home/ojab/.rbenv/versions/2.7.2/lib/ruby/2.7.0/uri/rfc3986_parser.rb:67:in `split': bad URI(is not URI?): "tcp://::1:3000" (URI::InvalidURIError)
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
