### PR TITLE
extconf.rb - fix openssl with old Windows builds

### DIFF
--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -11,7 +11,7 @@ end
 unless ENV["DISABLE_SSL"]
   dir_config("openssl")
 
-  found_ssl = if pkg_config 'openssl'
+  found_ssl = if (!$mingw || RUBY_VERSION >= '2.4') && (t = pkg_config 'openssl')
     puts 'using OpenSSL pkgconfig (openssl.pc)'
     true
   elsif %w'crypto libeay32'.find {|crypto| have_library(crypto, 'BIO_read')} &&


### PR DESCRIPTION
### Description

Older Windows builds could compile with the wrong OpenSSL if more than one exists on the system.  This occurs with the Actions windows-2019 image.  Previous output from test log below:
```
                         Puma::MiniSSL                   OpenSSL
OPENSSL_LIBRARY_VERSION: OpenSSL 1.1.1  11 Sep 2018      OpenSSL 1.0.2j  26 Sep 2016
        OPENSSL_VERSION: OpenSSL 1.1.1l  24 Aug 2021     OpenSSL 1.0.2j  26 Sep 2016
```

CI did pass with the incorrect OpenSSL version, but if the app loaded Ruby's OpenSSL, two different OpenSSL libraries would be loaded.  Also, the install wouldn't be portable.  Probably not a good thing...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
