### PR TITLE
io_buffer.rb, request.rb - improve handling with a body array/enumeration

### DIFF
--- a/lib/puma/io_buffer.rb
+++ b/lib/puma/io_buffer.rb
@@ -1,11 +1,37 @@
 # frozen_string_literal: true
 
+require 'stringio'
+
 module Puma
-  class IOBuffer < String
-    def append(*args)
-      args.each { |a| concat(a) }
+  class IOBuffer < StringIO
+    def initialize
+      super.binmode
     end
 
-    alias reset clear
+    def empty?
+      length.zero?
+    end
+
+    def reset
+      truncate 0
+      rewind
+    end
+
+    def read
+      rewind
+      super.tap { |s| truncate 0; rewind }
+    end
+
+    # don't use, added just for existing CI tests
+    alias_method :to_s, :string
+
+    # before Ruby 2.5, `write` would only take one argument
+    if RUBY_VERSION >= '2.5' && RUBY_ENGINE != 'truffleruby'
+      alias_method :append, :write
+    else
+      def append(*strs)
+        strs.each { |str| write str }
+      end
+    end
   end
 end


### PR DESCRIPTION
### Description

Improve the speed of assembling the response.  Tested using the script in PR #2695, running 3 sets, with the rackup files to generate an array body response, a chunked body response, and a single string element body response.  All three were approx 50kB in size, the first two having ~ 50 'elements'.

Note that the current code has a small memory leak with the array and chunked rackup files, which does not occur with the PR code.

Summarizing the req/sec (RPS), there is significant improvement:

```
        Array   Chunked   String
PR      12210    11017     12207
Master   2717     1312     10507
```

The detail below also shows improvement in wrk's 'Request time distribution'.

<details>
  <summary>wrk overload results</summary>

```
benchmarks/local/bench_overload_wrk.sh -s tcp -w2 -t5:5 -b50 -c5 -R test/rackup/ci_array.ru

PR
────────wrk────────  ─Request─time─distribution─(ms)─  Worker─requests  ─wrk─requests─
 -t    -c   req/sec   50%    75%    90%    99%   100%  spread   total     total   bad
 10    50    12119    1.2   21.1   33.1   41.0   51.1   0.09   183071    183071     0
 13    65    12187    1.2   29.2   45.1   55.1   64.0   0.19   184105    184105     0
 17    85    12205    1.3   39.7   61.0   73.8   81.6   0.16   184399    184399     0
 23   115    12286    1.5   55.6   84.8  102.3  111.9   0.15   185727    185727     0
 30   150    12253    1.8   74.1  112.7  135.7  153.9   0.26   185162    185162     0
             12210                                    Totals   922464    922464
══════════════════════════════════════════════════════════════════════════════════════

Master
────────wrk────────  ─Request─time─distribution─(ms)─  Worker─requests  ─wrk─requests─
 -t    -c   req/sec   50%    75%    90%    99%   100%  spread   total     total   bad
 10    50     2692    5.6   81.8  131.6  157.2  173.5   1.03    40681     40681     0
 13    65     2726    5.7  114.1  179.0  212.3  229.0   1.92    41190     41190     0
 17    85     2719    6.0  156.5  244.7  286.1  298.4   1.39    41104     41104     0
 23   115     2732    6.9  221.7  342.3  396.4  414.0   2.29    41310     41310     0
 30   150     2719    7.0  298.8  458.7  528.1  552.1   1.15    41252     41252     0
              2717                                    Totals   205537    205537
══════════════════════════════════════════════════════════════════════════════════════


benchmarks/local/bench_overload_wrk.sh -s tcp -w2 -t5:5 -b50 -c5 -R test/rackup/ci_chunked.ru

PR
────────wrk────────  ─Request─time─distribution─(ms)─  Worker─requests  ─wrk─requests─
 -t    -c   req/sec   50%    75%    90%    99%   100%  spread   total     total   bad
 10    50    10978    1.3   23.3   36.6   45.3   53.9   0.14   165852    165852     0
 13    65    11025    1.4   32.3   49.9   60.9   79.8   0.07   166580    166580     0
 17    85    10988    1.5   44.1   67.8   82.1   91.5   0.17   166002    166002     0
 23   115    11050    1.6   61.6   94.1  113.4  129.2   0.16   166977    166977     0
 30   150    11044    1.8   81.8  124.3  149.9  161.6   0.24   166912    166912     0
             11017                                    Totals   832323    832323
══════════════════════════════════════════════════════════════════════════════════════

Master
────────wrk────────  ─Request─time─distribution─(ms)─  Worker─requests  ─wrk─requests─
 -t    -c   req/sec   50%    75%    90%    99%   100%  spread   total     total   bad
 10    50     1298     10    167    272    324    352   1.31    19631     19631     0
 13    65     1298     11    237    373    444    469   1.14    19654     19654     0
 17    85     1294     11    327    512    599    625   1.68    19593     19593     0
 23   115     1321     12    455    705    822    847   1.44    20006     20006     0
 30   150     1350     12    602    880   1080   1120   2.23    20482     20482     0
              1312                                    Totals    99366     99366
══════════════════════════════════════════════════════════════════════════════════════


benchmarks/local/bench_overload_wrk.sh -s tcp -w2 -t5:5 -b50 -c5 (uses ci_string.ru)

PR
────────wrk────────  ─Request─time─distribution─(ms)─  Worker─requests  ─wrk─requests─
 -t    -c   req/sec   50%    75%    90%    99%   100%  spread   total     total   bad
 10    50    12131    1.2   21.1   33.2   41.1   50.1   0.02   183259    183259     0
 13    65    12195    1.2   29.2   45.2   55.2   62.9   0.22   184263    184263     0
 17    85    12188    1.4   39.9   61.2   74.3   84.2   0.17   184156    184156     0
 23   115    12272    1.5   55.7   85.0  102.5  118.6   0.23   185429    185429     0
 30   150    12249    1.8   74.2  113.0  135.9  149.5   0.10   185193    185193     0
             12207                                    Totals   922300    922300
══════════════════════════════════════════════════════════════════════════════════════

Master
────────wrk────────  ─Request─time─distribution─(ms)─  Worker─requests  ─wrk─requests─
 -t    -c   req/sec   50%    75%    90%    99%   100%  spread   total     total   bad
 10    50    10490    1.4   24.5   38.6   48.0   57.7   0.42   158487    158487     0
 13    65    10535    1.5   34.2   52.9   64.9   77.7   0.13   159147    159147     0
 17    85    10509    1.6   46.7   71.8   87.3   96.7   0.20   158796    158796     0
 23   115    10489    1.8   65.4   99.7  120.6  131.6   0.09   158505    158505     0
 30   150    10512    2.3   87.4  132.8  160.2  173.0   0.48   158869    158869     0
             10507                                    Totals   793804    793804
══════════════════════════════════════════════════════════════════════════════════════

```

</details>

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
