### PR TITLE
server.rb - properly cork & uncork ssl clients

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 ## 5.2.1 / 2021-01-
 
 * Bugfixes
+  * Fix TCP cork/uncork operations to work with ssl clients (#2550)
+  * Require rack/common_logger explicitly if :verbose is true ([#2547])
   * MiniSSL::Socket#write - use data.byteslice(wrote..-1) ([#2543])
 
 ## 5.2.0 / 2021-01-27
@@ -19,7 +21,6 @@
   * Fix phased restart errors related to nio4r gem when using the Puma control server ([#2516])
   * Add `#string` method to `Puma::NullIO` ([#2520])
   * Fix binding via Rack handler to IPv6 addresses ([#2521])
-  * Require rack/common_logger explicitly if :verbose is true ([#2547])
 
 * Refactor
   * Refactor MiniSSL::Context on MRI, fix MiniSSL::Socket#write ([#2519])

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -30,7 +30,7 @@ module Puma
     #
     def handle_request(client, lines)
       env = client.env
-      io = client.io
+      io  = client.io   # io may be a MiniSSL::Socket
 
       return false if closed_socket?(io)
 


### PR DESCRIPTION
### Description

`Server##cork_socket` & `Server##uncork_socket` work on TCPSockets, but when using an ssl client, a MiniSSL::Socket is passed to them.

Use 'to_io', which is available with all 'socket objects' used in Puma.

I haven't worked with wireshark for a while, and that's probably the only way to see a difference?

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
