### PR TITLE
[ci skip] Add documentation on interlock issue in Rails development mode

### DIFF
--- a/docs/rails_dev_mode.md
+++ b/docs/rails_dev_mode.md
@@ -1,0 +1,29 @@
+# Running Puma in Rails Development Mode
+
+## "Loopback requests" 
+
+Be cautious of "loopback requests", where a Rails application executes a request to a server that in turn, results in another request back to the same Rails application before the first request is completed. Having a loopback request will trigger [Rails' load interlock](https://guides.rubyonrails.org/threading_and_code_execution.html#load-interlock) mechanism. The load interlock mechanism prevents a thread from using Rails autoloading mechanism to load constants while the application code is still running inside another thread.
+
+This issue only occurs in the development environment as Rails' load interlock is not used in production environments. 
+
+### Solutions
+
+
+#### 1. Bypass Rails' load interlock with `.permit_concurrent_loads`
+
+  Wrap the first request inside a block that will allow concurrent loads, [`ActiveSupport::Dependencies.interlock.permit_concurrent_loads`](https://guides.rubyonrails.org/threading_and_code_execution.html#permit-concurrent-loads). Anything wrapped inside the `.permit_concurrent_loads` block will bypass the load interlock mechanism, allowing new threads to access the Rails environment and boot properly. 
+
+    ###### Example 
+
+    ```ruby
+    response = ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+      # Your HTTP request code here. For example:
+      Faraday.post url, data: 'foo'
+    end
+
+    do_something_with response
+    ```
+
+####  2. Use multiple processes on Puma
+
+  Alternatively, you may also enable multiple single-threaded workers on Puma. By doing so, you are sidestepping the problem by creating multiple processes rather than new threads. However, this workaround is not ideal because debugging tools such as [byebug](https://github.com/deivid-rodriguez/byebug/issues/487) and [pry](https://github.com/pry/pry/issues/2153), work poorly with any multi-process web server. 


### PR DESCRIPTION
### Description

Hello, it's my first time here! 👋  

Closes https://github.com/puma/puma/issues/2352 

The documentation is a new file `docs/rails_dev_mode.md` as suggested and pretty much a paraphrase/copy pasta of @earksiinni's analysis and observation. 

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop. (I mean... it probs should cause this is just a documentation change) 
