### PR TITLE
Expose Puma::NullIO#closed?

### DIFF
--- a/lib/puma/null_io.rb
+++ b/lib/puma/null_io.rb
@@ -52,5 +52,9 @@ module Puma
     def flush
       self
     end
+
+    def closed?
+      true
+    end
   end
 end

--- a/test/test_null_io.rb
+++ b/test/test_null_io.rb
@@ -64,4 +64,8 @@ class TestNullIO < Minitest::Test
   def test_flush_returns_self
     assert_equal nio, nio.flush
   end
+
+  def test_closed_returns_true
+    assert_equal true, nio.closed?
+  end
 end


### PR DESCRIPTION
### Description

if you try to proxy a request in rails with `rest-client` 

```ruby
RestClient::Request.execute(method: request.method, url: SOME_URL, payload: request.body)
```

if fails with `NoMethodError - undefined method closed? for <#Puma::NullIO:xxx>` because the library does this at the end of the request phase:

```ruby
class RestClient::Payload::Base
  def close
    @stream.close unless @stream.closed?
  end
end
```

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] All new and existing tests passed, including Rubocop.
