### PR TITLE
Add SIGINFO to documentation [ci skip]

### DIFF
--- a/docs/signals.md
+++ b/docs/signals.md
@@ -42,6 +42,7 @@ Puma cluster responds to these signals:
 - `INT ` equivalent of sending Ctrl-C to cluster. Puma will attempt to finish then exit.
 - `CHLD`
 - `URG ` refork workers in phases from worker 0 if `fork_workers` option is enabled.
+- `INFO` print backtraces of all puma threads
 
 ## Callbacks order in case of different signals
 


### PR DESCRIPTION
### Description
SIGINFO (added in #1320) is missing from docs. Not sure if this should mention that SIGINFO  is not supported in Linux?

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
