### PR TITLE
Always send lowlevel_error response to client

### DIFF
--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -102,6 +102,7 @@ module Puma
       io  = client.io
 
       return false if closed_socket?(io)
+      lines.clear
 
       head = env[REQUEST_METHOD] == HEAD
       after_reply = env[RACK_AFTER_REPLY] || []

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -97,6 +97,15 @@ module Puma
       write_response(status, headers, res_body, lines, requests, client)
     end
 
+    # Does the actual response writing for Request#handle_request and Server#client_error
+    #
+    # @param status [Integer] the status returned by the Rack application
+    # @param headers [Hash] the headers returned by the Rack application
+    # @param res_body [Array] the body returned by the Rack application
+    # @param lines [Puma::IOBuffer] modified in place
+    # @param requests [Integer] number of inline requests handled
+    # @param client [Puma::Client]
+    # @return [Boolean,:async]
     def write_response(status, headers, res_body, lines, requests, client)
       env = client.env
       io  = client.io

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -46,11 +46,7 @@ module Puma
       env[HIJACK_P] = true
       env[HIJACK] = client
 
-      body = client.body
-
-      head = env[REQUEST_METHOD] == HEAD
-
-      env[RACK_INPUT] = body
+      env[RACK_INPUT] = client.body
       env[RACK_URL_SCHEME] ||= default_server_port(env) == PORT_443 ? HTTPS : HTTP
 
       if @early_hints
@@ -69,36 +65,48 @@ module Puma
       # A rack extension. If the app writes #call'ables to this
       # array, we will invoke them when the request is done.
       #
-      after_reply = env[RACK_AFTER_REPLY] = []
+      env[RACK_AFTER_REPLY] = []
 
       begin
-        begin
-          status, headers, res_body = @thread_pool.with_force_shutdown do
-            @app.call(env)
-          end
-
-          return :async if client.hijacked
-
-          status = status.to_i
-
-          if status == -1
-            unless headers.empty? and res_body == []
-              raise "async response must have empty headers and body"
-            end
-
-            return :async
-          end
-        rescue ThreadPool::ForceShutdown => e
-          @events.unknown_error e, client, "Rack app"
-          @events.log "Detected force shutdown of a thread"
-
-          status, headers, res_body = lowlevel_error(e, env, 503)
-        rescue Exception => e
-          @events.unknown_error e, client, "Rack app"
-
-          status, headers, res_body = lowlevel_error(e, env, 500)
+        status, headers, res_body = @thread_pool.with_force_shutdown do
+          @app.call(env)
         end
 
+        return :async if client.hijacked
+
+        status = status.to_i
+
+        if status == -1
+          unless headers.empty? and res_body == []
+            raise "async response must have empty headers and body"
+          end
+
+          return :async
+        end
+      rescue ThreadPool::ForceShutdown => e
+        @events.unknown_error e, client, "Rack app"
+        @events.log "Detected force shutdown of a thread"
+
+        status, headers, res_body = lowlevel_error(e, env, 503)
+      rescue Exception => e
+        @events.unknown_error e, client, "Rack app"
+
+        status, headers, res_body = lowlevel_error(e, env, 500)
+      end
+
+      write_response(status, headers, res_body, lines, requests, client)
+    end
+
+    def write_response(status, headers, res_body, lines, requests, client)
+      env = client.env
+      io  = client.io
+
+      return false if closed_socket?(io)
+
+      head = env[REQUEST_METHOD] == HEAD
+      after_reply = env[RACK_AFTER_REPLY] || []
+
+      begin
         res_info = {}
         res_info[:content_length] = nil
         res_info[:no_body] = head
@@ -149,9 +157,9 @@ module Puma
           res_body.each do |part|
             next if part.bytesize.zero?
             if chunked
-               fast_write io, (part.bytesize.to_s(16) << line_ending)
-               fast_write io, part            # part may have different encoding
-               fast_write io, line_ending
+                fast_write io, (part.bytesize.to_s(16) << line_ending)
+                fast_write io, part            # part may have different encoding
+                fast_write io, line_ending
             else
               fast_write io, part
             end
@@ -169,7 +177,7 @@ module Puma
       ensure
         uncork_socket io
 
-        body.close
+        client.body.close if client.body
         client.tempfile.unlink if client.tempfile
         res_body.close if res_body.respond_to? :close
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -482,7 +482,7 @@ module Puma
         end
         true
       rescue StandardError => e
-        client_error(e, client)
+        client_error(e, client, buffer, requests)
         # The ensure tries to close +client+ down
         requests > 0
       ensure
@@ -510,34 +510,36 @@ module Puma
     # :nocov:
 
     # Handle various error types thrown by Client I/O operations.
-    def client_error(e, client)
+    def client_error(e, client, buffer = ::Puma::IOBuffer.new, requests = 1)
       # Swallow, do not log
       return if [ConnectionError, EOFError].include?(e.class)
 
-      lowlevel_error(e, client.env)
       case e
       when MiniSSL::SSLError
         @events.ssl_error e, client.io
       when HttpParserError
-        client.write_error(400)
+        status, headers, res_body = lowlevel_error(e, client.env, 400)
+        write_response(status, headers, res_body, buffer, requests, client)
         @events.parse_error e, client
       else
-        client.write_error(500)
+        status, headers, res_body = lowlevel_error(e, client.env)
+        write_response(status, headers, res_body, buffer, requests, client)
         @events.unknown_error e, nil, "Read"
       end
     end
 
     # A fallback rack response if +@app+ raises as exception.
     #
-    def lowlevel_error(e, env, status=500)
+    def lowlevel_error(e, env, status = 500)
       if handler = @options[:lowlevel_error_handler]
         if handler.arity == 1
-          return handler.call(e)
+          handler_status, headers, res_body = handler.call(e)
         elsif handler.arity == 2
-          return handler.call(e, env)
+          handler_status, headers, res_body = handler.call(e, env)
         else
-          return handler.call(e, env, status)
+          handler_status, headers, res_body = handler.call(e, env, status)
         end
+        return [handler_status || status, headers || {}, res_body || []]
       end
 
       if @leak_stack_on_error

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1369,14 +1369,8 @@ EOF
     app = ->(env) { [200, nil, []] }
     server_run(**options, &app)
 
-    sock = send_http "GET / HTTP/1.0\r\n\r\n"
+    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    _h = header sock
-
-    body = sock.gets
-
-    assert_match /error page/, body
-
-    sock.close
+    assert_match /error page/, data
   end
 end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -364,14 +364,14 @@ EOF
   end
 
   def test_lowlevel_error_handler_custom_response
-    options = { lowlevel_error_handler: ->(_err) { [200, {}, ["error page"]] } }
+    options = { lowlevel_error_handler: ->(_err) { [500, {}, ["error page"]] } }
     # setting the headers argument to nil will trigger exception inside Puma
     broken_app = ->(_env) { [200, nil, []] }
     server_run(**options, &broken_app)
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match %r{HTTP/1.0 200 OK\r\nContent-Length: 10\r\n\r\nerror page}, data
+    assert_match %r{HTTP/1.0 500 Internal Server Error\r\nContent-Length: 10\r\n\r\nerror page}, data
   end
 
   def test_force_shutdown_error_default

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1362,4 +1362,21 @@ EOF
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
     assert_equal "user", data.split("\r\n").last
   end
+
+  # The server should send lowlevel_error handlers response to the client
+  def test_lowlevel_error
+    options = { lowlevel_error_handler: ->(err) { [200, {}, ["error page"]] } }
+    app = ->(env) { [200, nil, []] }
+    server_run(**options, &app)
+
+    sock = send_http "GET / HTTP/1.0\r\n\r\n"
+
+    _h = header sock
+
+    body = sock.gets
+
+    assert_match /error page/, body
+
+    sock.close
+  end
 end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1364,7 +1364,7 @@ EOF
   end
 
   # The server should send lowlevel_error handlers response to the client
-  def test_lowlevel_error
+  def test_lowlevel_error_handler
     options = { lowlevel_error_handler: ->(err) { [200, {}, ["error page"]] } }
     app = ->(env) { [200, nil, []] }
     server_run(**options, &app)

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -363,6 +363,17 @@ EOF
     assert (data.size > 0), "Expected response message to be not empty"
   end
 
+  def test_lowlevel_error_handler_custom_response
+    options = { lowlevel_error_handler: ->(_err) { [200, {}, ["error page"]] } }
+    # setting the headers argument to nil will trigger exception inside Puma
+    broken_app = ->(_env) { [200, nil, []] }
+    server_run(**options, &broken_app)
+
+    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+
+    assert_match %r{HTTP/1.0 200 OK\r\nContent-Length: 10\r\n\r\nerror page}, data
+  end
+
   def test_force_shutdown_error_default
     server_run(force_shutdown_after: 2) do
       @server.stop
@@ -1361,16 +1372,5 @@ EOF
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
     assert_equal "user", data.split("\r\n").last
-  end
-
-  # The server should send lowlevel_error handlers response to the client
-  def test_lowlevel_error_handler
-    options = { lowlevel_error_handler: ->(err) { [200, {}, ["error page"]] } }
-    app = ->(env) { [200, nil, []] }
-    server_run(**options, &app)
-
-    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
-
-    assert_match /error page/, data
   end
 end

--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -45,7 +45,7 @@ class TestResponseHeader < Minitest::Test
     server_run app: ->(env) { [200, { 1 => 'Boo'}, []] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.1 500 Internal Server Error/, data)
+    assert_match(/HTTP\/1.0 500 Internal Server Error/, data)
   end
 
   # The header must respond to each
@@ -53,7 +53,7 @@ class TestResponseHeader < Minitest::Test
     server_run app: ->(env) { [200, nil, []] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.1 500 Internal Server Error/, data)
+    assert_match(/HTTP\/1.0 500 Internal Server Error/, data)
   end
 
   # The values of the header must be Strings


### PR DESCRIPTION
### Description
Always send what the lowlevel_error handler returns to the client.

Refactors some code out of `Request#handle_request` to a new `Request#write_response` that can be used from `Server` to send the response from `lowlevel_error`
Closes #2341

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
