### PR TITLE
Patch Rubocop to work with newer Psych versions

### DIFF
--- a/.github/workflows/mri.yml
+++ b/.github/workflows/mri.yml
@@ -72,8 +72,6 @@ jobs:
         run:  bundle exec rake compile
 
       - name: rubocop
-        # 2021-05-20 - RuboCop won't run with Psych 4.0 - remove when fixed
-        if: (endsWith(matrix.ruby, 'head') == false) && (endsWith(matrix.ruby, 'ucrt') == false)
         run: bundle exec rake rubocop
 
       - name: Use yjit

--- a/.github/workflows/mri.yml
+++ b/.github/workflows/mri.yml
@@ -59,6 +59,13 @@ jobs:
         continue-on-error: true
         timeout-minutes: 5
 
+      # Fix RubyGems warnings about required_ruby_version bug with Bundler
+      - name: update rubygems for Ruby 2.2
+        if: matrix.ruby >= '2.3' && matrix.ruby < '2.6'
+        run: gem update --system 3.2.3 --no-document
+        continue-on-error: true
+        timeout-minutes: 5
+
       - name: Compile Puma without SSL support
         if: matrix.no-ssl == ' no SSL'
         shell: bash

--- a/.github/workflows/mri.yml
+++ b/.github/workflows/mri.yml
@@ -60,7 +60,7 @@ jobs:
         timeout-minutes: 5
 
       # Fix RubyGems warnings about required_ruby_version bug with Bundler
-      - name: update rubygems for Ruby 2.2
+      - name: update rubygems for Ruby 2.3 - 2.5
         if: matrix.ruby >= '2.3' && matrix.ruby < '2.6'
         run: gem update --system 3.2.3 --no-document
         continue-on-error: true

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,30 @@ gemspec = Gem::Specification.load("puma.gemspec")
 Gem::PackageTask.new(gemspec).define
 
 # Add rubocop task
-RuboCop::RakeTask.new
+RuboCop::RakeTask.new do
+  require 'rubocop'
+
+  # Patch RuboCop::ConfigLoader.yaml_safe_load to work with Psych >= 4.0.
+  module RuboCop
+    class ConfigLoader
+      class << self
+        def yaml_safe_load(yaml_code, filename)
+          if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0')
+            YAML.safe_load(
+              yaml_code,
+              permitted_classes: [Regexp, Symbol],
+              permitted_symbols: [],
+              aliases: true,
+              filename: filename
+            )
+          else
+            YAML.safe_load(yaml_code, [Regexp, Symbol], [], true, filename)
+          end
+        end
+      end
+    end
+  end
+end
 
 # generate extension code using Ragel (C and Java)
 desc "Generate extension code (C and Java) using Ragel"

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -72,7 +72,7 @@ module Puma
     attr_accessor :out_of_band_hook # @version 5.0.0
 
     def self.clean_thread_locals
-      Thread.current.keys.each do |key| # rubocop: disable Performance/HashEachMethods
+      Thread.current.keys.each do |key| # rubocop: disable Style/HashEachMethods
         Thread.current[key] = nil unless key == :__recursive_key__
       end
     end


### PR DESCRIPTION
### Description

Most recent RubyGems versions go with Psych >= 4.0 that breaks the RuboCop rake task. We use an old RuboCop version to target Ruby 2.2. So, we cannot upgrade RuboCop to latest and we have to patch it to work with the newer Psych versions.

We're also fixing some CI warnings for Ruby versions 2.3 - 2.5 for RubyGems versions having a bug that prevents `required_ruby_version` from working for Bundler.

You can see the failing CI builds here: https://github.com/puma/puma/actions/runs/1619499856.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
