### PR TITLE
Adding on_rack_before and on_rack_after hooks

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -162,6 +162,10 @@ module Puma
       end
     end
 
+    def stream?
+      false
+    end
+
     def try_to_finish
       return read_body unless @read_header
 

--- a/lib/puma/plugin.rb
+++ b/lib/puma/plugin.rb
@@ -57,6 +57,10 @@ module Puma
       raise UnknownPlugin, "file failed to register a plugin"
     end
 
+    def each
+      @plugins.each_value { |plugin| yield plugin }
+    end
+
     def add_background(blk)
       @background << blk
     end


### PR DESCRIPTION
### Description
This pull request is currently more like a POC and not ready to merge, but i'm opening it so anyone can test the code an discuss it.
The interface designed is based on https://github.com/puma/puma/pull/1849.
Closes #1316

--------------------

This patch adds two hooks for puma plugins: `on_before_rack` and `on_after_rack`
which will called before or after puma calls the rack app.

A POC for usage of this feature is a implementation of websocket support, which can be found [here](https://github.com/Mai-Lapyst/puma-websockets).
There is also a demo app build in sinatra [here](https://github.com/Mai-Lapyst/puma-websocket-test-sinatra).

There are a few things left:

Maybe creating a `Puma::StreamClient` baseclass; either bundled with the puma gem or in a single standalone gem.

Currently there is no default way for a stream client to be timed out, which is not ideal.
An idea here would be that either we put the plugin / stream client into full responsibility to
implement a timeout functionality via `#timeout` and `#timeout_at`, or we add an method like
`Puma::Client#set_timeout`.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
