### PR TITLE
Immediately unlink temporary files

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -295,6 +295,7 @@ module Puma
 
       if remain > MAX_BODY
         @body = Tempfile.new(Const::PUMA_TMP_BASE)
+        @body.unlink
         @body.binmode
         @tempfile = @body
       else
@@ -386,6 +387,7 @@ module Puma
       @prev_chunk = ""
 
       @body = Tempfile.new(Const::PUMA_TMP_BASE)
+      @body.unlink
       @body.binmode
       @tempfile = @body
       @chunked_content_length = 0


### PR DESCRIPTION
### Description

Puma has a limit (`Puma::Const::MAX_BODY` - around 110 KiB) over which
it will write request bodies to disk for handing off to the
application. When it does this, the request body can be left on disk
if the Puma process receives SIGKILL. Consider an extremely minimal
`config.ru`:

    run(proc { [204, {}, []] })

If we then:

1. Start `puma`, noting the process ID (to kill it later).
2. Start a slow file transfer, using `curl --limit-rate 100k` (for
   example) and `-T $PATH_TO_LARGE_FILE`.
3. Watch `$TMPDIR/puma*`.

We will see Puma start to write this temporary file. If we then send
SIGKILL to Puma, the file won't be cleaned up. With this patch, it
will - at least on POSIX systems. On Windows it may still be available.

This is suggested in the Ruby Tempfile documentation, and even uses this
specific example:
https://ruby-doc.org/stdlib-2.7.2/libdoc/tempfile/rdoc/Tempfile.html#class-Tempfile-label-Unlink+after+creation

> On POSIX systems, it's possible to unlink a file right after creating
> it, and before closing it. This removes the filesystem entry without
> closing the file handle, so it ensures that only the processes that
> already had the file handle open can access the file’s contents. It's
> strongly recommended that you do this if you do not want any other
> processes to be able to read from or write to the Tempfile, and you do
> not need to know the Tempfile's filename either.
>
> For example, a practical use case for unlink-after-creation would be
> this: you need a large byte buffer that's too large to comfortably fit
> in RAM, e.g. when you're writing a web server and you want to buffer
> the client's file upload data.

This was possibly the root cause of https://github.com/puma/puma/issues/1187, although the issue did not contain enough detail to determine whether or not that's the case.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
