### PR TITLE
Cleanup: Replace Process.respond_to?(:fork) with Puma.forkable?

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -74,7 +74,7 @@ module Puma
 
       generate_restart_data
 
-      if clustered? && !Process.respond_to?(:fork)
+      if clustered? && !Puma.forkable?
         unsupported "worker mode not supported on #{RUBY_ENGINE} on this platform"
       end
 


### PR DESCRIPTION
Process.respond_to?(:fork) is already defined as Puma.forkable?, so let's use it.