### PR TITLE
Improvements to keepalive-connection shedding

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -69,6 +69,7 @@ module Puma
       @hijacked = false
 
       @peerip = nil
+      @listener = nil
       @remote_addr_header = nil
 
       @body_remain = 0
@@ -81,7 +82,7 @@ module Puma
 
     attr_writer :peerip
 
-    attr_accessor :remote_addr_header
+    attr_accessor :remote_addr_header, :listener
 
     def_delegators :@io, :closed?
 

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -26,9 +26,10 @@ module Puma
     # Finally, it'll return +true+ on keep-alive connections.
     # @param client [Puma::Client]
     # @param lines [Puma::IOBuffer]
+    # @param requests [Integer]
     # @return [Boolean,:async]
     #
-    def handle_request(client, lines)
+    def handle_request(client, lines, requests)
       env = client.env
       io  = client.io   # io may be a MiniSSL::Socket
 
@@ -110,7 +111,7 @@ module Puma
 
         cork_socket io
 
-        str_headers(env, status, headers, res_info, lines, client)
+        str_headers(env, status, headers, res_info, lines, requests, client)
 
         line_ending = LINE_END
 
@@ -367,10 +368,11 @@ module Puma
     # @param headers [Hash] the headers returned by the Rack application
     # @param res_info [Hash] used to pass info between this method and #handle_request
     # @param lines [Puma::IOBuffer] modified inn place
+    # @param requests [Integer] number of inline requests handled
     # @param client [Puma::Client]
     # @version 5.0.3
     #
-    def str_headers(env, status, headers, res_info, lines, client)
+    def str_headers(env, status, headers, res_info, lines, requests, client)
       line_ending = LINE_END
       colon = COLON
 
@@ -411,11 +413,12 @@ module Puma
       # if running without request queueing
       res_info[:keep_alive] &&= @queue_requests
 
-      # Close the connection when the server is at capacity and
-      # the listener has a new connection waiting.
+      # Close the connection after a reasonable number of inline requests
+      # if the server is at capacity and the listener has a new connection ready.
       # This allows Puma to service connections fairly when the number
       # of concurrent connections exceeds the size of the threadpool.
-      res_info[:keep_alive] &&= @thread_pool.busy_threads < @max_threads ||
+      res_info[:keep_alive] &&= requests < @max_fast_inline ||
+        @thread_pool.busy_threads < @max_threads ||
         !IO.select([client.listener], nil, nil, 0)
 
       res_info[:response_hijack] = nil

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -435,7 +435,7 @@ module Puma
 
         while true
           @requests_count += 1
-          case handle_request(client, buffer, requests)
+          case handle_request(client, buffer, requests + 1)
           when false
             break
           when :async

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -341,6 +341,7 @@ module Puma
                 end
                 drain += 1 if shutting_down?
                 client = Client.new io, @binder.env(sock)
+                client.listener = sock
                 if remote_addr_value
                   client.peerip = remote_addr_value
                 elsif remote_addr_header
@@ -447,23 +448,14 @@ module Puma
 
             requests += 1
 
-            # Closing keepalive sockets after they've made a reasonable
-            # number of requests allows Puma to service many connections
-            # fairly, even when the number of concurrent connections exceeds
-            # the size of the threadpool. It also allows cluster mode Pumas
-            # to keep load evenly distributed across workers, because clients
-            # are randomly assigned a new worker when opening a new connection.
-            #
-            # Previously, Puma would kick connections in this conditional back
-            # to the reactor. However, because this causes the todo set to increase
-            # in size, the wait_until_full mutex would never unlock, leaving
-            # any additional connections unserviced.
-            break if requests >= @max_fast_inline
-
-            check_for_more_data = @status == :run
+            # As an optimization, try to read the next request from the
+            # socket for a short time before returning to the reactor,
+            # only if the server is running and no other requests are waiting.
+            fast_check = @status == :run &&
+              @thread_pool.backlog == 0
 
             next_request_ready = with_force_shutdown(client) do
-              client.reset(check_for_more_data)
+              client.reset(fast_check)
             end
 
             unless next_request_ready


### PR DESCRIPTION
### Description
As a followup to df72887170c7ef3614c941c9bdefb4a1f3546ebf, this PR is an attempt to refactor the 'keepalive-connection shedding' logic to improve its performance and reliability.

Summary of changes:

1. Instead of closing the socket by breaking out of the `Server#process_client` loop from the 'keepalive == true' branch, move the connection-shedding logic to modify the `res_info[:keep_alive]` variable in `Request#str_headers`. This writes the `Connection: close` header as part of the final response before closing the socket, allowing clients to reopen a new connection more gracefully (for example, preventing 'socket read' errors from being logged in `wrk`).

2. Instead of shedding the keepalive connection after a fixed number of consecutive inline requests, shed the connection whenever the server is 'at capacity' (busy threads >= max), _and_ there is a new pending connection in the listener socket waiting to be accepted.

3. Additionally, push a keepalive connection back to the reactor whenever there's a pending request in the threadpool backlog (but not a new connection pending), to ensure that requests are serviced fairly across all the keepalive connections already accepted in the server.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
