### PR TITLE
Do not raise error on CONNECT

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -163,6 +163,14 @@ module Puma
 
     REQUEST_METHOD = "REQUEST_METHOD".freeze
     HEAD = "HEAD".freeze
+    GET = "GET".freeze
+    POST = "POST".freeze
+    PUT = "PUT".freeze
+    DELETE = "DELETE".freeze
+    OPTIONS = "OPTIONS".freeze
+    TRACE = "TRACE".freeze
+    PATCH = "PATCH".freeze
+    SUPPORTED_HTTP_METHODS = [HEAD, GET, POST, PUT, DELETE, OPTIONS, TRACE, PATCH].freeze
     # ETag is based on the apache standard of hex mtime-size-inode (inode is 0 on win32)
     LINE_END = "\r\n".freeze
     REMOTE_ADDR = "REMOTE_ADDR".freeze

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -73,8 +73,13 @@ module Puma
 
       begin
         begin
-          status, headers, res_body = @thread_pool.with_force_shutdown do
-            @app.call(env)
+          if SUPPORTED_HTTP_METHODS.include?(env[REQUEST_METHOD])
+            status, headers, res_body = @thread_pool.with_force_shutdown do
+              @app.call(env)
+            end
+          else
+            @log_writer.log "Unsupported HTTP method used: #{env[REQUEST_METHOD]}"
+            status, headers, res_body = [501, {}, ["#{env[REQUEST_METHOD]} method is not supported"]]
           end
 
           return :async if client.hijacked
@@ -266,14 +271,12 @@ module Puma
         uri = URI.parse(env[REQUEST_URI])
         env[REQUEST_PATH] = uri.path
 
-        raise "No REQUEST PATH" unless env[REQUEST_PATH]
-
         # A nil env value will cause a LintError (and fatal errors elsewhere),
         # so only set the env value if there actually is a value.
         env[QUERY_STRING] = uri.query if uri.query
       end
 
-      env[PATH_INFO] = env[REQUEST_PATH]
+      env[PATH_INFO] = env[REQUEST_PATH].to_s # #to_s in case it's nil
 
       # From https://www.ietf.org/rfc/rfc3875 :
       # "Script authors should be aware that the REMOTE_ADDR and

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -79,6 +79,20 @@ class WebServerTest < Minitest::Test
     socket.close
   end
 
+  def test_unsupported_method
+    socket = do_test("CONNECT www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
+    response = socket.read
+    assert_match "Not Implemented", response
+    socket.close
+  end
+
+  def test_nonexistent_method
+    socket = do_test("FOOBARBAZ www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
+    response = socket.read
+    assert_match "Not Implemented", response
+    socket.close
+  end
+
   private
 
   def do_test(string, chunk)


### PR DESCRIPTION
### Description

Closes https://github.com/puma/puma/issues/1441

I'm trying to fix https://github.com/puma/puma/issues/1441 and to do this I've prepare a proof of concept. I've done two things:
1. Don't raise error on empty `REQUEST_PATH` - it's a completely valid request to send CONNECT without a request path.
2. Handle the fact that puma doesn't support `CONNECT` gracefully by responding with 501.

I'm not sure if I handle both things in the right places. Right now I have a working code with a simple test. I'd be grateful for feedback and hints how to improve the code to make it mergeable.


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
