### PR TITLE
Refactor Launcher#run to increase readability (no logic change)

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -490,7 +490,9 @@ module Puma
 
       begin
         Signal.trap "SIGTERM" do
-          graceful_stop
+          # This is a shortcut in control flow in case
+          # raise_exception_on_sigterm is true
+          do_graceful_stop
 
           raise(SignalException, "SIGTERM") if @options[:raise_exception_on_sigterm]
         end

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -490,8 +490,7 @@ module Puma
 
       begin
         Signal.trap "SIGTERM" do
-          # This is a shortcut in control flow in case
-          # raise_exception_on_sigterm is true
+          # Shortcut the control flow in case raise_exception_on_sigterm is true
           do_graceful_stop
 
           raise(SignalException, "SIGTERM") if @options[:raise_exception_on_sigterm]

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -161,16 +161,7 @@ module Puma
 
     # Run the server. This blocks until the server is stopped
     def run
-      previous_env =
-        if defined?(Bundler)
-          env = Bundler::ORIGINAL_ENV.dup
-          # add -rbundler/setup so we load from Gemfile when restarting
-          bundle = "-rbundler/setup"
-          env["RUBYOPT"] = [env["RUBYOPT"], bundle].join(" ").lstrip unless env["RUBYOPT"].to_s.include?(bundle)
-          env
-        else
-          ENV.to_h
-        end
+      previous_env = get_env
 
       @config.clamp
 
@@ -179,23 +170,11 @@ module Puma
       setup_signals
       set_process_title
       integrate_with_systemd
+
+      # This blocks until the server is stopped
       @runner.run
 
-      case @status
-      when :halt
-        log "* Stopping immediately!"
-        @runner.stop_control
-      when :run, :stop
-        graceful_stop
-      when :restart
-        log "* Restarting..."
-        ENV.replace(previous_env)
-        @runner.stop_control
-        restart!
-      when :exit
-        # nothing
-      end
-      close_binder_listeners unless @status == :restart
+      do_run_finished(previous_env)
     end
 
     # Return all tcp ports the launcher may be using, TCP or SSL
@@ -239,20 +218,46 @@ module Puma
 
     private
 
-    # If configured, write the pid of the current process out
-    # to a file.
-    def write_pid
-      path = @options[:pidfile]
-      return unless path
-      cur_pid = Process.pid
-      File.write path, cur_pid, mode: 'wb:UTF-8'
-      at_exit do
-        delete_pidfile if cur_pid == Process.pid
+    def get_env
+      if defined?(Bundler)
+        env = Bundler::ORIGINAL_ENV.dup
+        # add -rbundler/setup so we load from Gemfile when restarting
+        bundle = "-rbundler/setup"
+        env["RUBYOPT"] = [env["RUBYOPT"], bundle].join(" ").lstrip unless env["RUBYOPT"].to_s.include?(bundle)
+        env
+      else
+        ENV.to_h
       end
     end
 
-    def reload_worker_directory
-      @runner.reload_worker_directory if @runner.respond_to?(:reload_worker_directory)
+    def do_run_finished(previous_env)
+      case @status
+      when :halt
+        do_forceful_stop
+      when :run, :stop
+        do_graceful_stop
+      when :restart
+        do_restart(previous_env)
+      end
+
+      close_binder_listeners unless @status == :restart
+    end
+
+    def do_forceful_stop
+      log "* Stopping immediately!"
+      @runner.stop_control
+    end
+
+    def do_graceful_stop
+      @events.fire_on_stopped!
+      @runner.stop_blocked
+    end
+
+    def do_restart(previous_env)
+      log "* Restarting..."
+      ENV.replace(previous_env)
+      @runner.stop_control
+      restart!
     end
 
     def restart!
@@ -277,6 +282,22 @@ module Puma
         argv += [@binder.redirects_for_restart]
         Kernel.exec(*argv)
       end
+    end
+
+    # If configured, write the pid of the current process out
+    # to a file.
+    def write_pid
+      path = @options[:pidfile]
+      return unless path
+      cur_pid = Process.pid
+      File.write path, cur_pid, mode: 'wb:UTF-8'
+      at_exit do
+        delete_pidfile if cur_pid == Process.pid
+      end
+    end
+
+    def reload_worker_directory
+      @runner.reload_worker_directory if @runner.respond_to?(:reload_worker_directory)
     end
 
     # @!attribute [r] files_to_require_after_prune
@@ -376,11 +397,6 @@ module Puma
     def unsupported(str)
       @events.error(str)
       raise UnsupportedOption
-    end
-
-    def graceful_stop
-      @events.fire_on_stopped!
-      @runner.stop_blocked
     end
 
     def set_process_title


### PR DESCRIPTION
This PR refactors Launcher#run to increase code readability. It does **not** change any logic or ordering of operations.

Reason: When reading the code of Launcher, initially it wasn't obvious to me how the `@status` variable was used. This makes the control flow much more obvious.

Things to watch out for:
- I added methods `do_run_finished`, `do_graceful_stop`, etc. I'm happy to name these methods something other than `do_xxx`
- I've removed the `# do nothing` condition for `@status == :exit`. Not only is there no need to have a `# do nothing` condition for it, it doesn't appear `@status = :exit` is actually set anywhere in Puma.
