### PR TITLE
CI - itermittent fix and RuboCop

### DIFF
--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -26,6 +26,9 @@ class TestCLI < Minitest::Test
 
   def wait_booted
     @wait.sysread 1
+  rescue Errno::EAGAIN
+    sleep 0.001
+    retry
   end
 
   def teardown

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -145,8 +145,7 @@ class TestThreadPool < Minitest::Test
     end
 
     start = Time.now
-    Thread.pass until pool.spawned == 1 ||
-      Time.now - start > 1
+    Thread.pass until pool.spawned == 1 || Time.now - start > 1
 
     assert_equal 1, pool.spawned
   end
@@ -211,8 +210,7 @@ class TestThreadPool < Minitest::Test
     pool << 2
 
     start = Time.now
-    Thread.pass until pool.spawned == 0 ||
-      Time.now - start > 1
+    Thread.pass until pool.spawned == 0 || Time.now - start > 1
 
     assert_equal 0, pool.spawned
   end


### PR DESCRIPTION
### Description

1. `test_thread_pool.rb` - newer RuboCop fixes - fix RuboCop issue (newer RuboCop)

2. `test_cli.rb` - fix (?) CI itermittent error. See https://github.com/puma/puma/runs/4073168355?check_suite_focus=true#step:9:602

```
TestCLI#test_control_clustered:
Errno::EAGAIN: Resource temporarily unavailable
    /Users/runner/work/puma/puma/test/test_cli.rb:28:in `sysread'
    /Users/runner/work/puma/puma/test/test_cli.rb:28:in `wait_booted'
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
