### PR TITLE
Gracefully handle Rack not accepting CLI options

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -343,6 +343,8 @@ module Puma
       raise "Missing rackup file '#{rackup}'" unless File.exist?(rackup)
 
       rack_app, rack_options = rack_builder.parse_file(rackup)
+      rack_options = rack_options || {}
+
       @options.file_options.merge!(rack_options)
 
       config_ru_binds = []


### PR DESCRIPTION
### Description

Closes https://github.com/puma/puma/issues/2626

In https://github.com/rack/rack/commit/b95cb72463bac5a087294c7ecf94674db7aa41fe#diff-79892c6315a7f9c02489803e95ce828a8a32759b9f8f196aa98e6826eb562e55R96, Rack removed the ability to pass options from the command line. It now  fails when you try to do that, and no longer exposes them from`Builder.load_file`. Puma shouldn't fail when this happens.

This commit falls back to an empty object when Rack does not pass options back from `Builder.load_file`.
### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
