### PR TITLE
Response refactor, increase requests-per-second, body type handling

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -63,11 +63,7 @@ module Puma
       @io = io
       @to_io = io.to_io
       @proto_env = env
-      if !env
-        @env = nil
-      else
-        @env = env.dup
-      end
+      @env = env ? env.dup : nil
 
       @parser = HttpParser.new
       @parsed_bytes = 0

--- a/lib/puma/io_buffer.rb
+++ b/lib/puma/io_buffer.rb
@@ -1,11 +1,36 @@
 # frozen_string_literal: true
 
+require 'stringio'
+
 module Puma
-  class IOBuffer < String
-    def append(*args)
-      args.each { |a| concat(a) }
+  class IOBuffer < StringIO
+    def initialize
+      super.binmode
     end
 
-    alias reset clear
+    def empty?
+      length.zero?
+    end
+
+    def reset
+      truncate 0
+      rewind
+    end
+
+    def to_s
+      rewind
+      read
+    end
+
+    alias_method :clear, :reset
+
+    # before Ruby 2.5, `write` would only take one argument
+    if RUBY_VERSION >= '2.5' && RUBY_ENGINE != 'truffleruby'
+      alias_method :append, :write
+    else
+      def append(*strs)
+        strs.each { |str| write str }
+      end
+    end
   end
 end

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -282,7 +282,7 @@ module Puma
           end
         end
         body.close unless body.closed?
-      elsif body.respond_to?(:to_ary) && body.length == 1
+      elsif body.is_a?(::Array) && body.length == 1
         body_first = body.first
         if body_first.is_a?(::String) && body_first.bytesize >= BODY_LEN_MAX
           # large body, write both header & body to socket

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -93,6 +93,7 @@ class TestPersistent < Minitest::Test
 
   def test_chunked
     @body << "Chunked"
+    @body = @body.to_enum
 
     @client << @valid_request
 
@@ -102,6 +103,7 @@ class TestPersistent < Minitest::Test
   def test_chunked_with_empty_part
     @body << ""
     @body << "Chunked"
+    @body = @body.to_enum
 
     @client << @valid_request
 
@@ -110,6 +112,7 @@ class TestPersistent < Minitest::Test
 
   def test_no_chunked_in_http10
     @body << "Chunked"
+    @body = @body.to_enum
 
     @client << @http10_request
 
@@ -120,6 +123,7 @@ class TestPersistent < Minitest::Test
   def test_hex
     str = "This is longer and will be in hex"
     @body << str
+    @body = @body.to_enum
 
     @client << @valid_request
 

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -3,10 +3,18 @@ require_relative "helper"
 require "net/http"
 
 require "rack"
+require "rack/chunked" if Rack::RELEASE >= '3'
+
 require "nio"
+require "securerandom"
+require "open3"
 
 class TestRackServer < Minitest::Test
   parallelize_me!
+
+  TRANSFER_ENCODING_CHUNKED = 'transfer-encoding: chunked'
+
+  STR_1KB = "──#{SecureRandom.hex 507}─\n".freeze
 
   class ErrorChecker
     def initialize(app)
@@ -219,4 +227,39 @@ class TestRackServer < Minitest::Test
 
     assert_match %r!GET /test HTTP/1\.1!, log.string
   end
+
+  def test_rack_chunked_array1
+    body = [STR_1KB]
+    app = lambda { |env| [200, { 'content-type' => 'text/plain; charset=utf-8' }, body] }
+    rack_app = Rack::Chunked.new app
+    @server.app = rack_app
+    @server.run
+
+    resp_body, headers, _status = Open3.capture3 "curl -v #{@tcp}/"
+    assert_includes headers.downcase, TRANSFER_ENCODING_CHUNKED
+    assert_equal STR_1KB, resp_body
+  end if Rack::RELEASE < '3.1'
+
+  def test_rack_chunked_array10
+    body = Array.new 10, STR_1KB
+    app = lambda { |env| [200, { 'content-type' => 'text/plain; charset=utf-8' }, body] }
+    rack_app = Rack::Chunked.new app
+    @server.app = rack_app
+    @server.run
+
+    resp_body, headers, _status = Open3.capture3 "curl -v #{@tcp}/"
+    assert_includes headers.downcase, TRANSFER_ENCODING_CHUNKED
+    assert_equal STR_1KB * 10, resp_body
+  end if Rack::RELEASE < '3.1'
+
+  def test_puma_enum
+    body = Array.new(10, STR_1KB).to_enum
+    @server.app = lambda { |env| [200, { 'content-type' => 'text/plain; charset=utf-8' }, body] }
+    @server.run
+
+    resp_body, headers, _status = Open3.capture3 "curl -v #{@tcp}/"
+    assert_includes headers.downcase, TRANSFER_ENCODING_CHUNKED
+    assert_equal STR_1KB * 10, resp_body
+  end
+
 end

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -3,6 +3,7 @@ require_relative "helper"
 require "net/http"
 
 require "rack"
+require "nio"
 
 class TestRackServer < Minitest::Test
   parallelize_me!
@@ -156,6 +157,51 @@ class TestRackServer < Minitest::Test
     socket.close
 
     stop
+  end
+
+  def test_rack_body_proxy
+    closed = false
+    body = Rack::BodyProxy.new(["Hello"]) { closed = true }
+
+    @server.app = lambda { |env| [200, { "X-Header" => "Works" }, body] }
+
+    @server.run
+
+    hit(["#{@tcp}/test"])
+
+    stop
+
+    assert_equal true, closed
+  end
+
+  def test_rack_body_proxy_content_length
+    str_ary = %w[0123456789 0123456789 0123456789 0123456789]
+    str_ary_bytes = str_ary.to_ary.inject(0) { |sum, el| sum + el.bytesize }
+
+    body = Rack::BodyProxy.new(str_ary) { }
+
+    @server.app = lambda { |env| [200, { "X-Header" => "Works" }, body] }
+
+    @server.run
+
+    socket = TCPSocket.open "127.0.0.1", @port
+    socket.puts "GET /test HTTP/1.1\r\n"
+    socket.puts "Connection: Keep-Alive\r\n"
+    socket.puts "\r\n"
+
+    headers = socket.readline("\r\n\r\n")
+      .split("\r\n")
+      .drop(1)
+      .map { |line| line.split(/:\s?/) }
+      .to_h
+
+    content_length = headers["Content-Length"].to_i
+
+    socket.close
+
+    stop
+
+    assert_equal str_ary_bytes, content_length
   end
 
   def test_common_logger

--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -96,7 +96,7 @@ class TestResponseHeader < Minitest::Test
     server_run app: ->(env) { [200, {'Teapot-Status' => 'Boiling'}, []] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.0 200 OK\r\nTeapot-Status: Boiling\r\n\r\n/, data)
+    assert_match(/HTTP\/1.0 200 OK\r\nTeapot-Status: Boiling\r\nContent-Length: 0\r\n\r\n/, data)
   end
 
   # Special headers starting “rack.” are for communicating with the server, and must not be sent back to the client.
@@ -109,7 +109,7 @@ class TestResponseHeader < Minitest::Test
     server_run app: ->(env) { [200, {'Racket' => 'Bouncy'}, []] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.0 200 OK\r\nRacket: Bouncy\r\n\r\n/, data)
+    assert_match(/HTTP\/1.0 200 OK\r\nRacket: Bouncy\r\nContent-Length: 0\r\n\r\n/, data)
   end
 
   # testing header key must conform rfc token specification


### PR DESCRIPTION
### Description
This PR refactors response generation, speeding up operations with various body types and sizes.  It also adds code to better handle the various body types returned by Rails and/or Rack.  Much of this has been worked on by @guilleiguaran, so thanks for his work on it (see #2892).  Essentially, body types fall into five categories:

1. An Array - Puma will determine the content-length if not provided.
2. An Enum - this would be chunked by Puma or sent as is if chunked encoding has already been applied.
3. A File object - dependent on its size, it will either be sent with the headers, or sent after the headers using `IO.copy_stream`.
4. An object that responds to `to_path` - Puma will attempt to open the file, and if successful, will send as above.
5. An object that responds to `call`.

This PR has been around for a while, and I'm sure I've run millions of requests thru it.  Two items:

1. Duplicating client errors is difficult.  I believe I've got the error handling correct, but we may see some issues with it.  Not.sure.
2. Previously, Puma didn't ever call `to_path` on a response body.  This PR has been updated to do so when the body responds to it, but isn't a File object.  It opens the file (based on the name in `to_path`), and treats it as a File/IO object.  This may cause issues with the [Rack::Sendfile](https://msp-greg.github.io/rack/Rack/Sendfile.html) middleware.

Below summarizes performance using the code in benchmarks/local, all using:
benchmarks/local/response_time_wrk.sh -w2 -t5:5 -s tcp6 -Y
wrk -t8 -c16 -d10s
Server cluster mode -w2 -t5:5, bind: tcp6
ruby 3.2.0dev (2022-09-12T13:13:32Z master 2aa8edaec7) +YJIT [x86_64-linux]
Both include 'test/rackup/ci_*.ru files - cache response bodies' (#2952)
Windows WSL2/Ubuntu 22.04

```

Body    ────────── req/sec ──────────   ─────── req 50% times ─────── Master
 KB     array   chunk  string      io   array   chunk  string      io
1       13780    9719   13581   10964    0.65    1.22    0.68    0.90
10       5920    2769   13203   10831    1.78    4.04    0.80    0.95
100      1063     404   11002    9153   10.54   26.85    0.98    1.21
256       448     159   11264    9039   24.39   65.65    0.92    1.23
512       234      85   10757    8848   45.18  121.76    0.96    1.22
1024      129      43    8822    8543   79.86  237.58    0.77    1.21
2048       68      22    6342    8405  152.13  456.80    1.54    1.21
─────────────────────────────────────────────────────────────────────

Body    ────────── req/sec ──────────   ─────── req 50% times ─────── PR #2896
 KB     array   chunk  string      io   array   chunk  string      io
1       15889   15885   15594   10898   0.200   0.197   0.195   0.960
10      15419   15204   15605   11073   0.297   0.285   0.225   0.728
100     10596    9660   11324    9396   1.020   1.120   0.960   1.180
256      9198    7501   11960    9286   1.120   1.360   0.860   1.190
512      7112    5512   11012    9017   1.430   1.870   0.930   1.190
1024     4355    3315    9302    8762   1.740   2.760   0.709   1.170
2048     2801    1938    6595    8562   3.460   5.240   1.470   1.170
─────────────────────────────────────────────────────────────────────
```

There are significant speed increases for almost all body types/sizes, with the exception of 'single string' and 'io/file' bodies, which show smaller increases.

The commits:
* [io_buffer.rb - change to using StringIO](https://github.com/puma/puma/commit/8ca473f7b0c0da4d1a3bda06be0d9500e5dbe5f1) - allows IOBuffer to be used both as a string and as an IO.  Previously it was subclassed from `String`.

* [request.rb - refactor](https://github.com/puma/puma/commit/75837c456295e69713e2247b3e46004bdb0391a3) - Split `fast_write` into `fast_write_response` and `fast_write_str`.  Refactor.  Compute array bodies' `Content-Length` only when it's not provided by app.  See #2892 by @guilleiguaran.  Only an Array responds to `#to_ary`, so it is used for the body type check.

* [client.rb - small refactor](https://github.com/puma/puma/commit/c2cd372aa858f4d976709b7d917b26b4ad35d898)

All three of the below are small refactors

* [test_persistent.rb - chunked tests must be enum, not array](https://github.com/puma/puma/commit/0962c28596a354cf7360e65440f7b2f57a67a36b)
* [test_rack_server.rb - Add Rack::BodyProxy tests](https://github.com/puma/puma/commit/c1e6028d971093459d798c99e431a8d1c91c31dc) - from PR #2892.
* [test_puma_server.rb - always start one thread](https://github.com/puma/puma/commit/3dd99b064210e108d226b23fe4762bdb1fecb8af)

* [request.rb - rename variables](https://github.com/puma/puma/pull/2896/commits/1d58951da1d4) - Rename `lines` to `io_buffer`, which is what it is.  Rename `io` to `socket`.

Most of the remaining commits involve code to handle various body types, along with tests.

Please feel free to test these changes.

Closes #2892, closes #2703, closes #2457

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
