### PR TITLE
MiniSSL - detect SSL_CTX_set_dh_auto

### DIFF
--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -35,7 +35,10 @@ unless ENV["DISABLE_SSL"]
     have_func  "X509_STORE_up_ref"
     have_func "SSL_CTX_set_ecdh_auto(NULL, 0)"         , "openssl/ssl.h"
 
-    # below are yes for 3.0.0 & later, use for OpenSSL 3 detection
+    # below exists in 1.1.0 and later, but isn't documented until 3.0.0
+    have_func "SSL_CTX_set_dh_auto(NULL, 0)"           , "openssl/ssl.h"
+
+    # below is yes for 3.0.0 & later
     have_func "SSL_get1_peer_certificate"              , "openssl/ssl.h"
 
     # Random.bytes available in Ruby 2.5 and later, Random::DEFAULT deprecated in 3.0

--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -55,7 +55,7 @@ const rb_data_type_t engine_data_type = {
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
-#ifndef HAVE_SSL_GET1_PEER_CERTIFICATE
+#ifndef HAVE_SSL_CTX_SET_DH_AUTO
 DH *get_dh2048(void) {
   /* `openssl dhparam -C 2048`
    * -----BEGIN DH PARAMETERS-----
@@ -217,7 +217,7 @@ sslctx_initialize(VALUE self, VALUE mini_ssl_ctx) {
   int ssl_options;
   VALUE key, cert, ca, verify_mode, ssl_cipher_filter, no_tlsv1, no_tlsv1_1,
     verification_flags, session_id_bytes, cert_pem, key_pem;
-#ifndef HAVE_SSL_GET1_PEER_CERTIFICATE
+#ifndef HAVE_SSL_CTX_SET_DH_AUTO
   DH *dh;
 #endif
   BIO *bio;
@@ -373,7 +373,7 @@ sslctx_initialize(VALUE self, VALUE mini_ssl_ctx) {
 
   // printf("\ninitialize end security_level %d\n", SSL_CTX_get_security_level(ctx));
 
-#ifdef HAVE_SSL_GET1_PEER_CERTIFICATE
+#ifdef HAVE_SSL_CTX_SET_DH_AUTO
   // https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_dh_auto.html
   SSL_CTX_set_dh_auto(ctx, 1);
 #else


### PR DESCRIPTION
### Description

The link for `SSL_CTX_set_dh_auto` is at https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_dh_auto.html.  But, it doesn't show links to other OpenSSL versions, which many functions do show.

It is defined for OpenSSL 1.1, so change to use function detection.

Closes #2863

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
