### PR TITLE
Fix error message in test_verify_fail_if_client_unknown_ca

### DIFF
--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -303,7 +303,7 @@ class TestPumaServerSSLClient < Minitest::Test
   end
 
   def test_verify_fail_if_client_unknown_ca
-    assert_ssl_client_error_match('self signed certificate in certificate chain', '/DC=net/DC=puma/CN=CAU') do |http|
+    assert_ssl_client_error_match(/self[- ]signed certificate in certificate chain/, '/DC=net/DC=puma/CN=CAU') do |http|
       key = "#{CERT_PATH}/client_unknown.key"
       crt = "#{CERT_PATH}/client_unknown.crt"
       http.key = OpenSSL::PKey::RSA.new File.read(key)


### PR DESCRIPTION
### Description

In Ubuntu 22.04 (development release), we have got the following error:
```
  1) Failure:
TestPumaServerSSLClient#test_verify_fail_if_client_unknown_ca [/tmp/autopkgtest.nnOHcD/build.YFu/src/test/test_puma_server_ssl.rb:306]:
Expected /self\ signed\ certificate\ in\ certificate\ chain/ to match # encoding: ASCII-8BIT
\#    valid: true
"OpenSSL certificate verification error: self-signed certificate in certificate chain - 19".
```
Changing the expected error message from "self signed certificate" to "self-signed certificate" fixes the test failure.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
