### PR TITLE
remove double-splat from options param, puma.rb

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+## 5.2.2 / 2021-02-15
+
+* Bugfixes
+  * Remove `**` from `options` parameter ([#2555])
+
 ## 5.2.2 / 2021-02-
 
 * Bugfixes

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -60,7 +60,7 @@ module Rack
         conf
       end
 
-      def self.run(app, **options)
+      def self.run(app, options)
         conf   = self.config(app, options)
 
         events = options.delete(:Silent) ? ::Puma::Events.strings : ::Puma::Events.stdio


### PR DESCRIPTION
### Description
Please describe your pull request. Thank you for contributing! You're the best.
- remove double-splat from options parameter, in puma.rb line 63
- was throwing argument error when running sinatra and puma with shotgun
- all existing tests still pass after removing and the bug is fixed - shotgun now raises no error and works as expected

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
