### PR TITLE
In fork_worker mode, worker_culling_strategy "oldest" shouldn't cull worker 0

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -108,19 +108,21 @@ module Puma
     def cull_workers
       diff = @workers.size - @options[:workers]
       return if diff < 1
-
       debug "Culling #{diff} workers"
 
-      workers_to_cull = @workers.sort_by(&:started_at)
-      workers_to_cull.reject! { |w| w.index == 0 } if @options[:fork_worker]
-      workers_to_cull = workers_to_cull[cull_start_index(diff), diff]
+      workers = workers_to_cull(diff)
+      debug "Workers to cull: #{workers.inspect}"
 
-      debug "Workers to cull: #{workers_to_cull.inspect}"
-
-      workers_to_cull.each do |worker|
+      workers.each do |worker|
         log "- Worker #{worker.index} (PID: #{worker.pid}) terminating"
         worker.term
       end
+    end
+
+    def workers_to_cull(diff)
+      workers = @workers.sort_by(&:started_at)
+      workers.reject! { |w| w.index == 0 } if @options[:fork_worker]
+      workers[cull_start_index(diff), diff]
     end
 
     def cull_start_index(diff)

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -111,7 +111,9 @@ module Puma
 
       debug "Culling #{diff} workers"
 
-      workers_to_cull = @workers.sort_by(&:started_at)[cull_start_index(diff), diff]
+      workers_to_cull = @workers.sort_by(&:started_at)
+      workers_to_cull.reject! { |w| w.index == 0 } if @options[:fork_worker]
+      workers_to_cull = workers_to_cull[cull_start_index(diff), diff]
 
       debug "Workers to cull: #{workers_to_cull.inspect}"
 
@@ -124,7 +126,7 @@ module Puma
     def cull_start_index(diff)
       case @options[:worker_culling_strategy]
       when :oldest
-        @options[:fork_worker] ? 1 : 0
+        0
       else # :youngest
         -diff
       end

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -121,7 +121,11 @@ module Puma
 
     def workers_to_cull(diff)
       workers = @workers.sort_by(&:started_at)
+
+      # In fork_worker mode, worker 0 acts as our master process.
+      # We should avoid culling it to preserve copy-on-write memory gains.
       workers.reject! { |w| w.index == 0 } if @options[:fork_worker]
+
       workers[cull_start_index(diff), diff]
     end
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -401,6 +401,25 @@ RUBY
     assert_match(/Worker 0 \(PID: \d+\) terminating/, line)
   end
 
+  def test_culling_strategy_oldest_fork_worker
+    cli_server "-w 2 test/rackup/hello.ru", config: <<RUBY
+worker_culling_strategy :oldest
+fork_worker
+RUBY
+
+    get_worker_pids # to consume server logs
+
+    Process.kill :TTIN, @pid
+
+    line = @server.gets
+    assert_match(/Worker 2 \(PID: \d+\) booted in/, line)
+
+    Process.kill :TTOU, @pid
+
+    line = @server.gets
+    assert_match(/Worker 1 \(PID: \d+\) terminating/, line)
+  end
+
   private
 
   def worker_timeout(timeout, iterations, details, config)


### PR DESCRIPTION
PR #2773 introduced `worker_culling_strategy = :oldest` which was designed to improve memory efficiency by culling "leaky" older workers first.

In `:fork_worker` mode however, this option culls worker0 (which tends to be the oldest), which seems contrary to the intention of improving memory efficiency. This will spawn an entirely new worker0 process, and the other childs (n >= 1) will not have any CoW memory share with this process.

Instead, it's better to exclude worker0 from the culling in `:fork_worker` mode.