### PR TITLE
preload_app! is not always disabled by default [ci skip]

### DIFF
--- a/docs/restart.md
+++ b/docs/restart.md
@@ -45,7 +45,7 @@ Any of the following will cause a Puma server to perform a phased restart:
 ### Supported configurations
 
 * Works in cluster mode only
-* To support upgrading the application that Puma is serving, ensure `prune_bundler` is enabled and that `preload_app` is disabled (it is disabled by default).
+* To support upgrading the application that Puma is serving, ensure `prune_bundler` is enabled and that `preload_app!` is disabled
 * Supported on all platforms where cluster mode is supported
 
 ### Client experience


### PR DESCRIPTION
### Description

See https://github.com/puma/puma/blob/v5.2.2/lib/puma/dsl.rb#L615-L623

The default changed in Puma 5 with #2143. Docs later updated in #2481.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
