### PR TITLE
Fix "log_writer.rb:59:in `write': deadlock; recursive locking (ThreadError)"

### DIFF
--- a/lib/puma/log_writer.rb
+++ b/lib/puma/log_writer.rb
@@ -3,6 +3,7 @@
 require 'puma/null_io'
 require 'puma/error_logger'
 require 'stringio'
+require 'io/wait'
 
 module Puma
 
@@ -56,14 +57,17 @@ module Puma
 
     # Write +str+ to +@stdout+
     def log(str)
+      @stdout.is_a?(IO) and @stdout.wait_writable(1)
       @stdout.puts(format(str)) if @stdout.respond_to? :puts
-
       @stdout.flush unless @stdout.sync
-    rescue Errno::EPIPE
+    rescue Errno::EPIPE, Errno::EBADF
     end
 
     def write(str)
+      @stdout.is_a?(IO) and @stdout.wait_writable(1)
       @stdout.write(format(str))
+      @stdout.flush unless @stdout.sync
+    rescue Errno::EPIPE, Errno::EBADF
     end
 
     def debug(str)

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -238,7 +238,7 @@ class TestIntegration < Minitest::Test
     else
       # Errno::ECONNABORTED is thrown intermittently on TCPSocket.new
       DARWIN ? [Errno::EBADF, Errno::ECONNREFUSED, Errno::EPIPE, EOFError, Errno::ECONNABORTED] :
-        [IOError, Errno::ECONNREFUSED]
+        [IOError, Errno::ECONNREFUSED, Errno::EPIPE]
     end
   end
 

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -62,7 +62,7 @@ class TestIntegrationPumactl < TestIntegration
     skip_unless :fork
     cli_server "-q -w #{workers} test/rackup/sleep.ru --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}", unix: true
 
-    start = Time.now
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
     s = UNIXSocket.new @bind_path
     @ios_to_close << s
@@ -89,7 +89,7 @@ class TestIntegrationPumactl < TestIntegration
 
     _, status = Process.wait2(@pid)
     assert_equal 0, status
-    assert_operator Time.now - start, :<, (DARWIN ? 8 : 6)
+    assert_operator Process.clock_gettime(Process::CLOCK_MONOTONIC) - start, :<, (DARWIN ? 8 : 7)
     @server = nil
   end
 


### PR DESCRIPTION
### Description

CI intermittently fails with "log_writer.rb:59:in `write': deadlock; recursive locking (ThreadError)".  This is happening in log writes/puts, and this code maybe called in signal handlers.  Mutex and other locking mechanisms cannot be used in signal handlers, so this PR is an attempt to fix the problem.

Example log:
```
/Users/runner/work/puma/puma/lib/puma/log_writer.rb:59:in `write': deadlock; recursive locking (ThreadError)
	from /Users/runner/work/puma/puma/lib/puma/log_writer.rb:59:in `puts'
	from /Users/runner/work/puma/puma/lib/puma/log_writer.rb:59:in `log'
	from /Users/runner/work/puma/puma/lib/puma/launcher.rb:329:in `log'
	from /Users/runner/work/puma/puma/lib/puma/launcher.rb:205:in `close_binder_listeners'
	from /Users/runner/work/puma/puma/lib/puma/cluster.rb:329:in `block in setup_signals'
	from /Users/runner/work/puma/puma/lib/puma/log_writer.rb:59:in `write'
	from /Users/runner/work/puma/puma/lib/puma/log_writer.rb:59:in `puts'
	from /Users/runner/work/puma/puma/lib/puma/log_writer.rb:59:in `log'
	from /Users/runner/work/puma/puma/lib/puma/runner.rb:44:in `log'
	from /Users/runner/work/puma/puma/lib/puma/cluster.rb:460:in `run'
```

While doing recent work in my fork I have also seen the error.  Can't repo locally, and tried to get code independent of Puma to fail, again, no luck.

Wondering if anyone has a better idea?

Second commit contains minor test fixes for intermittent issues.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
