### PR TITLE
Fix build with Opaque DH in LibreSSL 3.5.

### DIFF
--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -92,13 +92,13 @@ DH *get_dh2048(void) {
   static unsigned char dh2048_g[] = { 0x02 };
 
   DH *dh;
-#if !(OPENSSL_VERSION_NUMBER < 0x10100005L || defined(LIBRESSL_VERSION_NUMBER))
+#if !(OPENSSL_VERSION_NUMBER < 0x10100005L)
   BIGNUM *p, *g;
 #endif
 
   dh = DH_new();
 
-#if OPENSSL_VERSION_NUMBER < 0x10100005L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100005L
   dh->p = BN_bin2bn(dh2048_p, sizeof(dh2048_p), NULL);
   dh->g = BN_bin2bn(dh2048_g, sizeof(dh2048_g), NULL);
 


### PR DESCRIPTION
patch by Theo Buehler <tb@openbsd.org>

Signed-off-by: Aisha Tammy <floss@bsd.ac>

### Description
Patch currently used in OpenBSD - https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/www/ruby-puma/patches/

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
