### PR TITLE
Set session id context while creating SSLContext

### DIFF
--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -208,7 +208,7 @@ sslctx_initialize(VALUE self, VALUE mini_ssl_ctx) {
 #endif
   int ssl_options;
   VALUE key, cert, ca, verify_mode, ssl_cipher_filter, no_tlsv1, no_tlsv1_1,
-    verification_flags;
+    verification_flags, session_id_bytes;
   DH *dh;
 
 #if OPENSSL_VERSION_NUMBER < 0x10002000L
@@ -309,6 +309,14 @@ sslctx_initialize(VALUE self, VALUE mini_ssl_ctx) {
   } else {
     SSL_CTX_set_verify(ctx, NUM2INT(verify_mode), engine_verify_callback);
   }
+
+  session_id_bytes = rb_funcall(rb_const_get(rb_cRandom, rb_intern_const("DEFAULT")),
+                                rb_intern_const("bytes"),
+                                1, ULL2NUM(SSL_MAX_SSL_SESSION_ID_LENGTH));
+  SSL_CTX_set_session_id_context(ctx,
+                                 (unsigned char *) RSTRING_PTR(session_id_bytes),
+                                 SSL_MAX_SSL_SESSION_ID_LENGTH);
+
   // printf("\ninitialize end security_level %d\n", SSL_CTX_get_security_level(ctx));
   rb_obj_freeze(self);
   return self;


### PR DESCRIPTION
When using client certificates, session id context needs to be set. OpenSSL documentation covers it like this:

> If the session id context is not set on an SSL/TLS server and client
certificates are used, stored sessions will not be reused but a fatal
error will be flagged and the handshake will fail. 

Details: https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_session_id_context.html

Ruby OpenSSL wrapper conforms to this by setting the session id context to a random sequence of bytes whenever a context is created:
http://github.com/ruby/openssl/blob/master/lib/openssl/ssl.rb#L493

I am open to suggestions about generating random bytes. I feel like there can be a better way than this.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
