### PR TITLE
Updates for OpenSSL 3

### DIFF
--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -33,11 +33,14 @@ unless ENV["DISABLE_SSL"]
     have_func  "SSL_CTX_set_min_proto_version(NULL, 0)", "openssl/ssl.h"
 
     have_func  "X509_STORE_up_ref"
-    have_func("SSL_CTX_set_ecdh_auto(NULL, 0)", "openssl/ssl.h")
+    have_func "SSL_CTX_set_ecdh_auto(NULL, 0)"         , "openssl/ssl.h"
+
+    # below are yes for 3.0.0 & later, use for OpenSSL 3 detection
+    have_func "SSL_get1_peer_certificate"              , "openssl/ssl.h"
 
     # Random.bytes available in Ruby 2.5 and later, Random::DEFAULT deprecated in 3.0
     if Random.respond_to?(:bytes)
-      $defs.push("-DHAVE_RANDOM_BYTES")
+      $defs.push "-DHAVE_RANDOM_BYTES"
       puts "checking for Random.bytes... yes"
     else
       puts "checking for Random.bytes... no"

--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -49,6 +49,7 @@ const rb_data_type_t engine_data_type = {
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
+#ifndef HAVE_SSL_GET1_PEER_CERTIFICATE
 DH *get_dh2048() {
   /* `openssl dhparam -C 2048`
    * -----BEGIN DH PARAMETERS-----
@@ -119,6 +120,7 @@ DH *get_dh2048() {
 
   return dh;
 }
+#endif
 
 static void
 sslctx_free(void *ptr) {
@@ -209,7 +211,9 @@ sslctx_initialize(VALUE self, VALUE mini_ssl_ctx) {
   int ssl_options;
   VALUE key, cert, ca, verify_mode, ssl_cipher_filter, no_tlsv1, no_tlsv1_1,
     verification_flags, session_id_bytes, cert_pem, key_pem;
+#ifndef HAVE_SSL_GET1_PEER_CERTIFICATE
   DH *dh;
+#endif
   BIO *bio;
   X509 *x509;
   EVP_PKEY *pkey;
@@ -317,9 +321,6 @@ sslctx_initialize(VALUE self, VALUE mini_ssl_ctx) {
     SSL_CTX_set_cipher_list(ctx, "HIGH:!aNULL@STRENGTH");
   }
 
-  dh = get_dh2048();
-  SSL_CTX_set_tmp_dh(ctx, dh);
-
 #if OPENSSL_VERSION_NUMBER < 0x10002000L
   // Remove this case if OpenSSL 1.0.1 (now EOL) support is no
   // longer needed.
@@ -353,6 +354,15 @@ sslctx_initialize(VALUE self, VALUE mini_ssl_ctx) {
                                  SSL_MAX_SSL_SESSION_ID_LENGTH);
 
   // printf("\ninitialize end security_level %d\n", SSL_CTX_get_security_level(ctx));
+
+#ifdef HAVE_SSL_GET1_PEER_CERTIFICATE
+  // https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_dh_auto.html
+  SSL_CTX_set_dh_auto(ctx, 1);
+#else
+  dh = get_dh2048();
+  SSL_CTX_set_tmp_dh(ctx, dh);
+#endif
+
   rb_obj_freeze(self);
   return self;
 }
@@ -551,7 +561,11 @@ VALUE engine_peercert(VALUE self) {
 
   TypedData_Get_Struct(self, ms_conn, &engine_data_type, conn);
 
+#ifdef HAVE_SSL_GET1_PEER_CERTIFICATE
+  cert = SSL_get1_peer_certificate(conn->ssl);
+#else
   cert = SSL_get_peer_certificate(conn->ssl);
+#endif
   if(!cert) {
     /*
      * See if there was a failed certificate associated with this client.


### PR DESCRIPTION
### Description

This makes a change for OpenSSL 3 which is recommended by OpenSSL, and also removes the deprecation warnings when compiled with OpenSSL 3.

I've only tested Puma with OpenSSL 3 on Windows, if anyone can test on other platforms, that would be appreciated.  Make sure to use a Ruby that is also compiled with OpenSSL 3.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
