### PR TITLE
Fix two 'old-style-definition' compile warning

### DIFF
--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -50,7 +50,7 @@ const rb_data_type_t engine_data_type = {
 };
 
 #ifndef HAVE_SSL_GET1_PEER_CERTIFICATE
-DH *get_dh2048() {
+DH *get_dh2048(void) {
   /* `openssl dhparam -C 2048`
    * -----BEGIN DH PARAMETERS-----
    * MIIBCAKCAQEAjmh1uQHdTfxOyxEbKAV30fUfzqMDF/ChPzjfyzl2jcrqQMhrk76o

--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -451,7 +451,7 @@ VALUE HttpParser_body(VALUE self) {
 void Init_mini_ssl(VALUE mod);
 #endif
 
-void Init_puma_http11()
+void Init_puma_http11(void)
 {
 
   VALUE mPuma = rb_define_module("Puma");


### PR DESCRIPTION
### Description

Fix compile warnings in `ext/puma_http11/mini_ssl.c` and `ext/puma_http11/puma_http11.c`.

Closes #2806

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.