### PR TITLE
Adds a --silent option to the CLI

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -185,7 +185,7 @@ module Puma
             user_config.restart_command cmd
           end
 
-          o.on "-s", "--silent", "Do not log prompt messages other than errors" do |arg|
+          o.on "-s", "--silent", "Do not log prompt messages other than errors" do
             @events = Events.new NullIO.new, $stderr
           end
 

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -185,8 +185,8 @@ module Puma
             user_config.restart_command cmd
           end
 
-          o.on "-s", "--silent", "Do not log prompt messages" do |arg|
-            @events = Events.null
+          o.on "-s", "--silent", "Do not log prompt messages other than errors" do |arg|
+            @events = Events.new NullIO.new, $stderr
           end
 
           o.on "-S", "--state PATH", "Where to store the state details" do |arg|

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -185,6 +185,10 @@ module Puma
             user_config.restart_command cmd
           end
 
+          o.on "-s", "--silent", "Do not log prompt messages" do |arg|
+            @events = Events.null
+          end
+
           o.on "-S", "--state PATH", "Where to store the state details" do |arg|
             user_config.state_path arg
           end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -480,6 +480,10 @@ class TestCLI < Minitest::Test
     cli = Puma::CLI.new ['--silent']
     cli.send(:setup_options)
 
-    assert_equal cli.instance_variable_get(:@events).class, Puma::Events.null.class
+    events = cli.instance_variable_get(:@events)
+
+    assert_equal events.class, Puma::Events.null.class
+    assert_equal events.stdout.class, Puma::NullIO
+    assert_equal events.stderr, $stderr
   end
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -475,4 +475,11 @@ class TestCLI < Minitest::Test
   ensure
     ENV.delete 'RAILS_ENV'
   end
+
+  def test_silent
+    cli = Puma::CLI.new ['--silent']
+    cli.send(:setup_options)
+
+    assert_equal cli.instance_variable_get(:@events).class, Puma::Events.null.class
+  end
 end


### PR DESCRIPTION
### Description

This PR adds a `-s`, `--silent` option which deactivate Puma messages displayed on the prompt.

Without the option:

```sh
$ bundle exec bin/puma test/rackup/hello.ru
Puma starting in single mode...
* Puma version: 5.5.2 (ruby 2.6.6-p146) ("Zawgyi")
*  Min threads: 0
*  Max threads: 5
*  Environment: development
*          PID: 88245
* Listening on http://0.0.0.0:9292
Use Ctrl-C to stop
^C- Gracefully stopping, waiting for requests to finish
=== puma shutdown: 2022-01-18 16:38:07 +0100 ===
- Goodbye!
```

With the option:

```sh
$ bundle exec bin/puma --silent test/rackup/hello.ru
^C%
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
