### PR TITLE
Fix deadlock issue in thread pool

### DIFF
--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -119,6 +119,7 @@ module Puma
                 @trim_requested -= 1
                 @spawned -= 1
                 @workers.delete th
+                not_full.signal
                 Thread.exit
               end
 


### PR DESCRIPTION
### Description
Fix deadlock issue in thread pool.

This deadlock can happen when a thread is being trimmed, if the main server thread has already accepted a new incoming request and is waiting for the thread pool to not be full.

I was unable to write a test for this (race conditions are hard to reproduce!), but I was able to confirm this is a regression introduced in 5.0 by #2220. Previously, Puma did call `not_full.signal` when a thread was being trimmed: https://github.com/puma/puma/blob/v4.3.8/lib/puma/thread_pool.rb#L109.

I'm happy to add a test if anyone has suggestions for how to write one :)

Fixes #2655.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
