### PR TITLE
tests: add `TEST_CASE_TIMEOUT`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,11 @@ To run a single test:
 bundle exec m test/test_binder.rb:37
 ```
 
+To run a single test with 5 seconds as the test case timeout:
+```sh
+TEST_CASE_TIMEOUT=5 bundle exec m test/test_binder.rb:37
+```
+
 ## How to contribute
 
 Puma could use your help in several areas!

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,9 @@ Thread.abort_on_exception = true
 
 $debugging_info = ''.dup
 $debugging_hold = false    # needed for TestCLI#test_control_clustered
+$test_case_timeout = ENV.fetch("TEST_CASE_TIMEOUT") do
+  RUBY_ENGINE == "ruby" ? 45 : 60
+end.to_i
 
 require "puma"
 require "puma/detect"
@@ -77,14 +80,14 @@ module TimeoutEveryTestCase
     with_info_handler do
       time_it do
         capture_exceptions do
-          ::Timeout.timeout(RUBY_ENGINE == 'ruby' ? 45 : 60, TestTookTooLong) do
+          ::Timeout.timeout($test_case_timeout, TestTookTooLong) do
             before_setup; setup; after_setup
             self.send self.name
           end
         end
 
         capture_exceptions do
-          ::Timeout.timeout(RUBY_ENGINE == 'ruby' ? 45 : 60, TestTookTooLong) do
+          ::Timeout.timeout($test_case_timeout, TestTookTooLong) do
             Minitest::Test::TEARDOWN_METHODS.each { |hook| self.send hook }
           end
         end


### PR DESCRIPTION
Useful if you want quicker feedback when you know something fails
instantly, example:

    rerun -x -c -- TEST_CASE_TIMEOUT=2 bundle e m test/test_integration_ssl.rb:126

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
