### PR TITLE
Fix TruffleRuby compile failure

### DIFF
--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -48,11 +48,14 @@ end
 if ENV["MAKE_WARNINGS_INTO_ERRORS"]
   # Make all warnings into errors
   # Except `implicit-fallthrough` since most failures comes from ragel state machine generated code
-  if respond_to? :append_cflags
+  if respond_to? :append_cflags # Ruby 2.5 and later
     append_cflags config_string 'WERRORFLAG'
     append_cflags '-Wno-implicit-fallthrough'
   else
-    $CFLAGS += ' ' << (config_string 'WERRORFLAG') << ' -Wno-implicit-fallthrough'
+    # flag may not exist on some platforms, -Werror may not be defined on some platforms, but
+    # works with all in current CI
+    $CFLAGS << ((t = config_string 'WERRORFLAG') ? " #{t}" : ' -Werror')
+    $CFLAGS << ' -Wno-implicit-fallthrough'
   end
 end
 


### PR DESCRIPTION
### Description

extconf.rb - fix WERRORFLAG is nil, which is causing CI failures with current TruffleRuby master.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
