### PR TITLE
improve remote_addr behavior

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -227,7 +227,7 @@ module Puma
       return @peerip if @peerip
 
       if @remote_addr_header
-        hdr = (@env[@remote_addr_header] || LOCALHOST_IP).split(/[\s,]/).first
+        hdr = (@env[@remote_addr_header] || @io.peeraddr.last).split(/[\s,]/).first
         @peerip = hdr
         return hdr
       end

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -69,6 +69,7 @@ module Puma
       @hijacked = false
 
       @peerip = nil
+      @peer_family = nil
       @listener = nil
       @remote_addr_header = nil
 
@@ -233,6 +234,16 @@ module Puma
       end
 
       @peerip ||= @io.peeraddr.last
+    end
+
+    def peer_family
+      return @peer_family if @peer_family
+
+      @peer_family ||= begin
+                         @io.local_address.afamily
+                       rescue
+                         Socket::AF_INET
+                       end
     end
 
     # Returns true if the persistent connection can be closed immediately

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -176,6 +176,7 @@ module Puma
     PORT_443 = "443".freeze
     LOCALHOST = "localhost".freeze
     LOCALHOST_IP = "127.0.0.1".freeze
+    UNSPECIFIED_IP = "0.0.0.0".freeze
 
     SERVER_PROTOCOL = "SERVER_PROTOCOL".freeze
     HTTP_11 = "HTTP/1.1".freeze

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -175,8 +175,10 @@ module Puma
     PORT_80 = "80".freeze
     PORT_443 = "443".freeze
     LOCALHOST = "localhost".freeze
-    LOCALHOST_IP = "127.0.0.1".freeze
-    UNSPECIFIED_IP = "0.0.0.0".freeze
+    LOCALHOST_IPV4 = "127.0.0.1".freeze
+    LOCALHOST_IPV6 = "::1".freeze
+    UNSPECIFIED_IPV4 = "0.0.0.0".freeze
+    UNSPECIFIED_IPV6 = "::".freeze
 
     SERVER_PROTOCOL = "SERVER_PROTOCOL".freeze
     HTTP_11 = "HTTP/1.1".freeze

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -830,7 +830,7 @@ module Puma
     #    `set_remote_address header: "X-Real-IP"`.
     #    Only the first word (as separated by spaces or comma) is used, allowing
     #    headers such as X-Forwarded-For to be used as well. If this header is absent,
-    #    Puma will fall back to the behavior of :socket
+    #    Puma will fall back to the behavior for :socket
     # 4. **\<Any string\>** - this allows you to hardcode remote address to any value
     #    you wish. Because Puma never uses this field anyway, it's format is
     #    entirely in your hands.

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -821,13 +821,16 @@ module Puma
     # There are 4 possible values:
     #
     # 1. **:socket** (the default) - read the peername from the socket using the
-    #    syscall. This is the normal behavior.
+    #    syscall. This is the normal behavior. If this fails for any reason (e.g.,
+    #    if the peer disconnects between the connection being accepted and the getpeername
+    #    system call), Puma will return "0.0.0.0"
     # 2. **:localhost** - set the remote address to "127.0.0.1"
     # 3. **header: <http_header>**- set the remote address to the value of the
     #    provided http header. For instance:
     #    `set_remote_address header: "X-Real-IP"`.
     #    Only the first word (as separated by spaces or comma) is used, allowing
-    #    headers such as X-Forwarded-For to be used as well.
+    #    headers such as X-Forwarded-For to be used as well. If this header is absent,
+    #    Puma will fall back to the behavior of :socket
     # 4. **\<Any string\>** - this allows you to hardcode remote address to any value
     #    you wish. Because Puma never uses this field anyway, it's format is
     #    entirely in your hands.

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -276,8 +276,8 @@ module Puma
           addr = client.peerip
         rescue Errno::ENOTCONN
           # Client disconnects can result in an inability to get the
-          # peeraddr from the socket; default to localhost.
-          addr = LOCALHOST_IP
+          # peeraddr from the socket; default to unspec.
+          addr = UNSPECIFIED_IP
         end
 
         # Set unix socket addrs to localhost

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -277,11 +277,21 @@ module Puma
         rescue Errno::ENOTCONN
           # Client disconnects can result in an inability to get the
           # peeraddr from the socket; default to unspec.
-          addr = UNSPECIFIED_IP
+          if client.peer_family == Socket::AF_INET6
+            addr = UNSPECIFIED_IPV6
+          else
+            addr = UNSPECIFIED_IPV4
+          end
         end
 
         # Set unix socket addrs to localhost
-        addr = LOCALHOST_IP if addr.empty?
+        if addr.empty?
+          if client.peer_family == Socket::AF_INET6
+            addr = LOCALHOST_IPV6
+          else
+            addr = LOCALHOST_IPV4
+          end
+        end
 
         env[REMOTE_ADDR] = addr
       end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1331,4 +1331,17 @@ EOF
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
     assert_equal "user", data.split("\r\n").last
   end
+
+  def test_remote_address_header
+    server_run(remote_address: :header, remote_address_header: 'HTTP_X_REMOTE_IP') do |env|
+      [200, {}, [env['REMOTE_ADDR']]]
+    end
+    remote_addr = send_http_and_read("GET / HTTP/1.1\r\nX-Remote-IP: 1.2.3.4\r\n\r\n").split("\r\n").last
+    assert_equal '1.2.3.4', remote_addr
+
+    # TODO: it would be great to test a connection from a non-localhost IP, but we can't really do that. For
+    # now, at least test that it doesn't return garbage.
+    remote_addr = send_http_and_read("GET / HTTP/1.1\r\n\r\n").split("\r\n").last
+    assert_equal @host, remote_addr
+  end
 end


### PR DESCRIPTION
Closes #2652

### Description
See #2652 for details; this makes two changes:

 - When using the `set_remote_address header: "header_name"` functionality, if the header is not passed, `REMOTE_ADDR` is now set to the physical peeraddr instead of always being set to 127.0.0.1
 - When an error occurs preventing the physical peeraddr from being fetched, `REMOTE_ADDR` is now set to the unspecified source address ('0.0.0.0') instead of to '127.0.0.1'

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
