### PR TITLE
Support for non-blocking fibers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,4 @@ if %w(2.2.7 2.2.8 2.2.9 2.2.10 2.3.4 2.4.1).include? RUBY_VERSION
 end
 
 gem 'm'
+gem 'libev_scheduler', github: 'digital-fabric/libev_scheduler'

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -143,7 +143,7 @@ module Puma
       else
         begin
           if fast_check &&
-              IO.select([@to_io], nil, nil, FAST_TRACK_KA_TIMEOUT)
+            @to_io.wait_readable(FAST_TRACK_KA_TIMEOUT)
             return try_to_finish
           end
         rescue IOError
@@ -201,13 +201,13 @@ module Puma
 
     def eagerly_finish
       return true if @ready
-      return false unless IO.select([@to_io], nil, nil, 0)
+      return false unless @to_io.ready?
       try_to_finish
     end
 
     def finish(timeout)
       return if @ready
-      IO.select([@to_io], nil, nil, timeout) || timeout! until try_to_finish
+      @to_io.wait_readable(timeout) || timeout! until try_to_finish
     end
 
     def timeout!

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -194,6 +194,7 @@ module Puma
     PUMA_SOCKET = "puma.socket".freeze
     PUMA_CONFIG = "puma.config".freeze
     PUMA_PEERCERT = "puma.peercert".freeze
+    PUMA_THREAD_QUEUE = "puma.thread_queue".freeze
 
     HTTP = "http".freeze
     HTTPS = "https".freeze

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -922,7 +922,7 @@ module Puma
     # Requires Ruby >= 3.0.
     def fiber_scheduler(scheduler=nil, &block)
       raise "Fiber scheduler not available in Ruby version #{RUBY_VERSION}" unless Fiber.respond_to?(:set_scheduler)
-      @options[:fiber_scheduler] = ->{scheduler.new} if scheduler.is_a?(Class)
+      @options[:fiber_scheduler] = -> {scheduler.new} if scheduler.is_a?(Class)
       @options[:fiber_scheduler] ||= block
       raise "Provide either a block or Class" unless @options[:fiber_scheduler].is_a?(Proc)
     end

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -910,5 +910,21 @@ module Puma
     def mutate_stdout_and_stderr_to_sync_on_write(enabled=true)
       @options[:mutate_stdout_and_stderr_to_sync_on_write] = enabled
     end
+
+    # Specify a Fiber scheduler implementation to process requests using non-blocking Fibers.
+    #
+    # Accepts either a block returning an Object implementing +Fiber::SchedulerInterface+
+    # or a Class to be instantiated when the server thread starts.
+    #
+    # If a fiber scheduler is provided, the server will use a pool of non-blocking Fibers
+    # instead of threads.
+    #
+    # Requires Ruby >= 3.0.
+    def fiber_scheduler(scheduler=nil, &block)
+      raise "Fiber scheduler not available in Ruby version #{RUBY_VERSION}" unless Fiber.respond_to?(:set_scheduler)
+      @options[:fiber_scheduler] = ->{scheduler.new} if scheduler.is_a?(Class)
+      @options[:fiber_scheduler] ||= block
+      raise "Provide either a block or Class" unless @options[:fiber_scheduler].is_a?(Proc)
+    end
   end
 end

--- a/lib/puma/fiber_pool.rb
+++ b/lib/puma/fiber_pool.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'fiber'
+require 'timeout'
+
+module Puma
+  class FiberPool
+    SHUTDOWN_GRACE_TIME = 5
+
+    def initialize(_min, _max, *extra, &block)
+      @block = block
+      @extra = extra.map { |i| i.new }
+
+      @shutdown = false
+      @out_of_band_pending = false
+      @fibers = []
+
+      @clean_thread_locals = false
+    end
+
+    def auto_reap!(*); end
+    def auto_trim!(*); end
+
+    def backlog; 0 end
+    def spawned; 0 end
+    def pool_capacity; 0 end
+
+    attr_accessor :clean_thread_locals
+    attr_accessor :out_of_band_hook # @version 5.0.0
+
+    def self.clean_thread_locals
+      Thread.current.keys.each do |key| # rubocop: disable Performance/HashEachMethods
+        Thread.current[key] = nil unless key == :__recursive_key__
+      end
+    end
+
+    # @!attribute [r] busy_threads
+    # @version 5.0.0
+    def busy_threads
+      @fibers.length
+    end
+
+    # @version 5.0.0
+    def trigger_out_of_band_hook
+      return false unless out_of_band_hook && out_of_band_hook.any?
+
+      # we execute on idle hook when all threads are free
+      return false unless @fibers.empty?
+
+      out_of_band_hook.each(&:call)
+      true
+    rescue Exception => e
+      STDERR.puts "Exception calling out_of_band_hook: #{e.message} (#{e.class})"
+      true
+    end
+
+    private :trigger_out_of_band_hook
+
+    # Add +work+ for a Fiber to pickup and process.
+    def <<(work)
+      if @shutdown
+        raise "Unable to add work while shutting down"
+      end
+
+      Fiber.schedule do
+        begin
+          @fibers << (fiber = Fiber.current)
+          @out_of_band_pending = @block.call(work, *@extra)
+          if @out_of_band_pending && trigger_out_of_band_hook
+            @out_of_band_pending = false
+          end
+        ensure
+          @fibers.delete fiber
+          @waiting.resume if @waiting
+        end
+      end
+    end
+
+    def wait_until_not_full
+    end
+
+    # @version 5.0.0
+    def wait_for_less_busy_worker(delay_s)
+      return unless delay_s && delay_s > 0
+
+      # Ruby MRI does GVL, this can result
+      # in processing contention when multiple threads
+      # (requests) are running concurrently
+      return unless Puma.mri?
+
+      return if @shutdown
+
+      # do not delay, if we are not busy
+      return unless busy_threads > 0
+
+      # this will be signaled once a request finishes,
+      # which can happen earlier than delay
+      @waiting = Fiber.current
+      sleep delay_s
+      @waiting = nil
+    end
+
+    def shutdown(timeout=nil)
+      @shutdown = true
+
+      join = ->(inner_timeout) do
+        start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        @fibers.count(&:alive?).times do
+          @waiting = Fiber.current
+          if inner_timeout
+            elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+            sleep inner_timeout - elapsed
+          else
+            sleep
+          end
+          @waiting = nil
+        end
+      end
+
+      # Wait +timeout+ seconds for threads to finish.
+      join.call(timeout) unless timeout == 0
+
+      # If threads are still running, raise ForceShutdown and wait to finish.
+      @fibers.dup.each {|f| f.raise ThreadPool::ForceShutdown if f.alive?}
+      join.call(SHUTDOWN_GRACE_TIME)
+
+      # If fibers are _still_ running, raise an error.
+      raise "Error: #{@fibers.length} fibers still running:\n#{@fibers.map(&:backtrace).join("\n")}" if @fibers.any?(&:alive?)
+    end
+
+    def with_force_shutdown(&block)
+      yield
+    end
+  end
+end

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -162,7 +162,7 @@ module Puma
       end
 
       def read_and_drop(timeout = 1)
-        return :timeout unless IO.select([@socket], nil, nil, timeout)
+        return :timeout unless @socket.wait_readable(timeout)
         case @socket.read_nonblock(1024, exception: false)
         when nil
           :eof

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -404,7 +404,7 @@ module Puma
 
       # regardless of what the client wants, we always close the connection
       # if running without request queueing
-      res_info[:keep_alive] &&= @queue_requests
+      res_info[:keep_alive] &&= !!(@queue_requests || @scheduler)
 
       res_info[:response_hijack] = nil
 

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -200,7 +200,7 @@ module Puma
         begin
           n = io.syswrite str
         rescue Errno::EAGAIN, Errno::EWOULDBLOCK
-          if !IO.select(nil, [io], nil, WRITE_TIMEOUT)
+          unless io.wait_writable(WRITE_TIMEOUT)
             raise ConnectionError, "Socket timeout writing data"
           end
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -101,7 +101,7 @@ module Puma
       # Test scheduler implementation using SCHEDULER=1 env variable.
       if ENV['SCHEDULER']
         require 'libev_scheduler'
-        @scheduler = ->{Libev::Scheduler.new}
+        @scheduler = -> {Libev::Scheduler.new}
       end
 
       temp = !!(@options[:environment] =~ /\A(development|test)\z/)

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'stringio'
+require 'io/wait'
 
 require 'puma/thread_pool'
 require 'puma/const'

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -22,10 +22,9 @@ class TestPumaServer < Minitest::Test
     @ios.each { |io| io.close if io && !io.closed? }
   end
 
-  def server_run(app: @app, early_hints: false)
-    @server.app = app
+  def server_run(**options, &block)
+    @server = Puma::Server.new block || @app, @events, options
     @port = (@server.add_tcp_listener @host, 0).addr[1]
-    @server.early_hints = true if early_hints
     @server.run
     sleep 0.15 if Puma.jruby?
   end
@@ -56,7 +55,7 @@ class TestPumaServer < Minitest::Test
   def test_proper_stringio_body
     data = nil
 
-    server_run app: ->(env) do
+    server_run do |env|
       data = env['rack.input'].read
       [200, {}, ["ok"]]
     end
@@ -75,7 +74,7 @@ class TestPumaServer < Minitest::Test
 
   def test_puma_socket
     body = "HTTP/1.1 750 Upgraded to Awesome\r\nDone: Yep!\r\n"
-    server_run app: ->(env) do
+    server_run do |env|
       io = env['puma.socket']
       io.write body
       io.close
@@ -90,7 +89,7 @@ class TestPumaServer < Minitest::Test
   def test_very_large_return
     giant = "x" * 2056610
 
-    server_run app: ->(env) do
+    server_run do
       [200, {}, [giant]]
     end
 
@@ -131,7 +130,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_default_server_port
-    server_run app: ->(env) do
+    server_run do |env|
       [200, {}, [env['SERVER_PORT']]]
     end
 
@@ -146,7 +145,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_default_server_port_respects_x_forwarded_proto
-    server_run app: ->(env) do
+    server_run do |env|
       [200, {}, [env['SERVER_PORT']]]
     end
 
@@ -162,7 +161,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_HEAD_has_no_body
-    server_run app: ->(env) { [200, {"Foo" => "Bar"}, ["hello"]] }
+    server_run { [200, {"Foo" => "Bar"}, ["hello"]] }
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
@@ -170,7 +169,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_GET_with_empty_body_has_sane_chunking
-    server_run app: ->(env) { [200, {}, [""]] }
+    server_run { [200, {}, [""]] }
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
@@ -178,7 +177,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_early_hints_works
-    server_run early_hints: true, app: ->(env) do
+    server_run(early_hints: true) do |env|
      env['rack.early_hints'].call("Link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload")
      [200, { "X-Hello" => "World" }, ["Hello world!"]]
     end
@@ -202,13 +201,13 @@ EOF
 
   def test_early_hints_are_ignored_if_connection_lost
 
-    def @server.fast_write(*args)
-      raise Puma::ConnectionError
-    end
-
-    server_run early_hints: true, app: ->(env) do
+    server_run(early_hints: true) do |env|
       env['rack.early_hints'].call("Link" => "</script.js>; rel=preload")
       [200, { "X-Hello" => "World" }, ["Hello world!"]]
+    end
+
+    def @server.fast_write(*args)
+      raise Puma::ConnectionError
     end
 
     # This request will cause the server to try and send early hints
@@ -222,7 +221,7 @@ EOF
   end
 
   def test_early_hints_is_off_by_default
-    server_run app: ->(env) do
+    server_run do |env|
      assert_nil env['rack.early_hints']
      [200, { "X-Hello" => "World" }, ["Hello world!"]]
     end
@@ -241,7 +240,7 @@ EOF
   end
 
   def test_GET_with_no_body_has_sane_chunking
-    server_run app: ->(env) { [200, {}, []] }
+    server_run { [200, {}, []] }
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
@@ -249,8 +248,7 @@ EOF
   end
 
   def test_doesnt_print_backtrace_in_production
-    @server.leak_stack_on_error = false
-    server_run app: ->(env) { raise "don't leak me bro" }
+    server_run(environment: :production) { raise "don't leak me bro" }
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
@@ -271,9 +269,7 @@ EOF
 
   def test_force_shutdown_custom_error_message
     handler = lambda {|err, env, status| [500, {"Content-Type" => "application/json"}, ["{}\n"]]}
-    @server = Puma::Server.new @app, @events, {:lowlevel_error_handler => handler, :force_shutdown_after => 2}
-
-    server_run app: ->(env) do
+    server_run(lowlevel_error_handler: handler, force_shutdown_after: 2) do
       @server.stop
       sleep 5
     end
@@ -286,9 +282,7 @@ EOF
   end
 
   def test_force_shutdown_error_default
-    @server = Puma::Server.new @app, @events, {:force_shutdown_after => 2}
-
-    server_run app: ->(env) do
+    server_run(force_shutdown_after: 2) do
       @server.stop
       sleep 5
     end
@@ -301,9 +295,7 @@ EOF
 
   def test_prints_custom_error
     re = lambda { |err| [302, {'Content-Type' => 'text', 'Location' => 'foo.html'}, ['302 found']] }
-    @server = Puma::Server.new @app, @events, {:lowlevel_error_handler => re}
-
-    server_run app: ->(env) { raise "don't leak me bro" }
+    server_run(lowlevel_error_handler: re) { raise "don't leak me bro" }
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
@@ -316,9 +308,7 @@ EOF
       [302, {'Content-Type' => 'text', 'Location' => 'foo.html'}, ['302 found']]
     }
 
-    @server = Puma::Server.new @app, @events, {:lowlevel_error_handler => re}
-
-    server_run app: ->(env) { raise "don't leak me bro" }
+    server_run(lowlevel_error_handler: re) { raise "don't leak me bro" }
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
@@ -331,9 +321,7 @@ EOF
       [302, {'Content-Type' => 'text', 'Location' => 'foo.html'}, ['302 found']]
     }
 
-    @server = Puma::Server.new @app, @events, {:lowlevel_error_handler => re}
-
-    server_run app: ->(env) { raise "don't leak me bro" }
+    server_run(lowlevel_error_handler: re) { raise "don't leak me bro" }
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
@@ -341,7 +329,7 @@ EOF
   end
 
   def test_custom_http_codes_10
-    server_run app: ->(env) { [449, {}, [""]] }
+    server_run { [449, {}, [""]] }
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
@@ -349,7 +337,7 @@ EOF
   end
 
   def test_custom_http_codes_11
-    server_run app: ->(env) { [449, {}, [""]] }
+    server_run { [449, {}, [""]] }
 
     data = send_http_and_read "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
 
@@ -357,7 +345,7 @@ EOF
   end
 
   def test_HEAD_returns_content_headers
-    server_run app: ->(env) { [200, {"Content-Type" => "application/pdf",
+    server_run { [200, {"Content-Type" => "application/pdf",
                                      "Content-Length" => "4242"}, []] }
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
@@ -371,7 +359,7 @@ EOF
 
     @events.register(:state) { |s| states << s }
 
-    server_run app: ->(env) { [200, {}, [""]] }
+    server_run { [200, {}, [""]] }
 
     _ = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
@@ -382,9 +370,8 @@ EOF
     assert_equal [:booting, :running, :stop, :done], states
   end
 
-  def test_timeout_in_data_phase
-    @server.first_data_timeout = 2
-    server_run
+  def test_timeout_in_data_phase(**options)
+    server_run(first_data_timeout: 2, **options)
 
     sock = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\n"
 
@@ -394,12 +381,11 @@ EOF
   end
 
   def test_timeout_data_no_queue
-    @server = Puma::Server.new @app, @events, queue_requests: false
-    test_timeout_in_data_phase
+    test_timeout_in_data_phase(queue_requests: false)
   end
 
   def test_http_11_keep_alive_with_body
-    server_run app: ->(env) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
+    server_run { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 
     sock = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\n\r\n"
 
@@ -414,7 +400,7 @@ EOF
   end
 
   def test_http_11_close_with_body
-    server_run app: ->(env) { [200, {"Content-Type" => "plain/text"}, ["hello"]] }
+    server_run { [200, {"Content-Type" => "plain/text"}, ["hello"]] }
 
     data = send_http_and_read "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
 
@@ -422,7 +408,7 @@ EOF
   end
 
   def test_http_11_keep_alive_without_body
-    server_run app: ->(env) { [204, {}, []] }
+    server_run { [204, {}, []] }
 
     sock = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\n\r\n"
 
@@ -432,7 +418,7 @@ EOF
   end
 
   def test_http_11_close_without_body
-    server_run app: ->(env) { [204, {}, []] }
+    server_run { [204, {}, []] }
 
     sock = send_http "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
 
@@ -442,7 +428,7 @@ EOF
   end
 
   def test_http_10_keep_alive_with_body
-    server_run app: ->(env) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
+    server_run { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 
     sock = send_http "GET / HTTP/1.0\r\nConnection: Keep-Alive\r\n\r\n"
 
@@ -455,7 +441,7 @@ EOF
   end
 
   def test_http_10_close_with_body
-    server_run app: ->(env) { [200, {"Content-Type" => "plain/text"}, ["hello"]] }
+    server_run { [200, {"Content-Type" => "plain/text"}, ["hello"]] }
 
     data = send_http_and_read "GET / HTTP/1.0\r\nConnection: close\r\n\r\n"
 
@@ -465,7 +451,7 @@ EOF
   def test_http_10_partial_hijack_with_content_length
     body_parts = ['abc', 'de']
 
-    server_run app: ->(env) do
+    server_run do
       hijack_lambda = proc do | io |
         io.write(body_parts[0])
         io.write(body_parts[1])
@@ -480,7 +466,7 @@ EOF
   end
 
   def test_http_10_keep_alive_without_body
-    server_run app: ->(env) { [204, {}, []] }
+    server_run { [204, {}, []] }
 
     sock = send_http "GET / HTTP/1.0\r\nConnection: Keep-Alive\r\n\r\n"
 
@@ -490,7 +476,7 @@ EOF
   end
 
   def test_http_10_close_without_body
-    server_run app: ->(env) { [204, {}, []] }
+    server_run { [204, {}, []] }
 
     data = send_http_and_read "GET / HTTP/1.0\r\nConnection: close\r\n\r\n"
 
@@ -498,7 +484,7 @@ EOF
   end
 
   def test_Expect_100
-    server_run app: ->(env) { [200, {}, [""]] }
+    server_run { [200, {}, [""]] }
 
     data = send_http_and_read "GET / HTTP/1.1\r\nConnection: close\r\nExpect: 100-continue\r\n\r\n"
 
@@ -508,7 +494,7 @@ EOF
   def test_chunked_request
     body = nil
     content_length = nil
-    server_run app: ->(env) {
+    server_run { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
@@ -524,7 +510,7 @@ EOF
   def test_large_chunked_request
     body = nil
     content_length = nil
-    server_run app: ->(env) {
+    server_run { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
@@ -554,7 +540,7 @@ EOF
   def test_chunked_request_pause_before_value
     body = nil
     content_length = nil
-    server_run app: ->(env) {
+    server_run { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
@@ -575,7 +561,7 @@ EOF
   def test_chunked_request_pause_between_chunks
     body = nil
     content_length = nil
-    server_run app: ->(env) {
+    server_run { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
@@ -596,7 +582,7 @@ EOF
   def test_chunked_request_pause_mid_count
     body = nil
     content_length = nil
-    server_run app: ->(env) {
+    server_run { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
@@ -617,7 +603,7 @@ EOF
   def test_chunked_request_pause_before_count_newline
     body = nil
     content_length = nil
-    server_run app: ->(env) {
+    server_run { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
@@ -638,7 +624,7 @@ EOF
   def test_chunked_request_pause_mid_value
     body = nil
     content_length = nil
-    server_run app: ->(env) {
+    server_run { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
@@ -659,7 +645,7 @@ EOF
   def test_chunked_request_pause_between_cr_lf_after_size_of_second_chunk
     body = nil
     content_length = nil
-    server_run app: ->(env)  {
+    server_run { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
@@ -689,7 +675,7 @@ EOF
   def test_chunked_request_pause_between_closing_cr_lf
     body = nil
     content_length = nil
-    server_run app: ->(env) {
+    server_run { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
@@ -711,7 +697,7 @@ EOF
   def test_chunked_request_pause_before_closing_cr_lf
     body = nil
     content_length = nil
-    server_run app: ->(env) {
+    server_run { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
@@ -733,7 +719,7 @@ EOF
   def test_chunked_request_header_case
     body = nil
     content_length = nil
-    server_run app: ->(env) {
+    server_run { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
@@ -749,7 +735,7 @@ EOF
   def test_chunked_keep_alive
     body = nil
     content_length = nil
-    server_run app: ->(env) {
+    server_run { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
@@ -769,7 +755,7 @@ EOF
   def test_chunked_keep_alive_two_back_to_back
     body = nil
     content_length = nil
-    server_run app: ->(env) {
+    server_run { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
@@ -810,8 +796,7 @@ EOF
     body = nil
     content_length = nil
     remote_addr =nil
-    @server = Puma::Server.new @app, @events, { remote_address: :header, remote_address_header: 'HTTP_X_FORWARDED_FOR'}
-    server_run app: ->(env) {
+    server_run(remote_address: :header, remote_address_header: 'HTTP_X_FORWARDED_FOR') { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       remote_addr = env['REMOTE_ADDR']
@@ -843,7 +828,7 @@ EOF
     enc = Encoding::UTF_16LE
     str = "──иї_テスト──\n".encode enc
 
-    server_run app: ->(env) {
+    server_run {
       hdrs = {}
       hdrs['Content-Type'] = "text; charset=#{enc.to_s.downcase}"
 
@@ -865,7 +850,7 @@ EOF
   end
 
   def test_empty_header_values
-    server_run app: ->(env) { [200, {"X-Empty-Header" => ""}, []] }
+    server_run { [200, {"X-Empty-Header" => ""}, []] }
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
@@ -874,7 +859,7 @@ EOF
 
   def test_request_body_wait
     request_body_wait = nil
-    server_run app: ->(env) {
+    server_run { |env|
       request_body_wait = env['puma.request_body_wait']
       [204, {}, []]
     }
@@ -892,7 +877,7 @@ EOF
 
   def test_request_body_wait_chunked
     request_body_wait = nil
-    server_run app: ->(env) {
+    server_run { |env|
       request_body_wait = env['puma.request_body_wait']
       [204, {}, []]
     }
@@ -908,8 +893,8 @@ EOF
     assert_operator request_body_wait, :>=, 900
   end
 
-  def test_open_connection_wait
-    server_run app: ->(_) { [200, {}, ["Hello"]] }
+  def test_open_connection_wait(**options)
+    server_run(**options) { [200, {}, ["Hello"]] }
     s = send_http nil
     sleep 0.1
     s << "GET / HTTP/1.0\r\n\r\n"
@@ -917,13 +902,12 @@ EOF
   end
 
   def test_open_connection_wait_no_queue
-    @server = Puma::Server.new @app, @events, queue_requests: false
-    test_open_connection_wait
+    test_open_connection_wait(queue_requests: false)
   end
 
   # Rack may pass a newline in a header expecting us to split it.
   def test_newline_splits
-    server_run app: ->(_) { [200, {'X-header' => "first line\nsecond line"}, ["Hello"]] }
+    server_run { [200, {'X-header' => "first line\nsecond line"}, ["Hello"]] }
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
@@ -931,7 +915,7 @@ EOF
   end
 
   def test_newline_splits_in_early_hint
-    server_run early_hints: true, app: ->(env) do
+    server_run(early_hints: true) do |env|
       env['rack.early_hints'].call({'X-header' => "first line\nsecond line"})
       [200, {}, ["Hello world!"]]
     end
@@ -944,7 +928,7 @@ EOF
   # To comply with the Rack spec, we have to split header field values
   # containing newlines into multiple headers.
   def assert_does_not_allow_http_injection(app, opts = {})
-    server_run(early_hints: opts[:early_hints], app: app)
+    server_run(early_hints: opts[:early_hints], &app)
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
@@ -987,10 +971,9 @@ EOF
 
   # Perform a server shutdown while requests are pending (one in app-server response, one still sending client request).
   def shutdown_requests(s1_complete: true, s1_response: nil, post: false, s2_response: nil, **options)
-    @server = Puma::Server.new @app, @events, options
     mutex = Mutex.new
     app_finished = ConditionVariable.new
-    server_run app: ->(env) {
+    server_run(**options) { |env|
       path = env['REQUEST_PATH']
       mutex.synchronize do
         app_finished.signal
@@ -1064,7 +1047,7 @@ EOF
   end
 
   def test_http11_connection_header_queue
-    server_run app: ->(_) { [200, {}, [""]] }
+    server_run { [200, {}, [""]] }
 
     sock = send_http "GET / HTTP/1.1\r\n\r\n"
     assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], header(sock)
@@ -1076,7 +1059,7 @@ EOF
   end
 
   def test_http10_connection_header_queue
-    server_run app: ->(_) { [200, {}, [""]] }
+    server_run { [200, {}, [""]] }
 
     sock = send_http "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n"
     assert_equal ["HTTP/1.0 200 OK", "Connection: Keep-Alive", "Content-Length: 0"], header(sock)
@@ -1087,16 +1070,14 @@ EOF
   end
 
   def test_http11_connection_header_no_queue
-    @server = Puma::Server.new @app, @events, queue_requests: false
-    server_run app: ->(_) { [200, {}, [""]] }
+    server_run(queue_requests: false) { [200, {}, [""]] }
     sock = send_http "GET / HTTP/1.1\r\n\r\n"
     assert_equal ["HTTP/1.1 200 OK", "Connection: close", "Content-Length: 0"], header(sock)
     sock.close
   end
 
   def test_http10_connection_header_no_queue
-    @server = Puma::Server.new @app, @events, queue_requests: false
-    server_run app: ->(_) { [200, {}, [""]] }
+    server_run(queue_requests: false) { [200, {}, [""]] }
     sock = send_http "GET / HTTP/1.0\r\n\r\n"
     assert_equal ["HTTP/1.0 200 OK", "Content-Length: 0"], header(sock)
     sock.close
@@ -1140,9 +1121,7 @@ EOF
       [500, {"Content-Type" => "application/json"}, ["{}\n"]]
     }
 
-    @server = Puma::Server.new @app, @events, {:lowlevel_error_handler => handler}
-
-    server_run app: ->(env) { [200, {}, ['Hello World']] }
+    server_run(lowlevel_error_handler: handler) { [200, {}, ['Hello World']] }
 
     # valid req & read, close
     sock = TCPSocket.new @host, @port

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1189,4 +1189,18 @@ EOF
 
     assert_equal selector.backend, backend
   end
+
+  def test_drain_on_shutdown
+    wait = Queue.new
+    server_run(drain_on_shutdown: true, max_threads: 1) do
+      wait.pop rescue nil
+      [200, {}, ["DONE"]]
+    end
+    connections = Array.new(10) {send_http "GET / HTTP/1.0\r\n\r\n"}
+    @server.stop
+    wait.close
+    connections.each do |s|
+      assert_match 'DONE', s.read
+    end
+  end
 end


### PR DESCRIPTION
### Description
This PR adds support for [Non-blocking Fibers](https://docs.ruby-lang.org/en/3.0.0/Fiber.html#class-Fiber-label-Non-blocking+Fibers) to the `Server` class.
`Puma::FiberPool` uses non-blocking fibers instead of threads to process connections.
A new `fiber_scheduler` configuration option sets a custom fiber scheduler and enables the use of the FiberPool.
For debugging/testing, use the `SCHEDULER=1` env variable which enables the `libev_scheduler` backend.

Some of the code is still pretty rough around the edges, but it's working well enough for basic benchmarks and passes most of the server tests at this point (some of the force-shutdown-related behavior is not quite working perfectly yet). Sharing this as an early draft PR so anyone else interested can take a look and start testing/experimenting with it!

(Resolves #2517)

### Performance

- `benchmarks/wrk/hello.sh` (Single-process, 4 concurrent keepalive connections):
<details><summary>Before: <strong>7362.54</strong> req/sec</summary>
<pre><code>$ benchmarks/wrk/hello.sh
Puma starting in single mode...
* Puma version: 5.2.2 (ruby 3.0.0-p0) ("Fettisdagsbulle")
*  Min threads: 4
*  Max threads: 4
*  Environment: development
*          PID: 2089795
* Listening on http://0.0.0.0:9292
Use Ctrl-C to stop
Running 30s test @ http://localhost:9292
  2 threads and 4 connections
connection 0: 55213 requests completed
connection 1: 55628 requests completed
connection 0: 55170 requests completed
connection 1: 55606 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   554.64us  289.19us   7.26ms   77.99%
    Req/Sec     3.70k   306.21     5.30k    87.87%
  Latency Distribution
     50%  511.00us
     75%  677.00us
     90%    0.90ms
     99%    1.47ms
  221617 requests in 30.10s, 16.06MB read
Requests/sec:   7362.54
Transfer/sec:    546.44KB</code></pre></details>

<details><summary>After: <strong>24432.62</strong> req/sec (3.3x faster)</summary>
<pre><code>$ SCHEDULER=1 benchmarks/wrk/hello.sh
Puma starting in single mode...
* Puma version: 5.2.2 (ruby 3.0.0-p0) ("Fettisdagsbulle")
*  Min threads: 4
*  Max threads: 4
*  Environment: development
*          PID: 2090586
* Listening on http://0.0.0.0:9292
Use Ctrl-C to stop
Running 30s test @ http://localhost:9292
  2 threads and 4 connections
connection 0: 183960 requests completed
connection 1: 183999 requests completed
connection 0: 183747 requests completed
connection 1: 183726 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   167.23us   80.32us   4.43ms   93.20%
    Req/Sec    12.28k   817.19    12.93k    96.18%
  Latency Distribution
     50%  152.00us
     75%  157.00us
     90%  195.00us
     99%  438.00us
  735432 requests in 30.10s, 53.30MB read
Requests/sec:  24432.62
Transfer/sec:      1.77MB
- Gracefully stopping, waiting for requests to finish</code></pre></details>

<details><summary>Fibers x Threads: <strong>15428.31</strong> req/sec (2.1x faster)</summary>
<pre><code>$ PUMA_DEBUG=1 SCHEDULER=1 FIBERS_THREADS=1 benchmarks/wrk/hello.sh 
Puma starting in single mode...
* Puma version: 5.2.2 (ruby 3.0.0-p0) ("Fettisdagsbulle")
*  Min threads: 4
*  Max threads: 4
*  Environment: development
*          PID: 2477704
* Listening on http://0.0.0.0:9292
% Using fibers + threads
Use Ctrl-C to stop
% Using fiber scheduler
Running 30s test @ http://localhost:9292
  2 threads and 4 connections
connection 0: 116712 requests completed
connection 1: 117022 requests completed
connection 0: 115425 requests completed
connection 1: 115239 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   352.48us  673.99us  16.55ms   96.71%
    Req/Sec     7.75k     1.05k    9.49k    72.59%
  Latency Distribution
     50%  221.00us
     75%  293.00us
     90%  435.00us
     99%    3.62ms
  464398 requests in 30.10s, 33.66MB read
Requests/sec:  15428.31
Transfer/sec:      1.12MB
- Gracefully stopping, waiting for requests to finish
% Drained 0 additional connections.</code></pre></details>


Comparisons to other Rack application servers:

<details><summary>Falcon: <strong>17351.79</strong> req/sec</summary>
<pre><code>Running 30s test @ http://localhost:9292
  2 threads and 4 connections
connection 0: 130575 requests completed
connection 1: 130579 requests completed
connection 0: 130577 requests completed
connection 1: 130566 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   231.18us   60.40us   3.07ms   92.73%
    Req/Sec     8.72k   571.45     9.29k    98.17%
  522297 requests in 30.10s, 49.31MB read
Requests/sec:  17351.79
Transfer/sec:      1.64MB</code></pre></details>

<details><summary>Agoo: <strong>37469.55</strong> req/sec</summary>
<pre><code>Running 30s test @ http://localhost:9292
  2 threads and 4 connections
connection 0: 288072 requests completed
connection 1: 300080 requests completed
connection 0: 264534 requests completed
connection 1: 271597 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.22ms    9.79ms 100.78ms   97.48%
    Req/Sec    18.83k     5.97k   32.71k    72.17%
  1124283 requests in 30.01s, 81.49MB read
Requests/sec:  37469.55
Transfer/sec:      2.72MB</code></pre></details>

<details><summary>Iodine: <strong>90763.71</strong> req/sec</summary>
<pre><code>Running 30s test @ http://localhost:9292
  2 threads and 4 connections
connection 0: 680118 requests completed
connection 1: 680111 requests completed
connection 0: 685893 requests completed
connection 1: 685896 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    48.59us   38.29us   1.29ms   94.16%
    Req/Sec    45.62k     4.26k   56.84k    86.71%
  2732018 requests in 30.10s, 463.77MB read
Requests/sec:  90763.71
Transfer/sec:     15.41MB</pre></code></details>

<details><summary>Tipi: <strong>62627.34</strong> req/sec</summary>
<pre><code>Running 30s test @ http://localhost:9292
  2 threads and 4 connections
connection 0: 471343 requests completed
connection 1: 471323 requests completed
connection 0: 471172 requests completed
connection 1: 471266 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    72.93us  116.81us   9.10ms   96.97%
    Req/Sec    31.47k     3.23k   40.86k    77.24%
  1885104 requests in 30.10s, 131.24MB read
Requests/sec:  62627.34
Transfer/sec:      4.36MB</pre></code></details>

---

- `hello.sh` with `"-H Connection: close"` (**NON**-keepalive connections):

<details><summary>Before: <strong>6362.43</strong> req/sec</summary>
<pre><code>$ wrk http://localhost:9292 -c 4 -d 30 -H "Connection: close"
Running 30s test @ http://localhost:9292
  2 threads and 4 connections
connection 0: 47881 requests completed
connection 1: 47880 requests completed
connection 0: 47876 requests completed
connection 1: 47876 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   604.18us  160.92us   5.15ms   73.62%
    Req/Sec     3.20k   443.62     5.59k    83.19%
  191513 requests in 30.10s, 17.35MB read
Requests/sec:   6362.43
Transfer/sec:    590.26KB</code></pre></details>

<details><summary>After: <strong>15379.49</strong> req/sec (2.4x faster)</summary>
<pre><code>$ wrk http://localhost:9292 -c 4 -d 30 -H "Connection: close"
Running 30s test @ http://localhost:9292
  2 threads and 4 connections
connection 0: 115722 requests completed
connection 1: 115722 requests completed
connection 0: 115743 requests completed
connection 1: 115743 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   246.48us  104.18us   3.35ms   91.47%
    Req/Sec     7.73k   669.82     8.42k    89.20%
  462930 requests in 30.10s, 41.94MB read
Requests/sec:  15379.49
Transfer/sec:      1.39MB
</code></pre></details>

<details><summary>Fibers x Threads: <strong>9643.85</strong> req/sec (1.5x faster)</summary>
<pre><code>$ PUMA_DEBUG=1 SCHEDULER=1 FIBERS_THREADS=1 benchmarks/wrk/hello.sh -H "Connection: close"
Puma starting in single mode...
* Puma version: 5.2.2 (ruby 3.0.0-p0) ("Fettisdagsbulle")
*  Min threads: 4
*  Max threads: 4
*  Environment: development
*          PID: 2478095
* Listening on http://0.0.0.0:9292
% Using fibers + threads
Use Ctrl-C to stop
% Using fiber scheduler
Running 30s test @ http://localhost:9292
  2 threads and 4 connections
connection 0: 72571 requests completed
connection 1: 72571 requests completed
connection 0: 72572 requests completed
connection 1: 72571 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   398.24us  141.27us   4.23ms   88.16%
    Req/Sec     4.85k   495.18     5.65k    77.24%
  Latency Distribution
     50%  345.00us
     75%  397.00us
     90%  599.00us
     99%    0.91ms
  290285 requests in 30.10s, 26.30MB read
Requests/sec:   9643.85
Transfer/sec:      0.87MB
- Gracefully stopping, waiting for requests to finish
% Drained 0 additional connections.
</code></pre></details>

Comparisons:

<details><summary>Falcon: <strong>6412.59</strong> req/sec</summary>
<pre><code>$ wrk http://localhost:9292 -c 4 -d 30 -H "Connection: close"
Running 30s test @ http://localhost:9292
  2 threads and 4 connections
connection 0: 48412 requests completed
connection 1: 48109 requests completed
connection 0: 47919 requests completed
connection 1: 48146 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     7.49ms   24.54ms 430.51ms   93.36%
    Req/Sec     3.25k     1.38k    5.57k    68.69%
  192586 requests in 30.03s, 21.67MB read
Requests/sec:   6412.59
Transfer/sec:    738.95KB
</code></pre></details>

<details><summary>Agoo: <strong>2181.67</strong> req/sec</summary>
<code><pre>$ wrk http://localhost:9292 -c 4 -d 30 -H "Connection: close"
Running 30s test @ http://localhost:9292
  2 threads and 4 connections
connection 0: 16361 requests completed
connection 1: 16273 requests completed
connection 0: 16441 requests completed
connection 1: 16411 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.25ms    3.85ms  20.55ms   81.69%
    Req/Sec     1.10k   455.37     2.64k    67.67%
  65486 requests in 30.02s, 4.75MB read
  Socket errors: connect 0, read 65482, write 0, timeout 0
Requests/sec:   2181.67
Transfer/sec:    161.92KB
</code></pre></details>

<details><summary>Iodine: <strong>41072.78</strong> req/sec</summary>
<code><pre>$ wrk http://localhost:9292 -c 4 -d 30 -H "Connection: close"
Running 30s test @ http://localhost:9292
  2 threads and 4 connections
connection 0: 308778 requests completed
connection 1: 308777 requests completed
connection 0: 309375 requests completed
connection 1: 309373 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    91.63us   53.56us   1.15ms   91.83%
    Req/Sec    20.64k     1.96k   25.15k    80.40%
  1236303 requests in 30.10s, 203.97MB read
Requests/sec:  41072.78
Transfer/sec:      6.78MB
</code></pre></details>

<details><summary>Tipi: <strong>17297.16</strong> req/sec</summary>
Running 30s test @ http://localhost:9292
  2 threads and 4 connections
connection 0: 130266 requests completed
connection 1: 130286 requests completed
connection 0: 130120 requests completed
connection 1: 129980 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   219.16us  196.05us   3.77ms   90.12%
    Req/Sec     8.71k     0.87k   11.02k    69.55%
  520652 requests in 30.10s, 36.25MB read
  Socket errors: connect 0, read 520648, write 0, timeout 0
Requests/sec:  17297.16
Transfer/sec:      1.20MB
</code></pre></details>



[more to come]

### Notes

- Based off #2600 (cleaning up the connection-draining code) to make this implementation a bit easier to accomplish.
- I've linked the [`libev_scheduler`](https://github.com/digital-fabric/libev_scheduler) backend to the GitHub version in the `Gemfile` for now for testing, since it includes some fixes not included in the latest Rubygems release.
- The scheduler implementation is swappable. I added `libev_scheduler` into this draft PR for now because it seemed the fastest in initial tests, but more detailed comparisons and benchmarks against the other existing implementations (such as `async`, `evt`, or the plain Ruby implementation in its test suite) would be helpful.
- There is currently no limit on the number of fibers in the FiberPool, though there are probably cases where setting a per-process concurrency limit could still be helpful so I'll look into adding this at some point.
- This PR is currently written so that that the Rack applications themselves are also running on non-blocking fibers, which could have some undesired impact on behavior of existing apps. More testing and experimentation would be helpful to see how compatible existing applications will be with the fiber scheduler, as well as how their performance compares to threads.
- An alternate implementation would pass the complete buffered HTTP request from the Fiber pool to a Thread pool, and then pass the Rack response back to the Fiber to be written to the client. This would give the Rack app the same existing multi-threaded environment, so shouldn't have any change in behavior. However, this had a performance impact in some initial tests. I still think the option is promising and could use further investigation (it may offer better performance than Puma's existing reactor, even if it's not as fast as the all-fiber approach).
  - Update: commit 1ec4c58 demonstrates an alternate implementation along these lines, enabled using the `FIBERS_THREADS` env variable for testing. I've added microbenchmark results to the performance section for comparison.]

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
