### PR TITLE
Do not remove pre-existing socket after USR2+TERM (#2816)

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -189,7 +189,7 @@ module Puma
           end
 
           if fd = @inherited_fds.delete(str)
-            @unix_paths << path unless abstract
+            @unix_paths << path unless abstract || File.exist?(path)
             io = inherit_unix_listener path, fd
             log_writer.log "* Inherited #{str}"
           elsif sock = @activated_sockets.delete([ :unix, path ]) ||

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -43,6 +43,26 @@ class TestIntegrationCluster < TestIntegration
     end
   end
 
+  def test_pre_existing_unix_stop_after_restart
+    skip_unless :unix
+
+    File.open(@bind_path, mode: 'wb') { |f| f.puts 'pre existing' }
+
+    cli_server "-w #{workers} -q test/rackup/sleep_step.ru", unix: :unix
+    connection = connect(nil, unix: true)
+    restart_server connection
+
+    connect(nil, unix: true)
+    stop_server
+
+    assert File.exist?(@bind_path)
+
+  ensure
+    if UNIX_SKT_EXIST
+      File.unlink @bind_path if File.exist? @bind_path
+    end
+  end
+
   def test_siginfo_thread_print
     skip_unless_signal_exist? :INFO
 


### PR DESCRIPTION
Closes #2816 
Please review. This change fixes the issue but there are some concerns.

### Description
So, the issue was that when reloading the server, the socket was inherited, and it was added to the list of unix sockets, to be removed later (unlike on startup, when pre-existing sockets are excluded from that list).

The problem is that, as it seems to me, for inherited socket there is no way to tell if it was pre-existing or not. Hence the inadvertent result of my fix is that even not pre-existing socket will be preserved. Now, this may be acceptable. As you can see in the table in #2816, in single mode socket file is always preserved.

Another option: I may be mistaken, but from the subsequent code it seems possible to detect if the socket is activated, so it may be possible to prevent activated sockets from being removed (but as I understand, activated does not mean the same as pre-existing). (Sorry, I do not know a lot about Unix sockets etc, just trying to figure out the logic.)

Thank you.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
