### PR TITLE
Keep thread names under 15 characters

### DIFF
--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -34,7 +34,7 @@ module Puma
         Signal.trap "SIGCHLD", "DEFAULT"
 
        Thread.new do
-          Puma.set_thread_name "worker check pipe"
+          Puma.set_thread_name "wrkr check"
           @check_pipe.wait_readable
           log "! Detected parent died, dying"
           exit! 1
@@ -76,7 +76,7 @@ module Puma
           end
 
           Thread.new do
-            Puma.set_thread_name "worker fork pipe"
+            Puma.set_thread_name "wrkr fork"
             while (idx = @fork_pipe.gets)
               idx = idx.to_i
               if idx == -1 # stop server
@@ -114,7 +114,7 @@ module Puma
         while restart_server.pop
           server_thread = server.run
           stat_thread ||= Thread.new(@worker_write) do |io|
-            Puma.set_thread_name "stat payload"
+            Puma.set_thread_name "stat pld"
             base_payload = "p#{Process.pid}"
 
             while true

--- a/lib/puma/plugin.rb
+++ b/lib/puma/plugin.rb
@@ -64,7 +64,7 @@ module Puma
     def fire_background
       @background.each_with_index do |b, i|
         Thread.new do
-          Puma.set_thread_name "plugin background #{i}"
+          Puma.set_thread_name "plgn bg #{i}"
           b.call
         end
       end

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -69,7 +69,7 @@ module Puma
 
       control.binder.parse [str], self, 'Starting control server'
 
-      control.run thread_name: 'control'
+      control.run thread_name: 'ctl'
       @control = control
     end
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -220,7 +220,7 @@ module Puma
     # up in the background to handle requests. Otherwise requests
     # are handled synchronously.
     #
-    def run(background=true, thread_name: 'server')
+    def run(background=true, thread_name: 'srv')
       BasicSocket.do_not_reverse_lookup = true
 
       @events.fire :state, :booting

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -102,7 +102,7 @@ module Puma
       @spawned += 1
 
       th = Thread.new(@spawned) do |spawned|
-        Puma.set_thread_name '%s threadpool %03i' % [@name, spawned]
+        Puma.set_thread_name '%s tp %03i' % [@name, spawned]
         todo  = @todo
         block = @block
         mutex = @mutex

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -159,7 +159,7 @@ worker_timeout #{timeout}
 on_worker_boot do
   Thread.new do
     sleep 1
-    Thread.list.find {|t| t.name == 'puma stat payload'}.kill
+    Thread.list.find {|t| t.name == 'puma stat pld'}.kill
   end
 end
 RUBY

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -59,7 +59,7 @@ class TestThreadPool < Minitest::Test
     thread_name = nil
     pool = mutex_pool(0, 1) {thread_name = Thread.current.name}
     pool << 1
-    assert_equal('puma test threadpool 001', thread_name)
+    assert_equal('puma test tp 001', thread_name)
   end
 
   def test_converts_pool_sizes

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -10,12 +10,12 @@ class TestThreadPool < Minitest::Test
 
   def new_pool(min, max, &block)
     block = proc { } unless block
-    @pool = Puma::ThreadPool.new('test', min, max, &block)
+    @pool = Puma::ThreadPool.new('tst', min, max, &block)
   end
 
   def mutex_pool(min, max, &block)
     block = proc { } unless block
-    @pool = MutexPool.new('test', min, max, &block)
+    @pool = MutexPool.new('tst', min, max, &block)
   end
 
   # Wraps ThreadPool work in mutex for better concurrency control.
@@ -59,7 +59,32 @@ class TestThreadPool < Minitest::Test
     thread_name = nil
     pool = mutex_pool(0, 1) {thread_name = Thread.current.name}
     pool << 1
-    assert_equal('puma test tp 001', thread_name)
+    assert_equal('puma tst tp 001', thread_name)
+  end
+
+  def test_thread_name_linux
+    skip 'Thread.name not supported' unless Thread.current.respond_to?(:name)
+
+    task_dir = File.join('', 'proc', Process.pid.to_s, 'task')
+    skip 'This test only works under Linux with appropriate permissions' if !(File.directory?(task_dir) && File.readable?(task_dir))
+
+    expected_thread_name = 'puma tst tp 001'
+    found_thread = false
+    pool = mutex_pool(0, 1) do
+      # Read every /proc/<pid>/task/<tid>/comm file to find the thread name
+      Dir.entries(task_dir).select {|tid| File.directory?(File.join(task_dir, tid))}.each do |tid|
+        comm_file = File.join(task_dir, tid, 'comm')
+        next unless File.file?(comm_file) && File.readable?(comm_file)
+
+        if File.read(comm_file).strip == expected_thread_name
+          found_thread = true
+          break
+        end
+      end
+    end
+    pool << 1
+
+    assert(found_thread, "Did not find thread with name '#{expected_thread_name}'")
   end
 
   def test_converts_pool_sizes


### PR DESCRIPTION
### Description
Keep thread names under 15 characters.

Linux thread names are limited to 15 characters. Trying to set a longer name will just silently do nothing 😡 

This PR ensures that all threads created by Puma have names that are 15 characters or shorter. Who needs vowels anyway.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
