### PR TITLE
Ruby 3.2 will have native IO#wait_* methods, don't require io/wait

### DIFF
--- a/lib/puma/detect.rb
+++ b/lib/puma/detect.rb
@@ -8,6 +8,8 @@ module Puma
   # @version 5.2.1
   HAS_FORK = ::Process.respond_to? :fork
 
+  HAS_NATIVE_IO_WAIT = ::IO.public_instance_methods(false).include? :wait_readable
+
   IS_JRUBY = Object.const_defined? :JRUBY_VERSION
 
   IS_OSX = RUBY_PLATFORM.include? 'darwin'

--- a/lib/puma/log_writer.rb
+++ b/lib/puma/log_writer.rb
@@ -3,7 +3,7 @@
 require 'puma/null_io'
 require 'puma/error_logger'
 require 'stringio'
-require 'io/wait'
+require 'io/wait' unless Puma::HAS_NATIVE_IO_WAIT
 
 module Puma
 

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 begin
-  require 'io/wait'
+  require 'io/wait' unless Puma::HAS_NATIVE_IO_WAIT
 rescue LoadError
 end
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -15,7 +15,7 @@ require 'puma/io_buffer'
 require 'puma/request'
 
 require 'socket'
-require 'io/wait'
+require 'io/wait' unless Puma::HAS_NATIVE_IO_WAIT
 require 'forwardable'
 
 module Puma


### PR DESCRIPTION
### Description

In Ruby 3.1 and earlier versions, IO#wait_* methods were contained in the standard library gem `io/wait`.  Ruby 3.2 has moved the methods to the main IO code.  See 'Move wait* methods to io.c' https://github.com/ruby/ruby/pull/6036.

So, `io/wait` does not need to be required for Ruby 3.2 and later.  Adjust code to only require it when needed.


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
