### PR TITLE
Fix warning from Ruby master (will be 3.2.0)

### DIFF
--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -608,7 +608,10 @@ void Init_mini_ssl(VALUE puma) {
   ERR_load_crypto_strings();
 
   mod = rb_define_module_under(puma, "MiniSSL");
+
   eng = rb_define_class_under(mod, "Engine", rb_cObject);
+  rb_undef_alloc_func(eng);
+
   sslctx = rb_define_class_under(mod, "SSLContext", rb_cObject);
   rb_define_alloc_func(sslctx, sslctx_alloc);
   rb_define_method(sslctx, "initialize", sslctx_initialize, 1);

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -349,7 +349,6 @@ class TestPumaServerSSLWithCertPemAndKeyPem < Minitest::Test
     events = SSLEventsHelper.new STDOUT, STDERR
     server = Puma::Server.new app, events
     server.add_ssl_listener host, port, ctx
-    host_addrs = server.binder.ios.map { |io| io.to_io.addr[2] }
     server.run
 
     http = Net::HTTP.new host, server.connected_ports[0]


### PR DESCRIPTION
### Description

Fixes `warning: undefining the allocator of T_DATA class Puma::MiniSSL::Engine` which is the result of a (good) change to Ruby master (v3.2.0).

Removes unused variable in test_puma_server_ssl.rb - Fix warning: assigned but unused variable

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
