### PR TITLE
Remove thread name respond to check for Puma 6

### DIFF
--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -69,9 +69,7 @@ module Puma
     @get_stats.stats
   end
 
-  # Thread name is new in Ruby 2.3
   def self.set_thread_name(name)
-    return unless Thread.current.respond_to?(:name=)
     Thread.current.name = "puma #{name}"
   end
 end


### PR DESCRIPTION
### Description

Drop the thread name assignment check for Ruby < 2.4. Puma 6 will support Ruby 2.4 so we don’t need to check any more.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
