### PR TITLE
[CI] rescue more errors in teardown & wait_for_server_to_boot methods, RubyGems

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -85,6 +85,13 @@ jobs:
         continue-on-error: true
         timeout-minutes: 5
 
+      # fixes 'has a bug that prevents `required_ruby_version`'
+      - name: update rubygems for Ruby 2.3 - 2.5
+        if: contains('2.3 2.4 2.5', matrix.ruby)
+        run: gem update --system 3.3.14 --no-document
+        continue-on-error: true
+        timeout-minutes: 5
+
       - name: Compile Puma without SSL support
         if: matrix.no-ssl == ' no SSL'
         shell: bash

--- a/test/test_out_of_band_server.rb
+++ b/test/test_out_of_band_server.rb
@@ -15,7 +15,15 @@ class TestOutOfBandServer < Minitest::Test
     @oob_finished.broadcast
     @app_finished.broadcast
     @server.stop(true) if @server
-    @ios.each {|i| i.close unless i.closed?}
+
+    @ios.each do |io|
+      begin
+        io.close if io.is_a?(IO) && !io.closed?
+      rescue
+      ensure
+        io = nil
+      end
+    end
   end
 
   def new_connection


### PR DESCRIPTION
### Description

After reviewing far too many CI logs, many retries and intermittent failures/errors were due to problems with error handling in teardown methods, along with a timing related issue in `wait_for_server_to_boot`.  Fixed, and added a CI step to update RubyGems, removing all the extraneous logging of the below:
```
Your RubyGems version (<2.5 and earlier>) has a bug that prevents `required_ruby_version` from working for Bundler
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
