### PR TITLE
Add a semantic CLI option for no config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,13 @@ $ puma -C /path/to/config
 
 If no configuration file is specified, Puma will look for a configuration file at `config/puma.rb`. If an environment is specified, either via the `-e` and `--environment` flags, or through the `RACK_ENV` or the `RAILS_ENV` environment variables, Puma first looks for configuration at `config/puma/<environment_name>.rb`, and then falls back to `config/puma.rb`.
 
-If you want to prevent Puma from looking for a configuration file in those locations, provide a dash as the argument to the `-C` (or `--config`) flag:
+If you want to prevent Puma from looking for a configuration file in those locations, include the `--no-config` flag:
 
 ```
+$ puma -C --no-config
+
+# or
+
 $ puma -C "-"
 ```
 

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -112,6 +112,11 @@ module Puma
             file_config.load arg
           end
 
+          # Identical to supplying --config "-", but more semantic
+          o.on "--no-config", "Prevent Puma from searching for a config file" do |arg|
+            file_config.load "-"
+          end
+
           o.on "--control-url URL", "The bind url to use for the control server. Use 'auto' to use temp unix server" do |arg|
             configure_control_url(arg)
           end


### PR DESCRIPTION
### Description
Personally, I think `puma -C "-"` is pretty opaque, but `puma --no-config` is a bit easier to understand at glance.

This is totally my opinion, but I feel like it's an improvement and doesn't risk changing the old behavior unintentionally.

I'm also not quite sure how to best test this, so if there are any suggestions I'm happy to jump on that!
 
### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
