### PR TITLE
[CI] Fix Timeout Errors when reading responses

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -165,6 +165,8 @@ class TestIntegration < Minitest::Test
         sleep 0.01
       end
     end
+  rescue Timeout::Error
+    flunk "response read_body timeout error"
   end
 
   # gets worker pids from @server output

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -540,7 +540,7 @@ RUBY
     begin
       sleep delay
       s = connect "sleep#{sleep_time}-#{step}", unix: unix
-      body = read_body(s)
+      body = read_body(s, 15)
       if body[/\ASlept /]
         mutex.synchronize { replies[step] = :success }
       else


### PR DESCRIPTION
### Description

1. Currently, integration tests stop the CI if a response read timeout happens.  Catch the error and flunk the test.

2. There are two methods in `test_integration_cluster.rb` that are used when generating several requests.  One had a read timeout set to 20 seconds, the other (which has failed recently) had the timeout set to the default of 10.  Increase to 15.

These timeout errors seem to have recently increased, may be due to a change in Actions runners...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
