### PR TITLE
Minitest - Add code to group & summarize test skips [changelog skip]

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -167,3 +167,49 @@ Minitest.after_run do
     end
   end
 end
+
+module AggregatedResults
+  def aggregated_results(io)
+    filtered_results = results.dup
+
+    if options[:verbose]
+      skips = filtered_results.select(&:skipped?)
+      unless skips.empty?
+        dash = "\u2500"
+        io.puts '', "Skips:"
+        hsh = skips.group_by { |f| f.failures.first.error.message }
+        hsh_s = {}
+        hsh.each { |k, ary|
+          hsh_s[k] = ary.map { |s|
+            [s.source_location, s.klass, s.name]
+          }.sort_by(&:first)
+        }
+        num = 0
+        hsh_s = hsh_s.sort.to_h
+        hsh_s.each { |k,v|
+          io.puts " #{k} #{dash * 2}".rjust 90, dash
+          hsh_1 = v.group_by { |i| i.first.first }
+          hsh_1.each { |k,v|
+            io.puts "  #{k[/\/test\/(.*)/,1]}"
+            v.each { |item|
+              num += 1
+              io.puts format("    %3s %-5s #{item[1]} #{item[2]}", "#{num})", ":#{item[0][1]}")
+            }
+            puts ''
+          }
+        }
+      end
+    end
+
+    filtered_results.reject!(&:skipped?)
+
+    io.puts "Errors & Failures:" unless filtered_results.empty?
+
+    filtered_results.each_with_index { |result, i|
+      io.puts "\n%3d) %s" % [i+1, result]
+    }
+    io.puts
+    io
+  end
+end
+Minitest::SummaryReporter.prepend AggregatedResults


### PR DESCRIPTION
### Description

Many CI jobs have a large number of skips, and Minitest's verbose output lists skips, failures, & errors in the order they occurred.

This adds code to helper.rb to group the skips by their skip message, making it easier to see better information about the skips, and places the failure & error logging at the end of the summary output.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added an entry to [History.md](../blob/master/History.md) if this PR fixes a bug or adds a feature. If it doesn't need an entry to HISTORY.md, I have added `[changelog skip]` or `[ci skip]` to the pull request title.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.