### PR TITLE
Bug Fix - MiniSSL::Socket#write - use data.byteslice(wrote..-1)

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+## 5.2.1 / 2021-01-
+
+* Bugfixes
+  * MiniSSL::Socket#write - use data.byteslice(wrote..-1) ([#2543])
+
 ## 5.2.0 / 2021-01-27
 
 * Features

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -133,7 +133,7 @@ module Puma
 
           return data_size if need == 0
 
-          data = data[wrote..-1]
+          data = data.byteslice(wrote..-1)
         end
       end
 


### PR DESCRIPTION
### Description

MiniSSL::Socket#write performs some string 'dice & chop', and was using both byte and character methods.  Convert all to byte methods.

Closes https://github.com/puma/puma/issues/2542

Note that this is only noticeable when the response headers/body are such that x.length != x.bytesize

I will write a test for it, but did the checking locally with a 600kB body.  Was using `curl` and `git diff`, need to find a more Ruby based solution...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
