### PR TITLE
Support for cert_pem and key_pem with ssl_bind DSL

### DIFF
--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -208,6 +208,10 @@ module Puma
       def initialize
         @no_tlsv1   = false
         @no_tlsv1_1 = false
+        @key = nil
+        @cert = nil
+        @key_pem = nil
+        @cert_pem = nil
       end
 
       if IS_JRUBY
@@ -230,6 +234,8 @@ module Puma
         attr_reader :key
         attr_reader :cert
         attr_reader :ca
+        attr_reader :cert_pem
+        attr_reader :key_pem
         attr_accessor :ssl_cipher_filter
         attr_accessor :verification_flags
 
@@ -248,9 +254,19 @@ module Puma
           @ca = ca
         end
 
+        def cert_pem=(cert_pem)
+          raise ArgumentError, "'cert_pem' is not a String" unless cert_pem.is_a? String
+          @cert_pem = cert_pem
+        end
+
+        def key_pem=(key_pem)
+          raise ArgumentError, "'key_pem' is not a String" unless key_pem.is_a? String
+          @key_pem = key_pem
+        end
+
         def check
-          raise "Key not configured" unless @key
-          raise "Cert not configured" unless @cert
+          raise "Key not configured" if @key.nil? && @key_pem.nil?
+          raise "Cert not configured" if @cert.nil? && @cert_pem.nil?
         end
       end
 

--- a/lib/puma/minissl/context_builder.rb
+++ b/lib/puma/minissl/context_builder.rb
@@ -23,17 +23,19 @@ module Puma
           ctx.keystore_pass = params['keystore-pass']
           ctx.ssl_cipher_list = params['ssl_cipher_list'] if params['ssl_cipher_list']
         else
-          unless params['key']
-            events.error "Please specify the SSL key via 'key='"
+          if params['key'].nil? && params['key_pem'].nil?
+            events.error "Please specify the SSL key via 'key=' or 'key_pem='"
           end
 
-          ctx.key = params['key']
+          ctx.key = params['key'] if params['key']
+          ctx.key_pem = params['key_pem'] if params['key_pem']
 
-          unless params['cert']
-            events.error "Please specify the SSL cert via 'cert='"
+          if params['cert'].nil? && params['cert_pem'].nil?
+            events.error "Please specify the SSL cert via 'cert=' or 'cert_pem='"
           end
 
-          ctx.cert = params['cert']
+          ctx.cert = params['cert'] if params['cert']
+          ctx.cert_pem = params['cert_pem'] if params['cert_pem']
 
           if ['peer', 'force_peer'].include?(params['verify_mode'])
             unless params['ca']

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -308,11 +308,11 @@ class TestBinder < TestBinderBase
   def test_close_listeners_closes_ios
     @binder.parse ["tcp://127.0.0.1:#{UniquePort.call}"], @events
 
-    refute @binder.listeners.any? { |u, l| l.closed? }
+    refute @binder.listeners.any? { |_l, io| io.closed? }
 
     @binder.close_listeners
 
-    assert @binder.listeners.all? { |u, l| l.closed? }
+    assert @binder.listeners.all? { |_l, io| io.closed? }
   end
 
   def test_close_listeners_closes_ios_unless_closed?
@@ -322,11 +322,11 @@ class TestBinder < TestBinderBase
     bomb.close
     def bomb.close; raise "Boom!"; end # the bomb has been planted
 
-    assert @binder.listeners.any? { |u, l| l.closed? }
+    assert @binder.listeners.any? { |_l, io| io.closed? }
 
     @binder.close_listeners
 
-    assert @binder.listeners.all? { |u, l| l.closed? }
+    assert @binder.listeners.all? { |_l, io| io.closed? }
   end
 
   def test_listeners_file_unlink_if_unix_listener
@@ -344,8 +344,8 @@ class TestBinder < TestBinderBase
     @binder.parse ["tcp://127.0.0.1:0"], @events
     removals = @binder.create_inherited_fds(@binder.redirects_for_restart_env)
 
-    @binder.listeners.each do |url, io|
-      assert_equal io.to_i, @binder.inherited_fds[url]
+    @binder.listeners.each do |l, io|
+      assert_equal io.to_i, @binder.inherited_fds[l]
     end
     assert_includes removals, "PUMA_INHERIT_0"
   end

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -262,7 +262,7 @@ class TestBinder < TestBinderBase
     env_hash = @binder.envs[@binder.ios.first]
 
     @binder.proto_env.each do |k,v|
-      assert_equal env_hash[k], v
+      assert env_hash[k] == v
     end
   end
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -77,6 +77,28 @@ class TestConfigFile < TestConfigFileBase
     assert_equal [ssl_binding], conf.options[:binds]
   end
 
+  def test_ssl_bind_with_cert_and_key_pem
+    skip_if :jruby
+    skip_unless :ssl
+
+    cert_path = File.expand_path "../examples/puma/client-certs", __dir__
+    cert_pem = File.read("#{cert_path}/server.crt")
+    key_pem = File.read("#{cert_path}/server.key")
+
+    conf = Puma::Configuration.new do |c|
+      c.ssl_bind "0.0.0.0", "9292", {
+        cert_pem: cert_pem,
+        key_pem: key_pem,
+        verify_mode: "the_verify_mode",
+      }
+    end
+
+    conf.load
+
+    ssl_binding = "ssl://0.0.0.0:9292?cert=store:0&key=store:1&verify_mode=the_verify_mode"
+    assert_equal [ssl_binding], conf.options[:binds]
+  end
+
   def test_ssl_bind_jruby
     skip_unless :jruby
     skip_unless :ssl

--- a/test/test_integration_ssl.rb
+++ b/test/test_integration_ssl.rb
@@ -21,17 +21,47 @@ class TestIntegrationSSL < TestIntegration
     super
   end
 
-  def generate_config(opts = nil)
-    @bind_port = UniquePort.call
-    @control_tcp_port = UniquePort.call
+  def bind_port
+    @bind_port ||= UniquePort.call
+  end
 
+  def control_tcp_port
+    @control_tcp_port ||= UniquePort.call
+  end
+
+  def with_server(config)
+    config_file = Tempfile.new %w(config .rb)
+    config_file.write config
+    config_file.close
+    config_file.path
+
+    # start server
+    cmd = "#{BASE} bin/puma -C #{config_file.path}"
+    @server = IO.popen cmd, 'r'
+    wait_for_server_to_boot
+    @pid = @server.pid
+
+    http = Net::HTTP.new HOST, bind_port
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    yield http
+
+    # stop server
+    sock = TCPSocket.new HOST, control_tcp_port
+    @ios_to_close << sock
+    sock.syswrite "GET /stop?token=#{TOKEN} HTTP/1.1\r\n\r\n"
+    sock.read
+    assert_match 'Goodbye!', @server.read
+  end
+
+  def test_ssl_run
     config = <<RUBY
-#{opts}
 if ::Puma.jruby?
   keystore =  '#{File.expand_path '../examples/puma/keystore.jks', __dir__}'
   keystore_pass = 'jruby_puma'
 
-  ssl_bind '#{HOST}', '#{@bind_port}', {
+  ssl_bind '#{HOST}', '#{bind_port}', {
     keystore: keystore,
     keystore_pass:  keystore_pass,
     verify_mode: 'none'
@@ -40,53 +70,56 @@ else
   key  = '#{File.expand_path '../examples/puma/puma_keypair.pem', __dir__}'
   cert = '#{File.expand_path '../examples/puma/cert_puma.pem', __dir__}'
 
-  ssl_bind '#{HOST}', '#{@bind_port}', {
+  ssl_bind '#{HOST}', '#{bind_port}', {
     cert: cert,
     key:  key,
     verify_mode: 'none'
   }
 end
 
-activate_control_app 'tcp://#{HOST}:#{@control_tcp_port}', { auth_token: '#{TOKEN}' }
+activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
+
+app do |env|
+  [200, {}, [env['rack.url_scheme']]]
+end
+RUBY
+    with_server(config) do |http|
+      body = nil
+      http.start do
+        req = Net::HTTP::Get.new '/', {}
+        http.request(req) { |resp| body = resp.body }
+      end
+      assert_equal 'https', body
+    end
+  end
+
+  def test_ssl_run_with_pem
+    skip_if :jruby
+
+    config = <<RUBY
+  key_path  = '#{File.expand_path '../examples/puma/puma_keypair.pem', __dir__}'
+  cert_path = '#{File.expand_path '../examples/puma/cert_puma.pem', __dir__}'
+
+  ssl_bind '#{HOST}', '#{bind_port}', {
+    cert_pem: File.read(cert_path),
+    key_pem:  File.read(key_path),
+    verify_mode: 'none'
+  }
+
+activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
 
 app do |env|
   [200, {}, [env['rack.url_scheme']]]
 end
 RUBY
 
-    config_file = Tempfile.new %w(config .rb)
-    config_file.write config
-    config_file.close
-    config_file.path
-  end
-
-  def start_server(opts = nil)
-    cmd = "#{BASE} bin/puma -C #{generate_config opts}"
-    @server = IO.popen cmd, 'r'
-    wait_for_server_to_boot
-    @pid = @server.pid
-
-    @http = Net::HTTP.new HOST, @bind_port
-    @http.use_ssl = true
-    @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-  end
-
-  def stop_server
-    sock = TCPSocket.new HOST, @control_tcp_port
-    @ios_to_close << sock
-    sock.syswrite "GET /stop?token=#{TOKEN} HTTP/1.1\r\n\r\n"
-    sock.read
-    assert_match 'Goodbye!', @server.read
-  end
-
-  def test_ssl_run
-    body = nil
-    start_server
-    @http.start do
-      req = Net::HTTP::Get.new '/', {}
-      @http.request(req) { |resp| body = resp.body }
+    with_server(config) do |http|
+      body = nil
+      http.start do
+        req = Net::HTTP::Get.new '/', {}
+        http.request(req) { |resp| body = resp.body }
+      end
+      assert_equal 'https', body
     end
-    assert_equal 'https', body
-    stop_server
   end
 end if ::Puma::HAS_SSL

--- a/test/test_minissl.rb
+++ b/test/test_minissl.rb
@@ -25,5 +25,19 @@ class TestMiniSSL < Minitest::Test
       exception = assert_raises(ArgumentError) { ctx.cert = "/no/such/cert" }
       assert_equal("No such cert file '/no/such/cert'", exception.message)
     end
+
+    def test_raises_with_invalid_key_pem
+      ctx = Puma::MiniSSL::Context.new
+
+      exception = assert_raises(ArgumentError) { ctx.key_pem = nil }
+      assert_equal("'key_pem' is not a String", exception.message)
+    end
+
+    def test_raises_with_invalid_cert_pem
+      ctx = Puma::MiniSSL::Context.new
+
+      exception = assert_raises(ArgumentError) { ctx.cert_pem = nil }
+      assert_equal("'cert_pem' is not a String", exception.message)
+    end
   end
 end if ::Puma::HAS_SSL


### PR DESCRIPTION
### Description

We need a way to specify cert and key objects or PEM strings in Puma configuration without relying on file paths. The use-case is when deploying to cloud provider and fetching certificates from Secrets Manager on application boot-up to avoid persisting the certificates on disk for security reasons.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
  - This PR is more than 100 lines, but it all comes together to support this feature 
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
  - Other than some randomly failing tests, there is a failing build for [ubuntu-20.04 truffleruby-head](https://github.com/puma/puma/runs/4002932158?check_suite_focus=true) on master.

PR with clean history for: https://github.com/puma/puma/pull/2719