### PR TITLE
Use write_nonblock in fast_write

### DIFF
--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -199,7 +199,7 @@ module Puma
       while true
         begin
           n = io.write_nonblock str
-        rescue IO::WaitWritable, Errno::EAGAIN, Errno::EWOULDBLOCK
+        rescue IO::WaitWritable, Errno::EINTR
           if !IO.select(nil, [io], nil, WRITE_TIMEOUT)
             raise ConnectionError, "Socket timeout writing data"
           end

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -198,8 +198,8 @@ module Puma
       n = 0
       while true
         begin
-          n = io.syswrite str
-        rescue Errno::EAGAIN, Errno::EWOULDBLOCK
+          n = io.write_nonblock str
+        rescue IO::WaitWritable, Errno::EAGAIN, Errno::EWOULDBLOCK
           if !IO.select(nil, [io], nil, WRITE_TIMEOUT)
             raise ConnectionError, "Socket timeout writing data"
           end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -134,8 +134,8 @@ class TestIntegration < Minitest::Test
     n = 0
     while true
       begin
-        n = io.syswrite str
-      rescue Errno::EAGAIN, Errno::EWOULDBLOCK => e
+        n = io.write_nonblock str
+      rescue IO::WaitWritable, Errno::EAGAIN, Errno::EWOULDBLOCK => e
         if !IO.select(nil, [io], nil, 5)
           raise e
         end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -135,7 +135,7 @@ class TestIntegration < Minitest::Test
     while true
       begin
         n = io.write_nonblock str
-      rescue IO::WaitWritable, Errno::EAGAIN, Errno::EWOULDBLOCK => e
+      rescue IO::WaitWritable, Errno::EINTR => e
         if !IO.select(nil, [io], nil, 5)
           raise e
         end


### PR DESCRIPTION
### Description

I notice that we use `read_nonblock` when reading request, but use `syswrite`  in response, I test it with `write_nonblock` and get the following performance improvement in `-t 4` mode.

- hello.ru,                     RPS: [5048.41, 5245.66] to [6891.50, 6880.93], **1.33x**
- realistic_response.ru, RPS: [3037.08, 3019.65] to [3853.68, 3806.11], **1.26x**


However, `big_response.ru` is slower, I think blocking IO is better when doing large response.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
