### PR TITLE
Use the bundler shipped with ruby for non-MRI

### DIFF
--- a/.github/workflows/non_mri.yml
+++ b/.github/workflows/non_mri.yml
@@ -45,6 +45,9 @@ jobs:
           apt-get: ragel
           brew: ragel
           mingw: _upgrade_ openssl ragel
+          # Use the bundler shipped with that ruby,
+          # temporary workaround for https://github.com/oracle/truffleruby/issues/2586
+          bundler: none
           bundler-cache: true
         timeout-minutes: 10
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -349,6 +349,11 @@ EOF
     @server = Puma::Server.new @app, @events, {:force_shutdown_after => 2}
 
     server_run do
+      if TestSkips::TRUFFLE
+        # SystemStackError is too brittle, use something more reliable
+        raise Exception, "error"
+      end
+
       require 'json'
 
       # will raise fatal: machine stack overflow in critical region


### PR DESCRIPTION
* Should workaround https://github.com/oracle/truffleruby/issues/2586