### PR TITLE
Scatter/gather IO with writev

### DIFF
--- a/lib/puma/io_buffer.rb
+++ b/lib/puma/io_buffer.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 module Puma
-  class IOBuffer < String
-    def append(*args)
-      args.each { |a| concat(a) }
+  class IOBuffer < Array
+    def bytesize
+      sum(&:bytesize)
     end
 
     alias reset clear
+    alias size bytesize
+    alias to_s join
   end
 end

--- a/lib/puma/writer.rb
+++ b/lib/puma/writer.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Puma
+  class Writer
+    class << self
+      def write(io, data)
+        case data.class
+        when Array
+          write_array(io, data)
+        when String
+          write_str(io, data)
+        else
+          write_str(io, data.to_s)
+        end
+      end
+
+      def write_str(io, str)
+        n = 0
+
+        while true
+          handle_errors(io) do
+            n = io.write str
+          end
+
+          return if n == str.bytesize
+
+          str = str.byteslice(n..-1)
+        end
+      end
+
+      def write_array(io, array)
+        n = 0
+
+        while true
+          handle_errors(io) do
+            n = io.write(*array)
+          end
+
+          return if n == array_bytesize(array)
+
+          array = array_byteslice_at_byte(array, n)
+        end
+      end
+
+      private
+
+      def handle_errors(io)
+        yield
+      rescue Errno::EAGAIN, Errno::EWOULDBLOCK
+        if !IO.select(nil, [io], nil, WRITE_TIMEOUT)
+          raise ConnectionError, "Socket timeout writing data"
+        end
+
+        retry
+      rescue Errno::EPIPE, SystemCallError, IOError
+        raise ConnectionError, "Socket timeout writing data"
+      end
+
+      def array_bytesize(array)
+        array.sum(&:bytesize)
+      end
+
+      def array_byteslice_at_byte(array, byte)
+        remaining = byte
+
+        array.drop_while do |str|
+          remaining -= str.bytesize
+          remaining > 0
+        end
+
+        array[0] = array[0].byteslice(remaining)
+
+        array
+      end
+    end
+  end
+end

--- a/test/rackup/big_response.ru
+++ b/test/rackup/big_response.ru
@@ -1,1 +1,3 @@
-run lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Hello World" * 100_000]] }
+big_array = 100_000.times.map { "Hello World" }
+
+run lambda { |env| [200, {"Content-Type" => "text/plain"}, big_array] }


### PR DESCRIPTION
### Description

:wave: Apologies in advance for the half-finished PR. I'm not sure if this is the right way to implement this and I'm very open to feedback on how to improve it/collaborating with others :smile: 

This adds scatter/gather IO support using `writev`, which supports writing arrays directly to the output since Ruby 2.5 (this'll need a version switch somewhere): https://bugs.ruby-lang.org/issues/9323. This means we can avoid generating big strings before writing the output, which will save memory and GC effort.

I'd expect to see a pretty reasonable performance improvement from this but it will require support further down the stack too. I've got [some investigation details](https://gitlab.com/gitlab-org/gitlab/-/issues/301025) of where support is currently lacking from the stack I'm working with, but there's most likely others that do/don't work elsewhere.

I _think_ my current implementation works but it would be nice to see if it works for others too. It's written quite verbosely due to my inexperience with the Puma codebase :sweat_smile: 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
