### PR TITLE
Fail hard if SSL certs or keys cannot be read by user

### DIFF
--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -214,6 +214,11 @@ module Puma
         @cert_pem = nil
       end
 
+      def check_file(file, desc)
+        raise ArgumentError, "#{desc} file '#{file}' does not exist" unless File.exist? file
+        raise ArgumentError, "#{desc} file '#{file}' is not readable" unless File.readable? file
+      end
+
       if IS_JRUBY
         # jruby-specific Context properties: java uses a keystore and password pair rather than a cert/key pair
         attr_reader :keystore
@@ -221,7 +226,7 @@ module Puma
         attr_accessor :ssl_cipher_list
 
         def keystore=(keystore)
-          raise ArgumentError, "No such keystore file '#{keystore}'" unless File.exist? keystore
+          check_file keystore, 'Keystore'
           @keystore = keystore
         end
 
@@ -240,23 +245,17 @@ module Puma
         attr_accessor :verification_flags
 
         def key=(key)
-          raise ArgumentError, "No such key file '#{key}'" unless File.exist? key
-          raise ArgumentError, "Key file '#{key}' is not readable" unless File.readable? key
-
+          check_file key, 'Key'
           @key = key
         end
 
         def cert=(cert)
-          raise ArgumentError, "No such cert file '#{cert}'" unless File.exist? cert
-          raise ArgumentError, "Cert file '#{key}' is not readable" unless File.readable? cert
-
+          check_file cert, 'Cert'
           @cert = cert
         end
 
         def ca=(ca)
-          raise ArgumentError, "No such ca file '#{ca}'" unless File.exist? ca
-          raise ArgumentError, "ca file '#{ca}' is not readable" unless File.readable? ca
-
+          check_file ca, 'ca'
           @ca = ca
         end
 

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -241,16 +241,22 @@ module Puma
 
         def key=(key)
           raise ArgumentError, "No such key file '#{key}'" unless File.exist? key
+          raise ArgumentError, "Key file '#{key}' is not readable" unless File.readable? key
+
           @key = key
         end
 
         def cert=(cert)
           raise ArgumentError, "No such cert file '#{cert}'" unless File.exist? cert
+          raise ArgumentError, "Cert file '#{key}' is not readable" unless File.readable? cert
+
           @cert = cert
         end
 
         def ca=(ca)
           raise ArgumentError, "No such ca file '#{ca}'" unless File.exist? ca
+          raise ArgumentError, "ca file '#{ca}' is not readable" unless File.readable? ca
+
           @ca = ca
         end
 

--- a/test/test_minissl.rb
+++ b/test/test_minissl.rb
@@ -9,14 +9,25 @@ class TestMiniSSL < Minitest::Test
       ctx = Puma::MiniSSL::Context.new
 
       exception = assert_raises(ArgumentError) { ctx.keystore = "/no/such/keystore" }
-      assert_equal("No such keystore file '/no/such/keystore'", exception.message)
+      assert_equal("Keystore file '/no/such/keystore' does not exist", exception.message)
+    end
+
+    def test_raises_with_unreadable_keystore_file
+      ctx = Puma::MiniSSL::Context.new
+
+      File.stub(:exist?, true) do
+        File.stub(:readable?, false) do
+          exception = assert_raises(ArgumentError) { ctx.keystore = "/unreadable/keystore" }
+          assert_equal("Keystore file '/unreadable/keystore' is not readable", exception.message)
+        end
+      end
     end
   else
     def test_raises_with_invalid_key_file
       ctx = Puma::MiniSSL::Context.new
 
       exception = assert_raises(ArgumentError) { ctx.key = "/no/such/key" }
-      assert_equal("No such key file '/no/such/key'", exception.message)
+      assert_equal("Key file '/no/such/key' does not exist", exception.message)
     end
 
     def test_raises_with_unreadable_key_file
@@ -34,7 +45,7 @@ class TestMiniSSL < Minitest::Test
       ctx = Puma::MiniSSL::Context.new
 
       exception = assert_raises(ArgumentError) { ctx.cert = "/no/such/cert" }
-      assert_equal("No such cert file '/no/such/cert'", exception.message)
+      assert_equal("Cert file '/no/such/cert' does not exist", exception.message)
     end
 
     def test_raises_with_unreadable_cert_file

--- a/test/test_minissl.rb
+++ b/test/test_minissl.rb
@@ -19,6 +19,17 @@ class TestMiniSSL < Minitest::Test
       assert_equal("No such key file '/no/such/key'", exception.message)
     end
 
+    def test_raises_with_unreadable_key_file
+      ctx = Puma::MiniSSL::Context.new
+
+      File.stub(:exist?, true) do
+        File.stub(:readable?, false) do
+          exception = assert_raises(ArgumentError) { ctx.key = "/unreadable/key" }
+          assert_equal("Key file '/unreadable/key' is not readable", exception.message)
+        end
+      end
+    end
+
     def test_raises_with_invalid_cert_file
       ctx = Puma::MiniSSL::Context.new
 
@@ -26,11 +37,33 @@ class TestMiniSSL < Minitest::Test
       assert_equal("No such cert file '/no/such/cert'", exception.message)
     end
 
+    def test_raises_with_unreadable_cert_file
+      ctx = Puma::MiniSSL::Context.new
+
+      File.stub(:exist?, true) do
+        File.stub(:readable?, false) do
+          exception = assert_raises(ArgumentError) { ctx.key = "/unreadable/cert" }
+          assert_equal("Key file '/unreadable/cert' is not readable", exception.message)
+        end
+      end
+    end
+
     def test_raises_with_invalid_key_pem
       ctx = Puma::MiniSSL::Context.new
 
       exception = assert_raises(ArgumentError) { ctx.key_pem = nil }
       assert_equal("'key_pem' is not a String", exception.message)
+    end
+
+    def test_raises_with_unreadable_ca_file
+      ctx = Puma::MiniSSL::Context.new
+
+      File.stub(:exist?, true) do
+        File.stub(:readable?, false) do
+          exception = assert_raises(ArgumentError) { ctx.ca = "/unreadable/cert" }
+          assert_equal("ca file '/unreadable/cert' is not readable", exception.message)
+        end
+      end
     end
 
     def test_raises_with_invalid_cert_pem


### PR DESCRIPTION
### Description

Previously if an SSL cert or key could not be read, Puma would bind to
the configured SSL port but not accept any connections. The only
indication that something went awry is an obscure log message:

```
 #<Puma::MiniSSL::SSLError: OpenSSL error: error:1417A0C1:SSL routines:tls_post_process_client_hello:no shared cipher - 193>
```

We now fail hard with an exception if this happens to make it clear
that the permissions need to be fixed.

Relates to https://github.com/puma/puma/issues/1339

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
