### PR TITLE
Load the configuration before passing it to the binder:

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -52,16 +52,16 @@ module Puma
       @original_argv = @argv.dup
       @config        = conf
 
+      # Advertise the Configuration
+      Puma.cli_config = @config if defined?(Puma.cli_config)
+
+      @config.load
+
       @binder        = Binder.new(@log_writer, conf)
       @binder.create_inherited_fds(ENV).each { |k| ENV.delete k }
       @binder.create_activated_fds(ENV).each { |k| ENV.delete k }
 
       @environment = conf.environment
-
-      # Advertise the Configuration
-      Puma.cli_config = @config if defined?(Puma.cli_config)
-
-      @config.load
 
       if @config.options[:bind_to_activated_sockets]
         @config.options[:binds] = @binder.synthesize_binds_from_activated_fs(

--- a/test/config/rack_url_scheme.rb
+++ b/test/config/rack_url_scheme.rb
@@ -1,0 +1,1 @@
+rack_url_scheme "https"

--- a/test/rackup/url_scheme.ru
+++ b/test/rackup/url_scheme.ru
@@ -1,0 +1,1 @@
+run lambda { |env| [200, {"Content-Type" => "text/plain"}, [env["rack.url_scheme"]]] }

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -53,6 +53,17 @@ class TestIntegrationSingle < TestIntegration
     assert_equal 0, status
   end
 
+  def test_conf_is_loaded_before_passing_it_to_binder
+    skip_unless_signal_exist? :TERM
+
+    cli_server("-C test/config/rack_url_scheme.rb test/rackup/url_scheme.ru")
+
+    reply = read_body(connect)
+    stop_server
+
+    assert_match("https", reply)
+  end
+
   def test_prefer_rackup_file_specified_by_cli
     skip_unless_signal_exist? :TERM
 

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -53,6 +53,17 @@ class TestIntegrationSingle < TestIntegration
     assert_equal 0, status
   end
 
+  def test_rack_url_scheme_default
+    skip_unless_signal_exist? :TERM
+
+    cli_server("test/rackup/url_scheme.ru")
+
+    reply = read_body(connect)
+    stop_server
+
+    assert_match("http", reply)
+  end
+
   def test_conf_is_loaded_before_passing_it_to_binder
     skip_unless_signal_exist? :TERM
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1368,26 +1368,6 @@ EOF
     test_drain_on_shutdown false
   end
 
-  def test_rack_url_scheme_dflt
-    server_run
-
-    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
-    assert_equal "http", data.split("\r\n").last
-  end
-
-  def test_rack_url_scheme_user
-    @port = UniquePort.call
-    opts = { rack_url_scheme: 'user', binds: ["tcp://#{@host}:#{@port}"] }
-    conf = Puma::Configuration.new(opts).tap(&:clamp)
-    @server = Puma::Server.new @app, @log_writer, @events, conf.options
-    @server.inherit_binder Puma::Binder.new(@log_writer, conf)
-    @server.binder.parse conf.options[:binds], @log_writer
-    @server.run
-
-    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
-    assert_equal "user", data.split("\r\n").last
-  end
-
   def test_remote_address_header
     server_run(remote_address: :header, remote_address_header: 'HTTP_X_REMOTE_IP') do |env|
       [200, {}, [env['REMOTE_ADDR']]]


### PR DESCRIPTION
Hi 👋 ! Thanks for your work on maintaining Puma!

- ### Problem

  The feature to manually set the "rack.url_scheme" header with
  Puma's `rack_url_scheme` option (introduced in commit https://github.com/puma/puma/commit/32852f715af9e6eb809284d910e647b8fd6e2ea6) has no effect.

  ### Context

  The Configuration object is not yet loaded at the time it's being
  passed to the Binder so any options set inside the config file (i.e.
  `config/puma.rb`) remains nil.
  https://github.com/puma/puma/blob/6a5bda5b4eeb8c86c64468d6916f7d3917e5640a/lib/puma/binder.rb#L45

  Worth noting that this is only true for options set inside the
  config file. Options passed as args to the CLI
  (i.e. `puma -t min_thread:max_thread`) are correctly set
  (they get loaded differently).
  https://github.com/puma/puma/blob/6a5bda5b4eeb8c86c64468d6916f7d3917e5640a/lib/puma/binder.rb#L42-L43

  ### Solution

  I originally tought I'd fix the issue by adding a new CLI flag for
  `rack_url_scheme` but ended up loading the config a bit earlier as
  it felt error prone for the future to have only some options
  available in the Binder.

  I did some git archeology to try to figure out why the config was
  loaded after passing it to the binder but couldn't find a legit
  reason, sorry if I missed it

  <details>
    <summary>Git archeology</summary>

    The Binder class originally didn't need the config so the ordering didn't
    matter.
    https://github.com/puma/puma/commit/ffae12c40f46f8372cc5ff68b84ef6091670c184

    It was later added in https://github.com/puma/puma/commit/47f933d076c57d5c2500360b09e55630c5c4a3e2
  </details>

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
