### PR TITLE
Fix timing out requests too early

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -295,6 +295,9 @@ module Puma
         @thread_pool << client
       elsif shutdown || client.timeout == 0
         client.timeout!
+      else
+        client.set_timeout(@first_data_timeout)
+        false
       end
     rescue StandardError => e
       client_error(e, client)

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -398,6 +398,30 @@ EOF
     test_timeout_in_data_phase
   end
 
+  # https://github.com/puma/puma/issues/2574
+  def test_no_timeout_after_data_received
+    @server.first_data_timeout = 1
+    server_run
+
+    sock = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 11\r\n\r\n"
+    sleep 0.5
+
+    sock << "hello"
+    sleep 0.5
+    sock << "world"
+    sleep 0.5
+    sock << "!"
+
+    data = sock.gets
+
+    assert_equal "HTTP/1.1 200 OK\r\n", data
+  end
+
+  def test_no_timeout_after_data_received_no_queue
+    @server = Puma::Server.new @app, @events, queue_requests: false
+    test_no_timeout_after_data_received
+  end
+
   def test_http_11_keep_alive_with_body
     server_run app: ->(env) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -383,10 +383,12 @@ EOF
   end
 
   def test_timeout_in_data_phase
-    @server.first_data_timeout = 2
+    @server.first_data_timeout = 1
     server_run
 
     sock = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\n"
+
+    sock << "Hello" unless IO.select([sock], nil, nil, 1.15)
 
     data = sock.gets
 


### PR DESCRIPTION
### Description

Fixes #2574 (a regression released in v5.0.3), with an added test to prevent future regressions.

#### See also

#2575 extends this fix by adding a `between_bytes_timeout` configuration option that allows for different timeout values for the initial data received by the client, and subsequent chunks of data. This extra option may eventually be useful but this PR is intended to more narrowly fix the regression first.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
