### PR TITLE
Bump RuboCop to work with newer Psych versions

### DIFF
--- a/.github/workflows/mri.yml
+++ b/.github/workflows/mri.yml
@@ -72,8 +72,6 @@ jobs:
         run:  bundle exec rake compile
 
       - name: rubocop
-        # 2021-05-20 - RuboCop won't run with Psych 4.0 - remove when fixed
-        if: (endsWith(matrix.ruby, 'head') == false) && (endsWith(matrix.ruby, 'ucrt') == false)
         run: bundle exec rake rubocop
 
       - name: Use yjit

--- a/.github/workflows/mri.yml
+++ b/.github/workflows/mri.yml
@@ -59,6 +59,13 @@ jobs:
         continue-on-error: true
         timeout-minutes: 5
 
+      # Fix RubyGems warnings about required_ruby_version bug with Bundler
+      - name: update rubygems for Ruby 2.2
+        if: matrix.ruby >= '2.3' && matrix.ruby < '2.6'
+        run: gem update --system 3.2.3 --no-document
+        continue-on-error: true
+        timeout-minutes: 5
+
       - name: Compile Puma without SSL support
         if: matrix.no-ssl == ' no SSL'
         shell: bash

--- a/.github/workflows/mri.yml
+++ b/.github/workflows/mri.yml
@@ -60,7 +60,7 @@ jobs:
         timeout-minutes: 5
 
       # Fix RubyGems warnings about required_ruby_version bug with Bundler
-      - name: update rubygems for Ruby 2.2
+      - name: update rubygems for Ruby 2.3 - 2.5
         if: matrix.ruby >= '2.3' && matrix.ruby < '2.6'
         run: gem update --system 3.2.3 --no-document
         continue-on-error: true

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "sd_notify"
 
 gem "jruby-openssl", :platform => "jruby"
 
-gem "rubocop", "~> 0.58.0"
+gem "rubocop", "~> 0.64.0"
 
 if %w(2.2.7 2.2.8 2.2.9 2.2.10 2.3.4 2.4.1).include? RUBY_VERSION
   gem "stopgap_13632", "~> 1.0", :platforms => ["mri", "mingw", "x64_mingw"]

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,30 @@ gemspec = Gem::Specification.load("puma.gemspec")
 Gem::PackageTask.new(gemspec).define
 
 # Add rubocop task
-RuboCop::RakeTask.new
+RuboCop::RakeTask.new do
+  require 'rubocop'
+
+  # Patch RuboCop::ConfigLoader.yaml_safe_load to work with Psych >= 4.0.
+  module RuboCop
+    class ConfigLoader
+      class << self
+        def yaml_safe_load(yaml_code, filename)
+          if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0')
+            YAML.safe_load(
+              yaml_code,
+              permitted_classes: [Regexp, Symbol],
+              permitted_symbols: [],
+              aliases: true,
+              filename: filename
+            )
+          else
+            YAML.safe_load(yaml_code, [Regexp, Symbol], [], true, filename)
+          end
+        end
+      end
+    end
+  end
+end
 
 # generate extension code using Ragel (C and Java)
 desc "Generate extension code (C and Java) using Ragel"

--- a/Rakefile
+++ b/Rakefile
@@ -11,30 +11,7 @@ gemspec = Gem::Specification.load("puma.gemspec")
 Gem::PackageTask.new(gemspec).define
 
 # Add rubocop task
-RuboCop::RakeTask.new do
-  require 'rubocop'
-
-  # Patch RuboCop::ConfigLoader.yaml_safe_load to work with Psych >= 4.0.
-  module RuboCop
-    class ConfigLoader
-      class << self
-        def yaml_safe_load(yaml_code, filename)
-          if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0')
-            YAML.safe_load(
-              yaml_code,
-              permitted_classes: [Regexp, Symbol],
-              permitted_symbols: [],
-              aliases: true,
-              filename: filename
-            )
-          else
-            YAML.safe_load(yaml_code, [Regexp, Symbol], [], true, filename)
-          end
-        end
-      end
-    end
-  end
-end
+RuboCop::RakeTask.new
 
 # generate extension code using Ragel (C and Java)
 desc "Generate extension code (C and Java) using Ragel"

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -72,7 +72,7 @@ module Puma
     attr_accessor :out_of_band_hook # @version 5.0.0
 
     def self.clean_thread_locals
-      Thread.current.keys.each do |key| # rubocop: disable Performance/HashEachMethods
+      Thread.current.keys.each do |key| # rubocop: disable Style/HashEachMethods
         Thread.current[key] = nil unless key == :__recursive_key__
       end
     end


### PR DESCRIPTION
From https://github.com/puma/puma/pull/2779

>Most recent RubyGems versions go with Psych >= 4.0 that breaks the RuboCop rake task. We use an old RuboCop version to target Ruby 2.2. So, we cannot upgrade RuboCop to latest and we have to patch it to work with the newer Psych versions.
>
>We're also fixing some CI warnings for Ruby versions 2.3 - 2.5 for RubyGems versions having a bug that prevents `required_ruby_version` from working for Bundler.
>
>You can see the failing CI builds here: https://github.com/puma/puma/actions/runs/1619499856.

but instead of patching RuboCop we bump it to the last version that still supports Ruby 2.2.

Close https://github.com/puma/puma/pull/2779