### PR TITLE
Handle fatal error that has no backtrace

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -528,7 +528,8 @@ module Puma
       end
 
       if @leak_stack_on_error
-        [status, {}, ["Puma caught this error: #{e.message} (#{e.class})\n#{e.backtrace.join("\n")}"]]
+        backtrace = e.backtrace.nil? ? '<no backtrace available>' :  e.backtrace.join("\n")
+        [status, {}, ["Puma caught this error: #{e.message} (#{e.class})\n#{backtrace}"]]
       else
         [status, {}, ["An unhandled lowlevel error occurred. The application logs may have details.\n"]]
       end

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -528,7 +528,7 @@ module Puma
       end
 
       if @leak_stack_on_error
-        backtrace = e.backtrace.nil? ? '<no backtrace available>' :  e.backtrace.join("\n")
+        backtrace = e.backtrace.nil? ? '<no backtrace available>' : e.backtrace.join("\n")
         [status, {}, ["Puma caught this error: #{e.message} (#{e.class})\n#{backtrace}"]]
       else
         [status, {}, ["An unhandled lowlevel error occurred. The application logs may have details.\n"]]

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -285,7 +285,7 @@ EOF
     assert_match(/{}\n$/, data)
   end
 
-  def test_low_level_error_message
+  def test_lowlevel_error_message
     skip_if :windows
     @server = Puma::Server.new @app, @events, {:force_shutdown_after => 2}
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -304,8 +304,6 @@ EOF
     assert (data.size > 0), "Expected response message to be not empty"
   end
 
-
-
   def test_force_shutdown_error_default
     @server = Puma::Server.new @app, @events, {:force_shutdown_after => 2}
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -286,7 +286,7 @@ EOF
   end
 
   def test_low_level_error_message
-    @server = Puma::Server.new @app, @events
+    @server = Puma::Server.new @app, @events, {:force_shutdown_after => 2}
 
     server_run app: ->(env) do
       require 'json'

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -286,6 +286,7 @@ EOF
   end
 
   def test_low_level_error_message
+    skip_if :windows
     @server = Puma::Server.new @app, @events, {:force_shutdown_after => 2}
 
     server_run app: ->(env) do


### PR DESCRIPTION
### Description
Handle error that `e.backtrace` is nil.

Current implementation assumes `e.backtrace` is an Array, and will raise `NoMethodError` to the top of thread-pool, this will output an empty response body.

Closes #2552

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
