### PR TITLE
server.rb - rescue handling (`Errno::EBADF`) for `@notify.close`

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -375,13 +375,14 @@ module Puma
       rescue Exception => e
         @events.unknown_error e, nil, "Exception handling servers"
       ensure
-        begin
-          @check.close unless @check.closed?
-        rescue Errno::EBADF, RuntimeError
-          # RuntimeError is Ruby 2.2 issue, can't modify frozen IOError
-          # Errno::EBADF is infrequently raised
+        # RuntimeError is Ruby 2.2 issue, can't modify frozen IOError
+        # Errno::EBADF is infrequently raised
+        [@check, @notify].each do |io|
+          begin
+            io.close unless io.closed?
+          rescue Errno::EBADF, RuntimeError
+          end
         end
-        @notify.close
         @notify = nil
         @check = nil
       end


### PR DESCRIPTION
### Description

Handle `@notify.close` in the same manner as `@check.close`

CI has very infrequent failures.  See https://github.com/puma/puma/runs/4085098935?check_suite_focus=true#step:9:385, which had the following error:
```
/Users/runner/work/puma/puma/lib/puma/server.rb:384:in `close': Bad file descriptor (Errno::EBADF)
	from /Users/runner/work/puma/puma/lib/puma/server.rb:384:in `handle_servers'
	from /Users/runner/work/puma/puma/lib/puma/server.rb:261:in `block in run'
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
