### PR TITLE
Replace usages of "MRI" with "CRuby"

### DIFF
--- a/.github/workflows/cruby.yml
+++ b/.github/workflows/cruby.yml
@@ -1,4 +1,4 @@
-name: non_MRI
+name: CRuby
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -14,13 +14,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, windows-2019 ]
+        ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', head ]
+        no-ssl: ['']
         include:
-          - { os: ubuntu-20.04 , ruby: jruby }
-          - { os: ubuntu-20.04 , ruby: jruby, no-ssl: ' no SSL' }
-          - { os: ubuntu-20.04 , ruby: jruby-head, allow-failure: true }
-          - { os: ubuntu-20.04 , ruby: truffleruby-head }
-          - { os: macos-10.15  , ruby: jruby }
-          - { os: macos-10.15  , ruby: truffleruby-head }
+          - { os: windows-2019 , ruby: mingw }
+          - { os: ubuntu-20.04 , ruby: 2.7   , no-ssl: ' no SSL' }
+          - { os: windows-2019 , ruby: 2.7   , no-ssl: ' no SSL' }
+        exclude:
+          - { os: ubuntu-20.04 , ruby: 2.2  }
+          - { os: ubuntu-20.04 , ruby: 2.3  }
+          - { os: ubuntu-20.04 , ruby: 2.4  }
+          - { os: ubuntu-20.04 , ruby: 2.6  }
+          - { os: windows-2019 , ruby: head }
 
     steps:
       - name: repo checkout
@@ -34,15 +40,15 @@ jobs:
           brew: ragel
           mingw: _upgrade_ openssl ragel
 
-      - name: set JAVA_HOME
-        if: startsWith(matrix.os, 'macos')
-        shell: bash
-        run:  |
-          echo JAVA_HOME=$JAVA_HOME_11_X64 >> $GITHUB_ENV
-
-      - name: bundle install
+      - name:  bundle install
         timeout-minutes: 5
-        run:  bundle install --jobs 4 --retry 3
+        shell: pwsh
+        run:   |
+          # update RubyGems in Ruby 2.2, bundle install
+          if ('${{ matrix.ruby }}' -lt '2.3') {
+            gem update --system 2.7.11 --no-document
+          }
+          bundle install --jobs 4 --retry 3
 
       - name: set SSL
         if: matrix.no-ssl == ' no SSL'
@@ -57,17 +63,9 @@ jobs:
         run:  bundle exec rake compile
 
       - name: rubocop
-        if: endsWith(matrix.ruby, '-head') == false
+        if: startsWith(matrix.ruby, 'truffleruby') == false
         run: bundle exec rake rubocop
 
       - name: test
-        id: test
-        timeout-minutes: 12
-        continue-on-error: ${{ matrix.allow-failure || false }}
-        if: success() # only run if previous steps have succeeded
+        timeout-minutes: 10
         run: bundle exec rake test:all
-
-      - name: >-
-          Test outcome: ${{ steps.test.outcome }}
-        # every step must define a `uses` or `run` key
-        run: echo NOOP

--- a/.github/workflows/non_cruby.yml
+++ b/.github/workflows/non_cruby.yml
@@ -1,4 +1,4 @@
-name: MRI
+name: non-CRuby
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -14,19 +14,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, windows-2019 ]
-        ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', head ]
-        no-ssl: ['']
         include:
-          - { os: windows-2019 , ruby: mingw }
-          - { os: ubuntu-20.04 , ruby: 2.7   , no-ssl: ' no SSL' }
-          - { os: windows-2019 , ruby: 2.7   , no-ssl: ' no SSL' }
-        exclude:
-          - { os: ubuntu-20.04 , ruby: 2.2  }
-          - { os: ubuntu-20.04 , ruby: 2.3  }
-          - { os: ubuntu-20.04 , ruby: 2.4  }
-          - { os: ubuntu-20.04 , ruby: 2.6  }
-          - { os: windows-2019 , ruby: head }
+          - { os: ubuntu-20.04 , ruby: jruby }
+          - { os: ubuntu-20.04 , ruby: jruby, no-ssl: ' no SSL' }
+          - { os: ubuntu-20.04 , ruby: jruby-head, allow-failure: true }
+          - { os: ubuntu-20.04 , ruby: truffleruby-head }
+          - { os: macos-10.15  , ruby: jruby }
+          - { os: macos-10.15  , ruby: truffleruby-head }
 
     steps:
       - name: repo checkout
@@ -40,15 +34,15 @@ jobs:
           brew: ragel
           mingw: _upgrade_ openssl ragel
 
-      - name:  bundle install
+      - name: set JAVA_HOME
+        if: startsWith(matrix.os, 'macos')
+        shell: bash
+        run:  |
+          echo JAVA_HOME=$JAVA_HOME_11_X64 >> $GITHUB_ENV
+
+      - name: bundle install
         timeout-minutes: 5
-        shell: pwsh
-        run:   |
-          # update RubyGems in Ruby 2.2, bundle install
-          if ('${{ matrix.ruby }}' -lt '2.3') {
-            gem update --system 2.7.11 --no-document
-          }
-          bundle install --jobs 4 --retry 3
+        run:  bundle install --jobs 4 --retry 3
 
       - name: set SSL
         if: matrix.no-ssl == ' no SSL'
@@ -63,9 +57,17 @@ jobs:
         run:  bundle exec rake compile
 
       - name: rubocop
-        if: startsWith(matrix.ruby, 'truffleruby') == false
+        if: endsWith(matrix.ruby, '-head') == false
         run: bundle exec rake rubocop
 
       - name: test
-        timeout-minutes: 10
+        id: test
+        timeout-minutes: 12
+        continue-on-error: ${{ matrix.allow-failure || false }}
+        if: success() # only run if previous steps have succeeded
         run: bundle exec rake test:all
+
+      - name: >-
+          Test outcome: ${{ steps.test.outcome }}
+        # every step must define a `uses` or `run` key
+        run: echo NOOP

--- a/5.0-Upgrade.md
+++ b/5.0-Upgrade.md
@@ -16,7 +16,7 @@ Puma 5 also welcomes [@MSP-Greg](https://github.com/puma/puma/commits?author=MSP
 
 ## What's New
 
-Puma 5 contains three new "experimental" performance features for cluster-mode Pumas running on MRI.
+Puma 5 contains three new "experimental" performance features for cluster-mode Pumas running on CRuby.
 
 If you try any of these features, please report your results to [our report issue](https://github.com/puma/puma/issues/2258).
 
@@ -28,7 +28,7 @@ If any of the features turn out to be particularly beneficial, we may make them 
 
 ### Lower latency, better throughput
 
-From our friends at GitLab, the new experimental `wait_for_less_busy_worker` config option may reduce latency and improve throughput for high-load Puma apps on MRI. See the [pull request](https://github.com/puma/puma/pull/2079) for more discussion.
+From our friends at GitLab, the new experimental `wait_for_less_busy_worker` config option may reduce latency and improve throughput for high-load Puma apps on CRuby. See the [pull request](https://github.com/puma/puma/pull/2079) for more discussion.
 
 Users of this option should see reduced request queue latency and possibly less overall latency.
 
@@ -48,7 +48,7 @@ Production testing at GitLab suggests values between `0.001` and `0.010` are bes
 
 #### nakayoshi_fork
 
-`nakayoshi_fork` calls GC a handful of times and compacts the heap on Ruby 2.7+ before forking. This may reduce memory usage of Puma on MRI with preload enabled. It's inspired by [Koichi Sasada's work](https://github.com/ko1/nakayoshi_fork).
+`nakayoshi_fork` calls GC a handful of times and compacts the heap on Ruby 2.7+ before forking. This may reduce memory usage of Puma on CRuby with preload enabled. It's inspired by [Koichi Sasada's work](https://github.com/ko1/nakayoshi_fork).
 
 To use it, you can add this to your `puma.rb`:
 
@@ -88,7 +88,7 @@ To learn more about using `refork` and `fork_worker`, see ['Fork Worker'](docs/f
 * If you did not explicitly set `environment` before, Puma now checks `RAILS_ENV` and will use that, if available in addition to `RACK_ENV`.
 * If you have been using the `--control` CLI option, update your scripts to use `--control-url`.
 * If you are using `worker_directory` in your config file, change it to `directory`.
-* If you are running MRI, default thread count on Puma is now 5, not 16. This may change the amount of threads running in your threadpool. We believe 5 is a better default for most Ruby web applications on MRI. Higher settings increase latency by causing GVL contention.
+* If you are running CRuby, default thread count on Puma is now 5, not 16. This may change the amount of threads running in your threadpool. We believe 5 is a better default for most Ruby web applications on CRuby. Higher settings increase latency by causing GVL contention.
 * If you are using a worker count of more than 1, set using `WEB_CONCURRENCY`, Puma will now preload the application by default (disable with `preload_app! false`). We believe this is a better default, but may cause issues in non-Rails applications if you do not have the proper `before` and `after` fork hooks configured. See documentation for your framework. Rails users do not need to change anything. **Please note that it is not possible to use [the phased restart](docs/restart.md) with preloading.**
 * tcp mode and daemonization have been removed without replacement. For daemonization, please use a modern process management solution, such as systemd or monit.
 * `connected_port` was renamed to `connected_ports` and now returns an Array, not an Integer.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 # Puma: A Ruby Web Server Built For Concurrency
 
-[![Actions MRI](https://github.com/puma/puma/workflows/MRI/badge.svg?branch=master)](https://github.com/puma/puma/actions?query=workflow%3AMRI)
-[![Actions non MRI](https://github.com/puma/puma/workflows/non_MRI/badge.svg?branch=master)](https://github.com/puma/puma/actions?query=workflow%3Anon_MRI)
+[![Actions CRuby](https://github.com/puma/puma/workflows/CRuby/badge.svg?branch=master)](https://github.com/puma/puma/actions?query=workflow%3ACRuby)
+[![Actions non CRuby](https://github.com/puma/puma/workflows/non_CRuby/badge.svg?branch=master)](https://github.com/puma/puma/actions?query=workflow%3Anon_CRuby)
 [![Code Climate](https://codeclimate.com/github/puma/puma.svg)](https://codeclimate.com/github/puma/puma)
 [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=puma&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=puma&package-manager=bundler&version-scheme=semver)
 [![StackOverflow](https://img.shields.io/badge/stackoverflow-Puma-blue.svg)]( https://stackoverflow.com/questions/tagged/puma )

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Puma is a **simple, fast, multi-threaded, and highly concurrent HTTP 1.1 server 
 
 Puma processes requests using a C-optimized Ragel extension (inherited from Mongrel) that provides fast, accurate HTTP 1.1 protocol parsing in a portable way. Puma then serves the request using a thread pool. Each request is served in a separate thread, so truly concurrent Ruby implementations (JRuby, Rubinius) will use all available CPU cores.
 
-Originally designed as a server for (Rubinius)[https://github.com/rubinius/rubinius], Puma also works well with Ruby (MRI) and JRuby.
+Originally designed as a server for (Rubinius)[https://github.com/rubinius/rubinius], Puma also works well with CRuby and JRuby.
 
-On MRI, there is a Global VM Lock (GVL) that ensures only one thread can run Ruby code at a time. But if you're doing a lot of blocking IO (such as HTTP calls to external APIs like Twitter), Puma still improves MRI's throughput by allowing IO waiting to be done in parallel.
+On CRuby, there is a Global VM Lock (GVL) that ensures only one thread can run Ruby code at a time. But if you're doing a lot of blocking IO (such as HTTP calls to external APIs like Twitter), Puma still improves CRuby's throughput by allowing IO waiting to be done in parallel.
 
 ## Quick Start
 
@@ -96,7 +96,7 @@ Puma uses a thread pool. You can set the minimum and maximum number of threads t
 $ puma -t 8:32
 ```
 
-Puma will automatically scale the number of threads, from the minimum until it caps out at the maximum, based on how much traffic is present. The current default is `0:16` and on MRI is `0:5`. Feel free to experiment, but be careful not to set the number of maximum threads to a large number, as you may exhaust resources on the system (or cause contention for the Global VM Lock, when using MRI).
+Puma will automatically scale the number of threads, from the minimum until it caps out at the maximum, based on how much traffic is present. The current default is `0:16` and on CRuby is `0:5`. Feel free to experiment, but be careful not to set the number of maximum threads to a large number, as you may exhaust resources on the system (or cause contention for the Global VM Lock, when using CRuby).
 
 Be aware that additionally Puma creates threads on its own for internal purposes (e.g. handling slow clients). So, even if you specify -t 1:1, expect around 7 threads created in your application.
 
@@ -269,7 +269,7 @@ Check out `Puma::DSL` or [dsl.rb](https://github.com/puma/puma/blob/master/lib/p
 
 ## Restart
 
-Puma includes the ability to restart itself. When available (MRI, Rubinius, JRuby), Puma performs a "hot restart". This is the same functionality available in *Unicorn* and *NGINX* which keep the server sockets open between restarts. This makes sure that no pending requests are dropped while the restart is taking place.
+Puma includes the ability to restart itself. When available (CRuby, Rubinius, JRuby), Puma performs a "hot restart". This is the same functionality available in *Unicorn* and *NGINX* which keep the server sockets open between restarts. This makes sure that no pending requests are dropped while the restart is taking place.
 
 For more, see the [Restart documentation](docs/restart.md).
 
@@ -287,7 +287,7 @@ Some platforms do not support all Puma features.
 
 ## Known Bugs
 
-For MRI versions 2.2.7, 2.2.8, 2.2.9, 2.2.10, 2.3.4 and 2.4.1, you may see ```stream closed in another thread (IOError)```. It may be caused by a [Ruby bug](https://bugs.ruby-lang.org/issues/13632). It can be fixed with the gem https://rubygems.org/gems/stopgap_13632:
+For CRuby versions 2.2.7, 2.2.8, 2.2.9, 2.2.10, 2.3.4 and 2.4.1, you may see ```stream closed in another thread (IOError)```. It may be caused by a [Ruby bug](https://bugs.ruby-lang.org/issues/13632). It can be fixed with the gem https://rubygems.org/gems/stopgap_13632:
 
 ```ruby
 if %w(2.2.7 2.2.8 2.2.9 2.2.10 2.3.4 2.4.1).include? RUBY_VERSION

--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ task :ragel => ['ext/puma_http11/org/jruby/puma/Http11Parser.java']
 
 if !Puma.jruby?
   # compile extensions using rake-compiler
-  # C (MRI, Rubinius)
+  # C (CRuby, Rubinius)
   Rake::ExtensionTask.new("puma_http11", gemspec) do |ext|
     # place extension inside namespace
     ext.lib_dir = "lib/puma"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,7 +24,7 @@ set the number of workers to 0, anything above will run in cluster mode.
 
 Here are some rules of thumb for cluster mode:
 
-### MRI
+### CRuby
 
 * Use cluster mode and set the number of workers to 1.5x the number of cpu cores
   in the machine, minimum 2.
@@ -48,7 +48,7 @@ See [systemd.md](systemd.md)
 
 **How do you know if you've got enough (or too many workers)?**
 
-A good question. Due to MRI's GIL, only one thread can be executing Ruby code at a time.
+A good question. Due to CRuby's GVL, only one thread can be executing Ruby code at a time.
 But since so many apps are waiting on IO from DBs, etc., they can utilize threads
 to make better use of the process.
 

--- a/docs/restart.md
+++ b/docs/restart.md
@@ -22,7 +22,7 @@ Any of the following will cause a Puma server to perform a hot restart:
 ### Client experience
 
 * All platforms: for clients with an in-flight request, those clients will be served responses before the connection is closed gracefully. Puma gracefully disconnects any idle HTTP persistent connections before restarting.
-* On MRI or TruffleRuby on Linux and BSD: Clients who connect just before the server restarts may experience increased latency while the server stops and starts again, but their connections will not be closed prematurely.
+* On CRuby or TruffleRuby on Linux and BSD: Clients who connect just before the server restarts may experience increased latency while the server stops and starts again, but their connections will not be closed prematurely.
 * On Windows and on JRuby: Clients who connect just before a restart may experience "connection reset" errors.
 
 ### Additional notes

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -182,7 +182,7 @@ module Puma
 
     # @version 5.0.0
     def default_max_threads
-      Puma.mri? ? 5 : 16
+      Puma.cruby? ? 5 : 16
     end
 
     def puma_default_options

--- a/lib/puma/detect.rb
+++ b/lib/puma/detect.rb
@@ -29,6 +29,10 @@ module Puma
     IS_MRI
   end
 
+  def self.cruby?
+    IS_MRI
+  end
+
   # @version 5.0.0
   def self.forkable?
     HAS_FORK

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -408,7 +408,7 @@ module Puma
     # The default is the environment variables +PUMA_MIN_THREADS+ / +PUMA_MAX_THREADS+
     # (or +MIN_THREADS+ / +MAX_THREADS+ if the +PUMA_+ variables aren't set).
     #
-    # If these environment variables aren't set, the default is "0, 5" in MRI or "0, 16" for other interpreters.
+    # If these environment variables aren't set, the default is "0, 5" in CRuby or "0, 16" for other interpreters.
     #
     # @example
     #   threads 0, 16
@@ -797,7 +797,7 @@ module Puma
     # listening on the socket, allowing workers which are not processing any
     # requests to pick up new requests first.
     #
-    # Only works on MRI. For all other interpreters, this setting does nothing.
+    # Only works on CRuby. For all other interpreters, this setting does nothing.
     # @see Puma::Server#handle_servers
     # @see Puma::ThreadPool#wait_for_less_busy_worker
     # @version 5.0.0
@@ -866,7 +866,7 @@ module Puma
 
     # When enabled, Puma will GC 4 times before forking workers.
     # If available (Ruby 2.7+), we will also call GC.compact.
-    # Not recommended for non-MRI Rubies.
+    # Not recommended for non-CRuby Rubies.
     #
     # Based on the work of Koichi Sasada and Aaron Patterson, this option may
     # decrease memory utilization of preload-enabled cluster-mode Pumas. It will

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -87,7 +87,7 @@ module Puma
       @early_hints         = options.fetch :early_hints, nil
       @first_data_timeout  = options.fetch :first_data_timeout, FIRST_DATA_TIMEOUT
       @min_threads         = options.fetch :min_threads, 0
-      @max_threads         = options.fetch :max_threads , (Puma.mri? ? 5 : 16)
+      @max_threads         = options.fetch :max_threads , (Puma.cruby? ? 5 : 16)
       @persistent_timeout  = options.fetch :persistent_timeout, PERSISTENT_TIMEOUT
       @queue_requests      = options.fetch :queue_requests, true
       @max_fast_inline     = options.fetch :max_fast_inline, MAX_FAST_INLINE

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -242,10 +242,10 @@ module Puma
     def wait_for_less_busy_worker(delay_s)
       return unless delay_s && delay_s > 0
 
-      # Ruby MRI does GVL, this can result
+      # CRuby has a GVL, this can result
       # in processing contention when multiple threads
       # (requests) are running concurrently
-      return unless Puma.mri?
+      return unless Puma.cruby?
 
       with_mutex do
         return if @shutdown

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -142,7 +142,7 @@ module TestSkips
       when :darwin  then "Skip unless darwin"           unless Puma::IS_OSX
       when :jruby   then "Skip unless JRuby"            unless Puma::IS_JRUBY
       when :windows then "Skip unless Windows"          unless Puma::IS_WINDOWS
-      when :mri     then "Skip unless MRI"              unless Puma::IS_MRI
+      when :cruby   then "Skip unless CRuby"            unless Puma.cruby?
       when :ssl     then "Skip unless SSL is supported" unless Puma::HAS_SSL
       when :fork    then MSG_FORK                       unless HAS_FORK
       when :unix    then MSG_UNIX                       unless Puma::HAS_UNIX_SOCKET

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -441,7 +441,7 @@ class TestBinderJRuby < TestBinderBase
   end
 end if ::Puma::IS_JRUBY
 
-class TestBinderMRI < TestBinderBase
+class TestBinderCRuby < TestBinderBase
   def test_binder_parses_ssl_cipher_filter
     skip_unless :ssl
 

--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -3,7 +3,7 @@ require "puma/events"
 
 class TestBusyWorker < Minitest::Test
   def setup
-    skip_unless :mri # This feature only makes sense on MRI
+    skip_unless :cruby # This feature only makes sense on CRuby
     @ios = []
     @server = nil
   end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestIntegrationCluster < TestIntegration
-  parallelize_me! if ::Puma.mri?
+  parallelize_me! if ::Puma.cruby?
 
   def workers ; 2 ; end
 

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -3,7 +3,7 @@ require_relative "helpers/integration"
 
 class TestIntegrationPumactl < TestIntegration
   include TmpPath
-  parallelize_me! if ::Puma.mri?
+  parallelize_me! if ::Puma.cruby?
 
   def workers ; 2 ; end
 

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestIntegrationSingle < TestIntegration
-  parallelize_me! if ::Puma.mri?
+  parallelize_me! if ::Puma.cruby?
 
   def workers ; 0 ; end
 

--- a/test/test_integration_ssl.rb
+++ b/test/test_integration_ssl.rb
@@ -10,7 +10,7 @@ require_relative "helpers/integration"
 # the server process isn't affected by whatever is loaded in the CI process.
 
 class TestIntegrationSSL < TestIntegration
-  parallelize_me! if ::Puma.mri?
+  parallelize_me! if ::Puma.cruby?
 
   require "net/http"
   require "openssl"

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -128,11 +128,11 @@ class TestLauncher < Minitest::Test
     end
     launcher = launcher(conf)
     launcher.events.on_booted {
-      sleep 1.1 unless Puma.mri?
+      sleep 1.1 unless Puma.cruby?
       launcher.stop
     }
     launcher.run
-    sleep 1 unless Puma.mri?
+    sleep 1 unless Puma.cruby?
     Puma::Server::STAT_METHODS.each do |stat|
       assert_includes Puma.stats_hash, stat
     end
@@ -182,7 +182,7 @@ class TestLauncher < Minitest::Test
 
     launcher = launcher(conf)
     launcher.events.on_booted {
-      sleep 1.1 unless Puma.mri?
+      sleep 1.1 unless Puma.cruby?
       launcher.stop
     }
     launcher.events.on_stopped { puts 'on_stopped called' }
@@ -190,7 +190,7 @@ class TestLauncher < Minitest::Test
     out, = capture_io do
       launcher.run
     end
-    sleep 0.2 unless Puma.mri?
+    sleep 0.2 unless Puma.cruby?
     assert_equal 'on_stopped called', out.strip
   end
 


### PR DESCRIPTION
### Description

Most places in the codebase and in the docs that reference "MRI" are actually talking about CRuby. For a discussion about the difference, this blog post is useful: https://engineering.appfolio.com/appfolio-engineering/2017/12/28/cruby-mri-jruby-rubyspec-rubinius-yarv-a-little-bit-of-ruby-naming

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [X] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [X] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
