### PR TITLE
Remove macOS 11 builds, try to stabilize CI [changelog skip]

### DIFF
--- a/.github/workflows/mri.yml
+++ b/.github/workflows/mri.yml
@@ -26,7 +26,6 @@ jobs:
           - { os: windows-2019 , ruby: mingw }
           - { os: ubuntu-20.04 , ruby: 2.7   , no-ssl: ' no SSL' }
           - { os: windows-2019 , ruby: 2.7   , no-ssl: ' no SSL' }
-          - { os: macos-11.0   , ruby: 2.7  }
         exclude:
           - { os: ubuntu-20.04 , ruby: 2.2  }
           - { os: ubuntu-20.04 , ruby: 2.3  }

--- a/.github/workflows/non_mri.yml
+++ b/.github/workflows/non_mri.yml
@@ -24,7 +24,6 @@ jobs:
           - { os: ubuntu-20.04 , ruby: jruby, no-ssl: ' no SSL' }
           - { os: ubuntu-20.04 , ruby: jruby-head, allow-failure: true }
           - { os: ubuntu-20.04 , ruby: truffleruby-head }
-          - { os: macos-11.0   , ruby: jruby }
           - { os: macos-10.15  , ruby: jruby }
           - { os: macos-10.15  , ruby: truffleruby-head }
 


### PR DESCRIPTION
Recent examples (these were all yellow but I cancelled them)

- https://github.com/puma/puma/runs/1826040463?check_suite_focus=true
- https://github.com/puma/puma/runs/1825682787?check_suite_focus=true
- https://github.com/puma/puma/runs/1825683423?check_suite_focus=true
- https://github.com/puma/puma/runs/1825636952?check_suite_focus=true
- https://github.com/puma/puma/runs/1825636286?check_suite_focus=true

GitHub Actions is out of capacity for macOS: https://github.com/actions/virtual-environments/issues/2486

Perhaps better to add macos-11.0 back when the above issue is resolved.