### PR TITLE
Reset peerip only if remote_addr_header is set

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -126,7 +126,7 @@ module Puma
       @parsed_bytes = 0
       @ready = false
       @body_remain = 0
-      @peerip = nil
+      @peerip = nil if @remote_addr_header
       @in_last_chunk = false
 
       if @buffer


### PR DESCRIPTION
### Description

In `tcp` mode when both `remote_addr_value` and `remote_addr_header` are not set, `client.peerip` method
calls `@io.peeraddr` in every request, I dont't think we need to reset `@peerip` to `nil` in such condition.

`@io.peeraddr` uses two syscalls `getpeername` and `recevfrom`, by caching the `@peerip` in `Client` instance, 
we can save two syscalls on every request in an established connection, except for the first request.

`hello.ru` performance improvement:

- master, 4107 RPS
- caching peerip, 5224 RPS

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
