### PR TITLE
Micro optimisations in `wait_for_less_busy_worker` feature

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -327,8 +327,7 @@ module Puma
                 break if handle_check
               else
                 pool.wait_until_not_full
-                pool.wait_for_less_busy_worker(
-                  @options[:wait_for_less_busy_worker].to_f)
+                pool.wait_for_less_busy_worker(@options[:wait_for_less_busy_worker])
 
                 io = begin
                   sock.accept_nonblock

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -240,7 +240,7 @@ module Puma
 
     # @version 5.0.0
     def wait_for_less_busy_worker(delay_s)
-      return unless delay_s > 0
+      return unless delay_s && delay_s > 0
 
       # Ruby MRI does GVL, this can result
       # in processing contention when multiple threads

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -240,11 +240,12 @@ module Puma
 
     # @version 5.0.0
     def wait_for_less_busy_worker(delay_s)
+      return unless delay_s > 0
+      
       # Ruby MRI does GVL, this can result
       # in processing contention when multiple threads
       # (requests) are running concurrently
       return unless Puma.mri?
-      return unless delay_s > 0
 
       with_mutex do
         return if @shutdown

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -241,7 +241,7 @@ module Puma
     # @version 5.0.0
     def wait_for_less_busy_worker(delay_s)
       return unless delay_s > 0
-      
+
       # Ruby MRI does GVL, this can result
       # in processing contention when multiple threads
       # (requests) are running concurrently


### PR DESCRIPTION
Two small things:

- https://github.com/puma/puma/pull/2079/files#r422738756 -> swap the order of calls so that the faster call (float comparison) runs first.
- https://github.com/puma/puma/pull/2079/files#r596114279 -> don't call `.to_f` on option that we already know is a float.
