### PR TITLE
Revise Actions workflows - fewer macos jobs, use Bundler cache, windows-2022, yjit job

### DIFF
--- a/.github/workflows/mri.yml
+++ b/.github/workflows/mri.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     name: >-
-      ${{ matrix.os }} ${{ matrix.ruby }}${{ matrix.no-ssl }}
+      ${{ matrix.os }} ${{ matrix.ruby }}${{ matrix.no-ssl }}${{ matrix.yjit }}
     env:
       CI: true
       TESTOPTS: -v
@@ -17,41 +17,47 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, macos-11, windows-2019 ]
+        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, macos-11, windows-2022 ]
         ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', head ]
         no-ssl: ['']
+        yjit: ['']
         include:
-          - { os: windows-2019 , ruby: mingw }
-          - { os: ubuntu-20.04 , ruby: 2.7   , no-ssl: ' no SSL' }
-          - { os: windows-2019 , ruby: 2.7   , no-ssl: ' no SSL' }
+          - { os: windows-2022 , ruby: ucrt }
+          - { os: windows-2022 , ruby: 2.7  , no-ssl: ' no SSL' }
+          - { os: ubuntu-20.04 , ruby: head , yjit: ' yjit' }
+          - { os: ubuntu-20.04 , ruby: 2.7  , no-ssl: ' no SSL' }
+
         exclude:
           - { os: ubuntu-20.04 , ruby: 2.2  }
           - { os: ubuntu-20.04 , ruby: 2.3  }
-          - { os: ubuntu-20.04 , ruby: 2.4  }
-          - { os: ubuntu-20.04 , ruby: 2.6  }
-          - { os: windows-2019 , ruby: head }
+          - { os: windows-2022 , ruby: head }
+          - { os: macos-10.15  , ruby: 2.6  }
+          - { os: macos-10.15  , ruby: 2.7  }
+          - { os: macos-10.15  , ruby: '3.0' }
+          - { os: macos-11     , ruby: 2.2  }
+          - { os: macos-11     , ruby: 2.3  }
 
     steps:
       - name: repo checkout
         uses: actions/checkout@v2
 
-      - name: load ruby, ragel
-        uses: MSP-Greg/setup-ruby-pkgs@v1
+      - name: load ruby
+        uses: MSP-Greg/setup-ruby-pkgs@win-ucrt-2
         with:
           ruby-version: ${{ matrix.ruby }}
           apt-get: ragel
           brew: ragel
-          mingw: _upgrade_ openssl ragel
+          mingw: openssl ragel
+          bundler-cache: true
+          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/win-ucrt-1
+        timeout-minutes: 10
 
-      - name:  bundle install
+      # Windows error thrown, doesn't affect CI
+      - name: update rubygems for Ruby 2.2
+        if: matrix.ruby < '2.3'
+        run: gem update --system 2.7.11 --no-document
+        continue-on-error: true
         timeout-minutes: 5
-        shell: pwsh
-        run:   |
-          # update RubyGems in Ruby 2.2, bundle install
-          if ('${{ matrix.ruby }}' -lt '2.3') {
-            gem update --system 2.7.11 --no-document
-          }
-          bundle install --jobs 4 --retry 3
 
       - name: Compile Puma without SSL support
         if: matrix.no-ssl == ' no SSL'
@@ -67,8 +73,13 @@ jobs:
 
       - name: rubocop
         # 2021-05-20 - RuboCop won't run with Psych 4.0 - remove when fixed
-        if: (endsWith(matrix.ruby, 'head') == false) && (endsWith(matrix.ruby, 'mingw') == false)
+        if: (endsWith(matrix.ruby, 'head') == false) && (endsWith(matrix.ruby, 'ucrt') == false)
         run: bundle exec rake rubocop
+
+      - name: Use yjit
+        if: matrix.yjit == ' yjit'
+        shell: bash
+        run: echo 'RUBYOPT=--yjit' >> $GITHUB_ENV
 
       - name: test
         timeout-minutes: 10

--- a/.github/workflows/non_mri.yml
+++ b/.github/workflows/non_mri.yml
@@ -32,6 +32,12 @@ jobs:
       - name: repo checkout
         uses: actions/checkout@v2
 
+      - name: set JAVA_HOME
+        if: startsWith(matrix.os, 'macos')
+        shell: bash
+        run:  |
+          echo JAVA_HOME=$JAVA_HOME_11_X64 >> $GITHUB_ENV
+
       - name: load ruby, ragel
         uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
@@ -39,16 +45,8 @@ jobs:
           apt-get: ragel
           brew: ragel
           mingw: _upgrade_ openssl ragel
-
-      - name: set JAVA_HOME
-        if: startsWith(matrix.os, 'macos')
-        shell: bash
-        run:  |
-          echo JAVA_HOME=$JAVA_HOME_11_X64 >> $GITHUB_ENV
-
-      - name: bundle install
-        timeout-minutes: 5
-        run:  bundle install --jobs 4 --retry 3
+          bundler-cache: true
+        timeout-minutes: 10
 
       - name: Compile Puma without SSL support
         if: matrix.no-ssl == ' no SSL'


### PR DESCRIPTION
### Description

Currently, GitHub Actions supports 20 concurrent Ubuntu/Widows jobs and 5 concurrent macOS jobs.  Below is the job count before and after this PR:
```
                    Ubuntu/Win  macOS   Total
Current CI  MRI         22        16      38
            non-MRI      5         4       9
            Total       27        20      47

PR CI       MRI         25        11      36
            non-MRI      5         4       9
            Total       30        15      45
```

Since there are currently 20 macos jobs, there are 4 sets that run.  Ubuntu/Widows only requires 2 sets (20 + 7).  This PR adjusts the number of macos jobs to 15, so three sets run.  Hence, speeding up CI.

Other changes:

1. Installed gems are cached by setup-ruby (thanks for @eregon's work)
2. A job is added with Ubuntu master using yjit
3. windows-2022 image is used
4. Windows master ucrt build is used (Windows 3.1 will be released as a ucrt build)

Jobs intermittently fail **before** compile due to problems downloading gems or updating packages/build tools.  The first and third changes above lower the number of external connections the jobs need to make.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
