### PR TITLE
Add threadpool deadlock fix to history for 5.4.0 [ci skip]

### DIFF
--- a/History.md
+++ b/History.md
@@ -9,6 +9,7 @@
   * `Binder#parse` - allow for symlinked unix path, add create_activated_fds debug ENV ([#2643], [#2638])
   * Fix deprecation warning: minissl.c - Use Random.bytes if available ([#2642])
   * Client certificates: set session id context while creating SSLContext ([#2633])
+  * Fix deadlock issue in thread pool ([#2656])
 
 * Refactor
   * Replace `IO.select` with `IO#wait_*` when checking a single IO ([#2666])
@@ -1768,6 +1769,7 @@ be added back in a future date when a java Puma::MiniSSL is added.
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
 
+[#2656]:https://github.com/puma/puma/pull/2656     "PR by @olivierbellone, merged 2021-07-07"
 [#2657]:https://github.com/puma/puma/pull/2657     "PR by @olivierbellone, merged 2021-07-13"
 [#2648]:https://github.com/puma/puma/pull/2648     "PR by @MSP-Greg, merged 2021-06-27"
 [#1412]:https://github.com/puma/puma/issues/1412   "Issue by @x-yuri, closed 2021-06-27"


### PR DESCRIPTION
### Description

I'm pretty sure History.md is mostly automatically generated and then manually cleaned up, but I think https://github.com/puma/puma/pull/2656 probably should've made the cut.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [X] All new and existing tests passed, including Rubocop.
