### PR TITLE
Simplify ThreadPool in Server class

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -88,6 +88,10 @@ module Puma
         .merge(file_options)
         .merge(user_options)
     end
+
+    def slice(keys)
+      final_options.slice(*keys)
+    end
   end
 
   # The main configuration class of Puma.
@@ -126,7 +130,9 @@ module Puma
   # configuration files.
   class Configuration
     DEFAULTS = {
+      auto_trim_time: 30,
       binds: ['tcp://0.0.0.0:9292'.freeze],
+      clean_thread_locals: false,
       debug: false,
       early_hints: nil,
       environment: 'development'.freeze,
@@ -145,11 +151,13 @@ module Puma
       min_threads: 0,
       mode: :http,
       mutate_stdout_and_stderr_to_sync_on_write: true,
+      out_of_band_hook: [],
       # Number of seconds for another request within a persistent session.
       persistent_timeout: 20,
       queue_requests: true,
       rackup: 'config.ru'.freeze,
       raise_exception_on_sigterm: true,
+      reaping_time: 1,
       remote_address: :socket,
       silence_single_worker_warning: false,
       tag: File.basename(Dir.getwd),

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -151,7 +151,7 @@ module Puma
       min_threads: 0,
       mode: :http,
       mutate_stdout_and_stderr_to_sync_on_write: true,
-      out_of_band_hook: [],
+      out_of_band: [],
       # Number of seconds for another request within a persistent session.
       persistent_timeout: 20,
       queue_requests: true,

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -37,7 +37,7 @@ module Puma
       :clean_thread_locals,
       :max_threads,
       :min_threads,
-      :out_of_band_hook,
+      :out_of_band,
       :reaping_time,
     ]
 
@@ -240,13 +240,15 @@ module Puma
       @events.fire :state, :booting
 
       @status = :run
-
-      @thread_pool = ThreadPool.new(thread_name, @options.slice(THREAD_POOL_OPTIONS).merge(block: method(:process_client)))
+      
+      thread_pool_opts = @options.slice(THREAD_POOL_OPTIONS).merge(block: method(:process_client))
+      @thread_pool = ThreadPool.new(thread_name, thread_pool_opts)
 
       if @queue_requests
         @reactor = Reactor.new(@io_selector_backend, &method(:reactor_wakeup))
         @reactor.run
       end
+
 
       @thread_pool.auto_reap! if @options[:reaping_time]
       @thread_pool.auto_trim! if @options[:auto_trim_time]

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -46,7 +46,7 @@ module Puma
       @max = Integer(options[:max_threads])
       @block = options[:block]
       @extra = [::Puma::IOBuffer]
-      @out_of_band_hook = options[:out_of_band_hook]
+      @out_of_band = options[:out_of_band]
       @clean_thread_locals = options[:clean_thread_locals]
       @reaping_time = options[:reaping_time]
       @auto_trim_time = options[:auto_trim_time]
@@ -73,8 +73,6 @@ module Puma
     end
 
     attr_reader :spawned, :trim_requested, :waiting
-    attr_accessor :clean_thread_locals
-    attr_accessor :out_of_band_hook # @version 5.0.0
 
     def self.clean_thread_locals
       Thread.current.keys.each do |key| # rubocop: disable Style/HashEachMethods
@@ -165,12 +163,12 @@ module Puma
 
     # @version 5.0.0
     def trigger_out_of_band_hook
-      return false unless out_of_band_hook && out_of_band_hook.any?
+      return false unless @out_of_band && @out_of_band.any?
 
       # we execute on idle hook when all threads are free
       return false unless @spawned == @waiting
 
-      out_of_band_hook.each(&:call)
+      @out_of_band.each(&:call)
       true
     rescue Exception => e
       STDERR.puts "Exception calling out_of_band_hook: #{e.message} (#{e.class})"

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1,5 +1,6 @@
 require_relative "helper"
 require "puma/events"
+require "puma/server"
 require "net/http"
 require "nio"
 require "ipaddr"

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -10,12 +10,22 @@ class TestThreadPool < Minitest::Test
 
   def new_pool(min, max, &block)
     block = proc { } unless block
-    @pool = Puma::ThreadPool.new('tst', min, max, &block)
+    options = {
+      min_threads: min,
+      max_threads: max,
+      block: block,
+    }
+    @pool = Puma::ThreadPool.new('tst', options)
   end
 
   def mutex_pool(min, max, &block)
     block = proc { } unless block
-    @pool = MutexPool.new('tst', min, max, &block)
+    options = {
+      min_threads: min,
+      max_threads: max,
+      block: block,
+    }
+    @pool = MutexPool.new('tst', options)
   end
 
   # Wraps ThreadPool work in mutex for better concurrency control.


### PR DESCRIPTION
### Description

*This Pull Request is on top of [#2928: Refactor/move configuration defaults](https://github.com/puma/puma/pull/2928)*

Simplify `ThreadPool` initializations code in `Puma::Server`.

This commit introduces four `ThreadPool` options in `Configuration::DEFAULTS`:
`auto_trim_time`, `reaping_time`, `clean_thread_locals`, and `out_of_band_hook`. 

They can be configured via file/user options `Puma::Configuration`.

The auto reap/trim methods stay in `Puma::Server` because the way we test in `Puma::Server` tests.

Adds `slice(keys)` method to `UserFileDefaultOptions` so it acts like a Hash and we could read `ThreadPool` options from the user-file-default options.

Adds missing require statement to `test/test_puma_server.rb`, so this test could run individually.

Closes #2921.

### Your checklist for this pull request

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
