### PR TITLE
Update helper.rb TestSkips, add HAS_UNIX_SOCKET to puma.rb [changelog skip]

### DIFF
--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -23,6 +23,8 @@ module Puma
   # not in minissl.rb
   HAS_SSL = const_defined?(:MiniSSL, false) && MiniSSL.const_defined?(:Engine, false)
 
+  HAS_UNIX_SOCKET = Object.const_defined? :UNIXSocket
+
   if HAS_SSL
     require 'puma/minissl'
   else

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -199,10 +199,10 @@ class TestIntegration < Minitest::Test
 
   def hot_restart_does_not_drop_connections(num_threads: 1, total_requests: 500)
     skipped = true
-    skip_on :jruby, suffix: <<-MSG
+    skip_if :jruby, suffix: <<-MSG
  - file descriptors are not preserved on exec on JRuby; connection reset errors are expected during restarts
     MSG
-    skip_on :truffleruby, suffix: ' - Undiagnosed failures on TruffleRuby'
+    skip_if :truffleruby, suffix: ' - Undiagnosed failures on TruffleRuby'
     skip "Undiagnosed failures on Ruby 2.2" if RUBY_VERSION < '2.3'
 
     args = "-w #{workers} -t 0:5 -q test/rackup/hello_with_delay.ru"

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -67,7 +67,7 @@ class TestCLI < Minitest::Test
   end
 
   def test_control_for_ssl
-    skip 'No ssl support' unless ::Puma::HAS_SSL
+    skip_unless :ssl
 
     require "net/http"
     control_port = UniquePort.call
@@ -105,8 +105,8 @@ class TestCLI < Minitest::Test
   end
 
   def test_control_clustered
-    skip NO_FORK_MSG  unless HAS_FORK
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    skip_unless :fork
+    skip_unless :unix
     url = "unix://#{@tmp_path}"
 
     cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
@@ -156,7 +156,7 @@ class TestCLI < Minitest::Test
   end
 
   def test_control
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    skip_unless :unix
     url = "unix://#{@tmp_path}"
 
     cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
@@ -183,7 +183,7 @@ class TestCLI < Minitest::Test
   end
 
   def test_control_stop
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    skip_unless :unix
     url = "unix://#{@tmp_path}"
 
     cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
@@ -248,7 +248,7 @@ class TestCLI < Minitest::Test
   end
 
   def test_control_thread_backtraces
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    skip_unless :unix
     url = "unix://#{@tmp_path}"
 
     cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
@@ -330,7 +330,7 @@ class TestCLI < Minitest::Test
   end
 
   def test_control_gc_stats_unix
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    skip_unless :unix
 
     uri  = "unix://#{@tmp_path2}"
     cntl = "unix://#{@tmp_path}"
@@ -339,7 +339,7 @@ class TestCLI < Minitest::Test
   end
 
   def test_tmp_control
-    skip_on :jruby, suffix: " - Unknown issue"
+    skip_if :jruby, suffix: " - Unknown issue"
 
     cli = Puma::CLI.new ["--state", @tmp_path, "--control-url", "auto"]
     cli.launcher.write_state
@@ -356,7 +356,7 @@ class TestCLI < Minitest::Test
   end
 
   def test_state_file_callback_filtering
-    skip NO_FORK_MSG unless HAS_FORK
+    skip_unless :fork
     cli = Puma::CLI.new [ "--config", "test/config/state_file_testing_config.rb",
                           "--state", @tmp_path ]
     cli.launcher.write_state
@@ -373,7 +373,7 @@ class TestCLI < Minitest::Test
   end
 
   def test_log_formatter_default_clustered
-    skip NO_FORK_MSG unless HAS_FORK
+    skip_unless :fork
 
     cli = Puma::CLI.new [ "-w 2" ]
     assert_instance_of Puma::Events::PidFormatter, cli.launcher.events.formatter
@@ -386,7 +386,7 @@ class TestCLI < Minitest::Test
   end
 
   def test_log_formatter_custom_clustered
-    skip NO_FORK_MSG unless HAS_FORK
+    skip_unless :fork
 
     cli = Puma::CLI.new [ "--config", "test/config/custom_log_formatter.rb", "-w 2" ]
     assert_instance_of Proc, cli.launcher.events.formatter

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -43,7 +43,7 @@ class TestConfigFile < TestConfigFileBase
   end
 
   def test_ssl_configuration_from_DSL
-    skip 'No ssl support' unless ::Puma::HAS_SSL
+    skip_unless :ssl
     conf = Puma::Configuration.new do |config|
       config.load "test/config/ssl_config.rb"
     end
@@ -60,8 +60,8 @@ class TestConfigFile < TestConfigFileBase
   end
 
   def test_ssl_bind
-    skip_on :jruby
-    skip 'No ssl support' unless ::Puma::HAS_SSL
+    skip_if :jruby
+    skip_unless :ssl
 
     conf = Puma::Configuration.new do |c|
       c.ssl_bind "0.0.0.0", "9292", {
@@ -79,7 +79,7 @@ class TestConfigFile < TestConfigFileBase
 
   def test_ssl_bind_jruby
     skip_unless :jruby
-    skip 'No ssl support' unless ::Puma::HAS_SSL
+    skip_unless :ssl
 
     cipher_list = "TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
 
@@ -104,8 +104,8 @@ class TestConfigFile < TestConfigFileBase
 
 
   def test_ssl_bind_no_tlsv1_1
-    skip_on :jruby
-    skip 'No ssl support' unless ::Puma::HAS_SSL
+    skip_if :jruby
+    skip_unless :ssl
 
     conf = Puma::Configuration.new do |c|
       c.ssl_bind "0.0.0.0", "9292", {
@@ -123,8 +123,8 @@ class TestConfigFile < TestConfigFileBase
   end
 
   def test_ssl_bind_with_cipher_filter
-    skip_on :jruby
-    skip 'No ssl support' unless ::Puma::HAS_SSL
+    skip_if :jruby
+    skip_unless :ssl
 
     cipher_filter = "!aNULL:AES+SHA"
     conf = Puma::Configuration.new do |c|
@@ -142,8 +142,8 @@ class TestConfigFile < TestConfigFileBase
   end
 
   def test_ssl_bind_with_verification_flags
-    skip_on :jruby
-    skip 'No ssl support' unless ::Puma::HAS_SSL
+    skip_if :jruby
+    skip_unless :ssl
 
     conf = Puma::Configuration.new do |c|
       c.ssl_bind "0.0.0.0", "9292", {
@@ -160,7 +160,7 @@ class TestConfigFile < TestConfigFileBase
   end
 
   def test_ssl_bind_with_ca
-    skip 'No ssl support' unless ::Puma::HAS_SSL
+    skip_unless :ssl
     conf = Puma::Configuration.new do |c|
       c.ssl_bind "0.0.0.0", "9292", {
         cert: "/path/to/cert",

--- a/test/test_http11.rb
+++ b/test/test_http11.rb
@@ -114,7 +114,7 @@ class Http11ParserTest < Minitest::Test
   end
 
   def test_semicolon_in_path
-    skip_on :jruby # Not yet supported on JRuby, see https://github.com/puma/puma/issues/1978
+    skip_if :jruby # Not yet supported on JRuby, see https://github.com/puma/puma/issues/1978
     parser = Puma::HttpParser.new
     req = {}
     get = "GET /forums/1/path;stillpath/2375?page=1 HTTP/1.1\r\n\r\n"

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -7,7 +7,7 @@ class TestIntegrationCluster < TestIntegration
   def workers ; 2 ; end
 
   def setup
-    skip NO_FORK_MSG unless HAS_FORK
+    skip_unless :fork
     super
   end
 
@@ -25,7 +25,7 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_pre_existing_unix
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    skip_unless :unix
 
     File.open(@bind_path, mode: 'wb') { |f| f.puts 'pre existing' }
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -306,9 +306,7 @@ RUBY
     cli_server "-w #{workers} --preload test/rackup/write_to_stdout_on_boot.ru"
 
     worker_load_count = 0
-    while (line = @server.gets) =~ /^Loading app/
-      worker_load_count += 1
-    end
+    worker_load_count += 1 while @server.gets =~ /^Loading app/
 
     assert_equal 0, worker_load_count
   end
@@ -321,7 +319,7 @@ RUBY
       output << line
     end
 
-    assert_match /WARNING: Detected running cluster mode with 1 worker/, output.join
+    assert_match(/WARNING: Detected running cluster mode with 1 worker/, output.join)
   end
 
   def test_warning_message_not_outputted_when_single_worker_silenced
@@ -332,7 +330,7 @@ RUBY
       output << line
     end
 
-    refute_match /WARNING: Detected running cluster mode with 1 worker/, output.join
+    refute_match(/WARNING: Detected running cluster mode with 1 worker/, output.join)
   end
 
   private

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -23,7 +23,7 @@ class TestIntegrationPumactl < TestIntegration
   end
 
   def test_stop_tcp
-    skip_on :jruby, :truffleruby # Undiagnose thread race. TODO fix
+    skip_if :jruby, :truffleruby # Undiagnose thread race. TODO fix
     @control_tcp_port = UniquePort.call
     cli_server "-q test/rackup/sleep.ru --control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN} -S #{@state_path}"
 
@@ -44,7 +44,7 @@ class TestIntegrationPumactl < TestIntegration
   end
 
   def ctl_unix(signal='stop')
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    skip_unless :unix
     stderr = Tempfile.new(%w(stderr .log))
     cli_server "-q test/rackup/sleep.ru --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}",
       config: "stdout_redirect nil, '#{stderr.path}'",
@@ -59,7 +59,7 @@ class TestIntegrationPumactl < TestIntegration
   end
 
   def test_phased_restart_cluster
-    skip NO_FORK_MSG unless HAS_FORK
+    skip_unless :fork
     cli_server "-q -w #{workers} test/rackup/sleep.ru --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}", unix: true
 
     start = Time.now
@@ -94,7 +94,7 @@ class TestIntegrationPumactl < TestIntegration
   end
 
   def test_prune_bundler_with_multiple_workers
-    skip NO_FORK_MSG unless HAS_FORK
+    skip_unless :fork
 
     cli_server "-q -C test/config/prune_bundler_with_multiple_workers.rb --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}", unix: true
 
@@ -114,7 +114,7 @@ class TestIntegrationPumactl < TestIntegration
   end
 
   def test_kill_unknown
-    skip_on :jruby
+    skip_if :jruby
 
     # we run ls to get a 'safe' pid to pass off as puma in cli stop
     # do not want to accidentally kill a valid other process

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -24,7 +24,7 @@ class TestIntegrationSingle < TestIntegration
   def test_usr2_restart_restores_environment
     # jruby has a bug where setting `nil` into the ENV or `delete` do not change the
     # next workers ENV
-    skip_on :jruby
+    skip_if :jruby
     skip_unless_signal_exist? :USR2
 
     initial_reply, new_reply = restart_server_and_listen("-q test/rackup/hello-env.ru")
@@ -36,7 +36,7 @@ class TestIntegrationSingle < TestIntegration
 
   def test_term_exit_code
     skip_unless_signal_exist? :TERM
-    skip_on :jruby # JVM does not return correct exit code for TERM
+    skip_if :jruby # JVM does not return correct exit code for TERM
 
     cli_server "test/rackup/hello.ru"
     _, status = stop_server
@@ -65,7 +65,7 @@ class TestIntegrationSingle < TestIntegration
 
   def test_term_not_accepts_new_connections
     skip_unless_signal_exist? :TERM
-    skip_on :jruby
+    skip_if :jruby
 
     cli_server 'test/rackup/sleep.ru'
 
@@ -94,7 +94,7 @@ class TestIntegrationSingle < TestIntegration
 
   def test_int_refuse
     skip_unless_signal_exist? :INT
-    skip_on :jruby  # seems to intermittently lockup JRuby CI
+    skip_if :jruby  # seems to intermittently lockup JRuby CI
 
     cli_server 'test/rackup/hello.ru'
     begin

--- a/test/test_integration_systemd.rb
+++ b/test/test_integration_systemd.rb
@@ -6,9 +6,9 @@ require 'sd_notify'
 class TestIntegrationSystemd < TestIntegration
   def setup
     skip "Skipped because Systemd support is linux-only" if windows? || osx?
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    skip_unless :unix
     skip_unless_signal_exist? :TERM
-    skip_on :jruby
+    skip_if :jruby
 
     super
 

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -8,7 +8,7 @@ class TestLauncher < Minitest::Test
   include TmpPath
 
   def test_files_to_require_after_prune_is_correctly_built_for_no_extra_deps
-    skip_on :no_bundler
+    skip_if :no_bundler
 
     dirs = launcher.send(:files_to_require_after_prune)
 
@@ -19,7 +19,7 @@ class TestLauncher < Minitest::Test
   end
 
   def test_files_to_require_after_prune_is_correctly_built_with_extra_deps
-    skip_on :no_bundler
+    skip_if :no_bundler
     conf = Puma::Configuration.new do |c|
       c.extra_runtime_dependencies ['rdoc']
     end
@@ -37,7 +37,7 @@ class TestLauncher < Minitest::Test
   end
 
   def test_extra_runtime_deps_directories_is_correctly_built
-    skip_on :no_bundler
+    skip_if :no_bundler
     conf = Puma::Configuration.new do |c|
       c.extra_runtime_dependencies ['rdoc']
     end
@@ -48,7 +48,7 @@ class TestLauncher < Minitest::Test
   end
 
   def test_puma_wild_location_is_an_absolute_path
-    skip_on :no_bundler
+    skip_if :no_bundler
     puma_wild_location = launcher.send(:puma_wild_location)
 
     assert_match(%r{bin/puma-wild$}, puma_wild_location)
@@ -139,7 +139,7 @@ class TestLauncher < Minitest::Test
   end
 
   def test_puma_stats_clustered
-    skip NO_FORK_MSG unless HAS_FORK
+    skip_unless :fork
 
     conf = Puma::Configuration.new do |c|
       c.app -> {[200, {}, ['']]}

--- a/test/test_preserve_bundler_env.rb
+++ b/test/test_preserve_bundler_env.rb
@@ -3,7 +3,7 @@ require_relative "helpers/integration"
 
 class TestPreserveBundlerEnv < TestIntegration
   def setup
-    skip NO_FORK_MSG unless HAS_FORK
+    skip_unless :fork
     super
   end
 

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -150,7 +150,7 @@ class TestPumaControlCli < TestConfigFileBase
   end
 
   def test_control_ssl
-    skip 'No ssl support' unless ::Puma::HAS_SSL
+    skip_unless :ssl
 
     host = "127.0.0.1"
     port = UniquePort.call

--- a/test/test_redirect_io.rb
+++ b/test/test_redirect_io.rb
@@ -28,7 +28,7 @@ class TestRedirectIO < TestIntegration
   end
 
   def test_sighup_redirects_io_single
-    skip_on :jruby # Server isn't coming up in CI, TODO Fix
+    skip_if :jruby # Server isn't coming up in CI, TODO Fix
 
     cli_args = [
       '--redirect-stdout', @out_file_path,
@@ -55,7 +55,7 @@ class TestRedirectIO < TestIntegration
   end
 
   def test_sighup_redirects_io_cluster
-    skip NO_FORK_MSG unless HAS_FORK
+    skip_unless :fork
 
     cli_args = [
       '-w', '1',

--- a/test/test_unix_socket.rb
+++ b/test/test_unix_socket.rb
@@ -22,7 +22,7 @@ class TestPumaUnixSocket < Minitest::Test
   end
 
   def test_server
-    skip UNIX_SKT_MSG unless UNIX_SKT_EXIST
+    skip_unless :unix
     sock = UNIXSocket.new @tmp_socket_path
 
     sock << "GET / HTTP/1.0\r\nHost: blah.com\r\n\r\n"

--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -3,7 +3,7 @@ require_relative "helpers/integration"
 
 class TestWorkerGemIndependence < TestIntegration
   def setup
-    skip NO_FORK_MSG unless HAS_FORK
+    skip_unless :fork
     super
   end
 


### PR DESCRIPTION
### Description

The TestSkips class was originally used for skipping tests based on OS and used `skip_on` & `skip_unless`.

1. Change `skip_on` to `skip_if`.
2. Add more options for things like `UNIXSocket`, `Kernel.fork`, ssl support, etc.
3. Update tests to use updated syntax.

This also makes skip messages more consistent, which is used by code that will be added to another PR that groups test skips so one doesn't have to wade thru a large list to see the failures & errors.

See:
https://github.com/MSP-Greg/puma/runs/2051481529?check_suite_focus=true#step:9:528

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.