### PR TITLE
Puma::ControlCLI - allow refork command to be sent as a request

### DIFF
--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -39,6 +39,9 @@ module Puma
           when 'phased-restart'
             @launcher.phased_restart ? 200 : 404
 
+          when 'refork'
+            @launcher.refork ? 200 : 404
+
           when 'reload-worker-directory'
             @launcher.send(:reload_worker_directory) ? 200 : 404
 

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -32,11 +32,13 @@ module Puma
     # @deprecated 6.0.0
     COMMANDS = CMD_PATH_SIG_MAP.keys.freeze
 
+    # Uncomment below statement & clause in run method statement if needed
+    #
     # commands that cannot be used in a request
-    NO_REQ_COMMANDS = %w{refork}.freeze
+    # NO_REQ_COMMANDS = %w[].freeze
 
     # @version 5.0.0
-    PRINTABLE_COMMANDS = %w{gc-stats stats thread-backtraces}.freeze
+    PRINTABLE_COMMANDS = %w[gc-stats stats thread-backtraces].freeze
 
     def initialize(argv, stdout=STDOUT, stderr=STDERR)
       @state = nil
@@ -185,8 +187,6 @@ module Puma
 
       if @command == 'status'
         message 'Puma is started'
-      elsif NO_REQ_COMMANDS.include? @command
-        raise "Invalid request command: #{@command}"
       else
         url = "/#{@command}"
 
@@ -268,7 +268,7 @@ module Puma
       return start if @command == 'start'
       prepare_configuration
 
-      if Puma.windows? || @control_url
+      if Puma.windows? || @control_url # && !NO_REQ_COMMANDS.include?(@command)
         send_request
       else
         send_signal

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -244,7 +244,11 @@ module Puma
           @stdout.flush unless @stdout.sync
           return
         elsif sig.start_with? 'SIG'
-          Process.kill sig, @pid
+          if Signal.list.key? sig.sub(/\ASIG/, '')
+            Process.kill sig, @pid
+          else
+            raise "Signal '#{sig}' not available'"
+          end
         elsif @command == 'status'
           begin
             Process.kill 0, @pid

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -17,25 +17,27 @@ module Puma
     CMD_PATH_SIG_MAP = {
       'gc'       => nil,
       'gc-stats' => nil,
-      'halt'     => 'SIGQUIT',
-      'phased-restart' => 'SIGUSR1',
-      'refork'   => 'SIGURG',
+      'halt'              => 'SIGQUIT',
+      'info'              => 'SIGINFO',
+      'phased-restart'    => 'SIGUSR1',
+      'refork'            => 'SIGURG',
       'reload-worker-directory' => nil,
-      'restart'  => 'SIGUSR2',
+      'reopen-log'        => 'SIGHUP',
+      'restart'           => 'SIGUSR2',
       'start'    => nil,
       'stats'    => nil,
       'status'   => '',
-      'stop'     => 'SIGTERM',
-      'thread-backtraces' => nil
+      'stop'              => 'SIGTERM',
+      'thread-backtraces' => nil,
+      'worker-count-down' => 'SIGTTOU',
+      'worker-count-up'   => 'SIGTTIN'
     }.freeze
 
     # @deprecated 6.0.0
     COMMANDS = CMD_PATH_SIG_MAP.keys.freeze
 
-    # Uncomment below statement & clause in run method statement if needed
-    #
     # commands that cannot be used in a request
-    # NO_REQ_COMMANDS = %w[].freeze
+    NO_REQ_COMMANDS = %w[info reopen-log worker-count-down worker-count-up].freeze
 
     # @version 5.0.0
     PRINTABLE_COMMANDS = %w[gc-stats stats thread-backtraces].freeze
@@ -268,7 +270,7 @@ module Puma
       return start if @command == 'start'
       prepare_configuration
 
-      if Puma.windows? || @control_url # && !NO_REQ_COMMANDS.include?(@command)
+      if Puma.windows? || @control_url && !NO_REQ_COMMANDS.include?(@command)
         send_request
       else
         send_signal

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -163,6 +163,17 @@ module Puma
       true
     end
 
+    # Begin a refork if supported
+    def refork
+      if clustered? && @runner.respond_to?(:fork_worker!) && @options[:fork_worker]
+        @runner.fork_worker!
+        true
+      else
+        log "* refork called but not available."
+        false
+      end
+    end
+
     # Run the server. This blocks until the server is stopped
     def run
       previous_env = get_env

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -229,7 +229,7 @@ RUBY
   end
 
   # use three workers to keep accepting clients
-  def test_refork
+  def test_fork_worker_on_refork
     refork = Tempfile.new 'refork'
     wrkrs = 3
     cli_server "-w #{wrkrs} test/rackup/hello_with_delay.ru", config: <<RUBY

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -19,7 +19,7 @@ class TestPumaControlCli < TestConfigFileBase
 
   def teardown
     @wait.close
-    @ready.close
+    @ready.close unless @ready.closed?
   end
 
   def with_config_file(path_to_config, port)
@@ -185,6 +185,42 @@ class TestPumaControlCli < TestConfigFileBase
     assert_command_cli_output opts + ["stop"], "Command stop sent success"
 
     assert_kind_of Thread, t.join, "server didn't stop"
+  end
+
+  # This checks that a 'signal only' command is sent
+  # they are defined by the `Puma::ControlCLI::NO_REQ_COMMANDS` array
+  # test is skipped unless NO_REQ_COMMANDS is defined
+  def test_control_url_with_signal_only_cmd
+    skip_if :windows
+    skip unless defined? Puma::ControlCLI::NO_REQ_COMMANDS
+    host = "127.0.0.1"
+    port = UniquePort.call
+    url = "tcp://#{host}:#{port}/"
+
+    opts = [
+      "--control-url", url,
+      "--control-token", "ctrl",
+      "--config-file", "test/config/app.rb",
+      "--pid", "1234"
+    ]
+    cmd = Puma::ControlCLI::NO_REQ_COMMANDS.first
+    log = ''.dup
+    control_cli = Puma::ControlCLI.new (opts + [cmd]), @ready, @ready
+
+    def control_cli.send_signal
+      message "send_signal #{@command}\n"
+    end
+    def control_cli.send_request
+      message "send_request #{@command}\n"
+    end
+
+    control_cli.run
+    @ready.close
+
+    log = @wait.read
+
+    assert_includes log, "send_signal #{cmd}"
+    refute_includes log, 'send_request'
   end
 
   def test_control_ssl


### PR DESCRIPTION
### Description

Currently, the refork command will only be sent as a signal by `Puma::ControlCLI`.  Change to allow it be sent as a request if the control server is setup with a uri.

Closes #2866

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
