### PR TITLE
Binder#parse - allow for symlinked unix path, add create_activated_fds debug ENV

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -96,6 +96,7 @@ module Puma
     # @version 5.0.0
     #
     def create_activated_fds(env_hash)
+      @events.debug "ENV['LISTEN_FDS'] #{ENV['LISTEN_FDS'].inspect}  env_hash['LISTEN_PID'] #{env_hash['LISTEN_PID'].inspect}"
       return [] unless env_hash['LISTEN_FDS'] && env_hash['LISTEN_PID'].to_i == $$
       env_hash['LISTEN_FDS'].to_i.times do |index|
         sock = TCPServer.for_fd(socket_activation_fd(index))
@@ -189,7 +190,8 @@ module Puma
             @unix_paths << path unless abstract
             io = inherit_unix_listener path, fd
             logger.log "* Inherited #{str}"
-          elsif sock = @activated_sockets.delete([ :unix, path ])
+          elsif sock = @activated_sockets.delete([ :unix, path ]) ||
+              @activated_sockets.delete([ :unix, File.realdirpath(path) ])
             @unix_paths << path unless abstract || File.exist?(path)
             io = inherit_unix_listener path, sock
             logger.log "* Activated #{str}"


### PR DESCRIPTION
### Description

When systemd creates a UNIXSocket with a path that is contained in a symlinked directory, Ruby may read the path as the real path.

Closes #2638

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
