### PR TITLE
Update docs for low_latency option and fix parsing issue

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -163,7 +163,7 @@ module Puma
             ios_len = @ios.length
             params = Util.parse_query uri.query
 
-            opt = params.key?('low_latency')
+            opt = params.key?('low_latency') && params['low_latency'] != 'false'
             bak = params.fetch('backlog', 1024).to_i
 
             io = add_tcp_listener uri.host, uri.port, opt, bak

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -201,7 +201,7 @@ module Puma
     # * Set the socket backlog depth with +backlog+, default is 1024.
     # * Set up an SSL certificate with +key+ & +cert+.
     # * Set whether to optimize for low latency instead of throughput with
-    #   +low_latency+, default is to optimize for low latency. This is done
+    #   +low_latency+, default is to not optimize for low latency. This is done
     #   via +Socket::TCP_NODELAY+.
     # * Set socket permissions with +umask+.
     #

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -193,6 +193,7 @@ class TestBinder < TestBinderBase
   end
 
   def test_binder_parses_nil_low_latency
+    skip_if :jruby
     @binder.parse ["tcp://0.0.0.0:0?low_latency"], @events
 
     socket = @binder.listeners.first.last
@@ -201,6 +202,7 @@ class TestBinder < TestBinderBase
   end
 
   def test_binder_parses_true_low_latency
+    skip_if :jruby
     @binder.parse ["tcp://0.0.0.0:0?low_latency=true"], @events
 
     socket = @binder.listeners.first.last
@@ -209,6 +211,7 @@ class TestBinder < TestBinderBase
   end
 
   def test_binder_parses_false_low_latency
+    skip_if :jruby
     @binder.parse ["tcp://0.0.0.0:0?low_latency=false"], @events
 
     socket = @binder.listeners.first.last

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -192,6 +192,30 @@ class TestBinder < TestBinderBase
     end
   end
 
+  def test_binder_parses_nil_low_latency
+    @binder.parse ["tcp://0.0.0.0:0?low_latency"], @events
+
+    socket = @binder.listeners.first.last
+
+    assert socket.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY).bool
+  end
+
+  def test_binder_parses_true_low_latency
+    @binder.parse ["tcp://0.0.0.0:0?low_latency=true"], @events
+
+    socket = @binder.listeners.first.last
+
+    assert socket.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY).bool
+  end
+
+  def test_binder_parses_false_low_latency
+    @binder.parse ["tcp://0.0.0.0:0?low_latency=false"], @events
+
+    socket = @binder.listeners.first.last
+
+    refute socket.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY).bool
+  end
+
   def test_binder_parses_tlsv1_disabled
     skip_unless :ssl
     @binder.parse ["ssl://0.0.0.0:0?#{ssl_query}&no_tlsv1=true"], @events


### PR DESCRIPTION
### Description
Closes https://github.com/puma/puma/issues/2623

As well as updating the docs to reflect that TCP_NODELAY is off by default, I've tweaked the code so that `low_latency=false` doesn't set TCP_NODELAY, which is consistent with how other options are parsed. Let me know if the tests are a bit overkill.

I'm not sure how best to test that the created socket has or lacks TCP_NODELAY in JRuby, since this version of JRuby has a very minimal Socket implementation (no constants, no bool method). For now I've skipped my new tests if we're running them in JRuby, but any guidance would be appreciated.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
