### PR TITLE
Gemfile - update Rack to >= 1.6.13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "rake-compiler", "~> 1.1.1"
 
 gem "json", "~> 2.3"
 gem "nio4r", "~> 2.0"
-gem "rack", "~> 1.6"
+gem "rack", ">= 1.6.13"
 gem "minitest", "~> 5.11"
 gem "minitest-retry"
 gem "minitest-proveit"


### PR DESCRIPTION
### Description

Currently, the Puma Gemfile has rack restricted to `"~> 1.6"`.  The current Rails Gemfile.lock is using [`rack (2.2.3)`](https://github.com/rails/rails/blob/e9f38a164e36104cc495d5ac5859e57f6be75f36/Gemfile.lock#L354).

Maybe we should use `">= 1.6.13"`, as older Ruby version will still test with `1.6`...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
