### PR TITLE
Log environment using option value

### DIFF
--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -94,12 +94,13 @@ module Puma
     def output_header(mode)
       min_t = @options[:min_threads]
       max_t = @options[:max_threads]
+      environment = @options[:environment]
 
       log "Puma starting in #{mode} mode..."
       log "* Puma version: #{Puma::Const::PUMA_VERSION} (#{ruby_engine}) (\"#{Puma::Const::CODE_NAME}\")"
       log "*  Min threads: #{min_t}"
       log "*  Max threads: #{max_t}"
-      log "*  Environment: #{ENV['RACK_ENV']}"
+      log "*  Environment: #{environment}"
 
       if mode == "cluster"
         log "*   Master PID: #{Process.pid}"


### PR DESCRIPTION
### Description

It's possible for the configured environment to be something other than `RACK_ENV`, e.g. `APP_ENV` or `RAILS_ENV`, but the runner will always log the value of `RACK_ENV`.

This changes the log output to show the configured environment value.

See https://github.com/puma/puma/blob/v5.5.2/lib/puma/configuration.rb#L203
