### PR TITLE
User supplied host overrides config file's port

### DIFF
--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -106,6 +106,31 @@ class TestUserSuppliedOptionsHostIsSet < Minitest::Test
   end
 end
 
+class TestUserSuppliedOptionsHostDontOverridePort < Minitest::Test
+  def setup
+    @options = {}
+    @options[:user_supplied_options] = [:Host]
+  end
+
+  def test_port_from_config_wins_over_default
+    file_port = 6001
+
+    Dir.mktmpdir do |d|
+      Dir.chdir(d) do
+        FileUtils.mkdir("config")
+        File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
+
+        @options[:Host] = '127.0.0.1'
+        conf = Rack::Handler::Puma.config(->{}, @options)
+        conf.load
+
+        assert_equal ["tcp://127.0.0.1:#{file_port}"], conf.options[:binds]
+      end
+    end
+  end
+end
+
+
 class TestUserSuppliedOptionsIsEmpty < Minitest::Test
   def setup
     @options = {}


### PR DESCRIPTION
### Description
I'm starting a WIP PR to discuss some apparently weird behavior. When a user supplies a host but no port, the port specified in puma's config file is ignored.

I added a failing test to show the issue. I wonder if that's the desired behavior, as the [responsible code](https://github.com/puma/puma/blob/2d5582a60bd9e896652dfeb1a0b8ad4a598aec72/lib/rack/handler/puma.rb#L100-L102) looks pretty intentional.

To reproduce it on Rails:
- Change the default port on `config/puma.rb` to `2000`.
- Run `bin/rails server --binding 127.0.0.1`
- The server will listen to `http://127.0.0.1:3000` instead of `http://127.0.0.1:2000`

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
