### PR TITLE
Improve localhost SSL integration docs [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,15 +191,15 @@ $ puma -b 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert'
 
 Puma supports the [`localhost`] gem for self-signed certificates. This is particularly useful if you want to use Puma with SSL locally, and self-signed certificates will work for your use-case. Currently, the integration can only be used in MRI. 
 
-Puma will automatically configure SSL if you require the [`localhost`] gem when running in environment `development`:
+Puma automatically configures SSL when the [`localhost`] gem is loaded in a `development` environment:
 
 ```ruby
-# Add the localhost gem to your Gemfile
+# Add the gem to your Gemfile
 group(:development) do 
   gem 'localhost'
 end
 
-# config.ru:
+# Alternatively, you can require the gem in config.ru:
 
 # Require it implicitly using bundler
 require "bundler"
@@ -211,13 +211,12 @@ require 'localhost'
 run Sinatra::Application
 ```
 
-You also need to make sure Puma listens to an SSL socket:
+Additionally, Puma must be listening to an SSL socket:
 
 ```shell
 $ puma -b 'ssl://localhost:9292' config.ru
 
-# You can still have Puma being reachable over HTTP by repeating
-# the -b flag (tcp://), but you need to use a different port:
+# The following options allow you to reach Puma over HTTP as well:
 $ puma -b ssl://localhost:9292 -b tcp://localhost:9393 config.ru
 ```
 

--- a/README.md
+++ b/README.md
@@ -199,13 +199,11 @@ group(:development) do
   gem 'localhost'
 end
 
-# Alternatively, you can require the gem in config.ru:
-
-# Require it implicitly using bundler
+# And require it implicitly using bundler
 require "bundler"
 Bundler.require(:default, ENV["RACK_ENV"].to_sym)
 
-# Or require it explicitly
+# Alternatively, you can require the gem in config.ru:
 require './app'
 require 'localhost'
 run Sinatra::Application

--- a/README.md
+++ b/README.md
@@ -187,29 +187,41 @@ Need a bit of security? Use SSL sockets:
 ```
 $ puma -b 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert'
 ```
-#### Self-signed SSL certificates (via _localhost_ gem, for development use): 
+#### Self-signed SSL certificates (via the [`localhost`] gem, for development use): 
 
-Puma supports [localhost](https://github.com/socketry/localhost) gem for self-signed certificates. This is particularly useful if you want to use Puma with SSL locally, and self-signed certificates will work for your use-case. Currently, `localhost-authority` can be used only in MRI. 
+Puma supports the [`localhost`] gem for self-signed certificates. This is particularly useful if you want to use Puma with SSL locally, and self-signed certificates will work for your use-case. Currently, the integration can only be used in MRI. 
 
-To use [localhost](https://github.com/socketry/localhost), you have to `require "localhost/authority"`: 
+Puma will automatically configure SSL if you require the [`localhost`] gem when running in environment `development`:
 
 ```ruby
-# Easiest way, in your Gemfile:
+# Add the localhost gem to your Gemfile
 group(:development) do 
-  gem 'localhost', require: 'localhost/authority'
-end 
+  gem 'localhost'
+end
 
-# Or in your config.ru:
+# config.ru:
+
+# Require it implicitly using bundler
+require "bundler"
+Bundler.require(:default, ENV["RACK_ENV"].to_sym)
+
+# Or require it explicitly
 require './app'
-require 'localhost/authority'
+require 'localhost'
 run Sinatra::Application
-
-...
-
-# Make sure you set up puma to run on an ssl socket:
-$ puma -b 'ssl://localhost:9292' config.ru
 ```
 
+You also need to make sure Puma listens to an SSL socket:
+
+```shell
+$ puma -b 'ssl://localhost:9292' config.ru
+
+# You can still have Puma being reachable over HTTP by repeating
+# the -b flag (tcp://), but you need to use a different port:
+$ puma -b ssl://localhost:9292 -b tcp://localhost:9393 config.ru
+```
+
+[`localhost`]: https://github.com/socketry/localhost
 
 #### Controlling SSL Cipher Suites
 


### PR DESCRIPTION
### Description

Since localhost v1.1.9 (https://github.com/socketry/localhost/commit/a4fe7db33c4a2da966e2faf93d33c4e005e912f2) just `require "localhost"` works: https://github.com/puma/puma/pull/2610#issuecomment-923354385

Close https://github.com/puma/puma/issues/2706

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
