### PR TITLE
Fix sigterm misbehavior

### DIFF
--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -39,7 +39,7 @@ module Puma
           log "! Detected parent died, dying"
           exit! 1
         end
-         
+
         # If we're not running under a Bundler context, then
         # report the info about the context we will be using
         if !ENV['BUNDLE_GEMFILE']
@@ -54,9 +54,9 @@ module Puma
         # things in shape before booting the app.
         @launcher.config.run_hooks :before_worker_boot, index, @launcher.events
 
-        begin 
+        begin
         server = @server ||= start_server
-        rescue Exception => e     
+        rescue Exception => e
           log "! Unable to start worker"
           log e.backtrace[0]
           exit 1

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -59,7 +59,6 @@ module Puma
         rescue Exception => e     
           log "! Unable to start worker"
           log e.backtrace[0]
-          sleep 1
           exit 1
         end
 


### PR DESCRIPTION
### Description
Closes [2222](https://github.com/puma/puma/issues/2222). 
The current issue occurs if the server can't be started and raised exceptions before signal re-registration is done.I put the code to log the first line of back trace to gives consistent error log if there is some error in worker starts. 


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
