### PR TITLE
Support for cert and key objects with ssl_bind DSL

### DIFF
--- a/lib/puma/bind_config.rb
+++ b/lib/puma/bind_config.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'puma/util'
+
+module Puma
+  class BindConfig
+
+    # Builds a BindConfig object from a URI
+    def self.parse(uri)
+      uri = URI.parse(uri)
+      new(
+        scheme: uri.scheme,
+        host: uri.host,
+        port: uri.port,
+        path: uri.path,
+        query: uri.query,
+        params: Util.parse_query(uri.query)
+      )
+    end
+
+    attr_reader :scheme, :host, :port, :path, :params
+
+    def initialize(scheme: , host: , port: , path: nil, query: nil, params: {})
+      @scheme = scheme
+      @host = host
+      @port = port
+      @path = path
+      @query = query
+      @params = params
+    end
+
+    def query
+      @query ||=
+        begin
+          # Don't add cert and key objects in the query params
+          query_params = @params.slice(*@params.keys - ['cert_object', 'key_object'])
+
+          # To properly handle file descriptors logic in binder, we need to
+          # uniquelly identify the BindConfig as URI using cert_object details.
+          if @params['cert_object']
+            query_params['cert_serial'] = @params['cert_object'].serial.to_s
+            query_params['cert_not_after'] = @params['cert_object'].not_after.utc.strftime('%Y-%m-%dT%H:%M:%S')
+          end
+          query_params.empty? ? nil : query_params.sort.map { |k, v| "#{k}=#{v}"}.join('&')
+        end
+    end
+
+    def uri
+      @uri ||=
+        if scheme == 'unix'
+          "unix://#{path}"
+        else
+          URI::Generic.build(scheme: scheme, host: host, port: port, path: path, query: query).to_s
+        end
+    end
+
+    def ==(other)
+      uri == other.uri
+    end
+  end
+end

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -208,6 +208,10 @@ module Puma
       def initialize
         @no_tlsv1   = false
         @no_tlsv1_1 = false
+        @key = nil
+        @cert = nil
+        @key_object = nil
+        @cert_object = nil
       end
 
       if IS_JRUBY
@@ -230,6 +234,8 @@ module Puma
         attr_reader :key
         attr_reader :cert
         attr_reader :ca
+        attr_reader :cert_object
+        attr_reader :key_object
         attr_accessor :ssl_cipher_filter
         attr_accessor :verification_flags
 
@@ -248,9 +254,23 @@ module Puma
           @ca = ca
         end
 
+        def cert_object=(cert_object)
+          unless cert_object.is_a?(OpenSSL::X509::Certificate)
+            raise ArgumentError, "'cert_object' is not of type OpenSSL::X509::Certificate"
+          end
+          @cert_object = cert_object
+        end
+
+        def key_object=(key_object)
+          unless key_object.is_a?(OpenSSL::PKey::RSA)
+            raise ArgumentError, "'key_object' is not of type OpenSSL::PKey::RSA"
+          end
+          @key_object = key_object
+        end
+
         def check
-          raise "Key not configured" unless @key
-          raise "Cert not configured" unless @cert
+          raise "Key not configured" if @key.nil? && @key_object.nil?
+          raise "Cert not configured" if @cert.nil? && @cert_object.nil?
         end
       end
 

--- a/lib/puma/minissl/context_builder.rb
+++ b/lib/puma/minissl/context_builder.rb
@@ -23,17 +23,19 @@ module Puma
           ctx.keystore_pass = params['keystore-pass']
           ctx.ssl_cipher_list = params['ssl_cipher_list'] if params['ssl_cipher_list']
         else
-          unless params['key']
-            events.error "Please specify the SSL key via 'key='"
+          if params['key'].nil? && params['key_object'].nil?
+            events.error "Please specify the SSL key via 'key=' or 'key_object='"
           end
 
-          ctx.key = params['key']
+          ctx.key = params['key'] if params['key']
+          ctx.key_object = params['key_object'] if params['key_object']
 
-          unless params['cert']
-            events.error "Please specify the SSL cert via 'cert='"
+          if params['cert'].nil? && params['cert_object'].nil?
+            events.error "Please specify the SSL cert via 'cert=' or 'cert_object='"
           end
 
-          ctx.cert = params['cert']
+          ctx.cert = params['cert'] if params['cert']
+          ctx.cert_object = params['cert_object'] if params['cert_object']
 
           if ['peer', 'force_peer'].include?(params['verify_mode'])
             unless params['ca']

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -262,7 +262,7 @@ class TestBinder < TestBinderBase
     env_hash = @binder.envs[@binder.ios.first]
 
     @binder.proto_env.each do |k,v|
-      assert_equal env_hash[k], v
+      assert env_hash[k] == v
     end
   end
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -50,11 +50,11 @@ class TestConfigFile < TestConfigFileBase
 
     conf.load
 
-    bind_configuration = conf.options.file_options[:binds].first
+    bind_config = conf.options.file_options[:binds].first
     app = conf.app
 
-    assert bind_configuration =~ %r{ca=.*ca.crt}
-    assert bind_configuration =~ /verify_mode=peer/
+    assert_match %r{.*ca.crt}, bind_config.params['ca']
+    assert_equal 'peer', bind_config.params['verify_mode']
 
     assert_equal [200, {}, ["embedded app"]], app.call({})
   end
@@ -73,7 +73,7 @@ class TestConfigFile < TestConfigFileBase
 
     conf.load
 
-    ssl_binding = "ssl://0.0.0.0:9292?cert=/path/to/cert&key=/path/to/key&verify_mode=the_verify_mode"
+    ssl_binding = Puma::BindConfig.parse("ssl://0.0.0.0:9292?cert=/path/to/cert&key=/path/to/key&verify_mode=the_verify_mode")
     assert_equal [ssl_binding], conf.options[:binds]
   end
 
@@ -94,9 +94,9 @@ class TestConfigFile < TestConfigFileBase
 
     conf.load
 
-    ssl_binding = "ssl://0.0.0.0:9292?keystore=/path/to/keystore" \
+    ssl_binding = Puma::BindConfig.parse("ssl://0.0.0.0:9292?keystore=/path/to/keystore" \
       "&keystore-pass=password&ssl_cipher_list=#{cipher_list}" \
-      "&verify_mode=the_verify_mode"
+      "&verify_mode=the_verify_mode")
     assert_equal [ssl_binding], conf.options[:binds]
   end
 
@@ -118,7 +118,7 @@ class TestConfigFile < TestConfigFileBase
 
     conf.load
 
-    ssl_binding = "ssl://0.0.0.0:9292?cert=/path/to/cert&key=/path/to/key&verify_mode=the_verify_mode&no_tlsv1_1=true"
+    ssl_binding = Puma::BindConfig.parse("ssl://0.0.0.0:9292?cert=/path/to/cert&key=/path/to/key&no_tlsv1_1=true&verify_mode=the_verify_mode")
     assert_equal [ssl_binding], conf.options[:binds]
   end
 
@@ -138,7 +138,7 @@ class TestConfigFile < TestConfigFileBase
     conf.load
 
     ssl_binding = conf.options[:binds].first
-    assert ssl_binding.include?("&ssl_cipher_filter=#{cipher_filter}")
+    assert_equal cipher_filter, ssl_binding.params['ssl_cipher_filter']
   end
 
   def test_ssl_bind_with_verification_flags
@@ -156,7 +156,7 @@ class TestConfigFile < TestConfigFileBase
     conf.load
 
     ssl_binding = conf.options[:binds].first
-    assert ssl_binding.include?("&verification_flags=TRUSTED_FIRST,NO_CHECK_TIME")
+    assert_equal "TRUSTED_FIRST,NO_CHECK_TIME", ssl_binding.params['verification_flags']
   end
 
   def test_ssl_bind_with_ca
@@ -173,8 +173,8 @@ class TestConfigFile < TestConfigFileBase
     conf.load
 
     ssl_binding = conf.options[:binds].first
-    assert_match "ca=/path/to/ca", ssl_binding
-    assert_match "verify_mode=peer", ssl_binding
+    assert_equal "/path/to/ca", ssl_binding.params['ca']
+    assert_equal "peer", ssl_binding.params['verify_mode']
   end
 
   def test_lowlevel_error_handler_DSL

--- a/test/test_minissl.rb
+++ b/test/test_minissl.rb
@@ -25,5 +25,19 @@ class TestMiniSSL < Minitest::Test
       exception = assert_raises(ArgumentError) { ctx.cert = "/no/such/cert" }
       assert_equal("No such cert file '/no/such/cert'", exception.message)
     end
+
+    def test_raises_with_invalid_key_object
+      ctx = Puma::MiniSSL::Context.new
+
+      exception = assert_raises(ArgumentError) { ctx.key_object = "key" }
+      assert_equal("'key_object' is not of type OpenSSL::PKey::RSA", exception.message)
+    end
+
+    def test_raises_with_invalid_cert_object
+      ctx = Puma::MiniSSL::Context.new
+
+      exception = assert_raises(ArgumentError) { ctx.cert_object = "cert" }
+      assert_equal("'cert_object' is not of type OpenSSL::X509::Certificate", exception.message)
+    end
   end
 end if ::Puma::HAS_SSL

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -333,3 +333,44 @@ class TestPumaServerSSLClient < Minitest::Test
     end
   end
 end if ::Puma::HAS_SSL
+
+class TestPumaServerSSLWithCertAndKeyObjects < Minitest::Test
+  CERT_PATH = File.expand_path "../examples/puma/client-certs", __dir__
+
+  def test_server_ssl_with_cert_and_key_objects
+    host = "localhost"
+    port = 0
+    ctx = Puma::MiniSSL::Context.new.tap { |ctx|
+      ctx.key_object = OpenSSL::PKey::RSA.new(File.read("#{CERT_PATH}/server.key"))
+      ctx.cert_object = OpenSSL::X509::Certificate.new(File.read("#{CERT_PATH}/server.crt"))
+    }
+
+    app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
+    events = SSLEventsHelper.new STDOUT, STDERR
+    server = Puma::Server.new app, events
+    server.add_ssl_listener host, port, ctx
+    host_addrs = server.binder.ios.map { |io| io.to_io.addr[2] }
+    server.run
+
+    http = Net::HTTP.new host, server.connected_ports[0]
+    http.use_ssl = true
+    http.ca_file = "#{CERT_PATH}/ca.crt"
+
+    client_error = nil
+    begin
+      http.start do
+        req = Net::HTTP::Get.new "/", {}
+        http.request(req)
+      end
+    rescue OpenSSL::SSL::SSLError, EOFError, Errno::ECONNRESET => e
+      # Errno::ECONNRESET TruffleRuby
+      client_error = e
+      # closes socket if open, may not close on error
+      http.send :do_finish
+    end
+
+    assert_nil client_error
+  ensure
+    server.stop(true) if server
+  end
+end if ::Puma::HAS_SSL && !Puma::IS_JRUBY


### PR DESCRIPTION
### Description

We need a way to specify cert and key objects in Puma configuration without relaying on file paths. The use-case is when deploying to cloud providers and fetching certificates from Secrets Managers on application boot-up to avoid persist the certificates on disk for security reasons.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
