### PR TITLE
Add a couple of accessors

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -27,6 +27,10 @@ module Puma
       @phased_restart = false
     end
 
+    # Returns the list of cluster worker handles.
+    # @return [Array<Puma::Cluster::WorkerHandle>]
+    attr_reader :workers
+
     def stop_workers
       log "- Gracefully shutting down workers..."
       @workers.each { |x| x.term }

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -18,6 +18,10 @@ module Puma
       @wakeup = nil
     end
 
+    # Returns the hash of configuration options.
+    # @return [Puma::UserFileDefaultOptions]
+    attr_reader :options
+
     def wakeup!
       return unless @wakeup
 


### PR DESCRIPTION
### Description
Add read accessors for `Puma::Cluster`'s `@workers` and `Puma::Runner`'s `@options`.

Somewhat related to #2773, these accessors would make it easier to implement a rolling restart strategy from a thread.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
