### PR TITLE
add support for the PROXY protocol (v1 only)

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -56,6 +56,7 @@ module Puma
       @parser = HttpParser.new
       @parsed_bytes = 0
       @read_header = true
+      @read_proxy = false
       @ready = false
 
       @body = nil
@@ -71,6 +72,7 @@ module Puma
       @peerip = nil
       @listener = nil
       @remote_addr_header = nil
+      @expect_proxy_proto = false
 
       @body_remain = 0
 
@@ -106,7 +108,7 @@ module Puma
 
     # @!attribute [r] in_data_phase
     def in_data_phase
-      !@read_header
+      !(@read_header || @read_proxy)
     end
 
     def set_timeout(val)
@@ -121,6 +123,7 @@ module Puma
     def reset(fast_check=true)
       @parser.reset
       @read_header = true
+      @read_proxy = !!@expect_proxy_proto
       @env = @proto_env.dup
       @body = nil
       @tempfile = nil
@@ -163,7 +166,7 @@ module Puma
     end
 
     def try_to_finish
-      return read_body unless @read_header
+      return read_body if in_data_phase
 
       begin
         data = @io.read_nonblock(CHUNK_SIZE)
@@ -186,6 +189,24 @@ module Puma
         @buffer << data
       else
         @buffer = data
+      end
+
+      if @read_proxy
+        if @expect_proxy_proto == :v1
+          if @buffer.include? "\r\n"
+            if md = PROXY_PROTOCOL_V1_REGEX.match(@buffer)
+              if md[1]
+                @peerip = md[1].split(" ")[0]
+              end
+              @buffer = md.post_match
+            end
+            # if the buffer has a \r\n but doesn't have a PROXY protocol
+            # request, this is just HTTP from a non-PROXY client; move on
+            @read_proxy = false
+          else
+            return false
+          end
+        end
       end
 
       @parsed_bytes = @parser.execute(@env, @buffer, @parsed_bytes)
@@ -242,6 +263,17 @@ module Puma
     def can_close?
       # Allow connection to close if we're not in the middle of parsing a request.
       @parsed_bytes == 0
+    end
+
+    def expect_proxy_proto=(val)
+      if val
+        if @read_header
+          @read_proxy = true
+        end
+      else
+        @read_proxy = false
+      end
+      @expect_proxy_proto = val
     end
 
     private

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -247,5 +247,7 @@ module Puma
 
     # Banned keys of response header
     BANNED_HEADER_KEY = /\A(rack\.|status\z)/.freeze
+
+    PROXY_PROTOCOL_V1_REGEX = /^PROXY (?:TCP4|TCP6|UNKNOWN) ([^\r]+)\r\n/.freeze
   end
 end

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -818,7 +818,7 @@ module Puma
     # a kernel syscall is required which for very fast rack handlers
     # slows down the handling significantly.
     #
-    # There are 4 possible values:
+    # There are 5 possible values:
     #
     # 1. **:socket** (the default) - read the peername from the socket using the
     #    syscall. This is the normal behavior.
@@ -828,7 +828,7 @@ module Puma
     #    `set_remote_address header: "X-Real-IP"`.
     #    Only the first word (as separated by spaces or comma) is used, allowing
     #    headers such as X-Forwarded-For to be used as well.
-    # 4. **proxy_protocol: v1**- set the remote address to the value read from the
+    # 4. **proxy_protocol: :v1**- set the remote address to the value read from the
     #    HAproxy PROXY protocol, version 1. If the request does not have the PROXY
     #    protocol attached to it, will fall back to :socket
     # 5. **\<Any string\>** - this allows you to hardcode remote address to any value
@@ -852,7 +852,7 @@ module Puma
         elsif protocol_version = val[:proxy_protocol]
           @options[:remote_address] = :proxy_protocol
           protocol_version = protocol_version.downcase.to_sym
-          if ! [:v1].include?(protocol_version)
+          unless [:v1].include?(protocol_version)
             raise "Invalid value for proxy_protocol - #{protocol_version.inspect}"
           end
           @options[:remote_address_proxy_protocol] = protocol_version

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -321,6 +321,8 @@ module Puma
           remote_addr_value = @options[:remote_address_value]
         when :header
           remote_addr_header = @options[:remote_address_header]
+        when :proxy_protocol
+          remote_addr_proxy_protocol = @options[:remote_address_proxy_protocol]
         end
 
         while @status == :run || (drain && shutting_down?)
@@ -346,6 +348,8 @@ module Puma
                   client.peerip = remote_addr_value
                 elsif remote_addr_header
                   client.remote_addr_header = remote_addr_header
+                elsif remote_addr_proxy_protocol
+                  client.expect_proxy_proto = remote_addr_proxy_protocol
                 end
                 pool << client
               end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -54,8 +54,7 @@ class TestPumaServer < Minitest::Test
     family = addr.ipv4? ? "TCP4" : "TCP6"
     target = addr.ipv4? ? "127.0.0.1" : "::1"
     conn = new_connection
-    conn << "PROXY #{family} #{remote_ip} #{target} 10000 80\r\n"
-    conn << req
+    conn << ("PROXY #{family} #{remote_ip} #{target} 10000 80\r\n" + req)
   end
 
   def new_connection

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -2,6 +2,7 @@ require_relative "helper"
 require "puma/events"
 require "net/http"
 require "nio"
+require "ipaddr"
 
 class TestPumaServer < Minitest::Test
   parallelize_me! unless JRUBY_HEAD
@@ -46,6 +47,15 @@ class TestPumaServer < Minitest::Test
 
   def send_http(req)
     new_connection << req
+  end
+
+  def send_proxy_v1_http(req, remote_ip)
+    addr = IPAddr.new(remote_ip)
+    family = addr.ipv4? ? "TCP4" : "TCP6"
+    target = addr.ipv4? ? "127.0.0.1" : "::1"
+    conn = new_connection
+    conn << "PROXY #{family} #{remote_ip} #{target} 10000 80\r\n"
+    conn << req
   end
 
   def new_connection
@@ -1015,6 +1025,18 @@ EOF
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
     assert_match "X-header: first line\r\nX-header: second line\r\n", data
+  end
+
+  def test_proxy_protocol
+    server_run(remote_address: :proxy_protocol, remote_address_proxy_protocol: :v1) do |env|
+      [200, {}, [env["REMOTE_ADDR"]]]
+    end
+
+    remote_addr = send_proxy_v1_http("GET / HTTP/1.0\r\n\r\n", "1.2.3.4").read.split("\r\n").last
+    assert_equal '1.2.3.4', remote_addr
+
+    remote_addr = send_proxy_v1_http("GET / HTTP/1.0\r\n\r\n", "fd00::1").read.split("\r\n").last
+    assert_equal 'fd00::1', remote_addr
   end
 
   # To comply with the Rack spec, we have to split header field values


### PR DESCRIPTION
### Description
This adds support for parsing the [PROXY Protocol](http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) (version 1 only). It's behind the `set_remote_address` feature when invoked like `set_remote_address proxy_protocol: :v1`. I put the `v1` in there in case some bold soul wants to add v2 support at some point.

This gracefully handles the case where the client doesn't send the PROXY protocol and falls back to normal logic.

Closes #2651 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
