### PR TITLE
Fail hard if SSL certs or keys are invalid

### DIFF
--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -231,6 +231,46 @@ class TestPumaServerSSL < Minitest::Test
 
     assert busy_threads.zero?, "Our connection is wasn't dropped"
   end
+
+  unless Puma.jruby?
+    def test_invalid_cert
+      assert_raises(Puma::MiniSSL::SSLError) do
+        start_server { |ctx| ctx.cert = __FILE__ }
+      end
+    end
+
+    def test_invalid_key
+      assert_raises(Puma::MiniSSL::SSLError) do
+        start_server { |ctx| ctx.key = __FILE__ }
+      end
+    end
+
+    def test_invalid_cert_pem
+      assert_raises(Puma::MiniSSL::SSLError) do
+        start_server { |ctx|
+          ctx.instance_variable_set(:@cert, nil)
+          ctx.cert_pem = 'Not a valid pem'
+        }
+      end
+    end
+
+    def test_invalid_key_pem
+      assert_raises(Puma::MiniSSL::SSLError) do
+        start_server { |ctx|
+          ctx.instance_variable_set(:@key, nil)
+          ctx.key_pem = 'Not a valid pem'
+        }
+      end
+    end
+
+    def test_invalid_ca
+      assert_raises(Puma::MiniSSL::SSLError) do
+        start_server { |ctx|
+          ctx.ca = __FILE__
+        }
+      end
+    end
+  end
 end if ::Puma::HAS_SSL
 
 # client-side TLS authentication tests


### PR DESCRIPTION
### Description

Previously if an invalid SSL cert or key (e.g. blank file, mismatching
private and public key, etc.) were specified, Puma would quietly
accept them, bind to the port, and mysteriously fail with an error
only after a client initiates a connection:

```
SSL error, peer: ::1, peer cert: : #<Puma::MiniSSL::SSLError: OpenSSL error: error:1417A0C1:SSL routines:tls_post_process_client_hello:no shared cipher - 193>
```

We now check the OpenSSL return values and raise an exception if the
cert or key cannot be loaded. For example:

```
puma/lib/puma/minissl.rb:330:in `initialize': SSL_CTX_use_certificate_chain_file: error in file '/tmp/cert.txt': error:0909006C:PEM routines:get_name:no start line (Puma::MiniSSL::SSLError)
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
