### PR TITLE
[CI] Update actions, fix intermittent test error

### DIFF
--- a/.github/workflows/mri.yml
+++ b/.github/workflows/mri.yml
@@ -44,14 +44,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: load ruby
-        uses: MSP-Greg/setup-ruby-pkgs@win-ucrt-2
+        uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           apt-get: ragel
           brew: ragel
           mingw: openssl ragel
           bundler-cache: true
-          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/win-ucrt-1
+          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/gem-update
         timeout-minutes: 10
 
       # Windows error thrown, doesn't affect CI

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -89,7 +89,7 @@ class TestIntegrationPumactl < TestIntegration
 
     _, status = Process.wait2(@pid)
     assert_equal 0, status
-    assert_operator Time.now - start, :<, (DARWIN ? 8 : 5)
+    assert_operator Time.now - start, :<, (DARWIN ? 8 : 6)
     @server = nil
   end
 


### PR DESCRIPTION
### Description

Currently CI is running on a 'special' branch of MSP-Greg/setup-ruby-pkgs.  It and ruby/setup-ruby have been updated to work with Ruby 3.1 and the new windows-2022 image.  Revert to the normal branches.

Fixes an intermittent error in `test/test_integration_pumactl.rb`

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
