### PR TITLE
test_binder.rb - split out test causing issues when run parallel

### DIFF
--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -31,7 +31,7 @@ class TestBinderBase < Minitest::Test
   end
 end
 
-class TestBinder < TestBinderBase
+class TestBinderParallel < TestBinderBase
   parallelize_me!
 
   def test_synthesize_binds_from_activated_fds_no_sockets
@@ -275,24 +275,6 @@ class TestBinder < TestBinderBase
     assert_equal @log_writer.stderr, env_hash["rack.errors"]
   end
 
-  def test_ssl_binder_sets_backlog
-    skip_unless :ssl
-
-    host = '127.0.0.1'
-    port = UniquePort.call
-    tcp_server = TCPServer.new(host, port)
-    tcp_server.define_singleton_method(:listen) do |backlog|
-      Thread.current[:backlog] = backlog
-      super(backlog)
-    end
-
-    TCPServer.stub(:new, tcp_server) do
-      @binder.parse ["ssl://#{host}:#{port}?#{ssl_query}&backlog=2048"], @log_writer
-    end
-
-    assert_equal 2048, Thread.current[:backlog]
-  end
-
   def test_close_calls_close_on_ios
     @mocked_ios = [Minitest::Mock.new, Minitest::Mock.new]
     @mocked_ios.each { |m| m.expect(:close, true) }
@@ -469,6 +451,26 @@ class TestBinder < TestBinderBase
     end
   ensure
     @binder.close_listeners if order.include?(:unix) && UNIX_SKT_EXIST
+  end
+end
+
+class TestBinderSinigle < TestBinderBase
+  def test_ssl_binder_sets_backlog
+    skip_unless :ssl
+
+    host = '127.0.0.1'
+    port = UniquePort.call
+    tcp_server = TCPServer.new(host, port)
+    tcp_server.define_singleton_method(:listen) do |backlog|
+      Thread.current[:backlog] = backlog
+      super(backlog)
+    end
+
+    TCPServer.stub(:new, tcp_server) do
+      @binder.parse ["ssl://#{host}:#{port}?#{ssl_query}&backlog=2048"], @log_writer
+    end
+
+    assert_equal 2048, Thread.current[:backlog]
   end
 end
 


### PR DESCRIPTION
### Description

Previous to the PR, `TestBinder#test_ssl_binder_sets_backlog` could cause intermittent failures in itself and other tests.  `TestBinder` is run parallel.

Split `TestBinder` into `TestBinderParallel` and `TestBinderSingle`, and move the test to Single.

The test was stubbing a method, and that can cause issues with parallel testing.  Note that the issue is more common on systems with a high number of cores, and the CI systems are VM's with two cores.

Closes #2825.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.