### PR TITLE
Add macOS 11 Big Sur to CI

### DIFF
--- a/.github/workflows/mri.yml
+++ b/.github/workflows/mri.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, windows-2019 ]
+        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, macos-11, windows-2019 ]
         ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', head ]
         no-ssl: ['']
         include:

--- a/.github/workflows/non_mri.yml
+++ b/.github/workflows/non_mri.yml
@@ -24,6 +24,8 @@ jobs:
           - { os: ubuntu-20.04 , ruby: truffleruby-head }
           - { os: macos-10.15  , ruby: jruby }
           - { os: macos-10.15  , ruby: truffleruby-head }
+          - { os: macos-11     , ruby: jruby }
+          - { os: macos-11     , ruby: truffleruby-head }
 
     steps:
       - name: repo checkout


### PR DESCRIPTION
https://github.blog/changelog/2021-08-16-github-actions-macos-11-big-sur-is-generally-available-on-github-hosted-runners/
