### PR TITLE
benchmarks - wrk overload testing files [ci skip]

### DIFF
--- a/benchmarks/local/bench_base.rb
+++ b/benchmarks/local/bench_base.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+module TestPuma
+  class BenchBase
+
+    # Signal used to trigger worker GC
+    GC_SIGNAL = 'SIGALRM'
+
+    # We're running under GitHub Actions
+    IS_GHA = ENV['GITHUB_ACTIONS'] == 'true'
+
+    WRK_PERCENTILE = [0.50, 0.75, 0.9, 0.99, 1.0].freeze
+
+    def initialize
+      sleep 5 # wait for server to boot
+
+      @thread_loops       = nil
+      @clients_per_thread = nil
+      @req_per_client     = nil
+      @body_kb            = 10
+      @dly_app            = nil
+      @bind_type          = :tcp
+
+      @ios_to_close = []
+
+      setup_options
+
+      unless File.exist? @state_file
+        puts "can't fined state file '#{@state_file}'"
+        exit 1
+      end
+
+      mstr_pid = File.binread(@state_file)[/^pid: +(\d+)/, 1].to_i
+      begin
+        Process.kill 0, mstr_pid
+      rescue Errno::ESRCH
+        puts 'Puma server stopped?'
+        exit 1
+      rescue Errno::EPERM
+      end
+
+      case @bind_type
+      when :ssl, :tcp
+        @bind_port = ENV.fetch('PORT', 40010).to_i
+      when :unix
+        @bind_path = "#{Dir.home}/skt.unix"
+      when :aunix
+        @bind_path = "@skt.aunix"
+      else
+        exit 1
+      end
+    end
+
+    def setup_options
+      OptionParser.new do |o|
+        o.on "-l", "--loops LOOPS", OptionParser::DecimalInteger, "create_clients: loops/threads" do |arg|
+          @thread_loops = arg.to_i
+        end
+
+        o.on "-c", "--connections CONNECTIONS", OptionParser::DecimalInteger, "create_clients: clients_per_thread" do |arg|
+          @clients_per_thread = arg.to_i
+        end
+
+        o.on "-r", "--requests REQUESTS", OptionParser::DecimalInteger, "create_clients: requests per client" do |arg|
+          @req_per_client = arg.to_i
+        end
+
+        o.on "-b", "--body_kb BODYKB", OptionParser::DecimalInteger, "CI RackUp: size of response body in kB" do |arg|
+          @body_kb = arg.to_i
+        end
+
+        o.on "-d", "--dly_app DELAYAPP", Float, "CI RackUp: app response delay" do |arg|
+          @dly_app = arg.to_f
+        end
+
+        o.on "-s", "--socket SOCKETTYPE", String, "Bind type: tcp, ssl, unix, aunix" do |arg|
+          @bind_type = arg.to_sym
+        end
+
+        o.on "-S", "--state STATEFILE", String, "Puma Server: state file" do |arg|
+          @state_file = arg
+        end
+
+        o.on "-t", "--threads THREADS", String, "Puma Server: threads" do |arg|
+          @threads = arg[/\d+\z/].to_i
+        end
+
+        o.on "-w", "--workers WORKERS", OptionParser::DecimalInteger, "Puma Server: workers" do |arg|
+          @workers = arg.to_i
+        end
+
+        o.on "-T", "--time TIME", OptionParser::DecimalInteger, "wrk: duration" do |arg|
+          @wrk_time = arg.to_i
+        end
+
+        o.on "-W", "--wrk_bind WRK_STR", String, "wrk: bind string" do |arg|
+          @wrk_bind_str = arg
+        end
+
+        o.on("-h", "--help", "Prints this help") do
+          puts o
+          exit
+        end
+      end.parse! ARGV
+    end
+
+    def close_clients
+      closed = 0
+      @ios_to_close.each do |socket|
+        if socket && socket.to_io.is_a?(IO) && !socket.closed?
+          begin
+            if @bind_type == :ssl
+              socket.sysclose
+            else
+              socket.close
+            end
+            closed += 1
+          rescue Errno::EBADF
+          end
+        end
+      end
+      puts "Closed #{closed} clients" unless closed.zero?
+    end
+
+    def run_wrk_parse(cmd)
+      print cmd.ljust 55
+
+      wrk_output = %x[#{cmd}]
+
+      wrk_data = "#{wrk_output[/\A.+ connections/m]}\n#{wrk_output[/  Thread Stats.+\z/m]}"
+
+      print " |#{wrk_data[/^ +\d+ +requests.+/].rstrip}\n"
+
+      # puts '', wrk_data, ''     # for debugging or output format changes
+
+      hsh = {}
+
+      hsh[:rps]      = wrk_data[/^Requests\/sec: +([\d.]+)/, 1].to_f.round
+      hsh[:requests] = wrk_data[/^ +(\d+) +requests/, 1].to_i
+      if (t = wrk_data[/^ +Socket errors: +(.+)/, 1])
+        hsh[:errors] = t
+      end
+
+      read = wrk_data[/ +([\d.]+)(GB|KB|MB) +read$/, 1].to_f
+      unit = wrk_data[/ +[\d.]+(GB|KB|MB) +read$/, 1]
+
+      mult =
+        case unit
+        when 'KB' then 1_024
+        when 'MB' then 1_024**2
+        when 'GB' then 1_024**3
+        end
+
+      hsh[:read] = (mult * read).round
+
+      if hsh[:errors]
+        t = hsh[:errors]
+        hsh[:errors] = t.sub('connect ', 'c').sub('read ', 'r')
+          .sub('write ', 'w').sub('timeout ', 't')
+      end
+
+      t_re = ' +([\d.ums]+)'
+
+      latency =
+         wrk_data.match(/^ +50%#{t_re}\s+75%#{t_re}\s+90%#{t_re}\s+99%#{t_re}/).captures
+      # add up max time
+      latency.push wrk_data[/^ +Latency.+/].split(' ')[-2]
+
+      hsh[:times] = WRK_PERCENTILE.zip(latency.map do |t|
+        if t.end_with?('ms')
+          t.to_f
+        elsif t.end_with?('us')
+          t.to_f/1000
+        elsif t.end_with?('s')
+          t.to_f * 1000
+        else
+          0
+        end
+      end).to_h
+      hsh
+    end
+
+    def parse_stats
+      obj = @puma_info.run 'stats'
+      # puts ''; pp obj; puts ''
+      wrks = obj[:worker_status]
+      stats = {}
+      wrks.each do |w|
+        pid = w[:pid]
+        req_cnt = w[:last_status][:requests_count]
+        id = format 'worker-%01d-%02d', w[:phase], w[:index]
+        hsh = {
+          pid: w[:pid],
+          requests: req_cnt - @worker_req_ttl[w[:pid]],
+          backlog: w[:last_status][:backlog]
+        }
+        @pids[hsh[:pid]] = id
+        @worker_req_ttl[pid] = req_cnt
+        stats[id] = hsh
+      end
+      stats
+    end
+
+    def parse_smem
+      @puma_info.run 'gc'
+      sleep 1
+
+      hsh_smem = Hash.new []
+      pids = @pids.keys
+
+      smem_info = %x[smem -c 'pid rss pss uss command']
+      # puts '', smem_info, ''
+      smem_info.lines.each do |l|
+        ary = l.strip.split ' ', 5
+        if pids.include? ary[0].to_i
+          hsh_smem[@pids[ary[0].to_i]] = {
+            pid: ary[0].to_i,
+            rss: ary[1].to_i,
+            pss: ary[2].to_i,
+            uss: ary[3].to_i
+          }
+        end
+      end
+      hsh_smem.sort.to_h
+    end
+  end
+end

--- a/benchmarks/local/bench_base.sh
+++ b/benchmarks/local/bench_base.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# -l client threads (loops)
+# -c connections per client thread
+# -r requests per client
+#
+# Total connections/requests = l * c * r
+#
+# -b response body size kB
+# -d app delay
+#
+# -s Puma bind socket type, default ssl, also tcp or unix
+# -t Puma threads, default 5:5
+# -w Puma workers, default 2
+# -r Puma rackup file
+
+
+export HOST=127.0.0.1
+export PORT=40001
+export CTRL=40010
+export STATE=tmp/bench_test_puma.state
+
+while getopts l:C:c:d:r:R:s:b:T:t:w: option
+do
+case "${option}"
+in
+#———————————————————— create_clients options
+l) loops=${OPTARG};;
+c) connections=${OPTARG};;
+r) req_per_client=${OPTARG};;
+#———————————————————— Puma options
+C) conf=${OPTARG};;
+t) threads=${OPTARG};;
+w) workers=${OPTARG};;
+R) rackup_file=${OPTARG};;
+#———————————————————— app/common options
+b) body_kb=${OPTARG};;
+s) skt_type=${OPTARG};;
+d) dly_app=${OPTARG};;
+#———————————————————— wrk options
+# c (connections) is also used for wrk
+T) time=${OPTARG};;
+esac
+done
+
+optional_args="-S $STATE"
+
+if [ -z "$loops" ] ; then
+  loops=10
+fi
+
+if [ -z "$connections" ]; then
+  connections=0
+fi
+
+if [ -z "$time" ] ; then
+  time=15
+fi
+
+if [ -z "$req_per_client" ]; then
+  req_per_client=1
+fi
+
+if [ -n "$dly_app" ]; then
+  optional_args="$optional_args -d$dly_app"
+fi
+
+if [ -n "$body_kb" ]; then
+  optional_args="$optional_args -b$body_kb"
+  export CI_TEST_KB=$body_kb
+fi
+
+if [ -z "$skt_type" ]; then
+  skt_type=tcp
+fi
+
+puma_args="-S $STATE"
+
+if [ -n "$workers" ]; then
+  puma_args="$puma_args -w$workers"
+fi
+
+if [ -n "$threads" ]; then
+  puma_args="$puma_args -t$threads"
+fi
+
+if [ -n "$conf" ]; then
+  puma_args="$puma_args -C $conf"
+fi
+
+if [ -z "$rackup_file" ]; then
+  rackup_file="test/rackup/ci_string.ru"
+fi
+
+case $skt_type in
+  ssl)
+  bind="ssl://$HOST:$PORT?cert=examples/puma/cert_puma.pem&key=examples/puma/puma_keypair.pem&verify_mode=none"
+  curl_str=https://$HOST:$PORT
+  wrk_str=https://$HOST:$PORT
+  ;;
+  tcp)
+  bind=tcp://$HOST:$PORT
+  curl_str=http://$HOST:$PORT
+  wrk_str=http://$HOST:$PORT
+  ;;
+  unix)
+  bind=unix://$HOME/skt.unix
+  curl_str="--unix-socket $HOME/skt.unix http:/n"
+  wrk_str=unix://$HOME/skt.unix
+  ;;
+  aunix)
+  bind=unix://@skt.aunix
+  curl_str="--abstract-unix-socket skt.aunix http:/n"
+  wrk_str=unix://@skt.aunix
+  ;;
+esac

--- a/benchmarks/local/bench_overload_wrk.rb
+++ b/benchmarks/local/bench_overload_wrk.rb
@@ -1,0 +1,379 @@
+# frozen_string_literal: true
+
+require_relative 'bench_base'
+require_relative 'puma_info'
+
+module TestPuma
+
+  # This file is meant to be run with `bench_overload_wrk.sh`.  It only works
+  # with workers, and it uses smem and @ioquatix's fork of wrk, available at:
+  # https://github.com/ioquatix/wrk
+  #
+  # It starts a Puma server, then runs 5 sets of wrk, with varying threads and
+  # connections.  The first set has the thread count equal to total Puma thread
+  # count, then four more are run with increasing thread count, ending with three
+  # times the intial value.  After each run, Puma stats and smem info are retrieved.
+  # Information is logged to the console, summarized, and also returned as a Ruby
+  # object, so it may be used for CI.
+  #
+  # Puma stats includes the request count per worker.  The output shows a metric
+  # called 'spread'.  If ary is the array of worker request counts -
+  # spread = 100 * (ary.max - ary.min)/ary.average
+  #
+  # `bench_overload_wrk.sh` arguments
+  #
+  # Puma Server
+  # ```
+  # -R rackup file, defaults to ci_string.ru
+  # -s socket type, tcp or ssl, no unix with wrk
+  # -t same as Puma --thread
+  # -w same as Puma --worker
+  # -C same as Puma --config
+  # The following only apply when using ci_string.ru, ci_array.ru, or ci_chunked.ru
+  # -b body size in kB, defaults to 10
+  # -d app delay in seconds, defaults to 0
+  # ```
+  # wrk cmd
+  # ```
+  # -c wrk connection count per thread, defaults to 10
+  # -T wrk time/duration, defaults to 15
+  # ```
+  #
+  # Examples
+  #
+  # runs wrk with 5 connections per thread and a response body size of 1kB, and a
+  # wrk duration of 10 sec.
+  # ```
+  # benchmarks/local/bench_overload_wrk.sh -c5 -s tcp -w4 -t5:5 -b1 -T10
+  # ```
+  # runs wrk with 5 connections per thread and use hello.ru, show object info after.
+  # ```
+  # benchmarks/local/bench_overload_wrk.sh -c5 -s tcp -w4 -t5:5 -C test/config/worker_object_info.rb -R test/rackup/hello.ru
+  # ```
+  #
+  class BenchOverloadWrk < BenchBase
+
+    # delay between wrk finishing and running stats
+    DELAY_STATS = 5
+
+    # thread multipliers used for wrk jobs, geometric sequence 1 to 3
+    MULTS = [
+      1,
+      1.316074013,
+      1.732050808,
+      2.279507057,
+      3
+    ].freeze
+
+    def run
+      @wrk_time ||= 15
+      wrk_connections_per_thread = @clients_per_thread > 0 ? @clients_per_thread : 10
+
+      if ENV['CI_TEST_KB']
+        puts '', "Reponse body size #{ENV['CI_TEST_KB']} kB, ENV['CI_TEST_KB']"
+      end
+
+      @puma_info = PumaInfo.new ['-S', @state_file]
+
+      # main data hash
+      @info = []
+
+      # summary hash
+      @summary = {}
+
+      @pids = {}
+      @pids[@puma_info.master_pid] = 'master'
+      @worker_req_ttl = Hash.new 0
+      client_dly = 0.000_01
+
+      threads = @threads * @workers
+      temp = MULTS.map { |m| (m * threads).round }
+      ttl_connections = threads * @clients_per_thread
+      loops_clients = temp.map { |m| [m, (ttl_connections/m.to_f).round] }
+
+      temp.each do |t|
+        @info << {
+          threads: t,
+          connections: t * wrk_connections_per_thread,
+          smem: nil,
+          stats: nil,
+          wrk: nil
+        }
+      end
+      @info.unshift({
+        threads: @info[0][:threads],
+        connections: @info[0][:threads],
+        smem: nil,
+        stats: nil,
+        wrk: nil
+      })
+
+      @errors = false
+
+      puts "\n─────────────────────────────────────────────────────────── WRK Overload Stats - app delay #{format '%5.3f s', (@dly_app || 0)}"
+
+      puts '##[group]wrk run data', '' if IS_GHA
+
+      warm_up
+
+      @info[1..-1].each do |info|
+
+        threads, connections = info[:threads], info[:connections]
+
+        header = @dly_app ? "-H 'Dly: #{@dly_app}' " : ""
+
+        wrk_cmd = %Q[wrk #{header}-t#{threads} -c#{connections} -d#{@wrk_time}s --latency #{@wrk_bind_str}]
+
+        hsh = run_wrk_parse wrk_cmd
+
+        info[:wrk] = hsh
+
+        info[:av_resp_size] = (hsh[:read]/hsh[:requests]).round
+
+        @errors = hsh.key? :errors
+
+        sleep DELAY_STATS
+
+        stats = parse_stats
+        info[:stats] = stats
+        stats_reqs = stats.map { |k, h| h[:requests] }
+        hsh[:req_spread] = 100 * (stats_reqs.max - stats_reqs.min) * stats_reqs.length.to_f/stats_reqs.sum
+        hsh[:stats_req_ttl] = stats_reqs.sum
+
+        info[:smem] = parse_smem
+        run_summary info
+      end
+
+      puts '::[endgroup]' if IS_GHA
+
+      overall_summary
+      leak_calc
+      puts RUBY_DESCRIPTION, ''
+      # puts ''; pp @info; puts ''
+      sleep 1
+      @puma_info.run 'stop'
+      sleep 3
+
+      if ENV['GITHUB_ACTIONS']
+        limits = {}
+        limits[:rps], loops_time = ci_test_rps
+
+        exit_code = 0
+        if @summary[:rps] < limits[:rps]
+          puts "loops_time #{loops_time}   #{@summary[:rps]} rps is less than #{limits[:rps]}"
+          exit_code += 1
+        else
+          puts "loops_time #{loops_time}   #{@summary[:rps]} rps is acceptable..."
+        end
+        exit exit_code
+      end
+    end
+
+    def warm_up
+      puts 'warm-up'
+      hdr = @dly_app ? "-H 'Dly: #{@dly_app}' " : ""
+      wu_loops = @info[0][:threads]
+      wu_conns = @info[0][:connections]
+      warm_up_cmd = %Q[wrk #{hdr}-t#{wu_loops} -c#{wu_conns} -d2s --latency #{@wrk_bind_str}]
+
+      @info[0][:wrk] = run_wrk_parse warm_up_cmd
+
+      sleep DELAY_STATS
+      @info[0][:stats] = parse_stats
+      @info[0][:smem] = parse_smem
+      run_summary @info[0]
+      puts ''
+    end
+
+    def run_summary(info)
+      str = "#{info[:wrk][:rps].to_s.rjust(info[:wrk][:requests].to_s.length)} req/sec"
+      fmt = '%6s %7s %7s %7s  %-12s  %7s'
+      puts format(fmt, 'PID', 'RSS', 'PSS', 'USS', 'Desc', "Requests     #{str}")
+      info[:smem].each do |k,v|
+        reqs = info[:stats][k] ? info[:stats][k][:requests].to_s : ''
+        puts format(fmt, *v.values, k, reqs)
+      end
+      puts ''
+    end
+
+    def overall_summary
+      puts " WRK and 'Puma stats' Information".rjust(86, '═'), ''
+
+      time_max = 0
+
+      @info[1..-1].each { |info| time_max = (info[:wrk][:times].values.push time_max).max }
+
+      digits = 3 - Math.log10(time_max).to_i
+      fmt_vals = '%3d %5d  %7d'.dup
+      @info[1][:wrk][:times].length.times { fmt_vals << "  %5.#{digits}f" }
+      fmt_vals << '  %5.2f %8d  %8d %5d'
+
+      header_base = '────────wrk────────  ─Request─time─distribution─(ms)─  Worker─requests'
+
+      reqs_puma = 0
+      reqs_wrk  = 0
+      summary_rps = 0
+
+      if @errors
+        fmt_vals << '   %s'
+        puts "#{header_base}  ─────────wrk─requests─────────"
+        puts " -t    -c   req/sec   50%    75%    90%    99%   100%  spread   total     total   bad         errors"
+      else
+        puts "#{header_base}  ─wrk─requests─"
+        puts " -t    -c   req/sec   50%    75%    90%    99%   100%  spread   total     total   bad"
+      end
+
+      @info[1..-1].each do |info|
+        wrk = info[:wrk]
+        reqs_puma += wrk[:stats_req_ttl]
+        reqs_wrk  += wrk[:requests]
+        if @errors
+          puts format(fmt_vals, info[:threads], info[:connections], wrk[:rps], *wrk[:times].values,
+            wrk[:req_spread], wrk[:stats_req_ttl], wrk[:requests], wrk[:stats_req_ttl] - wrk[:requests], wrk[:errors] || '')
+        else
+          puts format(fmt_vals, info[:threads], info[:connections], wrk[:rps], *wrk[:times].values,
+            wrk[:req_spread], wrk[:stats_req_ttl], wrk[:requests], wrk[:stats_req_ttl] - wrk[:requests])
+        end
+        summary_rps += wrk[:rps] * wrk[:requests]
+      end
+      if @errors
+        puts '', 'errors - c: connection, w: write, r: read, t: timeout'
+      end
+      @summary[:rps] = (summary_rps/reqs_wrk.to_f).to_i
+      puts format("#{' ' * 12}%6d#{' ' * 36}Totals %8d  %8d", @summary[:rps], reqs_puma, reqs_wrk)
+      puts '═'*86, ''
+    end
+
+    def leak_calc
+      workers = @pids.values.reject { |v| v == 'master'}.sort
+      len = @info.length - 1
+
+      info_loop = @info[1..-1]
+
+      # mem = [:pss, :rss, :uss]
+      mem = [:uss]
+
+      all_resp_size =  info_loop.sum { |h| h[:wrk][:read] } / info_loop.sum { |h| h[:wrk][:requests] }
+
+      fmt = '%-15s%-3s'.dup
+      fmt << ' %6d' * len
+
+      width = 18 + 7 * (len+1)
+
+      puts ' Memory Change per Request'.rjust(width, '═')
+      puts format    fmt      , 'WRK Threads'    , '' , *info_loop.map { |h| h[:threads]      }
+      puts format "#{fmt} %6s", '    Connections', '' , *info_loop.map { |h| h[:connections]  }, 'All'
+      puts format "#{fmt} %6d", '    Av Resp Siz', 'e', *info_loop.map { |h| h[:av_resp_size] }, all_resp_size.round
+      puts '═' * width
+
+      fmt << '  %5d'
+
+      ttl_leaks = {}
+      mem.each { |type| ttl_leaks[type] = Array.new len, 0 }
+
+      ttl_mem = Hash.new Array.new(len, 0)
+      ttl_req = Hash.new Array.new(len, 0)
+
+      summary_rps = 0
+
+      workers.each do |w|
+        desc = w
+        mem.each do |type|
+          worker_ttl_req = 0
+          leaks = []
+          info_loop.each_with_index do |hsh, i|
+            smem_last = @info[i][:smem]
+            smem, stats = hsh[:smem], hsh[:stats]
+            requests = stats[w][:requests]
+            ttl_req[type][i] += requests
+            worker_ttl_req   += requests
+            mem_increase = smem[w][type] - smem_last[w][type]
+            ttl_mem[type][i] += mem_increase
+            leaks << 1000 * mem_increase/requests
+          end
+          # total for worker/mem (far right column)
+          leaks << 1000 * (@info[-1][:smem][w][type] - @info[0][:smem][w][type])/worker_ttl_req
+          puts format fmt, desc, type.to_s.upcase, *leaks
+          desc = ''
+        end # mem
+        puts '─'*width if mem.length > 1
+      end # workers
+
+      # Bottom Total Line
+      desc = 'All'
+      mem.each do |type|
+        (0...len).each { |i| ttl_leaks[type][i] = 1000 * ttl_mem[type][i] / ttl_req[type][i] }
+        overall = 1000 * ttl_mem[type].sum / ttl_req[type].sum.to_f
+        puts format fmt, desc, type.to_s.upcase, *ttl_leaks[type], overall
+        desc = ''
+      end
+      puts '═'*width, ''
+    end
+
+    # Try to see how busy a CI system is...
+    def ci_test_rps
+      host = ENV['HOST']
+      port = ENV['PORT'].to_i
+
+      str = 'a' * 65_500
+
+      server = TCPServer.new host, port
+
+      svr_th = Thread.new do
+        loop do
+          begin
+            Thread.new(server.accept) do |client|
+              client.sysread 65_536
+              client.syswrite str
+              client.close
+            end
+          rescue => e
+            break
+          end
+        end
+      end
+
+      threads = []
+
+      t_st = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      100.times do
+        threads << Thread.new do
+          100.times {
+            s = TCPSocket.new host, port
+            s.syswrite str
+            s.sysread 65_536
+            s = nil
+          }
+        end
+      end
+
+      threads.each(&:join)
+      loops_time = (1_000*(Process.clock_gettime(Process::CLOCK_MONOTONIC) - t_st)).to_i
+
+      threads.clear
+      threads = nil
+
+      server.close
+      svr_th.join
+
+      req_limit =
+        if    loops_time > 3_050 then 13_000
+        elsif loops_time > 2_900 then 13_500
+        elsif loops_time > 2_500 then 14_000
+        elsif loops_time > 2_200 then 18_000
+        elsif loops_time > 2_100 then 19_000
+        elsif loops_time > 1_900 then 20_000
+        elsif loops_time > 1_800 then 21_000
+        elsif loops_time > 1_600 then 22_500
+        else                          23_000
+        end
+        [req_limit, loops_time]
+    end
+
+    def puts(*ary)
+      ary.each { |s| STDOUT.syswrite "#{s}\n" }
+    end
+  end
+end
+TestPuma::BenchOverloadWrk.new.run

--- a/benchmarks/local/bench_overload_wrk.sh
+++ b/benchmarks/local/bench_overload_wrk.sh
@@ -1,0 +1,32 @@
+source benchmarks/local/bench_base.sh
+
+if [ "$skt_type" == "unix" ] || [ "$skt_type" == "aunix" ]; then
+  printf "\nwrk doesn't support UNIXSockets...\n\n"
+  exit
+fi
+
+if [ -n "$GITHUB_ACTIONS" ]; then
+  printf "##[group]Puma server startup\n\n"
+else
+  printf "\n"
+fi
+
+echo bundle exec bin/puma -q -b $bind $puma_args --control-url=tcp://$HOST:$CTRL --control-token=test $rackup_file
+printf "\n"
+#exit
+
+bundle exec bin/puma -q -b $bind $puma_args --control-url=tcp://$HOST:$CTRL --control-token=test $rackup_file &
+sleep 5s
+
+if [ -n "$GITHUB_ACTIONS" ]; then
+  printf "::[endgroup]\n"
+else
+  printf "\n"
+fi
+
+ruby -I./lib benchmarks/local/bench_overload_wrk.rb -t$threads -w$workers -c$connections -T$time -r$req_per_client -W $wrk_str -s$skt_type $optional_args
+wrk_exit=$?
+
+printf "\n"
+
+exit $wrk_exit

--- a/benchmarks/local/puma_info.rb
+++ b/benchmarks/local/puma_info.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require_relative '../../lib/puma/state_file'
+require_relative '../../lib/puma/const'
+require_relative '../../lib/puma/detect'
+require_relative '../../lib/puma/configuration'
+require 'uri'
+require 'socket'
+require 'json'
+
+module TestPuma
+
+  # Similar to puma_ctl.rb, but returns objects.  Command list is minimal.
+  #
+  class PumaInfo
+    # @version 5.0.0
+    PRINTABLE_COMMANDS = %w{gc-stats stats stop thread-backtraces}.freeze
+
+    COMMANDS = (PRINTABLE_COMMANDS + %w{gc}).freeze
+
+    attr_reader :master_pid
+
+    def initialize(argv, stdout=STDOUT, stderr=STDERR)
+      @state = nil
+      @quiet = false
+      @pidfile = nil
+      @pid = nil
+      @control_url = nil
+      @control_auth_token = nil
+      @config_file = nil
+      @command = nil
+      @environment = ENV['RACK_ENV'] || ENV['RAILS_ENV']
+
+      @argv = argv
+      @stdout = stdout
+      @stderr = stderr
+      @cli_options = {}
+
+      opts = OptionParser.new do |o|
+        o.banner = "Usage: pumactl (-p PID | -P pidfile | -S status_file | -C url -T token | -F config.rb) (#{PRINTABLE_COMMANDS.join("|")})"
+
+        o.on "-S", "--state PATH", "Where the state file to use is" do |arg|
+          @state = arg
+        end
+
+        o.on "-Q", "--quiet", "Not display messages" do |arg|
+          @quiet = true
+        end
+
+        o.on "-C", "--control-url URL", "The bind url to use for the control server" do |arg|
+          @control_url = arg
+        end
+
+        o.on "-T", "--control-token TOKEN", "The token to use as authentication for the control server" do |arg|
+          @control_auth_token = arg
+        end
+
+        o.on "-F", "--config-file PATH", "Puma config script" do |arg|
+          @config_file = arg
+        end
+
+        o.on "-e", "--environment ENVIRONMENT",
+          "The environment to run the Rack app on (default development)" do |arg|
+          @environment = arg
+        end
+
+        o.on_tail("-H", "--help", "Show this message") do
+          @stdout.puts o
+          exit
+        end
+
+        o.on_tail("-V", "--version", "Show version") do
+          @stdout.puts Const::PUMA_VERSION
+          exit
+        end
+      end
+
+      opts.order!(argv) { |a| opts.terminate a }
+      opts.parse!
+
+      unless @config_file == '-'
+        environment = @environment || 'development'
+
+        if @config_file.nil?
+          @config_file = %W(config/puma/#{environment}.rb config/puma.rb).find do |f|
+            File.exist?(f)
+          end
+        end
+
+        if @config_file
+          config = Puma::Configuration.new({ config_files: [@config_file] }, {})
+          config.load
+          @state              ||= config.options[:state]
+          @control_url        ||= config.options[:control_url]
+          @control_auth_token ||= config.options[:control_auth_token]
+          @pidfile            ||= config.options[:pidfile]
+        end
+      end
+
+      @master_pid = File.binread(@state)[/^pid: +(\d+)/, 1].to_i
+
+    rescue => e
+      @stdout.puts e.message
+      exit 1
+    end
+
+    def message(msg)
+      @stdout.puts msg unless @quiet
+    end
+
+    def prepare_configuration
+      if @state
+        unless File.exist? @state
+          raise "State file not found: #{@state}"
+        end
+
+        sf = Puma::StateFile.new
+        sf.load @state
+
+        @control_url = sf.control_url
+        @control_auth_token = sf.control_auth_token
+        @pid = sf.pid
+      end
+    end
+
+    def send_request
+      uri = URI.parse @control_url
+
+      # create server object by scheme
+      server =
+        case uri.scheme
+        when 'ssl'
+          require 'openssl'
+          OpenSSL::SSL::SSLSocket.new(
+            TCPSocket.new(uri.host, uri.port),
+            OpenSSL::SSL::SSLContext.new)
+            .tap { |ssl| ssl.sync_close = true }  # default is false
+            .tap(&:connect)
+        when 'tcp'
+          TCPSocket.new uri.host, uri.port
+        when 'unix'
+          # check for abstract UNIXSocket
+          UNIXSocket.new(@control_url.start_with?('unix://@') ?
+            "\0#{uri.host}#{uri.path}" : "#{uri.host}#{uri.path}")
+        else
+          raise "Invalid scheme: #{uri.scheme}"
+        end
+
+      url = "/#{@command}"
+
+      if @control_auth_token
+        url = url + "?token=#{@control_auth_token}"
+      end
+
+      server.syswrite "GET #{url} HTTP/1.0\r\n\r\n"
+
+      unless data = server.read
+        raise 'Server closed connection before responding'
+      end
+
+      response = data.split("\r\n")
+
+      if response.empty?
+        raise "Server sent empty response"
+      end
+
+      @http, @code, @message = response.first.split(' ',3)
+
+      if @code == '403'
+        raise 'Unauthorized access to server (wrong auth token)'
+      elsif @code == '404'
+        raise "Command error: #{response.last}"
+      elsif @code == '500' && @command == 'stop-sigterm'
+        # expected with stop-sigterm
+      elsif @code != '200'
+        raise "Bad response from server: #{@code}"
+      end
+      return unless PRINTABLE_COMMANDS.include? @command
+      JSON.parse response.last, {symbolize_names: true}
+    ensure
+      if server
+        if uri.scheme == 'ssl'
+          server.sysclose
+        else
+          server.close unless server.closed?
+        end
+      end
+    end
+
+    def run(cmd)
+      return unless COMMANDS.include?(cmd)
+      @command = cmd
+      prepare_configuration
+      send_request
+    rescue => e
+      message e.message
+      exit 1
+    end
+  end
+end

--- a/test/rackup/ci_array.ru
+++ b/test/rackup/ci_array.ru
@@ -1,0 +1,28 @@
+require 'securerandom'
+
+env_len = ENV['CI_TEST_KB'] ? ENV['CI_TEST_KB'].to_i : 10
+
+ary_hdrs = []
+25.times { |i| ary_hdrs << ["X-My-Header-#{i}", SecureRandom.hex(25)] }
+ary_hdrs << ['Content-Type', 'text/plain; charset=utf-8']
+ary_hdrs.freeze
+
+run lambda { |env|
+  resp = "#{Process.pid}\nHello World\n".dup
+
+  if (dly = env['HTTP_DLY'])
+    sleep dly.to_f
+    resp << "Slept #{dly}\n"
+  end
+
+  # length = 1018  bytesize = 1024
+  str_1kb = "──#{SecureRandom.hex 507}─\n"
+
+  len = (env['HTTP_LEN'] || env_len).to_i
+
+  ary = Array.new len+1, str_1kb
+  ary[0] = resp
+  headers = ary_hdrs.to_h
+  headers['Content-Length'] = (resp.bytesize + 1024*len).to_s
+  [200, headers, ary]
+}

--- a/test/rackup/ci_chunked.ru
+++ b/test/rackup/ci_chunked.ru
@@ -1,0 +1,30 @@
+require 'securerandom'
+
+env_len = ENV['CI_TEST_KB'] ? ENV['CI_TEST_KB'].to_i : 10
+
+ary_hdrs = []
+25.times { |i| ary_hdrs << ["X-My-Header-#{i}", SecureRandom.hex(25)] }
+ary_hdrs << ['Content-Type', 'text/plain; charset=utf-8']
+ary_hdrs.freeze
+
+run lambda { |env|
+  resp = "#{Process.pid}\nHello World\n".dup
+
+  if (dly = env['HTTP_DLY'])
+    sleep dly.to_f
+    resp << "Slept #{dly}\n"
+  end
+
+  str_1kb = "──#{SecureRandom.hex 507}─\n"
+
+  len = (env['HTTP_LEN'] || env_len).to_i
+
+  body = Enumerator.new do |yielder|
+    yielder << resp
+    len.times do |entry|
+      yielder << str_1kb
+    end
+  end
+
+  [200, ary_hdrs.to_h, body]
+}

--- a/test/rackup/ci_string.ru
+++ b/test/rackup/ci_string.ru
@@ -1,0 +1,26 @@
+require 'securerandom'
+
+env_len = ENV['CI_TEST_KB'] ? ENV['CI_TEST_KB'].to_i : 10
+
+ary_hdrs = []
+25.times { |i| ary_hdrs << ["X-My-Header-#{i}", SecureRandom.hex(25)] }
+ary_hdrs << ['Content-Type', 'text/plain; charset=utf-8']
+ary_hdrs.freeze
+
+run lambda { |env|
+  body = "#{Process.pid}\nHello World\n".dup
+
+  if (dly = env['HTTP_DLY'])
+    sleep dly.to_f
+    body << "Slept #{dly}\n"
+  end
+
+  # length = 1018  bytesize = 1024
+  str_1kb = "──#{SecureRandom.hex 507}─\n"
+
+  len = (env['HTTP_LEN'] || env_len).to_i
+  body << (str_1kb * len)
+  headers = ary_hdrs.to_h
+  headers['Content-Length'] = body.bytesize.to_s
+  [200, headers, [body]]
+}

--- a/test/rackup/hello.ru
+++ b/test/rackup/hello.ru
@@ -1,1 +1,3 @@
-run lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Hello World"]] }
+hdrs = {'Content-Type'.freeze => 'text/plain'.freeze}.freeze
+body = ['Hello World'.freeze].freeze
+run lambda { |env| [200, hdrs, body] }


### PR DESCRIPTION
### Description

After working with wrk for a while, I thought having a script that ran several sets would be helpful.  Also, after each run, collecting  Puma stats and output from smem would show additional info.  The summary output is as below:
```
────────wrk────────  ─Request─time─distribution─(ms)─  Worker─requests  ─wrk─requests─
 -t    -c   req/sec   50%    75%    90%    99%   100%  spread   total     total   bad
 10    50    10504    1.3   24.6   38.8   48.2   58.9   0.29   158708    158708     0
 13    65    10536    1.4   34.1   52.8   64.7   74.4   0.28   159153    159153     0
 17    85    10580    1.5   46.3   71.2   86.4   96.5   0.19   159859    159859     0
 23   115    10627    1.7   65.5  100.1  121.0  131.5   0.27   160631    160631     0
 30   150    10604    2.4   86.9  132.4  159.6  170.9   0.22   160249    160249     0
             10570                                    Totals   798600    798600
══════════════════════════════════════════════════════════════════════════════════════

══════════════════════════════════ Memory Change per Request
WRK Threads            10     13     17     23     30
    Connections        50     65     85    115    150    All
    Av Resp Size    52974  52960  52995  53008  53000  52987
════════════════════════════════════════════════════════════
worker-0-00    USS     42     25     17    -17      9     15
worker-0-01    USS     23     21     19    -12      6     11
All            USS     32     23     18    -15      7     13
════════════════════════════════════════════════════════════
```

The top section shows data from the five wrk runs, which start at the total number of threads the Puma server has, and stop at three times that number.  The 'spread' column shows how consistent the requests are spread between workers.  It's interesting that as the load increases, throughput (req/sec) stays about the same, but the response time increases, especially in the slowest responses.

The bottom section shows memory used after each wrk run, and should remain low.  Oddly, using this with Ruby head lead to the discover of a memory leak in Ruby head, as the 'All' column was over 500 bytes per request.

Some notes:

1. Since CI is not consistent enough to check performance, a good wrk script is helpful for determining whether changes improve performance.
2. The code is commented in `overload/benchmarks/local/bench_overload_wrk.rb`.  It uses smem for memory info, and also uses @ioquatix's [fork of wrk](https://github.com/ioquatix/wrk).  It only works with Puma in cluster mode (with workers).
3. wrk doesn't support UNIXSockets, so I may try to get code running using some of the files in #2694, which shares rackup files with this PR.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.