### PR TITLE
[CI] Remove the t3-pid file after tests

### DIFF
--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -44,6 +44,7 @@ class TestPumaControlCli < TestConfigFileBase
   def test_config_file
     control_cli = Puma::ControlCLI.new ["--config-file", "test/config/state_file_testing_config.rb", "halt"]
     assert_equal "t3-pid", control_cli.instance_variable_get("@pidfile")
+    File.unlink "t3-pid" if File.file? "t3-pid"
   end
 
   def test_app_env_without_environment


### PR DESCRIPTION
### Description
Here's a small hotfix to remove the pid-file in the end of the test.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
