### PR TITLE
Fix `Puma::StateFile#load` incompatibility

### DIFF
--- a/lib/puma/state_file.rb
+++ b/lib/puma/state_file.rb
@@ -50,6 +50,7 @@ module Puma
         v = v.strip
         @options[k] =
           case v
+          when ''              then nil
           when /\A\d+\z/       then v.to_i
           when /\A\d+\.\d+\z/  then v.to_f
           else                      v.gsub(/\A"|"\z/, '')

--- a/test/test_state_file.rb
+++ b/test/test_state_file.rb
@@ -1,0 +1,26 @@
+require_relative "helper"
+require_relative "helpers/tmp_path"
+
+require 'puma/state_file'
+
+class TestStateFile < Minitest::Test
+  include TmpPath
+
+  def test_load_empty_value_as_nil
+    state_path = tmp_path('.state')
+    File.write state_path, <<-STATE
+---
+pid: 123456
+control_url:
+control_auth_token:
+running_from: "/path/to/app"
+    STATE
+
+    sf = Puma::StateFile.new
+    sf.load(state_path)
+    assert_equal 123456, sf.pid
+    assert_equal nil, sf.control_url
+    assert_equal nil, sf.control_auth_token
+    assert_equal '/path/to/app', sf.running_from
+  end
+end

--- a/test/test_state_file.rb
+++ b/test/test_state_file.rb
@@ -19,8 +19,9 @@ running_from: "/path/to/app"
     sf = Puma::StateFile.new
     sf.load(state_path)
     assert_equal 123456, sf.pid
-    assert_equal nil, sf.control_url
-    assert_equal nil, sf.control_auth_token
     assert_equal '/path/to/app', sf.running_from
+    assert_nil, sf.control_url
+    assert_nil, sf.control_auth_token
+
   end
 end

--- a/test/test_state_file.rb
+++ b/test/test_state_file.rb
@@ -20,8 +20,8 @@ running_from: "/path/to/app"
     sf.load(state_path)
     assert_equal 123456, sf.pid
     assert_equal '/path/to/app', sf.running_from
-    assert_nil, sf.control_url
-    assert_nil, sf.control_auth_token
+    assert_nil sf.control_url
+    assert_nil sf.control_auth_token
 
   end
 end


### PR DESCRIPTION
### Description
Until 5.5.2, empty values were read as `nil`.
Since 5.6.0, empty values are read as `""`.
This PR fixes the incompatibility.

This incompatibility affects [here](https://github.com/puma/puma/blob/e0753de846a1651401343687a22bfd52c97bc72a/lib/puma/control_cli.rb#L271-L272) for example.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
