### PR TITLE
systemd - fix event firing

### DIFF
--- a/test/test_integration_systemd.rb
+++ b/test/test_integration_systemd.rb
@@ -33,16 +33,16 @@ class TestIntegrationSystemd < TestIntegration
 
   def test_systemd_notify_usr1_phased_restart_cluster
     skip_unless :fork
-    restart :USR1
+    assert_restarts_with_systemd :USR1
   end
 
   def test_systemd_notify_usr2_hot_restart_cluster
     skip_unless :fork
-    restart :USR2
+    assert_restarts_with_systemd :USR2
   end
 
   def test_systemd_notify_usr2_hot_restart_single
-      restart :USR2, workers: 0
+    assert_restarts_with_systemd :USR2, workers: 0
   end
 
   def test_systemd_watchdog
@@ -59,7 +59,7 @@ class TestIntegrationSystemd < TestIntegration
 
   private
 
-  def restart(signal, workers: 2)
+  def assert_restarts_with_systemd(signal, workers: 2)
     cli_server "-w#{workers} test/rackup/hello.ru"
     assert_equal socket_message, 'READY=1'
 

--- a/test/test_integration_systemd.rb
+++ b/test/test_integration_systemd.rb
@@ -31,21 +31,18 @@ class TestIntegrationSystemd < TestIntegration
     ENV["WATCHDOG_USEC"] = nil
   end
 
-  def socket_message
-    @socket.recvfrom(15)[0]
+  def test_systemd_notify_usr1_phased_restart_cluster
+    skip_unless :fork
+    restart :USR1
   end
 
-  def test_systemd_integration
-    cli_server "test/rackup/hello.ru"
-    assert_equal(socket_message, "READY=1")
+  def test_systemd_notify_usr2_hot_restart_cluster
+    skip_unless :fork
+    restart :USR2
+  end
 
-    connection = connect
-    restart_server connection
-    assert_equal(socket_message, "RELOADING=1")
-    assert_equal(socket_message, "READY=1")
-
-    stop_server
-    assert_equal(socket_message, "STOPPING=1")
+  def test_systemd_notify_usr2_hot_restart_single
+      restart :USR2, workers: 0
   end
 
   def test_systemd_watchdog
@@ -58,5 +55,29 @@ class TestIntegrationSystemd < TestIntegration
 
     stop_server
     assert_match(socket_message, "STOPPING=1")
+  end
+
+  private
+
+  def restart(signal, workers: 2)
+    cli_server "-w#{workers} test/rackup/hello.ru"
+    assert_equal socket_message, 'READY=1'
+
+    Process.kill signal, @pid
+    connect.write "GET / HTTP/1.1\r\n\r\n"
+    assert_equal socket_message, 'RELOADING=1'
+    assert_equal socket_message, 'READY=1'
+
+    Process.kill signal, @pid
+    connect.write "GET / HTTP/1.1\r\n\r\n"
+    assert_equal socket_message, 'RELOADING=1'
+    assert_equal socket_message, 'READY=1'
+
+    stop_server
+    assert_equal socket_message, 'STOPPING=1'
+  end
+
+  def socket_message
+    @socket.recvfrom(15)[0]
   end
 end


### PR DESCRIPTION
### Description

Fixes event firings needed for systemd integration.

Closes #2572.

Note that `@events.fire_on_stopped!` was not called when in cluster mode, this also fixes that.

These tests take some time, I tested locally with two restarts, it passed.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
