### PR TITLE
Fix missing `Concurrency` -> `Parallelism`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Puma is a **simple, fast, multi-threaded, and highly parallel HTTP 1.1 server for Ruby/Rack applications**.
 
-## Built For Speed &amp; Concurrency
+## Built For Speed &amp; Parallelism
 
 Puma processes requests using a C-optimized Ragel extension (inherited from Mongrel) that provides fast, accurate HTTP 1.1 protocol parsing in a portable way. Puma then serves the request using a thread pool. Each request is served in a separate thread, so truly parallel Ruby implementations (JRuby, Rubinius) will use all available CPU cores.
 


### PR DESCRIPTION
Also, the GitHub project description mentions "Concurrency" but I believe it's better to use "Parallelism" here for consistency.