### PR TITLE
Handle segfault in Ruby 2.6.6 on thread-locals

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,6 +7,7 @@
 
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
+  * Ensure no segfaults when accessing thread-local variables on Ruby < 2.7.0 (#2567)
   * Don't close systemd activated socket on pumactl restart (#2563, #2504)
 
 ## 5.2.2 / 2021-02-22

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -332,16 +332,22 @@ module Puma
       # This is aligned with the output from Runner, see Runner#output_header
       log "*      Workers: #{@options[:workers]}"
 
-      # Threads explicitly marked as fork safe will be ignored.
-      # Used in Rails, but may be used by anyone.
-      before = Thread.list.reject { |t| t.thread_variable_get(:fork_safe) }
-
       if preload?
+        # Threads explicitly marked as fork safe will be ignored. Used in Rails,
+        # but may be used by anyone. Note that we need to explicit
+        # Process::Waiter check here because there's a bug in Ruby 2.6 and below
+        # where calling thread_variable_get on a Process::Waiter will segfault.
+        # We can drop that clause once those versions of Ruby are no longer
+        # supported.
+        fork_safe = ->(t) { !t.is_a?(Process::Waiter) && t.thread_variable_get(:fork_safe) }
+
+        before = Thread.list.reject(&fork_safe)
+
         log "*     Restarts: (\u2714) hot (\u2716) phased"
         log "* Preloading application"
         load_and_bind
 
-        after = Thread.list.reject { |t| t.thread_variable_get(:fork_safe) }
+        after = Thread.list.reject(&fork_safe)
 
         if after.size > before.size
           threads = (after - before)


### PR DESCRIPTION
When you're trying to access a thread-local variable on Ruby < 2.7, and you call `thread_variable_get` on a `Process::Waiter` (a subclass of `Thread`), it will segfault. This adds a check for which Ruby version you're on to make it safe for Ruby 2.6.

Closes #2566.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
