### PR TITLE
Add `#flush` and `#sync` methods to `Puma::NullIO`

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+## 5.2.2 / 2021-02-
+
+* Bugfixes
+  * Add `#flush` and `#sync` methods to `Puma::NullIO`  ([#2553])
+
 ## 5.2.1 / 2021-02-05
 
 * Bugfixes

--- a/lib/puma/null_io.rb
+++ b/lib/puma/null_io.rb
@@ -36,6 +36,10 @@ module Puma
       true
     end
 
+    def sync
+      true
+    end
+
     def sync=(v)
     end
 
@@ -43,6 +47,10 @@ module Puma
     end
 
     def write(*ary)
+    end
+
+    def flush
+      self
     end
   end
 end

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -97,6 +97,14 @@ class TestEvents < Minitest::Test
     assert_equal "ready\n", out
   end
 
+  def test_null_log_does_nothing
+    out, _ = capture_io do
+      Puma::Events.null.log("ready")
+    end
+
+    assert_equal "", out
+  end
+
   def test_write_writes_to_stdout
     out, _ = capture_io do
       Puma::Events.stdio.write("ready")

--- a/test/test_null_io.rb
+++ b/test/test_null_io.rb
@@ -56,4 +56,12 @@ class TestNullIO < Minitest::Test
   def test_size
     assert_equal 0, nio.size
   end
+
+  def test_sync_returns_true
+    assert_equal true, nio.sync
+  end
+
+  def test_flush_returns_self
+    assert_equal nio, nio.flush
+  end
 end


### PR DESCRIPTION
### Description
Add `#flush` and `#sync` methods to `Puma::NullIO`.

This fixes an issue if you're using `Events.null`, e.g.:

```ruby
i = Puma::Launcher.new(Puma::Configuration.new, {events: Puma::Events.null})
i.run
```

Without this patch, this would fail with:
```
NoMethodError: undefined method `sync' for #<Puma::NullIO:0x00007fb0cbb7cec8>
Did you mean?  sync=
from /Users/ob/workspace/ruby/puma/lib/puma/events.rb:67:in `log'
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
