### PR TITLE
[jruby] enable TLSv1.3 support

### DIFF
--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -215,13 +215,13 @@ public class MiniSSL extends RubyObject { // MiniSSL::Engine
 
     String[] protocols;
     if (miniSSLContext.callMethod(context, "no_tlsv1").isTrue()) {
-        protocols = new String[] { "TLSv1.1", "TLSv1.2" };
+        protocols = new String[] { "TLSv1.1", "TLSv1.2", "TLSv1.3" };
     } else {
-        protocols = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
+        protocols = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" };
     }
 
     if (miniSSLContext.callMethod(context, "no_tlsv1_1").isTrue()) {
-        protocols = new String[] { "TLSv1.2" };
+        protocols = new String[] { "TLSv1.2", "TLSv1.3" };
     }
 
     engine.setEnabledProtocols(protocols);

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -13,9 +13,9 @@ module Puma
     # Define constant at runtime, as it's easy to determine at built time,
     # but Puma could (it shouldn't) be loaded with an older OpenSSL version
     # @version 5.0.0
-    HAS_TLS1_3 = !IS_JRUBY &&
-      (OPENSSL_VERSION[/ \d+\.\d+\.\d+/].split('.').map(&:to_i) <=> [1,1,1]) != -1 &&
-      (OPENSSL_LIBRARY_VERSION[/ \d+\.\d+\.\d+/].split('.').map(&:to_i) <=> [1,1,1]) !=-1
+    HAS_TLS1_3 = IS_JRUBY ||
+        ((OPENSSL_VERSION[/ \d+\.\d+\.\d+/].split('.').map(&:to_i) <=> [1,1,1]) != -1 &&
+         (OPENSSL_LIBRARY_VERSION[/ \d+\.\d+\.\d+/].split('.').map(&:to_i) <=> [1,1,1]) !=-1)
 
     class Socket
       def initialize(socket, engine)
@@ -50,7 +50,7 @@ module Puma
       # is made with TLSv1.3 as an available protocol
       # @version 5.0.0
       def bad_tlsv1_3?
-        HAS_TLS1_3 && @engine.ssl_vers_st == ['TLSv1.3', 'SSLERR']
+        HAS_TLS1_3 && ssl_version_state == ['TLSv1.3', 'SSLERR']
       end
       private :bad_tlsv1_3?
 

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -335,8 +335,8 @@ class TestPumaServerSSLClient < Minitest::Test
         req = Net::HTTP::Get.new "/", {}
         http.request(req)
       end
-    rescue OpenSSL::SSL::SSLError, EOFError, Errno::ECONNRESET => e
-      # Errno::ECONNRESET TruffleRuby
+    rescue OpenSSL::SSL::SSLError, EOFError, Errno::ECONNRESET, IOError => e
+      # Errno::ECONNRESET TruffleRuby, IOError macOS JRuby
       client_error = e
       # closes socket if open, may not close on error
       http.send :do_finish

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -193,6 +193,25 @@ class TestPumaServerSSL < Minitest::Test
     end
   end
 
+  def test_tls_v1_3
+    skip("TLSv1.3 protocol can not be set") unless OpenSSL::SSL::SSLContext.instance_methods(false).include?(:min_version=)
+
+    start_server
+
+    @http.min_version = :TLS1_3
+
+    body = nil
+    @http.start do
+      req = Net::HTTP::Get.new '/'
+      @http.request(req) do |rep|
+        assert_equal 'OK', rep.message
+        body = rep.body
+      end
+    end
+
+    assert_equal "https", body
+  end
+
   def test_http_rejection
     body_http  = nil
     body_https = nil
@@ -335,7 +354,7 @@ class TestPumaServerSSLClient < Minitest::Test
   end
 
   def test_verify_fail_if_no_client_cert
-    error = Puma.jruby? ? /Empty server certificate chain/ : 'peer did not return a certificate'
+    error = Puma.jruby? ? /Empty client certificate chain/ : 'peer did not return a certificate'
     assert_ssl_client_error_match(error) do |http|
       # nothing
     end


### PR DESCRIPTION
### Description

Puma did not have TLS 1.3 support on JRuby, the feature is now enabled and the protocol is usable by default. Note that TLS 1.3 is available with Java >= 8 (has been backported), current LTS Java version is 11 which was shipped with TLS 1.3 since day 1.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
