### PR TITLE
Remove the extra require for OpenSSL for Ruby 2.3 on Windows

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -12,15 +12,6 @@ module Puma
   if HAS_SSL
     require 'puma/minissl'
     require 'puma/minissl/context_builder'
-
-    # Odd bug in 'pure Ruby' nio4r version 2.5.2, which installs with Ruby 2.3.
-    # NIO doesn't create any OpenSSL objects, but it rescues an OpenSSL error.
-    # The bug was that it did not require openssl.
-    # @todo remove when Ruby 2.3 support is dropped
-    #
-    if windows? && RbConfig::CONFIG['ruby_version'] == '2.3.0'
-      require 'openssl'
-    end
   end
 
   class Binder


### PR DESCRIPTION
### Description

Remove this extra `require 'openssl'` that was introduced 09be7ce92 to help an issue with Ruby 2.3 and Windows. 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
