### PR TITLE
Explicitly require rack/common_logger if :Verbose is true

### DIFF
--- a/History.md
+++ b/History.md
@@ -14,6 +14,7 @@
   * Fix phased restart errors related to nio4r gem when using the Puma control server ([#2516])
   * Add `#string` method to `Puma::NullIO` ([#2520])
   * Fix binding via Rack handler to IPv6 addresses ([#2521])
+  * Require rack/common_logger explicitly if :verbose is true ([#2547])
 
 * Refactor
   * Refactor MiniSSL::Context on MRI, fix MiniSSL::Socket#write ([#2519])

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -31,6 +31,7 @@ module Rack
 
         conf = ::Puma::Configuration.new(options, default_options) do |user_config, file_config, default_config|
           if options.delete(:Verbose)
+            require 'rack/common_logger'
             app = Rack::CommonLogger.new(app, STDOUT)
           end
 


### PR DESCRIPTION
### Description
Hello! 

I found an issue where I had to require `'rack'` or more specifically, `'rack/common_logger'` when verbose is set to true, `:Verbose => true`. 

Take this example: 
```ruby
require 'rack/handler/puma'

app = -> environment {[200, {}, []]}
Rack::Handler::Puma.run(app, :Verbose => true)
```

This is the exception: 

```
Traceback (most recent call last):
       10: from /usr/bin/irb:23:in `<main>'
        9: from /usr/bin/irb:23:in `load'
        8: from /Library/Ruby/Gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        7: from (irb):3
        6: from /Users/mapleong/.gem/ruby/2.6.0/gems/puma-5.2.0/lib/rack/handler/puma.rb:63:in `run'
        5: from /Users/mapleong/.gem/ruby/2.6.0/gems/puma-5.2.0/lib/rack/handler/puma.rb:32:in `config'
        4: from /Users/mapleong/.gem/ruby/2.6.0/gems/puma-5.2.0/lib/rack/handler/puma.rb:32:in `new'
        3: from /Users/mapleong/.gem/ruby/2.6.0/gems/puma-5.2.0/lib/puma/configuration.rb:154:in `initialize'
        2: from /Users/mapleong/.gem/ruby/2.6.0/gems/puma-5.2.0/lib/puma/configuration.rb:161:in `configure'
        1: from /Users/mapleong/.gem/ruby/2.6.0/gems/puma-5.2.0/lib/rack/handler/puma.rb:34:in `block in config'
NameError (uninitialized constant Rack::CommonLogger)
```

Users shouldn't have to require rack/common_logger on their end so I added a `require "rack/common_logger"` in the block where Verbose is true. 

#### Questions:

* Do you agree with this change? If so, 
  * What is the best way to test this? I didn't find a good place to test it in `test_rack_handler.rb` 
  * ~Should I add this change to the changelog / `History.md`?~

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature. (pending question)
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop. (pending)
