### PR TITLE
Use correct paths in test/config/ssl_config.rb

### DIFF
--- a/test/config/ssl_config.rb
+++ b/test/config/ssl_config.rb
@@ -1,6 +1,6 @@
-key =  File.expand_path "../../examples/puma/puma_keypair.pem", __FILE__
-cert = File.expand_path "../../examples/puma/cert_puma.pem", __FILE__
-ca = File.expand_path "../../examples/puma/client-certs/ca.crt", __FILE__
+key =  File.expand_path "../../../examples/puma/puma_keypair.pem", __FILE__
+cert = File.expand_path "../../../examples/puma/cert_puma.pem", __FILE__
+ca = File.expand_path "../../../examples/puma/client-certs/ca.crt", __FILE__
 
 ssl_bind "0.0.0.0", 9292, :cert => cert, :key => key, :verify_mode => "peer", :ca => ca
 


### PR DESCRIPTION
Make `puma -C test/config/ssl_config.rb` works out-of-the-box. Looks
like tests haven't complained because `test_ssl_configuration_from_DSL`
doesn't actually start Puma.