### PR TITLE
Improve parsing of HTTP_HOST header

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -247,8 +247,5 @@ module Puma
 
     # Banned keys of response header
     BANNED_HEADER_KEY = /\A(rack\.|status\z)/.freeze
-
-    # Index of the colon separating host/port in the HTTP_HOST header for IPV4 and IPV6
-    COLON_INDEX_REGEX = /:\d+\z/.freeze
   end
 end

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -247,5 +247,8 @@ module Puma
 
     # Banned keys of response header
     BANNED_HEADER_KEY = /\A(rack\.|status\z)/.freeze
+
+    # Index of the colon separating host/port in the HTTP_HOST header for IPV4 and IPV6
+    COLON_INDEX_REGEX = /:\d+\z/.freeze
   end
 end

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -231,7 +231,7 @@ module Puma
     #
     def normalize_env(env, client)
       if host = env[HTTP_HOST]
-        if colon = host.index(/:\d+$/)
+        if colon = host.index(COLON_INDEX_REGEX)
           env[SERVER_NAME] = host[0, colon]
           env[SERVER_PORT] = host[colon+1, host.bytesize]
         else

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -231,7 +231,11 @@ module Puma
     #
     def normalize_env(env, client)
       if host = env[HTTP_HOST]
-        if colon = host.index(COLON_INDEX_REGEX)
+        # host can be a hostname, ipv4 or bracketed ipv6. Followed by an optional port.
+        if colon = host.rindex("]:") # IPV6 with port
+          env[SERVER_NAME] = host[0, colon+1]
+          env[SERVER_PORT] = host[colon+2, host.bytesize]
+        elsif !host.start_with?("[") && colon = host.index(":") # not hostname or IPV4 with port
           env[SERVER_NAME] = host[0, colon]
           env[SERVER_PORT] = host[colon+1, host.bytesize]
         else

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -231,7 +231,7 @@ module Puma
     #
     def normalize_env(env, client)
       if host = env[HTTP_HOST]
-        if colon = host.index(":")
+        if colon = host.index(/:\d+$/)
           env[SERVER_NAME] = host[0, colon]
           env[SERVER_PORT] = host[colon+1, host.bytesize]
         else


### PR DESCRIPTION
IPV6 Host was not properly parsed.

With the insanely detailed bug report his was fixed in no time:  👍



Closes #2584

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
