### PR TITLE
Add support for APP_ENV environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ You can also provide a configuration file with the `-C` (or `--config`) flag:
 $ puma -C /path/to/config
 ```
 
-If no configuration file is specified, Puma will look for a configuration file at `config/puma.rb`. If an environment is specified, either via the `-e` and `--environment` flags, or through the `RACK_ENV` or the `RAILS_ENV` environment variables, Puma first looks for configuration at `config/puma/<environment_name>.rb`, and then falls back to `config/puma.rb`.
+If no configuration file is specified, Puma will look for a configuration file at `config/puma.rb`. If an environment is specified (via the `--environment` flag or through the `APP_ENV`, `RACK_ENV`, or `RAILS_ENV` environment variables) Puma looks for a configuration file at `config/puma/<environment_name>.rb` and then falls back to `config/puma.rb`.
 
 If you want to prevent Puma from looking for a configuration file in those locations, include the `--no-config` flag:
 

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -200,7 +200,7 @@ module Puma
         :worker_shutdown_timeout => DefaultWorkerShutdownTimeout,
         :remote_address => :socket,
         :tag => method(:infer_tag),
-        :environment => -> { ENV['RACK_ENV'] || ENV['RAILS_ENV'] || "development" },
+        :environment => -> { ENV['APP_ENV'] || ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'development' },
         :rackup => DefaultRackup,
         :logger => STDOUT,
         :persistent_timeout => Const::PERSISTENT_TIMEOUT,

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -47,7 +47,7 @@ module Puma
       @control_auth_token = nil
       @config_file = nil
       @command = nil
-      @environment = ENV['RACK_ENV'] || ENV['RAILS_ENV']
+      @environment = ENV['APP_ENV'] || ENV['RACK_ENV'] || ENV['RAILS_ENV']
 
       @argv = argv.dup
       @stdout = stdout

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -426,6 +426,19 @@ class TestCLI < Minitest::Test
     assert_equal %w[a b], extra_dependencies
   end
 
+  def test_environment_app_env
+    ENV['RACK_ENV'] = @environment
+    ENV['RAILS_ENV'] = @environment
+    ENV['APP_ENV'] = 'test'
+
+    cli = Puma::CLI.new []
+
+    assert_equal 'test', cli.environment
+
+    ENV.delete 'APP_ENV'
+    ENV.delete 'RAILS_ENV'
+  end
+
   def test_environment_rack_env
     ENV.delete 'RACK_ENV'
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -466,6 +466,15 @@ class TestConfigFileWithFakeEnv < TestConfigFileBase
     File.write("config/puma/fake-env.rb", "")
   end
 
+  def test_config_files_with_app_env
+    with_env('APP_ENV' => 'fake-env') do
+      conf = Puma::Configuration.new do
+      end
+
+      assert_equal ['config/puma/fake-env.rb'], conf.config_files
+    end
+  end
+
   def test_config_files_with_rack_env
     with_env('RACK_ENV' => 'fake-env') do
       conf = Puma::Configuration.new do


### PR DESCRIPTION
### Description
Using APP_ENV to set the environment is supported by Sinatra and
Sidekiq, so it makes sense to support the same behavior in Puma.

Like Sidekiq, APP_ENV will take precedence over RACK_ENV and RAILS_ENV.
APP_ENV defers to any argument passed via the --environment flag.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
