### PR TITLE
Add between_bytes_timeout to fix timing out when we get a slow request

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@
   * Your feature goes here <Most recent on the top, like GitHub> (#Github Number)
   * Warn when running Cluster mode with a single worker (#2565)
   * Add reason to worker time out and startup time when worked boots ([#2528])
+  * Add :between_bytes_timeout to prevent timeout during slow incoming requests (#2575)
 
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -207,7 +207,7 @@ module Puma
 
     def finish(first_data_timeout, between_bytes_timeout)
       return if @ready
-      timeout = @parsed_bytes > 0 ? first_data_timeout : between_bytes_timeout
+      timeout = @parsed_bytes > 0 ? between_bytes_timeout : first_data_timeout
       IO.select([@to_io], nil, nil, timeout) || timeout! until try_to_finish
     end
 

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -205,8 +205,9 @@ module Puma
       try_to_finish
     end
 
-    def finish(timeout)
+    def finish(first_data_timeout, between_bytes_timeout)
       return if @ready
+      timeout = @parsed_bytes > 0 ? first_data_timeout : between_bytes_timeout
       IO.select([@to_io], nil, nil, timeout) || timeout! until try_to_finish
     end
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -272,6 +272,12 @@ module Puma
       @options[:first_data_timeout] = Integer(seconds)
     end
 
+    # Define how long the tcp socket stays open, once data has been received.
+    # @see Puma::Server.new
+    def between_bytes_timeout(seconds)
+      @options[:between_bytes_timeout] = Integer(seconds)
+    end
+
     # Work around leaky apps that leave garbage in Thread locals
     # across requests.
     def clean_thread_locals(which=true)

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -299,7 +299,7 @@ module Puma
       elsif shutdown || client.timeout == 0
         client.timeout!
       else
-        client.set_timeout(between_bytes_timeout)
+        client.set_timeout(@between_bytes_timeout)
         false
       end
     rescue StandardError => e

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -40,12 +40,14 @@ module Puma
     attr_reader :requests_count             # @version 5.0.0
 
     # @todo the following may be deprecated in the future
-    attr_reader :auto_trim_time, :early_hints, :first_data_timeout,
+    attr_reader :auto_trim_time, :early_hints,
+      :first_data_timeout, :between_bytes_timeout,
       :leak_stack_on_error,
       :persistent_timeout, :reaping_time
 
     # @deprecated v6.0.0
-    attr_writer :auto_trim_time, :early_hints, :first_data_timeout,
+    attr_writer :auto_trim_time, :early_hints,
+      :first_data_timeout, :between_bytes_timeout,
       :leak_stack_on_error, :min_threads, :max_threads,
       :persistent_timeout, :reaping_time
 
@@ -84,14 +86,15 @@ module Puma
 
       @options = options
 
-      @early_hints         = options.fetch :early_hints, nil
-      @first_data_timeout  = options.fetch :first_data_timeout, FIRST_DATA_TIMEOUT
-      @min_threads         = options.fetch :min_threads, 0
-      @max_threads         = options.fetch :max_threads , (Puma.mri? ? 5 : 16)
-      @persistent_timeout  = options.fetch :persistent_timeout, PERSISTENT_TIMEOUT
-      @queue_requests      = options.fetch :queue_requests, true
-      @max_fast_inline     = options.fetch :max_fast_inline, MAX_FAST_INLINE
-      @io_selector_backend = options.fetch :io_selector_backend, :auto
+      @early_hints           = options.fetch :early_hints, nil
+      @first_data_timeout    = options.fetch :first_data_timeout, FIRST_DATA_TIMEOUT
+      @between_bytes_timeout = options.fetch :between_bytes_timeout, @first_data_timeout
+      @min_threads           = options.fetch :min_threads, 0
+      @max_threads           = options.fetch :max_threads , (Puma.mri? ? 5 : 16)
+      @persistent_timeout    = options.fetch :persistent_timeout, PERSISTENT_TIMEOUT
+      @queue_requests        = options.fetch :queue_requests, true
+      @max_fast_inline       = options.fetch :max_fast_inline, MAX_FAST_INLINE
+      @io_selector_backend   = options.fetch :io_selector_backend, :auto
 
       temp = !!(@options[:environment] =~ /\A(development|test)\z/)
       @leak_stack_on_error = @options[:environment] ? temp : true
@@ -295,6 +298,9 @@ module Puma
         @thread_pool << client
       elsif shutdown || client.timeout == 0
         client.timeout!
+      else
+        client.set_timeout(between_bytes_timeout)
+        false
       end
     rescue StandardError => e
       client_error(e, client)

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -429,7 +429,7 @@ module Puma
         end
 
         with_force_shutdown(client) do
-          client.finish(@first_data_timeout)
+          client.finish(@first_data_timeout, @between_bytes_timeout)
         end
 
         while true

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -401,6 +401,11 @@ EOF
     assert_equal "HTTP/1.1 408 Request Timeout\r\n", data
   end
 
+  def test_timeout_data_no_queue
+    @server = Puma::Server.new @app, @events, queue_requests: false
+    test_timeout_in_data_phase
+  end
+
   def test_timeout_after_data_received
     @server.first_data_timeout = 4
     @server.between_bytes_timeout = 2
@@ -419,19 +424,7 @@ EOF
 
   def test_timeout_after_data_received_no_queue
     @server = Puma::Server.new @app, @events, queue_requests: false
-    @server.first_data_timeout = 4
-    @server.between_bytes_timeout = 2
-    server_run
-
-    sock = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 100\r\n\r\n"
-    sleep 0.1
-
-    sock << "hello"
-    sleep 0.1
-
-    data = assert_proper_timeout(@server.between_bytes_timeout) { sock.gets }
-
-    assert_equal "HTTP/1.1 408 Request Timeout\r\n", data
+    test_timeout_after_data_received
   end
 
   def test_no_timeout_after_data_received
@@ -451,9 +444,9 @@ EOF
     assert_equal "HTTP/1.1 200 OK\r\n", data
   end
 
-  def test_timeout_data_no_queue
+  def test_no_timeout_after_data_received_no_queue
     @server = Puma::Server.new @app, @events, queue_requests: false
-    test_timeout_in_data_phase
+    test_no_timeout_after_data_received
   end
 
   def test_http_11_keep_alive_with_body

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -382,9 +382,9 @@ EOF
     assert_equal [:booting, :running, :stop, :done], states
   end
 
-  def assert_proper_timeout(expected, &block)
+  def assert_proper_timeout(expected)
     now = Time.now
-    ret = block.call
+    ret = yield
     t = Time.now - now
     assert_in_delta expected, t, 0.5, "unexpected timeout, #{t} instead of ~#{expected}"
     ret


### PR DESCRIPTION
### Description
Closes #2574 by adding a `between_bytes_timeout` config option to handle slow requests instead of treating `first_data_timeout` as a global request timeout.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.


### Some notes

- I didn't set a default in `const.rb` for this since it defaults to whatever is provided for `:first_data_timeout`
- I added the `assert_proper_timeout` method in the server test file because I saw another assertion added to that file, there was only one, and I didn't see a rhyme or reason as to where I should add that assertion. Let me know if there's a better spot for it.