### PR TITLE
Allow backlog parameter to be set with ssl_bind DSL

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,10 +31,10 @@ _workers_, and we sometimes call the threads created by Puma's
 ![https://bit.ly/2zwzhEK](images/puma-connection-flow.png)
 
 * Upon startup, Puma listens on a TCP or UNIX socket.
-  * The backlog of this socket is configured (with a default of 1024). The
-    backlog determines the size of the queue for unaccepted connections.
-    Generally, you'll never hit the backlog cap in production. If the backlog is
-    full, the operating system refuses new connections.
+  * The backlog of this socket is configured with a default of 1024, but the
+    actual backlog value is capped by the `net.core.somaxconn` sysctl value.
+    The backlog determines the size of the queue for unaccepted connections. If
+    the backlog is full, the operating system is not accepting new connections.
   * This socket backlog is distinct from the `backlog` of work as reported by
     `Puma.stats` or the control server. The backlog that `Puma.stats` refers to
     represents the number of connections in the process' `todo` set waiting for

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -168,9 +168,9 @@ module Puma
             params = Util.parse_query uri.query
 
             opt = params.key?('low_latency') && params['low_latency'] != 'false'
-            bak = params.fetch('backlog', 1024).to_i
+            backlog = params.fetch('backlog', 1024).to_i
 
-            io = add_tcp_listener uri.host, uri.port, opt, bak
+            io = add_tcp_listener uri.host, uri.port, opt, backlog
 
             @ios[ios_len..-1].each do |i|
               addr = loc_addr_str i
@@ -255,7 +255,8 @@ module Puma
             logger.log "* Activated #{str}"
           else
             ios_len = @ios.length
-            io = add_ssl_listener uri.host, uri.port, ctx
+            backlog = params.fetch('backlog', 1024).to_i
+            io = add_ssl_listener uri.host, uri.port, ctx, optimize_for_latency = true, backlog
 
             @ios[ios_len..-1].each do |i|
               addr = loc_addr_str i

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -46,6 +46,8 @@ module Puma
         else ''
         end
 
+      backlog_str = opts[:backlog] ? "&backlog=#{opts[:backlog]}" : ''
+
       ca_additions = "&ca=#{opts[:ca]}" if ['peer', 'force_peer'].include?(verify)
 
       if defined?(JRUBY_VERSION)
@@ -55,7 +57,7 @@ module Puma
         keystore_additions = "keystore=#{opts[:keystore]}&keystore-pass=#{opts[:keystore_pass]}"
 
         "ssl://#{host}:#{port}?#{keystore_additions}#{ssl_cipher_list}" \
-          "&verify_mode=#{verify}#{tls_str}#{ca_additions}"
+          "&verify_mode=#{verify}#{tls_str}#{ca_additions}#{backlog_str}"
       else
         ssl_cipher_filter = opts[:ssl_cipher_filter] ?
           "&ssl_cipher_filter=#{opts[:ssl_cipher_filter]}" : nil
@@ -64,7 +66,7 @@ module Puma
           "&verification_flags=#{Array(ary).join ','}" : nil
 
         "ssl://#{host}:#{port}?cert=#{opts[:cert]}&key=#{opts[:key]}" \
-          "#{ssl_cipher_filter}&verify_mode=#{verify}#{tls_str}#{ca_additions}#{v_flags}"
+          "#{ssl_cipher_filter}&verify_mode=#{verify}#{tls_str}#{ca_additions}#{v_flags}#{backlog_str}"
       end
     end
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -46,9 +46,9 @@ module Puma
         else ''
         end
 
-      backlog_str = opts[:backlog] ? "&backlog=#{opts[:backlog]}" : ''
-
       ca_additions = "&ca=#{opts[:ca]}" if ['peer', 'force_peer'].include?(verify)
+
+      backlog_str = opts[:backlog] ? "&backlog=#{Integer(opts[:backlog])}" : ''
 
       if defined?(JRUBY_VERSION)
         ssl_cipher_list = opts[:ssl_cipher_list] ?

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -283,6 +283,7 @@ class TestBinder < TestBinderBase
     tcp_server = TCPServer.new(host, port)
     tcp_server.define_singleton_method(:listen) do |backlog|
       Thread.current[:backlog] = backlog
+      super(backlog)
     end
 
     TCPServer.stub(:new, tcp_server) do

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -109,8 +109,8 @@ class TestConfigFile < TestConfigFileBase
 
     conf.load
 
-    ssl_binding = "ssl://0.0.0.0:9292?cert=&key=&verify_mode=none&backlog=2048"
-    assert_equal [ssl_binding], conf.options[:binds]
+    ssl_binding = conf.options[:binds].first
+    assert ssl_binding.include?('&backlog=2048')
   end
 
   def test_ssl_bind_jruby

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -98,6 +98,21 @@ class TestConfigFile < TestConfigFileBase
     assert_equal [ssl_binding], conf.options[:binds]
   end
 
+  def test_ssl_bind_with_backlog
+    skip_unless :ssl
+
+    conf = Puma::Configuration.new do |c|
+      c.ssl_bind "0.0.0.0", "9292", {
+        backlog: "2048",
+      }
+    end
+
+    conf.load
+
+    ssl_binding = "ssl://0.0.0.0:9292?cert=&key=&verify_mode=none&backlog=2048"
+    assert_equal [ssl_binding], conf.options[:binds]
+  end
+
   def test_ssl_bind_jruby
     skip_unless :jruby
     skip_unless :ssl

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -5,7 +5,7 @@ require "puma/thread_pool"
 class TestThreadPool < Minitest::Test
 
   def teardown
-    @pool.shutdown(1) if @pool
+    @pool.shutdown(1) if defined?(@pool)
   end
 
   def new_pool(min, max, &block)


### PR DESCRIPTION
### Description

We're adding option for setting the socket backlog value with the `ssl_bind` DSL, and updating the docs with a hint to the `net.core.somaxconn` sysctl value. What's interesting here is that on older Linux kernels it defaults to 128 ([reference](https://github.com/torvalds/linux/blob/ca2ef2d9f2aad7a28d346522bb4c473a0aa05249/Documentation/networking/ip-sysctl.rst#tcp-variables)), so the actual backlog value is capped to it.

> somaxconn - INTEGER
> Limit of socket listen() backlog, known in userspace as SOMAXCONN. Defaults to 4096. (Was 128 before linux-5.4) See also tcp_max_syn_backlog for additional tuning for TCP sockets.

Even with the default backlog value of 1024 (when kernel allows it), we are seeing some requests get dropped (504 errors with AWS ALB). That happens with a super fast end-points that respond in < 5ms occasionally when receiving a blast of requests within few seconds and there are other slower end-points that saturate the queue causing some requests to get dropped. So, I'm tweaking slightly the original doc about `backlog` that were misleading:

> Generally, you'll never hit the backlog cap in production.


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.