### PR TITLE
[jruby] a couple refactorings - avoid copy-ing bytes

### DIFF
--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -174,8 +174,6 @@ public class MiniSSL extends RubyObject {
   @JRubyMethod
   public IRubyObject initialize(ThreadContext threadContext, IRubyObject miniSSLContext)
       throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
-    KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-    KeyStore ts = KeyStore.getInstance(KeyStore.getDefaultType());
 
     String keystoreFile = miniSSLContext.callMethod(threadContext, "keystore").convertToString().asJavaString();
     KeyManagerFactory kmf = keyManagerFactoryMap.get(keystoreFile);

--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -116,7 +116,7 @@ public class MiniSSL extends RubyObject {
 
       buffer.get(bss);
       buffer.clear();
-      return new ByteList(bss);
+      return new ByteList(bss, false);
     }
 
     @Override

--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -80,11 +80,11 @@ public class MiniSSL extends RubyObject {
     /**
      * Writes bytes to the buffer after ensuring there's room
      */
-    public void put(byte[] bytes) {
-      if (buffer.remaining() < bytes.length) {
-        resize(buffer.limit() + bytes.length);
+    private void put(byte[] bytes, final int offset, final int length) {
+      if (buffer.remaining() < length) {
+        resize(buffer.limit() + length);
       }
-      buffer.put(bytes);
+      buffer.put(bytes, offset, length);
     }
 
     /**
@@ -231,8 +231,8 @@ public class MiniSSL extends RubyObject {
   @JRubyMethod
   public IRubyObject inject(IRubyObject arg) {
     try {
-      byte[] bytes = arg.convertToString().getBytes();
-      inboundNetData.put(bytes);
+      ByteList bytes = arg.convertToString().getByteList();
+      inboundNetData.put(bytes.unsafeBytes(), bytes.getBegin(), bytes.getRealSize());
       return this;
     } catch (Exception e) {
       e.printStackTrace();

--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -297,7 +297,7 @@ public class MiniSSL extends RubyObject {
   }
 
   @JRubyMethod
-  public IRubyObject read() throws Exception {
+  public IRubyObject read() {
     try {
       inboundNetData.flip();
 
@@ -342,9 +342,7 @@ public class MiniSSL extends RubyObject {
         return getRuntime().getNil();
       }
 
-      RubyString str = getRuntime().newString("");
-      str.setValue(appDataByteList);
-      return str;
+      return RubyString.newString(getRuntime(), appDataByteList);
     } catch (Exception e) {
       throw getRuntime().newEOFError(e.getMessage());
     }
@@ -364,30 +362,25 @@ public class MiniSSL extends RubyObject {
   }
 
   @JRubyMethod
-  public IRubyObject extract() throws SSLException {
+  public IRubyObject extract(ThreadContext context) {
     try {
       ByteList dataByteList = outboundNetData.asByteList();
       if (dataByteList != null) {
-        RubyString str = getRuntime().newString("");
-        str.setValue(dataByteList);
-        return str;
+        return RubyString.newString(context.runtime, dataByteList);
       }
 
       if (!outboundAppData.hasRemaining()) {
-        return getRuntime().getNil();
+        return context.nil;
       }
 
       outboundNetData.clear();
       doOp(SSLOperation.WRAP, outboundAppData, outboundNetData);
       dataByteList = outboundNetData.asByteList();
       if (dataByteList == null) {
-        return getRuntime().getNil();
+        return context.nil;
       }
 
-      RubyString str = getRuntime().newString("");
-      str.setValue(dataByteList);
-
-      return str;
+      return RubyString.newString(context.runtime, dataByteList);
     } catch (Exception e) {
       e.printStackTrace();
       throw new RuntimeException(e);


### PR DESCRIPTION
### Description
Was reviewing the JRuby native bits and noticed a few low hanging fruits around unnecessary byte[] copying.
The `String` instances retrieved from `read` / `extract` will now be ASCII-8BIT just like the C bits (w `rb_str_new`).

Also, the exception handling seems to be incomplete thus it would be better to allow to raise the original exception instead of dummy wrapping into a Java `RuntimeException`, and where wrapping is present let's have the original Java cause around.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
