### PR TITLE
Change 'Goodbye!' message to be output after listeners are closed

### DIFF
--- a/History.md
+++ b/History.md
@@ -8,6 +8,7 @@
 
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
+  * Change 'Goodbye!' message to be output after listeners are closed (#2529)
   * Fix compiler warnings, but skipped warnings related to ragel state machine generated code ([#1953])
   * Fix phased restart errors related to nio4r gem when using the Puma control server (#2516)
   * Add `#string` method to `Puma::NullIO` ([#2520])

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -217,6 +217,10 @@ module Puma
     def close_binder_listeners
       @runner.close_control_listeners
       @binder.close_listeners
+      unless @status == :restart
+        log "=== puma shutdown: #{Time.now} ==="
+        log "- Goodbye!"
+      end
     end
 
     # @!attribute [r] thread_status
@@ -374,8 +378,6 @@ module Puma
     def graceful_stop
       @events.fire_on_stopped!
       @runner.stop_blocked
-      log "=== puma shutdown: #{Time.now} ==="
-      log "- Goodbye!"
     end
 
     def set_process_title


### PR DESCRIPTION
### Description

When a server is stopped, the last line of the log is `Goodbye!`.  Currently, this line is output before the listeners are closed.  Note that this is not output when a server is halted.

While working with updated tests, and checking for closed listeners, I noticed this.

Hence, change `Goodbye!` to appear after the listeners are closed.  Whether `Goodbye!` should be output when a server is halted, not sure...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
