### PR TITLE
Define `UNPACK_TCP_STATE_FROM_TCP_INFO` in the right place

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -137,8 +137,6 @@ module Puma
     # socket parameter may be an MiniSSL::Socket, so use to_io
     #
     if tcp_cork_supported?
-      UNPACK_TCP_STATE_FROM_TCP_INFO = "C".freeze
-
       # 6 == Socket::IPPROTO_TCP
       # 3 == TCP_CORK
       # 1/0 == turn on/off
@@ -168,6 +166,8 @@ module Puma
     end
 
     if closed_socket_supported?
+      UNPACK_TCP_STATE_FROM_TCP_INFO = "C".freeze
+
       def closed_socket?(socket)
         return false unless socket.kind_of? TCPSocket
         return false unless @precheck_closing


### PR DESCRIPTION
### Description

This fixes the issue for me when I run Puma in FreeBSD using Vagrant. Instructions for that over at https://github.com/dentarg/puma-vagrant/tree/0c858e572fff48b3148b3bec81518471393f94df#freebsd

Close https://github.com/puma/puma/issues/2556

This change is included in https://github.com/puma/puma/pull/2554, but that PR has a lot of other changes too, hopefully this will be easier to review, merge and release.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
