### PR TITLE
Preserve BUNDLE_APP_CONFIG on worker fork

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -319,10 +319,12 @@ module Puma
       log '* Pruning Bundler environment'
       home = ENV['GEM_HOME']
       bundle_gemfile = Bundler.original_env['BUNDLE_GEMFILE']
+      bundle_app_config = Bundler.original_env['BUNDLE_APP_CONFIG']
       with_unbundled_env do
         ENV['GEM_HOME'] = home
         ENV['BUNDLE_GEMFILE'] = bundle_gemfile
         ENV['PUMA_BUNDLER_PRUNED'] = '1'
+        ENV["BUNDLE_APP_CONFIG"] = bundle_app_config
         args = [Gem.ruby, puma_wild_location, '-I', dirs.join(':')] + @original_argv
         # Ruby 2.0+ defaults to true which breaks socket activation
         args += [{:close_others => false}]

--- a/test/bundle_app_config_test/.bundle/config
+++ b/test/bundle_app_config_test/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/test/bundle_app_config_test/Gemfile
+++ b/test/bundle_app_config_test/Gemfile
@@ -1,0 +1,1 @@
+gem 'puma', path: '../..'

--- a/test/bundle_app_config_test/config.ru
+++ b/test/bundle_app_config_test/config.ru
@@ -1,0 +1,1 @@
+run lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Hello World"]] }

--- a/test/test_preserve_bundler_env.rb
+++ b/test/test_preserve_bundler_env.rb
@@ -39,6 +39,27 @@ class TestPreserveBundlerEnv < TestIntegration
     assert_match("Gemfile.bundle_env_preservation_test", new_reply)
   end
 
+  def test_worker_forking_preserves_bundler_config_path
+    skip_unless_signal_exist? :TERM
+
+    @tcp_port = UniquePort.call
+    env = {
+      # Disable the .bundle/config file in the bundle_app_config_test directory
+      "BUNDLE_APP_CONFIG" => "/dev/null",
+      # Don't allow our (rake test's) original env to interfere with the child process
+      "BUNDLE_GEMFILE" => nil,
+      "BUNDLER_ORIG_BUNDLE_GEMFILE" => nil
+    }
+    cmd = "bundle exec puma -q -w 1 --prune-bundler -b tcp://#{HOST}:#{@tcp_port}"
+    Dir.chdir File.expand_path("bundle_app_config_test", __dir__) do
+      @server = IO.popen(env, cmd.split, "r")
+    end
+    wait_for_server_to_boot
+    @pid = @server.pid
+    reply = read_body(connect)
+    assert_equal("Hello World", reply)
+  end
+
   def test_phased_restart_preserves_unspecified_bundle_gemfile
     skip_unless_signal_exist? :USR1
 


### PR DESCRIPTION
Without this, if puma is launched with BUNDLE_APP_CONFIG set, that will
be lost inside of unbundled_env, which causes the worker processes to use a
potentially different bundler configuration.

Closes #2687


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
