### PR TITLE
Set @env[CONTENT_LENGTH] value as string.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,7 +1,8 @@
-## 5.2.1 / 2021-01-
+## 5.2.1 / 2021-02-
 
 * Bugfixes
   * MiniSSL::Socket#write - use data.byteslice(wrote..-1) ([#2543])
+  * Set @env[CONTENT_LENGTH] value as string.
 
 ## 5.2.0 / 2021-01-27
 

--- a/History.md
+++ b/History.md
@@ -2,7 +2,7 @@
 
 * Bugfixes
   * MiniSSL::Socket#write - use data.byteslice(wrote..-1) ([#2543])
-  * Set @env[CONTENT_LENGTH] value as string.
+  * Set `@env[CONTENT_LENGTH]` value as string.
 
 ## 5.2.0 / 2021-01-27
 

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -374,7 +374,7 @@ module Puma
         end
 
         if decode_chunk(chunk)
-          @env[CONTENT_LENGTH] = @chunked_content_length
+          @env[CONTENT_LENGTH] = @chunked_content_length.to_s
           return true
         end
       end
@@ -391,7 +391,7 @@ module Puma
       @chunked_content_length = 0
 
       if decode_chunk(body)
-        @env[CONTENT_LENGTH] = @chunked_content_length
+        @env[CONTENT_LENGTH] = @chunked_content_length.to_s
         return true
       end
     end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -518,7 +518,7 @@ EOF
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
-    assert_equal 5, content_length
+    assert_equal "5", content_length
   end
 
   def test_large_chunked_request
@@ -546,7 +546,7 @@ EOF
       data = send_http_and_read request
 
       assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
-      assert_equal size, content_length
+      assert_equal size, Integer(content_length)
       assert_equal request_body, body
     end
   end
@@ -569,7 +569,7 @@ EOF
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
-    assert_equal 5, content_length
+    assert_equal "5", content_length
   end
 
   def test_chunked_request_pause_between_chunks
@@ -590,7 +590,7 @@ EOF
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
-    assert_equal 5, content_length
+    assert_equal "5", content_length
   end
 
   def test_chunked_request_pause_mid_count
@@ -611,7 +611,7 @@ EOF
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
-    assert_equal 5, content_length
+    assert_equal "5", content_length
   end
 
   def test_chunked_request_pause_before_count_newline
@@ -632,7 +632,7 @@ EOF
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
-    assert_equal 5, content_length
+    assert_equal "5", content_length
   end
 
   def test_chunked_request_pause_mid_value
@@ -653,7 +653,7 @@ EOF
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
-    assert_equal 5, content_length
+    assert_equal "5", content_length
   end
 
   def test_chunked_request_pause_between_cr_lf_after_size_of_second_chunk
@@ -683,7 +683,7 @@ EOF
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal (part1 + 'b'), body
-    assert_equal 4201, content_length
+    assert_equal "4201", content_length
   end
 
   def test_chunked_request_pause_between_closing_cr_lf
@@ -705,7 +705,7 @@ EOF
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal 'hello', body
-    assert_equal 5, content_length
+    assert_equal "5", content_length
   end
 
   def test_chunked_request_pause_before_closing_cr_lf
@@ -727,7 +727,7 @@ EOF
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal 'hello', body
-    assert_equal 5, content_length
+    assert_equal "5", content_length
   end
 
   def test_chunked_request_header_case
@@ -743,7 +743,7 @@ EOF
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
-    assert_equal 5, content_length
+    assert_equal "5", content_length
   end
 
   def test_chunked_keep_alive
@@ -761,7 +761,7 @@ EOF
 
     assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], h
     assert_equal "hello", body
-    assert_equal 5, content_length
+    assert_equal "5", content_length
 
     sock.close
   end
@@ -789,7 +789,7 @@ EOF
     h = header(sock)
     assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], h
     assert_equal "hello", body
-    assert_equal 5, content_length
+    assert_equal "5", content_length
     assert_equal true, last_crlf_written
 
     last_crlf_writer.join
@@ -801,7 +801,7 @@ EOF
 
     assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], h
     assert_equal "goodbye", body
-    assert_equal 7, content_length
+    assert_equal "7", content_length
 
     sock.close
   end
@@ -823,7 +823,7 @@ EOF
     h = header sock
     assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], h
     assert_equal "hello", body
-    assert_equal 5, content_length
+    assert_equal "5", content_length
     assert_equal "127.0.0.1", remote_addr
 
     sock << "GET / HTTP/1.1\r\nX-Forwarded-For: 127.0.0.2\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ngood\r\n3\r\nbye\r\n0\r\n\r\n"
@@ -833,7 +833,7 @@ EOF
 
     assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], h
     assert_equal "goodbye", body
-    assert_equal 7, content_length
+    assert_equal "7", content_length
     assert_equal "127.0.0.2", remote_addr
 
     sock.close


### PR DESCRIPTION
### Description
Rack expects CGI keys as strings (see [lint.rb](https://github.com/rack/rack/blob/a05f8d56f9ac4da14dddb8f312a3b43644f73397/lib/rack/lint.rb#L305)). 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
    - Existing tests updated.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] ~If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.~
- [ ] ~If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.~
- [ ] ~I have updated the documentation accordingly.~
- [x] All new and existing tests passed, including Rubocop.
    - One error and some rubocop offenses, but they are there also for the base repository.
