### PR TITLE
Allow `run_hooks` to pass a hash to blocks for use later

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -302,10 +302,18 @@ module Puma
       @plugins.create name
     end
 
-    def run_hooks(key, arg, log_writer)
+    # @param key [:Symbol] hook to run
+    # @param arg [Launcher, Int] `:on_restart` passes Launcher
+    #
+    def run_hooks(key, arg, log_writer, hook_data = nil)
       @options.all_of(key).each do |b|
         begin
-          b.call arg
+          if Array === b
+            hook_data[b[1]] ||= Hash.new
+            b[0].call arg, hook_data[b[1]]
+          else
+            b.call arg
+          end
         rescue => e
           log_writer.log "WARNING hook #{key} failed with exception (#{e.class}) #{e.message}"
           log_writer.debug e.backtrace.join("\n")

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -32,7 +32,25 @@ module Puma
   # You can also find many examples being used by the test suite in
   # +test/config+.
   #
+  # Puma v6 adds the option to specify a key name (String or Symbol) to the
+  # hooks that run inside the forked workers.  All the hooks run inside the
+  # {Puma::Cluster::Worker#run} method.
+  #
+  # Previously, the worker index and the LogWriter instance were passed to the
+  # hook blocks/procs.  If a key name is specified, a hash is passed as the last
+  # parameter.  This allows storage of data, typically objects that are created
+  # before the worker that need to be passed to the hook when the worker is shutdown.
+  #
+  # The following hooks have been updated:
+  #
+  #     | DSL Method         |  Options Key            | Fork Block Location |
+  #     | on_worker_boot     | :before_worker_boot     | inside, before      |
+  #     | on_worker_shutdown | :before_worker_shutdown | inside, after       |
+  #     | on_refork          | :before_refork          | inside              |
+  #
   class DSL
+    ON_WORKER_KEY = [String, Symbol].freeze
+
     # convenience method so logic can be used in CI
     # @see ssl_bind
     #
@@ -499,7 +517,7 @@ module Puma
     #   ssl_bind '127.0.0.1', '9292', {
     #     cert_pem: File.read(path_to_cert),
     #     key_pem: File.read(path_to_key),
-    #     reuse: {size: 2_000, timeout: 20}
+    #     reuse: {size: 2_000, timeout: 20} # optional
     #   }
     #
     # @example For JRuby, two keys are required: +keystore+ & +keystore_pass+
@@ -592,9 +610,8 @@ module Puma
     #   on_worker_boot do
     #     puts 'Before worker boot...'
     #   end
-    def on_worker_boot(&block)
-      @options[:before_worker_boot] ||= []
-      @options[:before_worker_boot] << block
+    def on_worker_boot(key = nil, &block)
+      process_hook :before_worker_boot, key, block, 'on_worker_boot'
     end
 
     # Code to run immediately before a worker shuts
@@ -609,9 +626,8 @@ module Puma
     #   on_worker_shutdown do
     #     puts 'On worker shutdown...'
     #   end
-    def on_worker_shutdown(&block)
-      @options[:before_worker_shutdown] ||= []
-      @options[:before_worker_shutdown] << block
+    def on_worker_shutdown(key = nil, &block)
+      process_hook :before_worker_shutdown, key, block, 'on_worker_shutdown'
     end
 
     # Code to run in the master right before a worker is started. The worker's
@@ -625,8 +641,7 @@ module Puma
     #     puts 'Before worker fork...'
     #   end
     def on_worker_fork(&block)
-      @options[:before_worker_fork] ||= []
-      @options[:before_worker_fork] << block
+      process_hook :before_worker_fork, nil, block, 'on_worker_fork'
     end
 
     # Code to run in the master after a worker has been started. The worker's
@@ -640,8 +655,7 @@ module Puma
     #     puts 'After worker fork...'
     #   end
     def after_worker_fork(&block)
-      @options[:after_worker_fork] ||= []
-      @options[:after_worker_fork] << block
+      process_hook :after_worker_fork, nil, block, 'after_worker_fork'
     end
 
     alias_method :after_worker_boot, :after_worker_fork
@@ -664,9 +678,8 @@ module Puma
     #   end
     # @version 5.0.0
     #
-    def on_refork(&block)
-      @options[:before_refork] ||= []
-      @options[:before_refork] << block
+    def on_refork(key = nil, &block)
+      process_hook :before_refork, key, block, 'on_refork'
     end
 
     # Code to run out-of-band when the worker is idle.
@@ -679,8 +692,7 @@ module Puma
     #
     # This can be called multiple times to add several hooks.
     def out_of_band(&block)
-      @options[:out_of_band] ||= []
-      @options[:out_of_band] << block
+      process_hook :out_of_band, nil, block, 'out_of_band'
     end
 
     # The directory to operate out of.
@@ -1024,6 +1036,17 @@ module Puma
           @options[:store] << opts[opt_key]
           opts[v] = "store:#{index}"
         end
+      end
+    end
+
+    def process_hook(options_key, key, block, meth)
+      @options[options_key] ||= []
+      if ON_WORKER_KEY.include? key.class
+        @options[options_key] << [block, key.to_sym]
+      elsif key.nil?
+        @options[options_key] << block
+      else
+        raise "'#{method}' key must be String or Symbol"
       end
     end
   end

--- a/test/config/hook_data.rb
+++ b/test/config/hook_data.rb
@@ -1,0 +1,9 @@
+workers 2
+
+on_worker_boot(:test) do |index, data|
+  data[:test] = index
+end
+
+on_worker_shutdown(:test) do |index, data|
+  File.write "hook_data-#{index}.txt", "index #{index} data #{data[:test]}", mode: 'wb:UTF-8'
+end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -67,7 +67,7 @@ class TestIntegration < Minitest::Test
     assert(system(*args, out: File::NULL, err: File::NULL))
   end
 
-  def cli_server(argv, unix: false, config: nil, merge_err: false)
+  def cli_server(argv, unix: false, config: nil, merge_err: false, log: false)
     if config
       config_file = Tempfile.new(%w(config .rb))
       config_file.write config
@@ -86,7 +86,7 @@ class TestIntegration < Minitest::Test
     else
       @server = IO.popen(cmd, "r")
     end
-    wait_for_server_to_boot
+    wait_for_server_to_boot(log: log)
     @pid = @server.pid
     @server
   end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -421,6 +421,22 @@ RUBY
     assert_match(/Worker 1 \(PID: \d+\) terminating/, line)
   end
 
+  def test_hook_data
+    skip_unless_signal_exist? :TERM
+
+    cli_server "-C test/config/hook_data.rb test/rackup/hello.ru"
+    get_worker_pids 0, 2
+    stop_server
+
+    file = 'hook_data-0.txt'
+    assert_equal 'index 0 data 0', File.read(file, mode: 'rb:UTF-8')
+    File.unlink file if File.file? file
+
+    file = 'hook_data-1.txt'
+    assert_equal 'index 1 data 1', File.read(file, mode: 'rb:UTF-8')
+    File.unlink file if File.file? file
+  end
+
   private
 
   def worker_timeout(timeout, iterations, details, config)


### PR DESCRIPTION
### Description

See #2915 'Callbacks for app lifecycle?'.

When one calls DSL methods to register callbacks **inside of the fork block** (`on_worker_boot`, `on_worker_shutdown`, & `on_refork`), adds a parameter that is used as a key.  It can be a String or a Symbol, and it defines which callbacks a Hash object is passed to.

This allows the hooks to access objects stored in a hook called earlier.

See comments added to the DSL class.

Closes #2915

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
