### PR TITLE
Remove Server#read_body

### DIFF
--- a/History.md
+++ b/History.md
@@ -15,6 +15,9 @@
   * Add `#string` method to `Puma::NullIO` ([#2520])
   * Fix binding via Rack handler to IPv6 addresses (#2521)
 
+* Refactor
+  * Remove `Server#read_body` ([#2531])
+
 ## 5.1.1 / 2020-12-10
 
 * Bugfixes


### PR DESCRIPTION
`Server#read_body` seems to have been left behind as part of a refactoring done in 6777c771d829a31634b968c74a829cc53b80a144, where the contents of this method were copied into the newly-created `Client` class but never removed from `Server`, even though it's no longer called anywhere. This PR removes the unused method.