### PR TITLE
Puma 6 gemspec - required_ruby_version to Ruby 2.4, RuboCop updates

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,8 +38,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, macos-11, windows-2022 ]
-        ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, head ]
+        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, macos-11, macos-12, windows-2022 ]
+        ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, head ]
         no-ssl: ['']
         yjit: ['']
         include:
@@ -52,16 +52,16 @@ jobs:
           - { os: ubuntu-22.04 , ruby: head }
 
         exclude:
-          - { os: ubuntu-20.04 , ruby: 2.2  }
-          - { os: ubuntu-20.04 , ruby: 2.3  }
           - { os: windows-2022 , ruby: head }
-          - { os: macos-10.15  , ruby: 2.6  }
           - { os: macos-10.15  , ruby: 2.7  }
           - { os: macos-10.15  , ruby: '3.0'}
           - { os: macos-10.15  , ruby: 3.1  }
-          - { os: macos-11     , ruby: 2.2  }
-          - { os: macos-11     , ruby: 2.3  }
+          - { os: macos-10.15  , ruby: head }
           - { os: macos-11     , ruby: 2.4  }
+          - { os: macos-11     , ruby: 2.5  }
+          - { os: macos-12     , ruby: 2.4  }
+          - { os: macos-12     , ruby: 2.5  }
+          - { os: macos-12     , ruby: 2.6  }
 
     steps:
       - name: repo checkout
@@ -73,21 +73,14 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           apt-get: ragel
           brew: ragel
-          # below is only needed for Rubies 2.4 and earlier
-          mingw: openssl ragel
+          # below is only needed for Ruby 2.4
+          mingw: openssl
           bundler-cache: true
         timeout-minutes: 10
 
-      # Windows error thrown, doesn't affect CI
-      - name: update rubygems for Ruby 2.2
-        if: matrix.ruby < '2.3'
-        run: gem update --system 2.7.11 --no-document
-        continue-on-error: true
-        timeout-minutes: 5
-
       # fixes 'has a bug that prevents `required_ruby_version`'
-      - name: update rubygems for Ruby 2.3 - 2.5
-        if: contains('2.3 2.4 2.5', matrix.ruby)
+      - name: update rubygems for Ruby 2.4 - 2.5
+        if: contains('2.4 2.5', matrix.ruby)
         run: gem update --system 3.3.14 --no-document
         continue-on-error: true
         timeout-minutes: 5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.4
   DisplayCopNames: true
   StyleGuideCopsOnly: false
   Exclude:
@@ -9,6 +9,16 @@ AllCops:
     - 'examples/**/*'
     - 'pkg/**/*'
     - 'Rakefile'
+
+# ————————————————————————————————————————— disabled cops
+
+Performance/RegexpMatch:
+  Enabled: false
+
+Performance/UnfreezeString:
+  Enabled: false
+
+# ————————————————————————————————————————— enabled cops
 
 Layout/SpaceAfterColon:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 AllCops:
   DisabledByDefault: true
   TargetRubyVersion: 2.4
@@ -9,6 +11,8 @@ AllCops:
     - 'examples/**/*'
     - 'pkg/**/*'
     - 'Rakefile'
+  SuggestExtensions: false
+  NewCops: disable
 
 # ————————————————————————————————————————— disabled cops
 
@@ -16,6 +20,9 @@ Performance/RegexpMatch:
   Enabled: false
 
 Performance/UnfreezeString:
+  Enabled: false
+
+Style/RedundantReturn:
   Enabled: false
 
 # ————————————————————————————————————————— enabled cops
@@ -36,10 +43,10 @@ Layout/SpaceBeforeFirstArg:
 Layout/SpaceInsideParens:
   Enabled: true
 
-Layout/Tab:
+Layout/IndentationStyle:
   Enabled: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 Layout/TrailingWhitespace:
@@ -87,5 +94,3 @@ Style/WhileUntilModifier:
 Style/TernaryParentheses:
   Enabled: true
 
-Style/RedundantReturn:
-  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,8 @@ gem "sd_notify"
 gem "jruby-openssl", :platform => "jruby"
 
 unless ENV['PUMA_NO_RUBOCOP'] || RUBY_PLATFORM.include?('mswin')
-  gem "rubocop", "~> 0.64.0"
+  gem "rubocop", "1.12.1"
+  gem 'rubocop-performance', require: false
 end
 
 if %w(2.2.7 2.2.8 2.2.9 2.2.10 2.3.4 2.4.1).include? RUBY_VERSION

--- a/puma.gemspec
+++ b/puma.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   end
 
   s.license = "BSD-3-Clause"
-  s.required_ruby_version = Gem::Requirement.new(">= 2.2")
+  s.required_ruby_version = Gem::Requirement.new(">= 2.4")
 end


### PR DESCRIPTION
### Description

1. The Puma 5 gemspec sets Ruby version compatibility to Ruby 2.2 and later.  Update that to Ruby 2.4.

2. Remove Ruby 2.3 and 2.4 from CI testing.
 
3. This allows using a newer version of RuboCop.  Updated the versions used, and disabled a few Cops to keep CI passing.  

See Issue #1811 'Rev the minimum Ruby Version >= Ruby 2.5' from June 2018.

We could jump to 2.5...


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
