### PR TITLE
Autoload BundlePruner, fix CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rdoc"
 gem "rake-compiler", "~> 1.1.1"
 
 gem "json", "~> 2.3"

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -7,7 +7,6 @@ require 'puma/cluster'
 require 'puma/single'
 require 'puma/const'
 require 'puma/binder'
-require 'puma/launcher/bundle_pruner'
 
 module Puma
   # Puma::Launcher is the single entry point for starting a Puma server based on user
@@ -17,6 +16,8 @@ module Puma
   # It is responsible for either launching a cluster of Puma workers or a single
   # puma server.
   class Launcher
+    autoload :BundlePruner, 'puma/launcher/bundle_pruner'
+
     # @deprecated 6.0.0
     KEYS_NOT_TO_PERSIST_IN_STATE = [
        :logger, :lowlevel_error_handler,

--- a/test/config/prune_bundler_with_deps.rb
+++ b/test/config/prune_bundler_with_deps.rb
@@ -1,5 +1,5 @@
 prune_bundler true
-extra_runtime_dependencies ["rdoc"]
+extra_runtime_dependencies ["minitest"]
 before_fork do
   $LOAD_PATH.each do |path|
     puts "LOAD_PATH: #{path}"

--- a/test/test_bundle_pruner.rb
+++ b/test/test_bundle_pruner.rb
@@ -1,7 +1,6 @@
 require_relative 'helper'
 
 require 'puma/events'
-require 'puma/launcher/bundle_pruner'
 
 class TestBundlePruner < Minitest::Test
 
@@ -13,18 +12,18 @@ class TestBundlePruner < Minitest::Test
     assert_equal(2, dirs.length)
     assert_match(%r{#{REPO_NAME}/lib$}, dirs[0]) # lib dir
     assert_match(%r{puma-#{Puma::Const::PUMA_VERSION}$}, dirs[1]) # native extension dir
-    refute_match(%r{gems/rdoc-[\d.]+/lib$}, dirs[2])
+    refute_match(%r{gems/minitest-[\d.]+/lib$}, dirs[2])
   end
 
   def test_paths_to_require_after_prune_is_correctly_built_with_extra_deps
     skip_if :no_bundler
 
-    dirs = bundle_pruner([], ['rdoc']).send(:paths_to_require_after_prune)
+    dirs = bundle_pruner([], ['minitest']).send(:paths_to_require_after_prune)
 
     assert_equal(3, dirs.length)
     assert_match(%r{#{REPO_NAME}/lib$}, dirs[0]) # lib dir
     assert_match(%r{puma-#{Puma::Const::PUMA_VERSION}$}, dirs[1]) # native extension dir
-    assert_match(%r{gems/rdoc-[\d.]+/lib$}, dirs[2]) # rdoc dir
+    assert_match(%r{gems/minitest-[\d.]+/lib$}, dirs[2]) # minitest dir
   end
 
   def test_extra_runtime_deps_paths_is_empty_for_no_config
@@ -34,10 +33,10 @@ class TestBundlePruner < Minitest::Test
   def test_extra_runtime_deps_paths_is_correctly_built
     skip_if :no_bundler
 
-    dep_dirs = bundle_pruner([], ['rdoc']).send(:extra_runtime_deps_paths)
+    dep_dirs = bundle_pruner([], ['minitest']).send(:extra_runtime_deps_paths)
 
     assert_equal(1, dep_dirs.length)
-    assert_match(%r{gems/rdoc-[\d.]+/lib$}, dep_dirs.first)
+    assert_match(%r{gems/minitest-[\d.]+/lib$}, dep_dirs.first)
   end
 
   def test_puma_wild_path_is_an_absolute_path

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -67,9 +67,6 @@ class TestConfigFile < TestConfigFileBase
 
     conf.load
 
-    bind_configuration = conf.options.file_options[:binds].first
-    app = conf.app
-
     ssl_binding = "ssl://0.0.0.0:9292?&verify_mode=none"
     assert_equal [ssl_binding], conf.options[:binds]
   end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -298,7 +298,7 @@ RUBY
     while (line = @server.gets) =~ /^LOAD_PATH/
       load_path << line.gsub(/^LOAD_PATH: /, '')
     end
-    assert_match(%r{gems/rdoc-[\d.]+/lib$}, load_path.last)
+    assert_match(%r{gems/minitest-[\d.]+/lib$}, load_path.last)
   end
 
   def test_load_path_does_not_include_nio4r


### PR DESCRIPTION
### Description

1. Circular require issues with Launcher::BundlePruner, which is not always used. Rather than requiring it, autoload it.

2. RDoc is in the Gemfile, which has dependencies on Psych, and StringIO.  Both are extension gems, both may have pre-release gems in Ruby master, etc.  RDoc is used as a 'checked gem' with various Bundler tests.  Remove RDoc and use minitest in its place.

3. Fix two 'warning: assigned but unused variable' from test_config.rb

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
