### PR TITLE
Extra log

### DIFF
--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -59,6 +59,7 @@ module Puma
         rescue Exception => e
           log "! Unable to start worker"
           log e.backtrace
+          log e
           exit 1
         end
 

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -58,8 +58,8 @@ module Puma
         server = @server ||= start_server
         rescue Exception => e
           log "! Unable to start worker"
-          log e.backtrace
           log e
+          log e.backtrace.join("\n    ")
           exit 1
         end
 

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -58,7 +58,7 @@ module Puma
         server = @server ||= start_server
         rescue Exception => e
           log "! Unable to start worker"
-          log e.backtrace[0]
+          log e.backtrace
           exit 1
         end
 


### PR DESCRIPTION
### Description
When the worker fails to load, it currently logs only the first item from the backtrace, without the error message itself. This makes it very difficult to know exactly what the problem was.

This change logs the entire backtrace + the error message

see https://github.com/puma/puma/issues/2843#issuecomment-1141744150

### Your checklist for this pull request

(before I go further with tests etc, which might be difficult for me as I'm not familiar with the codebase, I'd like to check that the project team is open to accept/adopt this change)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
