### PR TITLE
Extract calls to purge_interrupt_queue

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -162,7 +162,7 @@ module Puma
       begin
         @io.close
       rescue IOError
-        Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+        Puma::Util.purge_interrupt_queue
       end
     end
 

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -106,7 +106,7 @@ module Puma
         begin
           @worker_write << "b#{Process.pid}:#{index}\n"
         rescue SystemCallError, IOError
-          Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+          Puma::Util.purge_interrupt_queue
           STDERR.puts "Master seems to have exited, exiting."
           return
         end
@@ -127,7 +127,7 @@ module Puma
                 payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r}, "pool_capacity":#{t}, "max_threads": #{m}, "requests_count": #{rc} }\n!
                 io << payload
               rescue IOError
-                Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+                Puma::Util.purge_interrupt_queue
                 break
               end
               sleep Const::WORKER_CHECK_INTERVAL

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -169,7 +169,7 @@ module Puma
             end
           end
         rescue IOError, SystemCallError
-          Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+          Puma::Util.purge_interrupt_queue
           # nothing
         ensure
           @socket.close

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -24,7 +24,7 @@ module Puma
       @wakeup.write "!" unless @wakeup.closed?
 
     rescue SystemCallError, IOError
-      Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+      Puma::Util.purge_interrupt_queue
     end
 
     def development?

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -146,7 +146,7 @@ module Puma
         begin
           skt.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_CORK, 1) if skt.kind_of? TCPSocket
         rescue IOError, SystemCallError
-          Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+          Puma::Util.purge_interrupt_queue
         end
       end
 
@@ -155,7 +155,7 @@ module Puma
         begin
           skt.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_CORK, 0) if skt.kind_of? TCPSocket
         rescue IOError, SystemCallError
-          Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+          Puma::Util.purge_interrupt_queue
         end
       end
     else
@@ -176,7 +176,7 @@ module Puma
         begin
           tcp_info = skt.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_INFO)
         rescue IOError, SystemCallError
-          Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+          Puma::Util.purge_interrupt_queue
           @precheck_closing = false
           false
         else
@@ -491,7 +491,7 @@ module Puma
         begin
           client.close if close_socket
         rescue IOError, SystemCallError
-          Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+          Puma::Util.purge_interrupt_queue
           # Already closed
         rescue StandardError => e
           @events.unknown_error e, nil, "Client"
@@ -583,11 +583,11 @@ module Puma
       @notify << message
     rescue IOError, NoMethodError, Errno::EPIPE
       # The server, in another thread, is shutting down
-      Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+      Puma::Util.purge_interrupt_queue
     rescue RuntimeError => e
       # Temporary workaround for https://bugs.ruby-lang.org/issues/13239
       if e.message.include?('IOError')
-        Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+        Puma::Util.purge_interrupt_queue
       else
         raise e
       end

--- a/lib/puma/util.rb
+++ b/lib/puma/util.rb
@@ -11,7 +11,7 @@ module Puma
     end
 
     # An instance method on Thread has been provided to address https://bugs.ruby-lang.org/issues/13632,
-    # which currently effects some older versions of Ruby.
+    # which currently effects some older versions of Ruby: 2.2.7 2.2.8 2.2.9 2.2.10 2.3.4 2.4.1
     # Additional context: https://github.com/puma/puma/pull/1345
     def purge_interrupt_queue
       Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue

--- a/lib/puma/util.rb
+++ b/lib/puma/util.rb
@@ -10,6 +10,13 @@ module Puma
       IO.pipe
     end
 
+    # An instance method on Thread has been provided to address https://bugs.ruby-lang.org/issues/13632,
+    # which currently effects some older versions of Ruby.
+    # Additional context: https://github.com/puma/puma/pull/1345
+    def purge_interrupt_queue
+      Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+    end
+
     # Unescapes a URI escaped string with +encoding+. +encoding+ will be the
     # target encoding of the string returned, and it defaults to UTF-8
     if defined?(::Encoding)

--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -17,7 +17,7 @@ class TestBusyWorker < Minitest::Test
   def new_connection
     TCPSocket.new('127.0.0.1', @port).tap {|s| @ios << s}
   rescue IOError
-    Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+    Puma::Util.purge_interrupt_queue
     retry
   end
 

--- a/test/test_out_of_band_server.rb
+++ b/test/test_out_of_band_server.rb
@@ -21,7 +21,7 @@ class TestOutOfBandServer < Minitest::Test
   def new_connection
     TCPSocket.new('127.0.0.1', @port).tap {|s| @ios << s}
   rescue IOError
-    Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
+    Puma::Util.purge_interrupt_queue
     retry
   end
 


### PR DESCRIPTION
### Description
Move calls to Thread#purge_interrupt_queue to a module function. This
means if/when this pattern needs to change it can change in one place
instead of a dozen or more places.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
