### PR TITLE
Re-fix my mistaken typo [changelog skip]

### DIFF
--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -41,8 +41,8 @@ static VALUE global_request_path;
 
 /** Defines common length and error messages for input length validation. */
 #define QUOTE(s) #s
-#define EXPLAIN_MAX_LENGTH_VALUE(s) QUOTE(s)
-#define DEF_MAX_LENGTH(N,length) const size_t MAX_##N##_LENGTH = length; const char *MAX_##N##_LENGTH_ERR = "HTTP element " # N  " is longer than the " EXPLAIN_MAX_LENGTH_VALUE(length) " allowed length (was %d)"
+#define EXPAND_MAX_LENGTH_VALUE(s) QUOTE(s)
+#define DEF_MAX_LENGTH(N,length) const size_t MAX_##N##_LENGTH = length; const char *MAX_##N##_LENGTH_ERR = "HTTP element " # N  " is longer than the " EXPAND_MAX_LENGTH_VALUE(length) " allowed length (was %d)"
 
 /** Validates the max length of given input and throws an HttpParserError exception if over. */
 #define VALIDATE_MAX_LENGTH(len, N) if(len > MAX_##N##_LENGTH) { rb_raise(eHttpParserError, MAX_##N##_LENGTH_ERR, len); }


### PR DESCRIPTION
Fix a mis-understanding in a name.


### Description

When I made a small PR to fix a typo, I myself had misunderstood the word used. dentarg, eagle-eye, saw through these typos & mistypes. https://github.com/puma/puma/pull/2502#issuecomment-1065474880

This changes the name of the locally-used `define` to be correctly spelled, and meaning the original thing.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
