### PR TITLE
Minor: Export puma/ruby versions in /stats

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -269,7 +269,7 @@ module Puma
         booted_workers: worker_status.count { |w| w[:booted] },
         old_workers: old_worker_count,
         worker_status: worker_status,
-      }
+      }.merge(super)
     end
 
     def preload?

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -178,5 +178,18 @@ module Puma
         raise "Cannot redirect #{io_name} to #{path}"
       end
     end
+
+    def stats
+      {
+        versions: {
+          puma: Puma::Const::PUMA_VERSION,
+          ruby: {
+            engine: RUBY_ENGINE,
+            version: RUBY_VERSION,
+            patchlevel: RUBY_PATCHLEVEL
+          }
+        }
+      }
+    end
   end
 end

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -17,7 +17,7 @@ module Puma
     def stats
       {
         started_at: @started_at.utc.iso8601
-      }.merge(@server.stats)
+      }.merge(@server.stats).merge(super)
     end
 
     def restart

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -65,7 +65,7 @@ class TestCLI < Minitest::Test
     assert_equal Puma.stats_hash, JSON.parse(Puma.stats, symbolize_names: true)
 
     dmt = Puma::Configuration.new.default_max_threads
-    assert_match(/{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0}/, body.split(/\r?\n/).last)
+    assert_match(/\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"\d+.\d+.\d+","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":\d+\}\}\}/, body.split(/\r?\n/).last)
 
   ensure
     cli.launcher.stop
@@ -144,7 +144,7 @@ class TestCLI < Minitest::Test
     body = s.read
     s.close
 
-    assert_match(/\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","workers":2,"phase":0,"booted_workers":2,"old_workers":0,"worker_status":\[\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":0,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\},\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":1,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\}\]\}/, body.split("\r\n").last)
+    assert_match(/\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","workers":2,"phase":0,"booted_workers":2,"old_workers":0,"worker_status":\[\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":0,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\},\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":1,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\}\],"versions":\{"puma":"\d+.\d+.\d+","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":\d+\}\}\}/, body.split("\r\n").last)
   ensure
     if UNIX_SKT_EXIST && HAS_FORK
       cli.launcher.stop
@@ -180,7 +180,7 @@ class TestCLI < Minitest::Test
     s.close
 
     dmt = Puma::Configuration.new.default_max_threads
-    assert_match(/{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0}/, body.split("\r\n").last)
+    assert_match(/{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"\d+.\d+.\d+","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":\d+\}\}\}/, body.split(/\r?\n/).last)
   ensure
     if UNIX_SKT_EXIST
       cli.launcher.stop

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -65,7 +65,7 @@ class TestCLI < Minitest::Test
     assert_equal Puma.stats_hash, JSON.parse(Puma.stats, symbolize_names: true)
 
     dmt = Puma::Configuration.new.default_max_threads
-    assert_match(/\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"\d+.\d+.\d+","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":\d+\}\}\}/, body.split(/\r?\n/).last)
+    assert_match(/\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"\d+.\d+.\d+","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/, body.split(/\r?\n/).last)
 
   ensure
     cli.launcher.stop
@@ -144,7 +144,7 @@ class TestCLI < Minitest::Test
     body = s.read
     s.close
 
-    assert_match(/\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","workers":2,"phase":0,"booted_workers":2,"old_workers":0,"worker_status":\[\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":0,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\},\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":1,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\}\],"versions":\{"puma":"\d+.\d+.\d+","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":\d+\}\}\}/, body.split("\r\n").last)
+    assert_match(/\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","workers":2,"phase":0,"booted_workers":2,"old_workers":0,"worker_status":\[\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":0,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\},\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":1,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\}\],"versions":\{"puma":"\d+.\d+.\d+","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/, body.split("\r\n").last)
   ensure
     if UNIX_SKT_EXIST && HAS_FORK
       cli.launcher.stop
@@ -180,7 +180,7 @@ class TestCLI < Minitest::Test
     s.close
 
     dmt = Puma::Configuration.new.default_max_threads
-    assert_match(/{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"\d+.\d+.\d+","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":\d+\}\}\}/, body.split(/\r?\n/).last)
+    assert_match(/{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"\d+.\d+.\d+","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/, body.split(/\r?\n/).last)
   ensure
     if UNIX_SKT_EXIST
       cli.launcher.stop


### PR DESCRIPTION
### Description
I added puma/ruby versions to the /stats endpoint this way when monitoring puma we have an easy way to know which versions are running, here is an example:

![Screenshot_2022-05-11_23-54-55](https://user-images.githubusercontent.com/1866809/167954321-3fcc9ba7-a207-4c8b-8182-e8ed20408313.png)


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
