### PR TITLE
Compute Content-Length header correctly when response body is an instance of Rack::BodyProxy

### DIFF
--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -93,6 +93,7 @@ class TestPersistent < Minitest::Test
 
   def test_chunked
     @body << "Chunked"
+    @body = @body.to_enum
 
     @client << @valid_request
 
@@ -102,6 +103,7 @@ class TestPersistent < Minitest::Test
   def test_chunked_with_empty_part
     @body << ""
     @body << "Chunked"
+    @body = @body.to_enum
 
     @client << @valid_request
 
@@ -110,6 +112,7 @@ class TestPersistent < Minitest::Test
 
   def test_no_chunked_in_http10
     @body << "Chunked"
+    @body = @body.to_enum
 
     @client << @http10_request
 
@@ -120,6 +123,7 @@ class TestPersistent < Minitest::Test
   def test_hex
     str = "This is longer and will be in hex"
     @body << str
+    @body = @body.to_enum
 
     @client << @valid_request
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -324,7 +324,7 @@ EOF
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
-    assert_equal "HTTP/1.0 200 OK\r\n\r\n", data
+    assert_equal "HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n", data
   end
 
   def test_doesnt_print_backtrace_in_production
@@ -987,7 +987,7 @@ EOF
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
-    assert_equal "HTTP/1.0 200 OK\r\nX-Empty-Header: \r\n\r\n", data
+    assert_equal "HTTP/1.0 200 OK\r\nX-Empty-Header: \r\nContent-Length: 0\r\n\r\n", data
   end
 
   def test_request_body_wait

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -197,6 +197,35 @@ class TestRackServer < Minitest::Test
     assert_equal str.bytesize, content_length
   end
 
+  def test_custom_rack_body_content_length
+    str = "Hello"
+    body = [str]
+    body.define_singleton_method(:to_ary) { nil }
+
+    @server.app = lambda { |env| [200, { "X-Header" => "Works" }, body] }
+
+    @server.run
+
+    socket = TCPSocket.open "127.0.0.1", @port
+    socket.puts "GET /test HTTP/1.1\r\n"
+    socket.puts "Connection: Keep-Alive\r\n"
+    socket.puts "\r\n"
+
+    headers = socket.readline("\r\n\r\n")
+      .split("\r\n")
+      .drop(1)
+      .map { |line| line.split(/:\s?/) }
+      .to_h
+
+    content_length = headers["Content-Length"].to_i
+
+    socket.close
+
+    stop
+
+    assert_equal str.bytesize, content_length
+  end
+
   def test_common_logger
     log = StringIO.new
 

--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -89,10 +89,10 @@ class TestResponseHeader < Minitest::Test
 
   # The header key can contain the word status.
   def test_key_containing_status
-    server_run app: ->(env) { [200, {'Teapot-Status' => 'Boiling'}, []] }
+    server_run app: ->(env) { [200, {'Teapot-Status' => 'Boiling'}, ["Hello"]] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.0 200 OK\r\nTeapot-Status: Boiling\r\n\r\n/, data)
+    assert_match(/HTTP\/1.0 200 OK\r\nTeapot-Status: Boiling\r\nContent-Length: 5\r\n\r\n/, data)
   end
 
   # Special headers starting “rack.” are for communicating with the server, and must not be sent back to the client.
@@ -102,10 +102,10 @@ class TestResponseHeader < Minitest::Test
 
   # The header key can still start with the word rack
   def test_racket_key
-    server_run app: ->(env) { [200, {'Racket' => 'Bouncy'}, []] }
+    server_run app: ->(env) { [200, {'Racket' => 'Bouncy'}, ["Hello"]] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.0 200 OK\r\nRacket: Bouncy\r\n\r\n/, data)
+    assert_match(/HTTP\/1.0 200 OK\r\nRacket: Bouncy\r\nContent-Length: 5\r\n\r\n/, data)
   end
 
   # testing header key must conform rfc token specification


### PR DESCRIPTION
### Description

Currently, Puma is not setting the Content-Length header when the Rack response body is an instance of Rack::BodyProxy due to the condition that is checking for an Array. 

This PR takes an approach similar to Rack::ContentLength that checks if the body responds to `to_ary` instead of checking if the body is an Array.

Additionally, I added a sanity check in `test_body_proxy` just to confirm that Puma handles correctly Rack::BodyProxy responses.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
