### PR TITLE
Print warning when running one-worker cluster

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 * Features
   * Your feature goes here <Most recent on the top, like GitHub> (#Github Number)
+  * Warn when running Cluster mode with a single worker (#2565)
 
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -332,6 +332,13 @@ module Puma
       # This is aligned with the output from Runner, see Runner#output_header
       log "*      Workers: #{@options[:workers]}"
 
+      if @options[:workers] == 1
+        log "! WARNING: Detected running cluster mode with 1 worker:"
+        log "! Running Puma in cluster mode with a single worker is often a misconfiguration."
+        log "! Consider running Puma in single-mode in order to reduce memory overhead."
+        log "! See: https://github.com/puma/puma/issues/2534"
+      end
+
       # Threads explicitly marked as fork safe will be ignored.
       # Used in Rails, but may be used by anyone.
       before = Thread.list.reject { |t| t.thread_variable_get(:fork_safe) }

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -332,12 +332,6 @@ module Puma
       # This is aligned with the output from Runner, see Runner#output_header
       log "*      Workers: #{@options[:workers]}"
 
-      if @options[:workers] == 1
-        log "! WARNING: Detected running cluster mode with 1 worker:"
-        log "! Running Puma in cluster mode with a single worker is often a misconfiguration."
-        log "! Consider running Puma in single-mode in order to reduce memory overhead."
-      end
-
       # Threads explicitly marked as fork safe will be ignored.
       # Used in Rails, but may be used by anyone.
       before = Thread.list.reject { |t| t.thread_variable_get(:fork_safe) }
@@ -387,6 +381,8 @@ module Puma
       @fork_pipe, @fork_writer = Puma::Util.pipe
 
       log "Use Ctrl-C to stop"
+
+      single_worker_warning
 
       redirect_io
 
@@ -475,6 +471,15 @@ module Puma
     end
 
     private
+
+    def single_worker_warning
+      return if @options[:workers] != 1 || @options[:silence_single_worker_warning]
+
+      log "! WARNING: Detected running cluster mode with 1 worker."
+      log "! Running Puma in cluster mode with a single worker is often a misconfiguration."
+      log "! Consider running Puma in single-mode in order to reduce memory overhead."
+      log "! Set the `silence_single_worker_warning` option to silence this warning message."
+    end
 
     # loops thru @workers, removing workers that exited, and calling
     # `#term` if needed

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -336,7 +336,6 @@ module Puma
         log "! WARNING: Detected running cluster mode with 1 worker:"
         log "! Running Puma in cluster mode with a single worker is often a misconfiguration."
         log "! Consider running Puma in single-mode in order to reduce memory overhead."
-        log "! See: https://github.com/puma/puma/issues/2534"
       end
 
       # Threads explicitly marked as fork safe will be ignored.

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -193,6 +193,7 @@ module Puma
         :debug => false,
         :binds => ["tcp://#{DefaultTCPHost}:#{DefaultTCPPort}"],
         :workers => Integer(ENV['WEB_CONCURRENCY'] || 0),
+        :silence_single_worker_warning => false,
         :mode => :http,
         :worker_timeout => DefaultWorkerTimeout,
         :worker_boot_timeout => DefaultWorkerTimeout,

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -482,6 +482,13 @@ module Puma
       @options[:workers] = count.to_i
     end
 
+    # Disable warning message when running in cluster mode with a single worker.
+    #
+    # @note Cluster mode only.
+    def silence_single_worker_warning
+      @options[:silence_single_worker_warning] = true
+    end
+
     # Code to run immediately before master process
     # forks workers (once on boot). These hooks can block if necessary
     # to wait for background operations unknown to Puma to finish before

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -342,6 +342,22 @@ class TestConfigFile < TestConfigFileBase
     assert_equal 2, conf.final_options[:max_threads]
   end
 
+  def test_silence_single_worker_warning_default
+    conf = Puma::Configuration.new
+    conf.load
+
+    assert_equal false, conf.options[:silence_single_worker_warning]
+  end
+
+  def test_silence_single_worker_warning_overwrite
+    conf = Puma::Configuration.new do |c|
+      c.silence_single_worker_warning
+    end
+    conf.load
+
+    assert_equal true, conf.options[:silence_single_worker_warning]
+  end
+
   private
 
   def assert_run_hooks(hook_name, options = {})

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -313,6 +313,28 @@ RUBY
     assert_equal 0, worker_load_count
   end
 
+  def test_warning_message_outputted_when_single_worker
+    cli_server "-w 1 test/rackup/hello.ru"
+
+    output = []
+    while (line = @server.gets) && line !~ /Worker \d \(PID/
+      output << line
+    end
+
+    assert_match /WARNING: Detected running cluster mode with 1 worker/, output.join
+  end
+
+  def test_warning_message_not_outputted_when_single_worker_silenced
+    cli_server "-w 1 test/rackup/hello.ru", config: "silence_single_worker_warning"
+
+    output = []
+    while (line = @server.gets) && line !~ /Worker \d \(PID/
+      output << line
+    end
+
+    refute_match /WARNING: Detected running cluster mode with 1 worker/, output.join
+  end
+
   private
 
   def worker_timeout(timeout, iterations, config)


### PR DESCRIPTION
Running Puma in cluster-mode is likely a misconfiguration in most
scenarios.

Cluster mode has some overhead of running an addtional 'control' process
in order to manage the cluster. If only running a single worker it is
likely not worth paying that overhead vs running in single mode with
additional threads instead.

There are some scenarios where running cluster mode with a single worker
may still be warranted and valid under certain deployment scenarios, see
the linked issue for details.

From experience at work, we were able to migrate our Rails applications
from single worker cluster to single-mode and saw a reduction of RAM
usage of around ~15%.

Closes #2534

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
