### PR TITLE
minissl.c - Use Random.bytes if available

### DIFF
--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -25,6 +25,14 @@ unless ENV["DISABLE_SSL"]
 
     have_func  "X509_STORE_up_ref"
     have_func("SSL_CTX_set_ecdh_auto(NULL, 0)", "openssl/ssl.h")
+
+    # Random.bytes available in Ruby 2.5 and later, Random::DEFAULT deprecated in 3.0
+    if Random.respond_to?(:bytes)
+      $defs.push("-DHAVE_RANDOM_BYTES")
+      puts "checking for Random.bytes... yes"
+    else
+      puts "checking for Random.bytes... no"
+    end
   end
 end
 

--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -310,9 +310,16 @@ sslctx_initialize(VALUE self, VALUE mini_ssl_ctx) {
     SSL_CTX_set_verify(ctx, NUM2INT(verify_mode), engine_verify_callback);
   }
 
-  session_id_bytes = rb_funcall(rb_const_get(rb_cRandom, rb_intern_const("DEFAULT")),
-                                rb_intern_const("bytes"),
-                                1, ULL2NUM(SSL_MAX_SSL_SESSION_ID_LENGTH));
+  // Random.bytes available in Ruby 2.5 and later, Random::DEFAULT deprecated in 3.0
+  session_id_bytes = rb_funcall(
+#ifdef HAVE_RANDOM_BYTES
+    rb_cRandom,
+#else
+    rb_const_get(rb_cRandom, rb_intern_const("DEFAULT")),
+#endif
+    rb_intern_const("bytes"),
+    1, ULL2NUM(SSL_MAX_SSL_SESSION_ID_LENGTH));
+
   SSL_CTX_set_session_id_context(ctx,
                                  (unsigned char *) RSTRING_PTR(session_id_bytes),
                                  SSL_MAX_SSL_SESSION_ID_LENGTH);


### PR DESCRIPTION
### Description

PR #2633 throws deprecation warnings in Ruby 3.  Fix by using `Random.bytes` when available.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
