### PR TITLE
Do not run rubocop on non-CRuby

### DIFF
--- a/.github/workflows/non_mri.yml
+++ b/.github/workflows/non_mri.yml
@@ -62,10 +62,6 @@ jobs:
       - name: compile
         run:  bundle exec rake compile
 
-      - name: rubocop
-        if: endsWith(matrix.ruby, '-head') == false
-        run: bundle exec rake rubocop
-
       - name: test
         id: test
         timeout-minutes: 12


### PR DESCRIPTION
It does not seem useful (redundant with running it on CRuby), makes builds slower, and also sometimes makes builds fail: https://github.com/puma/puma/runs/4047984193?check_suite_focus=true