### PR TITLE
Restore sync=true on global stdout/stderr streams

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 * Bugfixes
   * Add `#flush` and `#sync` methods to `Puma::NullIO`  ([#2553])
+  * Restore `sync=true` on `STDOUT` and `STDERR` streams #2557
 
 ## 5.2.1 / 2021-02-05
 

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -206,7 +206,8 @@ module Puma
         :first_data_timeout => Const::FIRST_DATA_TIMEOUT,
         :raise_exception_on_sigterm => true,
         :max_fast_inline => Const::MAX_FAST_INLINE,
-        :io_selector_backend => :auto
+        :io_selector_backend => :auto,
+        :mutate_stdout_and_stderr_to_sync_on_write => true,
       }
     end
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -888,5 +888,9 @@ module Puma
     def io_selector_backend(backend)
       @options[:io_selector_backend] = backend.to_sym
     end
+
+    def mutate_stdout_and_stderr_to_sync_on_write(enabled=true)
+      @options[:mutate_stdout_and_stderr_to_sync_on_write] = enabled
+    end
   end
 end

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -150,6 +150,11 @@ module Puma
     end
 
     def start_server
+      if @options[:mutate_stdout_and_stderr_to_sync_on_write]
+        STDOUT.sync = true
+        STDERR.sync = true
+      end
+
       server = Puma::Server.new app, @launcher.events, @options
       server.inherit_binder @launcher.binder
       server

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -126,6 +126,11 @@ module Puma
         STDERR.puts "=== puma startup: #{Time.now} ==="
         STDERR.flush unless STDERR.sync
       end
+
+      if @options[:mutate_stdout_and_stderr_to_sync_on_write]
+        STDOUT.sync = true
+        STDERR.sync = true
+      end
     end
 
     def load_and_bind
@@ -150,11 +155,6 @@ module Puma
     end
 
     def start_server
-      if @options[:mutate_stdout_and_stderr_to_sync_on_write]
-        STDOUT.sync = true
-        STDERR.sync = true
-      end
-
       server = Puma::Server.new app, @launcher.events, @options
       server.inherit_binder @launcher.binder
       server

--- a/test/rackup/write_to_stdout.ru
+++ b/test/rackup/write_to_stdout.ru
@@ -1,0 +1,6 @@
+app = lambda do |env|
+  $stdout.write "hello\n"
+  [200, {"Content-Type" => "text/plain"}, ["Hello World"]]
+end
+
+run app

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -163,4 +163,11 @@ class TestIntegrationSingle < TestIntegration
     assert(!File.file?("t2-pid"))
     assert_equal("Puma is started\n", out)
   end
+
+  def test_application_logs_are_flushed_on_write
+    cli_server 'test/rackup/write_to_stdout.ru'
+    read_body connect
+    log_line = @server.gets
+    assert_equal "hello\n", log_line
+  end
 end


### PR DESCRIPTION
### Description

Fixes #2545. In Puma 5.2, Puma stopped mutating the `sync` flag on the global `STDOUT` and `STDERR` objects. This can cause user application logs to be not flushed on every write if users were depending on this behavior. This PR restores `sync` behavior for those streams to the pre-5.2 behavior. We may re-introduce the change again in 6.0 with better documentation.

To verify this change, I used a Rack app that writes to stdout on every request

```ruby
#stdout_test.ru
app = lambda do |env|
  $stdout.write "hello\n"
  [200, {"Content-Type" => "text/plain"}, ["Hello World"]]
end

run app
```

Start puma, piping its stdout to something that's not a TTY:

```sh
bundle exec ruby -Ilib bin/puma stdout_test.ru | tee puma.out
```

Then, send a bunch of requests

```sh
seq 100 | xargs -n 1 -I{} curl http://localhost:9292
```

On Puma 5.2, you can observe that no output is visible from Puma until many more requests complete.

This change introduces a config option to the config DSL, so that users can opt into making it so that puma doesn't set `sync` flag on the stdout and stderr streams. The default behavior is consistent with Puma's behavior prior to 5.2. In a future release (maybe 6.0), we may change the default or remove the option altogether.

```ruby
mutate_stdout_and_stderr_to_sync_on_write false
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [X] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
