### PR TITLE
Escape SSL cert and filenames

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'puma/const'
+require 'puma/util'
 
 module Puma
   # The methods that are available for use inside the configuration file.
@@ -46,7 +47,7 @@ module Puma
         else ''
         end
 
-      ca_additions = "&ca=#{opts[:ca]}" if ['peer', 'force_peer'].include?(verify)
+      ca_additions = "&ca=#{Puma::Util.escape(opts[:ca])}" if ['peer', 'force_peer'].include?(verify)
 
       backlog_str = opts[:backlog] ? "&backlog=#{Integer(opts[:backlog])}" : ''
 
@@ -65,7 +66,10 @@ module Puma
         v_flags = (ary = opts[:verification_flags]) ?
           "&verification_flags=#{Array(ary).join ','}" : nil
 
-        "ssl://#{host}:#{port}?cert=#{opts[:cert]}&key=#{opts[:key]}" \
+        cert_flags = (cert = opts[:cert]) ? "cert=#{Puma::Util.escape(opts[:cert])}" : nil
+        key_flags = (cert = opts[:key]) ? "&key=#{Puma::Util.escape(opts[:key])}" : nil
+
+        "ssl://#{host}:#{port}?#{cert_flags}#{key_flags}" \
           "#{ssl_cipher_filter}&verify_mode=#{verify}#{tls_str}#{ca_additions}#{v_flags}#{backlog_str}"
       end
     end

--- a/lib/puma/util.rb
+++ b/lib/puma/util.rb
@@ -17,18 +17,27 @@ module Puma
       Thread.current.purge_interrupt_queue if Thread.current.respond_to? :purge_interrupt_queue
     end
 
-    # Unescapes a URI escaped string with +encoding+. +encoding+ will be the
-    # target encoding of the string returned, and it defaults to UTF-8
+    # Escapes and unescapes a URI escaped string with
+    # +encoding+. +encoding+ will be the target encoding of the string
+    # returned, and it defaults to UTF-8
     if defined?(::Encoding)
+      def escape(s, encoding = Encoding::UTF_8)
+        URI.encode_www_form_component(s, encoding)
+      end
+
       def unescape(s, encoding = Encoding::UTF_8)
         URI.decode_www_form_component(s, encoding)
       end
     else
+      def escape(s, encoding = nil)
+        URI.encode_www_form_component(s, encoding)
+      end
+
       def unescape(s, encoding = nil)
         URI.decode_www_form_component(s, encoding)
       end
     end
-    module_function :unescape
+    module_function :unescape, :escape
 
     # @version 5.0.0
     def nakayoshi_gc(log_writer)

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -70,7 +70,7 @@ class TestConfigFile < TestConfigFileBase
     bind_configuration = conf.options.file_options[:binds].first
     app = conf.app
 
-    ssl_binding = "ssl://0.0.0.0:9292?cert=&key=&verify_mode=none"
+    ssl_binding = "ssl://0.0.0.0:9292?&verify_mode=none"
     assert_equal [ssl_binding], conf.options[:binds]
   end
 
@@ -88,7 +88,26 @@ class TestConfigFile < TestConfigFileBase
 
     conf.load
 
-    ssl_binding = "ssl://0.0.0.0:9292?cert=/path/to/cert&key=/path/to/key&verify_mode=the_verify_mode"
+    ssl_binding = "ssl://0.0.0.0:9292?cert=%2Fpath%2Fto%2Fcert&key=%2Fpath%2Fto%2Fkey&verify_mode=the_verify_mode"
+    assert_equal [ssl_binding], conf.options[:binds]
+  end
+
+  def test_ssl_bind_with_escaped_filenames
+    skip_if :jruby
+    skip_unless :ssl
+
+    conf = Puma::Configuration.new do |c|
+      c.ssl_bind "0.0.0.0", "9292", {
+        cert: "/path/to/cert+1",
+        ca: "/path/to/ca+1",
+        key: "/path/to/key+1",
+        verify_mode: :peer
+      }
+    end
+
+    conf.load
+
+    ssl_binding = "ssl://0.0.0.0:9292?cert=%2Fpath%2Fto%2Fcert%2B1&key=%2Fpath%2Fto%2Fkey%2B1&verify_mode=peer&ca=%2Fpath%2Fto%2Fca%2B1"
     assert_equal [ssl_binding], conf.options[:binds]
   end
 
@@ -110,7 +129,7 @@ class TestConfigFile < TestConfigFileBase
 
     conf.load
 
-    ssl_binding = "ssl://0.0.0.0:9292?cert=store:0&key=store:1&verify_mode=the_verify_mode"
+    ssl_binding = "ssl://0.0.0.0:9292?cert=store%3A0&key=store%3A1&verify_mode=the_verify_mode"
     assert_equal [ssl_binding], conf.options[:binds]
   end
 
@@ -167,7 +186,7 @@ class TestConfigFile < TestConfigFileBase
 
     conf.load
 
-    ssl_binding = "ssl://0.0.0.0:9292?cert=/path/to/cert&key=/path/to/key&verify_mode=the_verify_mode&no_tlsv1_1=true"
+    ssl_binding = "ssl://0.0.0.0:9292?cert=%2Fpath%2Fto%2Fcert&key=%2Fpath%2Fto%2Fkey&verify_mode=the_verify_mode&no_tlsv1_1=true"
     assert_equal [ssl_binding], conf.options[:binds]
   end
 
@@ -222,8 +241,8 @@ class TestConfigFile < TestConfigFileBase
     conf.load
 
     ssl_binding = conf.options[:binds].first
-    assert_match "ca=/path/to/ca", ssl_binding
-    assert_match "verify_mode=peer", ssl_binding
+    assert_includes ssl_binding, Puma::Util.escape("/path/to/ca")
+    assert_includes ssl_binding, "verify_mode=peer"
   end
 
   def test_lowlevel_error_handler_DSL


### PR DESCRIPTION
### Description

Filenames with `+` would fail to load because it would be
misinterpreted as a space. Since Puma already unescapes the query
string, we should escape the value to fix this.

We also make `cert` and `key` conditional in the query string because
that gives a clearer error message:

```
ERROR: Please specify the SSL key via 'key=' or 'key_pem='
```

Rather than:

```
puma/lib/puma/minissl.rb:218:in `check_file': Key file '' does not exist (ArgumentError)
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
