### PR TITLE
Rescue `Errno::EBADF` in `Client#close`

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -161,7 +161,7 @@ module Puma
     def close
       begin
         @io.close
-      rescue IOError
+      rescue IOError, Errno::EBADF
         Puma::Util.purge_interrupt_queue
       end
     end


### PR DESCRIPTION
Spotted happening in CI: https://github.com/puma/puma/runs/4095295281?check_suite_focus=true

    2021-11-03 16:34:54 +0000 Exception handling servers: #<Errno::EBADF: Bad file descriptor>/Users/runner/work/puma/puma/lib/puma/client.rb:163:in `close': Bad file descriptor (Errno::EBADF)
    TestRackServer#test_large_post_body =
            from /Users/runner/work/puma/puma/lib/puma/client.rb:163:in `close'

Related to #2700? (that changed `rescue Object` to `IOError, Errno::EBADF` and re-raises these two)

See also #2312 that added `Errno::EBADF` (and #2745 that improves on that)

