### PR TITLE
extconf.rb - don't use pkg_config('openssl') if '--with-openssl-dir' is used

### DIFF
--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -9,9 +9,11 @@ if $mingw && RUBY_VERSION >= '2.4'
 end
 
 unless ENV["DISABLE_SSL"]
-  dir_config("openssl")
+  # don't use pkg_config('openssl') if '--with-openssl-dir' is used
+  has_openssl_dir = dir_config('openssl').any?
+  found_pkg_config = !has_openssl_dir && pkg_config('openssl')
 
-  found_ssl = if (!$mingw || RUBY_VERSION >= '2.4') && (t = pkg_config 'openssl')
+  found_ssl = if (!$mingw || RUBY_VERSION >= '2.4') && found_pkg_config
     puts 'using OpenSSL pkgconfig (openssl.pc)'
     true
   elsif have_library('libcrypto', 'BIO_read') && have_library('libssl', 'SSL_CTX_new')


### PR DESCRIPTION
### Description

If installing Puma with `--with-openssl-dir`, `pkg_config('openssl')` may locate the system OpenSSL, which is not desirable.

Hence, only use `pkg_config('openssl')` when `--with-openssl-dir` is not used.

See https://github.com/ruby/openssl/pull/486

This problem has generated a few issues with macOS.  If anyone with multiple OpenSSL installs (and a Ruby that is not using the system OpenSSL), can check this, it would be appreciated.

Note that this PR only affects using `--with-openssl-dir` with a Puma install.

Closes #2839. Not.sure

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
