### PR TITLE
Allow specifying the desired IO selector backend for nio4r

### DIFF
--- a/History.md
+++ b/History.md
@@ -16,9 +16,9 @@
 
 ## 5.1.1 / 2020-12-10
 
-* Bugfixes
+* Bugfixes 
   * Fix over eager matching against banned header names ([#2510])
-
+  
 ## 5.1.0 / 2020-11-30
 
 * Features

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 * Features
   * Your feature goes here <Most recent on the top, like GitHub> (#Github Number)
+  * Add option to specify the desired IO selector backend for libev ([#pending])
   * Add ability to set OpenSSL verification flags (MRI only) ([#2490])
   * Uses `flush` after writing messages to avoid mutating $stdout and $stderr using `sync=true` ([#2486])
   * Fail build if compiling extensions raises warnings on GH Actions ([#1953])
@@ -15,9 +16,9 @@
 
 ## 5.1.1 / 2020-12-10
 
-* Bugfixes 
+* Bugfixes
   * Fix over eager matching against banned header names ([#2510])
-  
+
 ## 5.1.0 / 2020-11-30
 
 * Features

--- a/History.md
+++ b/History.md
@@ -2,7 +2,7 @@
 
 * Features
   * Your feature goes here <Most recent on the top, like GitHub> (#Github Number)
-  * Add option to specify the desired IO selector backend for libev ([#pending])
+  * Add option to specify the desired IO selector backend for libev ([#2522])
   * Add ability to set OpenSSL verification flags (MRI only) ([#2490])
   * Uses `flush` after writing messages to avoid mutating $stdout and $stderr using `sync=true` ([#2486])
   * Fail build if compiling extensions raises warnings on GH Actions ([#1953])

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -205,7 +205,8 @@ module Puma
         :persistent_timeout => Const::PERSISTENT_TIMEOUT,
         :first_data_timeout => Const::FIRST_DATA_TIMEOUT,
         :raise_exception_on_sigterm => true,
-        :max_fast_inline => Const::MAX_FAST_INLINE
+        :max_fast_inline => Const::MAX_FAST_INLINE,
+        :io_selector_backend => :auto
       }
     end
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -866,9 +866,18 @@ module Puma
       @options[:max_fast_inline] = Float(num_of_requests)
     end
 
-    # Change the backend for the IO selector.
+    # Specify the backend for the IO selector.
     #
-    # The default is +:auto+ which will let nio4r choose the backend.
+    # Provided values will be passed directly to +NIO::Selector.new+, with the
+    # exception of +:auto+ which will let nio4r choose the backend.
+    #
+    # Check the documentation of +NIO::Selector.backends+ for the list of valid
+    # options. The available options on your system will depend on the operating
+    # system.
+    #
+    # The default is +:auto+.
+    #
+    # @see https://github.com/socketry/nio4r/blob/master/lib/nio/selector.rb
     #
     def io_selector_backend(backend)
       @options[:io_selector_backend] = backend.to_sym

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -872,8 +872,10 @@ module Puma
     # exception of +:auto+ which will let nio4r choose the backend.
     #
     # Check the documentation of +NIO::Selector.backends+ for the list of valid
-    # options. The available options on your system will depend on the operating
-    # system.
+    # options. Note that the available options on your system will depend on the
+    # operating system. If you want to use the pure Ruby backend (not
+    # recommended due to its comparatively low performance), set environment
+    # variable +NIO4R_PURE+ to +true+.
     #
     # The default is +:auto+.
     #

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -865,5 +865,13 @@ module Puma
     def max_fast_inline(num_of_requests)
       @options[:max_fast_inline] = Float(num_of_requests)
     end
+
+    # Change the backend for the IO selector.
+    #
+    # The default is +:auto+ which will let nio4r choose the backend.
+    #
+    def io_selector_backend(backend)
+      @options[:io_selector_backend] = backend.to_sym
+    end
   end
 end

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -18,9 +18,9 @@ module Puma
     # Create a new Reactor to monitor IO objects added by #add.
     # The provided block will be invoked when an IO has data available to read,
     # its timeout elapses, or when the Reactor shuts down.
-    def initialize(&block)
+    def initialize(backend, &block)
       require 'nio'
-      @selector = NIO::Selector.new
+      @selector = backend == :auto ? NIO::Selector.new : NIO::Selector.new(backend)
       @input = Queue.new
       @timeouts = []
       @block = block

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -84,13 +84,14 @@ module Puma
 
       @options = options
 
-      @early_hints        = options.fetch :early_hints, nil
-      @first_data_timeout = options.fetch :first_data_timeout, FIRST_DATA_TIMEOUT
-      @min_threads        = options.fetch :min_threads, 0
-      @max_threads        = options.fetch :max_threads , (Puma.mri? ? 5 : 16)
-      @persistent_timeout = options.fetch :persistent_timeout, PERSISTENT_TIMEOUT
-      @queue_requests     = options.fetch :queue_requests, true
-      @max_fast_inline    = options.fetch :max_fast_inline, MAX_FAST_INLINE
+      @early_hints         = options.fetch :early_hints, nil
+      @first_data_timeout  = options.fetch :first_data_timeout, FIRST_DATA_TIMEOUT
+      @min_threads         = options.fetch :min_threads, 0
+      @max_threads         = options.fetch :max_threads , (Puma.mri? ? 5 : 16)
+      @persistent_timeout  = options.fetch :persistent_timeout, PERSISTENT_TIMEOUT
+      @queue_requests      = options.fetch :queue_requests, true
+      @max_fast_inline     = options.fetch :max_fast_inline, MAX_FAST_INLINE
+      @io_selector_backend = options.fetch :io_selector_backend, :auto
 
       temp = !!(@options[:environment] =~ /\A(development|test)\z/)
       @leak_stack_on_error = @options[:environment] ? temp : true
@@ -237,7 +238,7 @@ module Puma
       @thread_pool.clean_thread_locals = @options[:clean_thread_locals]
 
       if @queue_requests
-        @reactor = Reactor.new(&method(:reactor_wakeup))
+        @reactor = Reactor.new(@io_selector_backend, &method(:reactor_wakeup))
         @reactor.run
       end
 

--- a/test/config/with_symbol_convert.rb
+++ b/test/config/with_symbol_convert.rb
@@ -1,0 +1,1 @@
+io_selector_backend :ruby

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -274,6 +274,14 @@ class TestConfigFile < TestConfigFileBase
     assert_equal Float::INFINITY, conf.options[:max_fast_inline]
   end
 
+  def test_config_files_with_symbol_convert
+    conf = Puma::Configuration.new(config_files: ['test/config/with_symbol_convert.rb']) do
+    end
+    conf.load
+
+    assert_equal :ruby, conf.options[:io_selector_backend]
+  end
+
   def test_config_raise_exception_on_sigterm
     conf = Puma::Configuration.new do |c|
       c.raise_exception_on_sigterm false

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1179,19 +1179,8 @@ EOF
     backend = NIO::Selector.backends.first
 
     @server = Puma::Server.new @app, @events, {:io_selector_backend => backend}
-
-    server_run app: ->(env) do
-      [200, {}, [env['SERVER_PORT']]]
-    end
-
-    req = Net::HTTP::Get.new '/'
-    req['HOST'] = 'example.com'
-
-    res = Net::HTTP.start @host, @port do |http|
-      http.request(req)
-    end
-
-    assert_equal '200', res.code
+    @server.run
+    @server.stop
 
     selector = @server.instance_variable_get(:@reactor).instance_variable_get(:@selector)
 


### PR DESCRIPTION
### Description

nio4r will soon have experimental support for io_uring via libev. The brave might want to try it out :) regardless of that, allowing users to explicitly set the IO selector backend seems like a good idea to me.


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
