### PR TITLE
Reference restart docs from deployment docs [ci skip]

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -97,20 +97,5 @@ and use `runit` or hell, even `monit`.
 ## Restarting
 
 You probably will want to deploy some new code at some point, and you'd like
-puma to start running that new code. Minimizing the amount of time the server
-is unavailable would be nice as well. Here's how to do it:
-
-1. Don't use `preload_app!`. This dirties the master process and means it will have
-to shutdown all the workers and re-exec itself to get your new code. It is not compatible with phased-restart and `prune_bundler` as well.
-
-1. Use `prune_bundler`. This makes it so that the cluster master will detach itself
-from a Bundler context on start. This allows the cluster workers to load your app
-and start a brand new Bundler context within the worker only. This means your
-master remains pristine and can live on between new releases of your code.
-
-1. Use phased-restart (`SIGUSR1` or `pumactl phased-restart`). This tells the master
-to kill off one worker at a time and restart them in your new code. This minimizes
-downtime and staggers the restart nicely. **WARNING** This means that both your
-old code and your new code will be running concurrently. Most deployment solutions
-already cause that, but it's worth warning you about it again. Be careful with your
-migrations, etc!
+puma to start running that new code. There are a few options for restarting
+puma, described separately in our [restart documentation](restart.md).


### PR DESCRIPTION
### Description

I noticed in #2663 that we had some redundant restart documentation. I replaced it with a reference to the authoritative restart docs.

### Your checklist for this pull request

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
