### PR TITLE
[changelog skip] Reduce puma_parser struct padding

### DIFF
--- a/ext/puma_http11/http11_parser.h
+++ b/ext/puma_http11/http11_parser.h
@@ -29,8 +29,8 @@ typedef void (*field_cb)(struct puma_parser* hp,
 
 typedef struct puma_parser {
   int cs;
-  size_t body_start;
   int content_len;
+  size_t body_start;
   size_t nread;
   size_t mark;
   size_t field_start;


### PR DESCRIPTION
### Description
Modify `puma_parser` struct to remove 8 bytes padding in 64-bit machine.

`benchmarks/wrk/hello.sh` shows performance improvement from 4631.424 to 4750.686 (5 times average).

I use Ruby 3.0.0 and WSL2 Ubuntu 20.04 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
