### PR TITLE
fork_worker! should not require worker.phase == 0

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -281,7 +281,6 @@ module Puma
         if (fork_requests = @options[:fork_worker].to_i) > 0
           @launcher.events.register(:ping!) do |w|
             fork_worker! if w.index == 0 &&
-              w.phase == 0 &&
               w.last_status[:requests_count] >= fork_requests
           end
         end


### PR DESCRIPTION
In `Puma::Cluster`, currently `fork_worker!` requires `worker.phase == 0` to be invoked. This looks incorrect based on a reading of the code. (I have not actually observed this failing in production.)

If worker0 (i.e. the worker at index 0) dies, `spawn_worker` will create a new worker at index 0 with the latest `@phase` value. If happens after any worker forking or phase restart, then `fork_worker!` will no longer be invoked.