### PR TITLE
Rack 3.0.0 release

### DIFF
--- a/.github/workflows/rack2.yaml
+++ b/.github/workflows/rack2.yaml
@@ -1,0 +1,63 @@
+name: Rack_v2
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+
+jobs:
+  rack_v2:
+    name: >-
+      Rack_v2: ${{ matrix.os }} ${{ matrix.ruby }}
+    env:
+      CI: true
+      TESTOPTS: -v
+      PUMA_NO_RUBOCOP: true
+      PUMA_CI_RACK_2: true
+
+    runs-on: ${{ matrix.os }}
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]'))
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-20.04 ]
+        ruby: [ 2.4, 3.1 ]
+
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v3
+
+      - name: load ruby
+        uses: ruby/setup-ruby-pkgs@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          apt-get: ragel
+          brew: ragel
+          # below is only needed for Ruby 2.4
+          mingw: openssl
+          bundler-cache: true
+        timeout-minutes: 10
+
+      # fixes 'has a bug that prevents `required_ruby_version`'
+      - name: update rubygems for Ruby 2.4 - 2.5
+        if: contains('2.4 2.5', matrix.ruby)
+        run: gem update --system 3.3.14 --no-document
+        continue-on-error: true
+        timeout-minutes: 5
+
+      - name: set WERRORFLAG
+        shell: bash
+        run: echo 'PUMA_MAKE_WARNINGS_INTO_ERRORS=true' >> $GITHUB_ENV
+
+      - name: compile
+        run:  bundle exec rake compile
+
+      - name: test
+        timeout-minutes: 10
+        run: bundle exec rake test:all

--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,13 @@ gem "rake-compiler", "~> 1.1.1"
 
 gem "json", "~> 2.3"
 gem "nio4r", "~> 2.0"
-gem "rack", ">= 1.6.13"
 gem "minitest", "~> 5.11"
 gem "minitest-retry"
 gem "minitest-proveit"
 gem "minitest-stub-const"
 gem "sd_notify"
+
+gem "rack", (ENV['PUMA_CI_RACK_2'] ? "~> 2.2" : ">= 2.2")
 
 gem "jruby-openssl", :platform => "jruby"
 

--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -85,8 +85,8 @@ module Puma
 
       def rack_response(status, body, content_type='application/json')
         headers = {
-          'Content-Type' => content_type,
-          'Content-Length' => body.bytesize.to_s
+          'content-type' => content_type,
+          'content-length' => body.bytesize.to_s
         }
 
         [status, headers, [body]]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -149,6 +149,7 @@ module TestSkips
         when :fork        then "Skipped if Kernel.fork exists"   if HAS_FORK
         when :unix        then "Skipped if UNIXSocket exists"    if Puma::HAS_UNIX_SOCKET
         when :aunix       then "Skipped if abstract UNIXSocket"  if Puma.abstract_unix_socket?
+        when :rack3       then "Skipped if Rack 3.x"             if Rack::RELEASE >= '3'
         else false
       end
       skip skip_msg, bt if skip_msg

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -49,7 +49,7 @@ class TestCLI < Minitest::Test
     cli = Puma::CLI.new ["-b", "tcp://127.0.0.1:0",
                          "--control-url", url,
                          "--control-token", "",
-                         "test/rackup/lobster.ru"], @log_writer, @events
+                         "test/rackup/hello.ru"], @log_writer, @events
 
     t = Thread.new do
       cli.run
@@ -84,7 +84,7 @@ class TestCLI < Minitest::Test
     cli = Puma::CLI.new ["-b", "tcp://127.0.0.1:0",
                          "--control-url", control_url,
                          "--control-token", token,
-                         "test/rackup/lobster.ru"], @log_writer, @events
+                         "test/rackup/hello.ru"], @log_writer, @events
 
     t = Thread.new do
       cli.run
@@ -120,7 +120,7 @@ class TestCLI < Minitest::Test
                          "-w", "2",
                          "--control-url", url,
                          "--control-token", "",
-                         "test/rackup/lobster.ru"], @log_writer, @events
+                         "test/rackup/hello.ru"], @log_writer, @events
 
     # without this, Minitest.after_run will trigger on this test ?
     $debugging_hold = true
@@ -168,7 +168,7 @@ class TestCLI < Minitest::Test
     cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
                          "--control-url", url,
                          "--control-token", "",
-                         "test/rackup/lobster.ru"], @log_writer, @events
+                         "test/rackup/hello.ru"], @log_writer, @events
 
     t = Thread.new { cli.run }
 
@@ -195,7 +195,7 @@ class TestCLI < Minitest::Test
     cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
                          "--control-url", url,
                          "--control-token", "",
-                         "test/rackup/lobster.ru"], @log_writer, @events
+                         "test/rackup/hello.ru"], @log_writer, @events
 
     t = Thread.new { cli.run }
 
@@ -219,7 +219,7 @@ class TestCLI < Minitest::Test
     cli = Puma::CLI.new ["-b", "tcp://127.0.0.1:#{tcp}",
                          "--control-url", url,
                          "--control-token", "",
-                         "test/rackup/lobster.ru"], @log_writer, @events
+                         "test/rackup/hello.ru"], @log_writer, @events
 
     t = Thread.new do
       cli.run
@@ -260,7 +260,7 @@ class TestCLI < Minitest::Test
     cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
                          "--control-url", url,
                          "--control-token", "",
-                         "test/rackup/lobster.ru"], @log_writer, @events
+                         "test/rackup/hello.ru"], @log_writer, @events
 
     t = Thread.new { cli.run }
 
@@ -281,7 +281,7 @@ class TestCLI < Minitest::Test
     cli = Puma::CLI.new ["-b", uri,
                          "--control-url", cntl,
                          "--control-token", "",
-                         "test/rackup/lobster.ru"], @log_writer, @events
+                         "test/rackup/hello.ru"], @log_writer, @events
 
     t = Thread.new do
       cli.run

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -5,6 +5,7 @@ require_relative "helpers/config_file"
 
 require "puma/configuration"
 require 'puma/log_writer'
+require 'rack'
 
 class TestConfigFile < TestConfigFileBase
   parallelize_me!
@@ -16,6 +17,7 @@ class TestConfigFile < TestConfigFileBase
   end
 
   def test_app_from_rackup
+    skip_if :rack3
     conf = Puma::Configuration.new do |c|
       c.rackup "test/rackup/hello-bind.ru"
     end

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -272,5 +272,4 @@ if Rack::RELEASE < '3'
       assert_equal user_log_requests_config, conf.options[:log_requests]
     end
   end
-
-end
+end # if Rack::RELEASE < '3'

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -1,270 +1,276 @@
 require_relative "helper"
 
-require "rack/handler/puma"
+require "rack"
 
-class TestHandlerGetStrSym < Minitest::Test
-  def test_handler
-    handler = Rack::Handler.get(:puma)
-    assert_equal Rack::Handler::Puma, handler
-    handler = Rack::Handler.get('Puma')
-    assert_equal Rack::Handler::Puma, handler
-  end
-end
+if Rack::RELEASE < '3'
 
-class TestPathHandler < Minitest::Test
-  def app
-    Proc.new {|env| @input = env; [200, {}, ["hello world"]]}
-  end
+  require "rack/handler/puma"
 
-  def setup
-    @input = nil
+  class TestHandlerGetStrSym < Minitest::Test
+    def test_handler
+      handler = Rack::Handler.get(:puma)
+      assert_equal Rack::Handler::Puma, handler
+      handler = Rack::Handler.get('Puma')
+      assert_equal Rack::Handler::Puma, handler
+    end
   end
 
-  def in_handler(app, options = {})
-    options[:Port] ||= 0
-    options[:Silent] = true
+  class TestPathHandler < Minitest::Test
+    def app
+      Proc.new {|env| @input = env; [200, {}, ["hello world"]]}
+    end
 
-    @launcher = nil
-    thread = Thread.new do
-      Rack::Handler::Puma.run(app, **options) do |s, p|
-        @launcher = s
+    def setup
+      @input = nil
+    end
+
+    def in_handler(app, options = {})
+      options[:Port] ||= 0
+      options[:Silent] = true
+
+      @launcher = nil
+      thread = Thread.new do
+        Rack::Handler::Puma.run(app, **options) do |s, p|
+          @launcher = s
+        end
       end
-    end
 
-    # Wait for launcher to boot
-    Timeout.timeout(10) do
-      sleep 0.5 until @launcher
-    end
-    sleep 1.5 unless Puma::IS_MRI
-
-    yield @launcher
-  ensure
-    @launcher.stop if @launcher
-    thread.join if thread
-  end
-
-  def test_handler_boots
-    host = '127.0.0.1'
-    port = UniquePort.call
-    opts = { Host: host, Port: port }
-    in_handler(app, opts) do |launcher|
-      hit(["http://#{host}:#{port}/test"])
-      assert_equal("/test", @input["PATH_INFO"])
-    end
-  end
-end
-
-class TestUserSuppliedOptionsPortIsSet < Minitest::Test
-  def setup
-    @options = {}
-    @options[:user_supplied_options] = [:Port]
-  end
-
-  def test_port_wins_over_config
-    user_port = 5001
-    file_port = 6001
-
-    Dir.mktmpdir do |d|
-      Dir.chdir(d) do
-        FileUtils.mkdir("config")
-        File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
-
-        @options[:Port] = user_port
-        conf = Rack::Handler::Puma.config(->{}, @options)
-        conf.load
-
-        assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+      # Wait for launcher to boot
+      Timeout.timeout(10) do
+        sleep 0.5 until @launcher
       end
+      sleep 1.5 unless Puma::IS_MRI
+
+      yield @launcher
+    ensure
+      @launcher.stop if @launcher
+      thread.join if thread
     end
-  end
-end
 
-class TestUserSuppliedOptionsHostIsSet < Minitest::Test
-  def setup
-    @options = {}
-    @options[:user_supplied_options] = [:Host]
-  end
-
-  def test_host_uses_supplied_port_default
-    user_port = rand(1000..9999)
-    user_host = "123.456.789"
-
-    @options[:Host] = user_host
-    @options[:Port] = user_port
-    conf = Rack::Handler::Puma.config(->{}, @options)
-    conf.load
-
-    assert_equal ["tcp://#{user_host}:#{user_port}"], conf.options[:binds]
-  end
-
-  def test_ipv6_host_supplied_port_default
-    @options[:Host] = "::1"
-    conf = Rack::Handler::Puma.config(->{}, @options)
-    conf.load
-
-    assert_equal ["tcp://[::1]:9292"], conf.options[:binds]
-  end
-end
-
-class TestUserSuppliedOptionsIsEmpty < Minitest::Test
-  def setup
-    @options = {}
-    @options[:user_supplied_options] = []
-  end
-
-  def test_config_file_wins_over_port
-    user_port = 5001
-    file_port = 6001
-
-    Dir.mktmpdir do |d|
-      Dir.chdir(d) do
-        FileUtils.mkdir("config")
-        File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
-
-        @options[:Port] = user_port
-        conf = Rack::Handler::Puma.config(->{}, @options)
-        conf.load
-
-        assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
+    def test_handler_boots
+      host = '127.0.0.1'
+      port = UniquePort.call
+      opts = { Host: host, Port: port }
+      in_handler(app, opts) do |launcher|
+        hit(["http://#{host}:#{port}/test"])
+        assert_equal("/test", @input["PATH_INFO"])
       end
     end
   end
 
-  def test_default_host_when_using_config_file
-    user_port = 5001
-    file_port = 6001
+  class TestUserSuppliedOptionsPortIsSet < Minitest::Test
+    def setup
+      @options = {}
+      @options[:user_supplied_options] = [:Port]
+    end
 
-    Dir.mktmpdir do |d|
-      Dir.chdir(d) do
-        FileUtils.mkdir("config")
-        File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
+    def test_port_wins_over_config
+      user_port = 5001
+      file_port = 6001
 
-        @options[:Host] = "localhost"
-        @options[:Port] = user_port
-        conf = Rack::Handler::Puma.config(->{}, @options)
-        conf.load
+      Dir.mktmpdir do |d|
+        Dir.chdir(d) do
+          FileUtils.mkdir("config")
+          File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
-        assert_equal ["tcp://localhost:#{file_port}"], conf.options[:binds]
+          @options[:Port] = user_port
+          conf = Rack::Handler::Puma.config(->{}, @options)
+          conf.load
+
+          assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+        end
       end
     end
   end
 
-  def test_default_host_when_using_config_file_with_explicit_host
-    user_port = 5001
-    file_port = 6001
-
-    Dir.mktmpdir do |d|
-      Dir.chdir(d) do
-        FileUtils.mkdir("config")
-        File.open("config/puma.rb", "w") { |f| f << "port #{file_port}, '1.2.3.4'" }
-
-        @options[:Host] = "localhost"
-        @options[:Port] = user_port
-        conf = Rack::Handler::Puma.config(->{}, @options)
-        conf.load
-
-        assert_equal ["tcp://1.2.3.4:#{file_port}"], conf.options[:binds]
-      end
+  class TestUserSuppliedOptionsHostIsSet < Minitest::Test
+    def setup
+      @options = {}
+      @options[:user_supplied_options] = [:Host]
     end
-  end
-end
 
-class TestUserSuppliedOptionsIsNotPresent < Minitest::Test
-  def setup
-    @options = {}
-  end
+    def test_host_uses_supplied_port_default
+      user_port = rand(1000..9999)
+      user_host = "123.456.789"
 
-  def test_default_port_when_no_config_file
-    conf = Rack::Handler::Puma.config(->{}, @options)
-    conf.load
+      @options[:Host] = user_host
+      @options[:Port] = user_port
+      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf.load
 
-    assert_equal ["tcp://0.0.0.0:9292"], conf.options[:binds]
-  end
+      assert_equal ["tcp://#{user_host}:#{user_port}"], conf.options[:binds]
+    end
 
-  def test_config_wins_over_default
-    file_port = 6001
+    def test_ipv6_host_supplied_port_default
+      @options[:Host] = "::1"
+      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf.load
 
-    Dir.mktmpdir do |d|
-      Dir.chdir(d) do
-        FileUtils.mkdir("config")
-        File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
-
-        conf = Rack::Handler::Puma.config(->{}, @options)
-        conf.load
-
-        assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
-      end
+      assert_equal ["tcp://[::1]:9292"], conf.options[:binds]
     end
   end
 
-  def test_user_port_wins_over_default_when_user_supplied_is_blank
-    user_port = 5001
-    @options[:user_supplied_options] = []
-    @options[:Port] = user_port
-    conf = Rack::Handler::Puma.config(->{}, @options)
-    conf.load
+  class TestUserSuppliedOptionsIsEmpty < Minitest::Test
+    def setup
+      @options = {}
+      @options[:user_supplied_options] = []
+    end
 
-    assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
-  end
+    def test_config_file_wins_over_port
+      user_port = 5001
+      file_port = 6001
 
-  def test_user_port_wins_over_default
-    user_port = 5001
-    @options[:Port] = user_port
-    conf = Rack::Handler::Puma.config(->{}, @options)
-    conf.load
+      Dir.mktmpdir do |d|
+        Dir.chdir(d) do
+          FileUtils.mkdir("config")
+          File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
-    assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
-  end
+          @options[:Port] = user_port
+          conf = Rack::Handler::Puma.config(->{}, @options)
+          conf.load
 
-  def test_user_port_wins_over_config
-    user_port = 5001
-    file_port = 6001
+          assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
+        end
+      end
+    end
 
-    Dir.mktmpdir do |d|
-      Dir.chdir(d) do
-        FileUtils.mkdir("config")
-        File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
+    def test_default_host_when_using_config_file
+      user_port = 5001
+      file_port = 6001
 
-        @options[:Port] = user_port
-        conf = Rack::Handler::Puma.config(->{}, @options)
-        conf.load
+      Dir.mktmpdir do |d|
+        Dir.chdir(d) do
+          FileUtils.mkdir("config")
+          File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
-        assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+          @options[:Host] = "localhost"
+          @options[:Port] = user_port
+          conf = Rack::Handler::Puma.config(->{}, @options)
+          conf.load
+
+          assert_equal ["tcp://localhost:#{file_port}"], conf.options[:binds]
+        end
+      end
+    end
+
+    def test_default_host_when_using_config_file_with_explicit_host
+      user_port = 5001
+      file_port = 6001
+
+      Dir.mktmpdir do |d|
+        Dir.chdir(d) do
+          FileUtils.mkdir("config")
+          File.open("config/puma.rb", "w") { |f| f << "port #{file_port}, '1.2.3.4'" }
+
+          @options[:Host] = "localhost"
+          @options[:Port] = user_port
+          conf = Rack::Handler::Puma.config(->{}, @options)
+          conf.load
+
+          assert_equal ["tcp://1.2.3.4:#{file_port}"], conf.options[:binds]
+        end
       end
     end
   end
 
-  def test_default_log_request_when_no_config_file
-    conf = Rack::Handler::Puma.config(->{}, @options)
-    conf.load
+  class TestUserSuppliedOptionsIsNotPresent < Minitest::Test
+    def setup
+      @options = {}
+    end
 
-    assert_equal false, conf.options[:log_requests]
+    def test_default_port_when_no_config_file
+      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf.load
+
+      assert_equal ["tcp://0.0.0.0:9292"], conf.options[:binds]
+    end
+
+    def test_config_wins_over_default
+      file_port = 6001
+
+      Dir.mktmpdir do |d|
+        Dir.chdir(d) do
+          FileUtils.mkdir("config")
+          File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
+
+          conf = Rack::Handler::Puma.config(->{}, @options)
+          conf.load
+
+          assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
+        end
+      end
+    end
+
+    def test_user_port_wins_over_default_when_user_supplied_is_blank
+      user_port = 5001
+      @options[:user_supplied_options] = []
+      @options[:Port] = user_port
+      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf.load
+
+      assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+    end
+
+    def test_user_port_wins_over_default
+      user_port = 5001
+      @options[:Port] = user_port
+      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf.load
+
+      assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+    end
+
+    def test_user_port_wins_over_config
+      user_port = 5001
+      file_port = 6001
+
+      Dir.mktmpdir do |d|
+        Dir.chdir(d) do
+          FileUtils.mkdir("config")
+          File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
+
+          @options[:Port] = user_port
+          conf = Rack::Handler::Puma.config(->{}, @options)
+          conf.load
+
+          assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+        end
+      end
+    end
+
+    def test_default_log_request_when_no_config_file
+      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf.load
+
+      assert_equal false, conf.options[:log_requests]
+    end
+
+    def test_file_log_requests_wins_over_default_config
+      file_log_requests_config = true
+
+      @options[:config_files] = [
+        'test/config/t1_conf.rb'
+      ]
+
+      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf.load
+
+      assert_equal file_log_requests_config, conf.options[:log_requests]
+    end
+
+    def test_user_log_requests_wins_over_file_config
+      user_log_requests_config = false
+
+      @options[:log_requests] = user_log_requests_config
+      @options[:config_files] = [
+        'test/config/t1_conf.rb'
+      ]
+
+      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf.load
+
+      assert_equal user_log_requests_config, conf.options[:log_requests]
+    end
   end
 
-  def test_file_log_requests_wins_over_default_config
-    file_log_requests_config = true
-
-    @options[:config_files] = [
-      'test/config/t1_conf.rb'
-    ]
-
-    conf = Rack::Handler::Puma.config(->{}, @options)
-    conf.load
-
-    assert_equal file_log_requests_config, conf.options[:log_requests]
-  end
-
-  def test_user_log_requests_wins_over_file_config
-    user_log_requests_config = false
-
-    @options[:log_requests] = user_log_requests_config
-    @options[:config_files] = [
-      'test/config/t1_conf.rb'
-    ]
-
-    conf = Rack::Handler::Puma.config(->{}, @options)
-    conf.load
-
-    assert_equal user_log_requests_config, conf.options[:log_requests]
-  end
 end

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -27,14 +27,18 @@ class TestRackServer < Minitest::Test
 
   class ServerLint < Rack::Lint
     def call(env)
-      check_env env
+      if Rack::RELEASE < '3'
+        check_env env
+      else
+        Wrapper.new(@app, env).check_environment env
+      end
 
       @app.call(env)
     end
   end
 
   def setup
-    @simple = lambda { |env| [200, { "X-Header" => "Works" }, ["Hello"]] }
+    @simple = lambda { |env| [200, { "x-header" => "Works" }, ["Hello"]] }
     @server = Puma::Server.new @simple
     @port = (@server.add_tcp_listener "127.0.0.1", 0).addr[1]
     @tcp = "http://127.0.0.1:#{@port}"


### PR DESCRIPTION
### Description

Rack 3.0.0 was released today, and breaks CI.

This PR makes the minimal changes needed to pass CI with Rack 3.0.0.

Currently, the Gemfile is `gem "rack", ">= 1.6.13"`.  Not sure if we should add an Actions workflow that runs a couple of jobs with Rack 2.2.x?


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
