### PR TITLE
Better names for thread pool threads

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -227,6 +227,7 @@ module Puma
       @status = :run
 
       @thread_pool = ThreadPool.new(
+        thread_name,
         @min_threads,
         @max_threads,
         ::Puma::IOBuffer,

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -29,7 +29,7 @@ module Puma
     # The block passed is the work that will be performed in each
     # thread.
     #
-    def initialize(min, max, *extra, &block)
+    def initialize(name, min, max, *extra, &block)
       @not_empty = ConditionVariable.new
       @not_full = ConditionVariable.new
       @mutex = Mutex.new
@@ -39,6 +39,7 @@ module Puma
       @spawned = 0
       @waiting = 0
 
+      @name = name
       @min = Integer(min)
       @max = Integer(max)
       @block = block
@@ -101,7 +102,7 @@ module Puma
       @spawned += 1
 
       th = Thread.new(@spawned) do |spawned|
-        Puma.set_thread_name 'threadpool %03i' % spawned
+        Puma.set_thread_name '%s threadpool %03i' % [@name, spawned]
         todo  = @todo
         block = @block
         mutex = @mutex
@@ -318,12 +319,12 @@ module Puma
     end
 
     def auto_trim!(timeout=30)
-      @auto_trim = Automaton.new(self, timeout, "threadpool trimmer", :trim)
+      @auto_trim = Automaton.new(self, timeout, "#{@name} threadpool trimmer", :trim)
       @auto_trim.start!
     end
 
     def auto_reap!(timeout=5)
-      @reaper = Automaton.new(self, timeout, "threadpool reaper", :reap)
+      @reaper = Automaton.new(self, timeout, "#{@name} threadpool reaper", :reap)
       @reaper.start!
     end
 

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -10,12 +10,12 @@ class TestThreadPool < Minitest::Test
 
   def new_pool(min, max, &block)
     block = proc { } unless block
-    @pool = Puma::ThreadPool.new(min, max, &block)
+    @pool = Puma::ThreadPool.new('test', min, max, &block)
   end
 
   def mutex_pool(min, max, &block)
     block = proc { } unless block
-    @pool = MutexPool.new(min, max, &block)
+    @pool = MutexPool.new('test', min, max, &block)
   end
 
   # Wraps ThreadPool work in mutex for better concurrency control.
@@ -59,7 +59,7 @@ class TestThreadPool < Minitest::Test
     thread_name = nil
     pool = mutex_pool(0, 1) {thread_name = Thread.current.name}
     pool << 1
-    assert_equal('puma threadpool 001', thread_name)
+    assert_equal('puma test threadpool 001', thread_name)
   end
 
   def test_converts_pool_sizes


### PR DESCRIPTION
### Description
Include the name of the server in thread pool threads.

This change makes it easier to distinguish between the threads created by the pools for the main server and the control server.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
