### PR TITLE
Replace IO.select with IO#wait_* when checking a single IO

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -143,8 +143,7 @@ module Puma
         return false
       else
         begin
-          if fast_check &&
-              IO.select([@to_io], nil, nil, FAST_TRACK_KA_TIMEOUT)
+          if fast_check && @to_io.wait_readable(FAST_TRACK_KA_TIMEOUT)
             return try_to_finish
           end
         rescue IOError
@@ -202,13 +201,13 @@ module Puma
 
     def eagerly_finish
       return true if @ready
-      return false unless IO.select([@to_io], nil, nil, 0)
+      return false unless @to_io.wait_readable(0)
       try_to_finish
     end
 
     def finish(timeout)
       return if @ready
-      IO.select([@to_io], nil, nil, timeout) || timeout! until try_to_finish
+      @to_io.wait_readable(timeout) || timeout! until try_to_finish
     end
 
     def timeout!

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -426,9 +426,7 @@ module Puma
 
             check_workers
 
-            res = IO.select([read], nil, nil, [0, @next_check - Time.now].max)
-
-            if res
+            if read.wait_readable([0, @next_check - Time.now].max)
               req = read.read_nonblock(1)
 
               @next_check = Time.now if req == "!"

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -35,7 +35,7 @@ module Puma
 
        Thread.new do
           Puma.set_thread_name "worker check pipe"
-          IO.select [@check_pipe]
+          @check_pipe.wait_readable
           log "! Detected parent died, dying"
           exit! 1
         end

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -162,7 +162,7 @@ module Puma
       end
 
       def read_and_drop(timeout = 1)
-        return :timeout unless IO.select([@socket], nil, nil, timeout)
+        return :timeout unless @socket.wait_readable(timeout)
         case @socket.read_nonblock(1024, exception: false)
         when nil
           :eof

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -201,7 +201,7 @@ module Puma
         begin
           n = io.syswrite str
         rescue Errno::EAGAIN, Errno::EWOULDBLOCK
-          if !IO.select(nil, [io], nil, WRITE_TIMEOUT)
+          unless io.wait_writable WRITE_TIMEOUT
             raise ConnectionError, "Socket timeout writing data"
           end
 
@@ -419,7 +419,7 @@ module Puma
       # of concurrent connections exceeds the size of the threadpool.
       res_info[:keep_alive] &&= requests < @max_fast_inline ||
         @thread_pool.busy_threads < @max_threads ||
-        !IO.select([client.listener], nil, nil, 0)
+        !client.listener.to_io.wait_readable(0)
 
       res_info[:response_hijack] = nil
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -14,6 +14,7 @@ require 'puma/io_buffer'
 require 'puma/request'
 
 require 'socket'
+require 'io/wait'
 require 'forwardable'
 
 module Puma

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -176,6 +176,7 @@ class TestIntegration < Minitest::Test
   # used to define correct 'refused' errors
   def thread_run_refused(unix: false)
     if unix
+      DARWIN ? [Errno::ENOENT, Errno::EPIPE, IOError] :
       [Errno::ENOENT, IOError]
     else
       DARWIN ? [Errno::EBADF, Errno::ECONNREFUSED, Errno::EPIPE, EOFError] :


### PR DESCRIPTION
### Description

Replace `IO.select` with `IO#wait_readable`/`IO#wait_writable` when checking a single IO.

This changed an intermittent macOS issue into something stable, which was an `Errno::EPIPE` error being raised when a client writes to a UNIXSocket, and the server is closing.  Fixed in test file.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
