### PR TITLE
[doc] Add missing link to GH issue in systemd.md [ci skip]

### DIFF
--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -248,3 +248,4 @@ cap $stage puma:stop  --dry-run
 
 [Restart]: https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=
 [#1367]: https://github.com/puma/puma/issues/1367
+[#1499]: https://github.com/puma/puma/issues/1499


### PR DESCRIPTION
### Description

This pull request fixes a link in the documentation.

In systemd.md, a link to GH issue is broken. 

https://github.com/puma/puma/blob/9e2f5d12b259ce0e7664ddcb8570425996e40bc9/docs/systemd.md
![210804173133](https://user-images.githubusercontent.com/4361134/128149230-118fb625-d372-4cfb-8029-0954fc7078f5.png)

Because the link notation needs a URL reference bottom of the document, but it doesn't exist.


This PR adds the URL reference. The link will work.
https://github.com/pocke/puma/blob/f788c40b07b80cffb84d2e8e28cf3e8b04964ce8/docs/systemd.md
![210804173359](https://user-images.githubusercontent.com/4361134/128149523-8baefe5e-d812-476d-b7af-1c6f8685a49c.png)



### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
