### PR TITLE
[CI] integration.rb - allow for nil in wait_for_server_to_boot

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -104,18 +104,17 @@ class TestIntegration < Minitest::Test
   end
 
   # wait for server to say it booted
+  # @server and/or @server.gets may be nil on slow CI systems
   def wait_for_server_to_boot(log: false)
-    # OSX 10.15 seems to need a little extra time, @server.gets fails
-    sleep 0.2 if Puma::IS_OSX
     if log
       puts "Waiting for server to boot..."
       begin
-        line = @server.gets
+        line = @server && @server.gets
         puts line if line && line.strip != ''
-      end until line.include? 'Ctrl-C'
+      end until line && line.include?('Ctrl-C')
       puts "Server booted!"
     else
-      true until @server.gets.include? 'Ctrl-C'
+      true until @server && (@server.gets || '').include?('Ctrl-C')
     end
   end
 


### PR DESCRIPTION
### Description

With recent CI, starting sub-processes may not happen as quickly as in the past.  This results in failures if objects are not yet initialized when used.

These changes fix the failure shown in https://github.com/puma/puma/runs/4093551821?check_suite_focus=true#step:9:570
```
test/helpers/integration.rb:118:in `wait_for_server_to_boot': undefined method `include?' for nil:NilClass (NoMethodError)
	from test/helpers/integration.rb:284:in `block in hot_restart_does_not_drop_connections'
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
