### PR TITLE
Move ssl detection to puma.rb [changelog skip]

### DIFF
--- a/lib/puma/detect.rb
+++ b/lib/puma/detect.rb
@@ -1,20 +1,24 @@
 # frozen_string_literal: true
 
+# This file can be loaded independently of puma.rb, so it cannot have any code
+# that assumes puma.rb is loaded.
+
+
 module Puma
-  # at present, MiniSSL::Engine is only defined in extension code, not in minissl.rb
-  HAS_SSL = const_defined?(:MiniSSL, false) && MiniSSL.const_defined?(:Engine, false)
+  # @version 5.2.1
+  HAS_FORK = ::Process.respond_to? :fork
 
-  def self.ssl?
-    HAS_SSL
-  end
+  IS_JRUBY = Object.const_defined? :JRUBY_VERSION
 
-  IS_JRUBY = defined?(JRUBY_VERSION)
+  IS_WINDOWS = !!(RUBY_PLATFORM =~ /mswin|ming|cygwin/ ||
+    IS_JRUBY && RUBY_DESCRIPTION =~ /mswin/)
+
+  # @version 5.2.0
+  IS_MRI = (RUBY_ENGINE == 'ruby' || RUBY_ENGINE.nil?)
 
   def self.jruby?
     IS_JRUBY
   end
-
-  IS_WINDOWS = RUBY_PLATFORM =~ /mswin|ming|cygwin/
 
   def self.windows?
     IS_WINDOWS
@@ -22,11 +26,11 @@ module Puma
 
   # @version 5.0.0
   def self.mri?
-    RUBY_ENGINE == 'ruby' || RUBY_ENGINE.nil?
+    IS_MRI
   end
 
   # @version 5.0.0
   def self.forkable?
-    ::Process.respond_to?(:fork)
+    HAS_FORK
   end
 end


### PR DESCRIPTION
### Description

`puma.rb` loads `puma/puma_http11`, which contains the compiled c code for ssl.  Move ssl detection from `puma/detect.rb` to `puma.rb`

Fix `Puma::IS_WINDOWS` and `Puma.windows?` to work with JRuby.

No breaking API changes.

JFYI, quick benchmark of predicate methods (`Puma.ssl?`) vs constants (`Puma::HAS_SSL`), showed constants were about twice as fast.  But, both are 'fast enough'.  Haven't looked thru the code to change...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
