### PR TITLE
Add ENV['PUMA_NO_RUBOCOP'] to disable RuboCop install, add mswin ci

### DIFF
--- a/.github/workflows/ragel.yml
+++ b/.github/workflows/ragel.yml
@@ -15,6 +15,8 @@ jobs:
   ragel:
     name: >-
       ragel ${{ matrix.os }} ${{ matrix.ruby }}
+    env:
+      PUMA_NO_RUBOCOP: true
 
     runs-on: ${{ matrix.os }}
     if: |
@@ -40,7 +42,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: load ruby
-        uses: MSP-Greg/setup-ruby-pkgs@v1
+        uses: ruby/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           apt-get: ragel

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,7 @@ jobs:
     env:
       CI: true
       TESTOPTS: -v
+      PUMA_NO_RUBOCOP: true
 
     runs-on: ${{ matrix.os }}
     if: |
@@ -36,6 +37,7 @@ jobs:
         yjit: ['']
         include:
           - { os: windows-2022 , ruby: ucrt }
+          - { os: windows-2022 , ruby: mswin }
           - { os: windows-2022 , ruby: 2.7  , no-ssl: ' no SSL' }
           - { os: ubuntu-20.04 , ruby: head , yjit: ' yjit' }
           - { os: ubuntu-20.04 , ruby: 2.7  , no-ssl: ' no SSL' }
@@ -59,7 +61,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: load ruby
-        uses: MSP-Greg/setup-ruby-pkgs@v1
+        uses: ruby/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           apt-get: ragel
@@ -103,6 +105,7 @@ jobs:
     env:
       CI: true
       TESTOPTS: -v
+      PUMA_NO_RUBOCOP: true
 
     runs-on: ${{ matrix.os }}
     if: |
@@ -133,14 +136,11 @@ jobs:
           echo JAVA_HOME=$JAVA_HOME_11_X64 >> $GITHUB_ENV
 
       - name: load ruby, ragel
-        uses: MSP-Greg/setup-ruby-pkgs@v1
+        uses: ruby/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           apt-get: ragel
           brew: ragel
-          mingw: _upgrade_ openssl ragel
-          # Use the bundler shipped with that ruby,
-          # temporary workaround for https://github.com/oracle/truffleruby/issues/2586
           bundler: none
           bundler-cache: true
         timeout-minutes: 10

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,9 @@ gem "sd_notify"
 
 gem "jruby-openssl", :platform => "jruby"
 
-gem "rubocop", "~> 0.64.0"
+unless ENV['PUMA_NO_RUBOCOP'] || RUBY_PLATFORM.include?('mswin')
+  gem "rubocop", "~> 0.64.0"
+end
 
 if %w(2.2.7 2.2.8 2.2.9 2.2.10 2.3.4 2.4.1).include? RUBY_VERSION
   gem "stopgap_13632", "~> 1.0", :platforms => ["mri", "mingw", "x64_mingw"]

--- a/Rakefile
+++ b/Rakefile
@@ -2,16 +2,19 @@ require "bundler/setup"
 require "rake/testtask"
 require "rake/extensiontask"
 require "rake/javaextensiontask"
-require "rubocop/rake_task"
 require_relative 'lib/puma/detect'
 require 'rubygems/package_task'
 require 'bundler/gem_tasks'
 
+begin
+  # Add rubocop task
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new
+rescue LoadError
+end
+
 gemspec = Gem::Specification.load("puma.gemspec")
 Gem::PackageTask.new(gemspec).define
-
-# Add rubocop task
-RuboCop::RakeTask.new
 
 # generate extension code using Ragel (C and Java)
 desc "Generate extension code (C and Java) using Ragel"

--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -14,6 +14,8 @@ unless ENV["DISABLE_SSL"]
   found_ssl = if (!$mingw || RUBY_VERSION >= '2.4') && (t = pkg_config 'openssl')
     puts 'using OpenSSL pkgconfig (openssl.pc)'
     true
+  elsif have_library('libcrypto', 'BIO_read') && have_library('libssl', 'SSL_CTX_new')
+    true
   elsif %w'crypto libeay32'.find {|crypto| have_library(crypto, 'BIO_read')} &&
       %w'ssl ssleay32'.find {|ssl| have_library(ssl, 'SSL_CTX_new')}
     true


### PR DESCRIPTION
### Description

1. Setting `ENV['PUMA_NO_RUBOCOP']` disables installation and use of RuboCop.  Since we're now doing RuboCop as a separate workflow, the other workflows do not need to install RuboCop and it's dependencies.  This lightens the resolution Bundler needs to do, and makes the bundle caches smaller.  Note that the extension gem [jaro_winkler](https://rubygems.org/gems/jaro_winkler) is a dependency of RuboCop, and it will not compile on mswin.

2. Small changes to allow Puma to build using Ruby Windows mswin build. Add to Actions CI.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
