### PR TITLE
CI: Skip TestIntegrationSingle#test_closed_listener on macOS

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -135,7 +135,7 @@ module TestSkips
   def skip_if(*engs, suffix: '', bt: caller)
     engs.each do |eng|
       skip_msg = case eng
-        when :darwin      then "Skipped if darwin#{suffix}"      if Puma::IS_OSX
+        when :darwin      then "Skipped if darwin#{suffix}"      if DARWIN
         when :jruby       then "Skipped if JRuby#{suffix}"       if Puma::IS_JRUBY
         when :truffleruby then "Skipped if TruffleRuby#{suffix}" if TRUFFLE
         when :windows     then "Skipped if Windows#{suffix}"     if Puma::IS_WINDOWS
@@ -154,7 +154,7 @@ module TestSkips
   # called with only one param
   def skip_unless(eng, bt: caller)
     skip_msg = case eng
-      when :darwin  then "Skip unless darwin"           unless Puma::IS_OSX
+      when :darwin  then "Skip unless darwin"           unless DARWIN
       when :jruby   then "Skip unless JRuby"            unless Puma::IS_JRUBY
       when :windows then "Skip unless Windows"          unless Puma::IS_WINDOWS
       when :mri     then "Skip unless MRI"              unless Puma::IS_MRI

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -182,6 +182,7 @@ class TestIntegrationSingle < TestIntegration
   # listener is closed 'externally' while Puma is in the IO.select statement
   def test_closed_listener
     skip_unless_signal_exist? :TERM
+    skip_if :darwin # been flaky with Ruby 2.2, 2.3, 2.4
 
     cli_server "test/rackup/close_listeners.ru", merge_err: true
     read_body connect


### PR DESCRIPTION
In an effort to have green CI more often.

It was introduced in https://github.com/puma/puma/pull/2700

I've seen it fail like this on macos-10.15 and Ruby
- 2.2: https://github.com/puma/puma/runs/4055009489?check_suite_focus=true#step:9:739
- 2.3: https://github.com/puma/puma/runs/4055009508?check_suite_focus=true#step:9:661
- macos-11 2.4: https://github.com/puma/puma/runs/4055009711?check_suite_focus=true#step:9:667

```ruby
      1) Error:
    TestIntegrationSingle#test_closed_listener:
    EOFError: end of file reached
        /Users/runner/work/puma/puma/test/helpers/integration.rb:160:in `readpartial'
        /Users/runner/work/puma/puma/test/helpers/integration.rb:160:in `block (2 levels) in read_body'
        /Users/runner/work/puma/puma/test/helpers/integration.rb:159:in `loop'
        /Users/runner/work/puma/puma/test/helpers/integration.rb:159:in `block in read_body'
        /Users/runner/hostedtoolcache/Ruby/2.2.10/x64/lib/ruby/2.2.0/timeout.rb:88:in `block in timeout'
        /Users/runner/hostedtoolcache/Ruby/2.2.10/x64/lib/ruby/2.2.0/timeout.rb:32:in `block in catch'
        /Users/runner/hostedtoolcache/Ruby/2.2.10/x64/lib/ruby/2.2.0/timeout.rb:32:in `catch'
        /Users/runner/hostedtoolcache/Ruby/2.2.10/x64/lib/ruby/2.2.0/timeout.rb:32:in `catch'
        /Users/runner/hostedtoolcache/Ruby/2.2.10/x64/lib/ruby/2.2.0/timeout.rb:103:in `timeout'
        /Users/runner/work/puma/puma/test/helpers/integration.rb:158:in `read_body'
        /Users/runner/work/puma/puma/test/test_integration_single.rb:187:in `test_closed_listener'
        /Users/runner/work/puma/puma/test/helper.rb:82:in `block (4 levels) in run'
        /Users/runner/hostedtoolcache/Ruby/2.2.10/x64/lib/ruby/2.2.0/timeout.rb:88:in `block in timeout'
        /Users/runner/hostedtoolcache/Ruby/2.2.10/x64/lib/ruby/2.2.0/timeout.rb:98:in `call'
        /Users/runner/hostedtoolcache/Ruby/2.2.10/x64/lib/ruby/2.2.0/timeout.rb:98:in `timeout'
        /Users/runner/work/puma/puma/test/helper.rb:80:in `block (3 levels) in run'
```

And like this on
- macos-10.15 Ruby 2.4: https://github.com/puma/puma/runs/4055009526?check_suite_focus=true#step:9:618
- macos-11 Ruby 2.3: https://github.com/MSP-Greg/puma/runs/3616720219?check_suite_focus=true#step:9:574 (when it was introduced)

```ruby
      1) Error:
    TestIntegrationSingle#test_closed_listener:
    TimeoutEveryTestCase::TestTookTooLong: execution expired
        /Users/runner/work/puma/puma/test/helpers/integration.rb:124:in `gets'
        /Users/runner/work/puma/puma/test/helpers/integration.rb:124:in `connect'
        /Users/runner/work/puma/puma/test/test_integration_single.rb:187:in `test_closed_listener'
        /Users/runner/work/puma/puma/test/helper.rb:82:in `block (4 levels) in run'
        /Users/runner/hostedtoolcache/Ruby/2.4.10/x64/lib/ruby/2.4.0/timeout.rb:103:in `timeout'
        /Users/runner/work/puma/puma/test/helper.rb:80:in `block (3 levels) in run'
```

Also: Can't see that `Puma::IS_OSX` has ever existed, so fix that (changed in #2576).