### PR TITLE
Rename the `Puma::JSON` module to `Puma::JSONSerialization`

### DIFF
--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -12,7 +12,7 @@ require 'thread'
 
 require 'puma/puma_http11'
 require 'puma/detect'
-require 'puma/json'
+require 'puma/json_serialization'
 
 module Puma
   autoload :Const, 'puma/const'
@@ -60,7 +60,7 @@ module Puma
 
   # @!attribute [rw] stats_object
   def self.stats
-    Puma::JSON.generate @get_stats.stats
+    Puma::JSONSerialization.generate @get_stats.stats
   end
 
   # @!attribute [r] stats_hash

--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'puma/json'
+require 'puma/json_serialization'
 
 module Puma
   module App
@@ -46,17 +46,17 @@ module Puma
             GC.start ; 200
 
           when 'gc-stats'
-            Puma::JSON.generate GC.stat
+            Puma::JSONSerialization.generate GC.stat
 
           when 'stats'
-            Puma::JSON.generate @launcher.stats
+            Puma::JSONSerialization.generate @launcher.stats
 
           when 'thread-backtraces'
             backtraces = []
             @launcher.thread_status do |name, backtrace|
               backtraces << { name: name, backtrace: backtrace }
             end
-            Puma::JSON.generate backtraces
+            Puma::JSONSerialization.generate backtraces
 
           else
             return rack_response(404, "Unsupported action", 'text/plain')

--- a/lib/puma/json_serialization.rb
+++ b/lib/puma/json_serialization.rb
@@ -17,7 +17,7 @@ module Puma
   # be particularly full-featured or fast. It just has to handle the few places
   # where Puma relies on JSON serialization internally.
 
-  module JSON
+  module JSONSerialization
     QUOTE = /"/
     BACKSLASH = /\\/
     CONTROL_CHAR_TO_ESCAPE = /[\x00-\x1F]/ # As required by ECMA-404

--- a/test/test_json_serialization.rb
+++ b/test/test_json_serialization.rb
@@ -1,8 +1,8 @@
 require_relative "helper"
 require "json"
-require "puma/json"
+require "puma/json_serialization"
 
-class TestJSON < Minitest::Test
+class TestJSONSerialization < Minitest::Test
   parallelize_me! unless JRUBY_HEAD
 
   def test_json_generates_string_for_hash_with_string_keys
@@ -17,8 +17,8 @@ class TestJSON < Minitest::Test
 
   def test_generate_raises_error_for_unexpected_key_type
     value = { [1] => 'b' }
-    ex = assert_raises Puma::JSON::SerializationError do
-      Puma::JSON.generate value
+    ex = assert_raises Puma::JSONSerialization::SerializationError do
+      Puma::JSONSerialization.generate value
     end
     assert_equal 'Could not serialize object of type Array as object key', ex.message
   end
@@ -85,8 +85,8 @@ class TestJSON < Minitest::Test
 
   def test_generate_raises_error_for_unexpected_value_type
     value = /abc/
-    ex = assert_raises Puma::JSON::SerializationError do
-      Puma::JSON.generate value
+    ex = assert_raises Puma::JSONSerialization::SerializationError do
+      Puma::JSONSerialization.generate value
     end
     assert_equal 'Unexpected value of type Regexp', ex.message
   end
@@ -94,7 +94,7 @@ class TestJSON < Minitest::Test
   private
 
   def assert_puma_json_generates_string(expected_output, value_to_serialize, expected_roundtrip: nil)
-    actual_output = Puma::JSON.generate(value_to_serialize)
+    actual_output = Puma::JSONSerialization.generate(value_to_serialize)
     assert_equal expected_output, actual_output
 
     if value_to_serialize.nil?


### PR DESCRIPTION
### Description

For the hooks defined in `Puma::DSL`, the previous naming had the unfortunate side-effect of causing `JSON` to resolve to `Puma::JSON` rather than, the likely more expected, `::JSON` module.

Closes #2639

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
