### PR TITLE
request.rb - fix chunked body assembly for ascii incompatible encodings

### DIFF
--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -148,8 +148,9 @@ module Puma
           res_body.each do |part|
             next if part.bytesize.zero?
             if chunked
-              str = part.bytesize.to_s(16) << line_ending << part << line_ending
-              fast_write io, str
+               fast_write io, (part.bytesize.to_s(16) << line_ending)
+               fast_write io, part            # part may have different encoding
+               fast_write io, line_ending
             else
               fast_write io, part
             end


### PR DESCRIPTION
### Description

Went through several versions, benched all of them, and this seemed the best compromise for small and large (100kb) chunked bodies, both ascii compatible and not.

Closes #2583

Also, Fix `TestPumaServer#test_custom_io_selector`. On fast systems, stopping the server happened fast enough so that `IOError: selector is closed` was raised.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
