### PR TITLE
Removes debug info from tests by default

### DIFF
--- a/.github/workflows/rack2.yaml
+++ b/.github/workflows/rack2.yaml
@@ -16,7 +16,7 @@ jobs:
     env:
       CI: true
       TESTOPTS: -v
-      PUMA_DEBUG: true
+      PUMA_TEST_DEBUG: true
       PUMA_NO_RUBOCOP: true
       PUMA_CI_RACK_2: true
 

--- a/.github/workflows/rack2.yaml
+++ b/.github/workflows/rack2.yaml
@@ -16,6 +16,7 @@ jobs:
     env:
       CI: true
       TESTOPTS: -v
+      PUMA_DEBUG: true
       PUMA_NO_RUBOCOP: true
       PUMA_CI_RACK_2: true
 

--- a/.github/workflows/ragel.yml
+++ b/.github/workflows/ragel.yml
@@ -17,7 +17,7 @@ jobs:
       ragel ${{ matrix.os }} ${{ matrix.ruby }}
     env:
       PUMA_NO_RUBOCOP: true
-      PUMA_DEBUG: true
+      PUMA_TEST_DEBUG: true
 
     runs-on: ${{ matrix.os }}
     if: |

--- a/.github/workflows/ragel.yml
+++ b/.github/workflows/ragel.yml
@@ -17,6 +17,7 @@ jobs:
       ragel ${{ matrix.os }} ${{ matrix.ruby }}
     env:
       PUMA_NO_RUBOCOP: true
+      PUMA_DEBUG: true
 
     runs-on: ${{ matrix.os }}
     if: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
     needs: rubocop
     env:
       CI: true
-      PUMA_DEBUG: true
+      PUMA_TEST_DEBUG: true
       TESTOPTS: -v
       PUMA_NO_RUBOCOP: true
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,6 +28,7 @@ jobs:
     needs: rubocop
     env:
       CI: true
+      PUMA_DEBUG: true
       TESTOPTS: -v
       PUMA_NO_RUBOCOP: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,10 +128,10 @@ To run a single test with 5 seconds as the test case timeout:
 TEST_CASE_TIMEOUT=5 bundle exec m test/test_binder.rb:37
 ```
 
-If you would like more information about extension building, SSL versions, your local Ruby version, and more, use the PUMA_DEBUG env variable:
+If you would like more information about extension building, SSL versions, your local Ruby version, and more, use the PUMA_TEST_DEBUG env variable:
 
 ```sh
-PUMA_DEBUG=1 bundle exec rake test
+PUMA_TEST_DEBUG=1 bundle exec rake test
 ```
 
 #### File limits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,9 +97,15 @@ See the [Bundler docs](https://bundler.io/man/gemfile.5.html#PATH) for more deta
 
 ## Running tests
 
-To run the entire test suite:
+To run rubocop + tests:
+
 ```sh
-bundle exec rake test:all
+bundle exec rake 
+```
+
+To run the test suite only:
+```sh
+bundle exec rake test
 ```
 
 To run a single test file:
@@ -120,6 +126,12 @@ bundle exec m test/test_binder.rb:37
 To run a single test with 5 seconds as the test case timeout:
 ```sh
 TEST_CASE_TIMEOUT=5 bundle exec m test/test_binder.rb:37
+```
+
+If you would like more information about extension building, SSL versions, your local Ruby version, and more, use the PUMA_DEBUG env variable:
+
+```sh
+PUMA_DEBUG=1 bundle exec rake test
 ```
 
 #### File limits

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ end
 gemspec = Gem::Specification.load("puma.gemspec")
 Gem::PackageTask.new(gemspec).define
 
-Rake::FileUtilsExt.verbose_flag = !!ENV['PUMA_DEBUG']
+Rake::FileUtilsExt.verbose_flag = !!ENV['PUMA_TEST_DEBUG']
 # generate extension code using Ragel (C and Java)
 desc "Generate extension code (C and Java) using Ragel"
 task :ragel

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ end
 gemspec = Gem::Specification.load("puma.gemspec")
 Gem::PackageTask.new(gemspec).define
 
+Rake::FileUtilsExt.verbose_flag = !!ENV['PUMA_DEBUG']
 # generate extension code using Ragel (C and Java)
 desc "Generate extension code (C and Java) using Ragel"
 task :ragel

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -192,7 +192,7 @@ end
 
 Minitest.after_run do
   # needed for TestCLI#test_control_clustered
-  if !$debugging_hold && ENV['PUMA_DEBUG']
+  if !$debugging_hold && ENV['PUMA_TEST_DEBUG']
     out = $debugging_info.strip
     unless out.empty?
       dash = "\u2500"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -22,7 +22,7 @@ require_relative "helpers/apps"
 Thread.abort_on_exception = true
 
 $debugging_info = ''.dup
-$debugging_hold = false    # needed for TestCLI#test_control_clustered
+$debugging_hold = false   # needed for TestCLI#test_control_clustered
 $test_case_timeout = ENV.fetch("TEST_CASE_TIMEOUT") do
   RUBY_ENGINE == "ruby" ? 45 : 60
 end.to_i
@@ -192,7 +192,7 @@ end
 
 Minitest.after_run do
   # needed for TestCLI#test_control_clustered
-  unless $debugging_hold
+  if !$debugging_hold && ENV['PUMA_DEBUG']
     out = $debugging_info.strip
     unless out.empty?
       dash = "\u2500"

--- a/test/test_preserve_bundler_env.rb
+++ b/test/test_preserve_bundler_env.rb
@@ -3,7 +3,6 @@ require_relative "helpers/integration"
 
 class TestPreserveBundlerEnv < TestIntegration
   def setup
-    skip
     skip_unless :fork
     super
   end
@@ -30,7 +29,7 @@ class TestPreserveBundlerEnv < TestIntegration
     Dir.chdir(File.expand_path("bundle_preservation_test", __dir__)) do
       @server = IO.popen(env, cmd.split, "r")
     end
-    wait_for_server_to_boot(log: true)
+    wait_for_server_to_boot
     @pid = @server.pid
     connection = connect
     initial_reply = read_body(connection)

--- a/test/test_preserve_bundler_env.rb
+++ b/test/test_preserve_bundler_env.rb
@@ -3,6 +3,7 @@ require_relative "helpers/integration"
 
 class TestPreserveBundlerEnv < TestIntegration
   def setup
+    skip
     skip_unless :fork
     super
   end
@@ -29,7 +30,7 @@ class TestPreserveBundlerEnv < TestIntegration
     Dir.chdir(File.expand_path("bundle_preservation_test", __dir__)) do
       @server = IO.popen(env, cmd.split, "r")
     end
-    wait_for_server_to_boot
+    wait_for_server_to_boot(log: true)
     @pid = @server.pid
     connection = connect
     initial_reply = read_body(connection)

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -4,7 +4,7 @@
 # loaded so HAS_SSL is defined
 require_relative "helper"
 
-if ::Puma::HAS_SSL && ENV['PUMA_DEBUG']
+if ::Puma::HAS_SSL && ENV['PUMA_TEST_DEBUG']
   require "puma/minissl"
   require "net/http"
 

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -4,7 +4,7 @@
 # loaded so HAS_SSL is defined
 require_relative "helper"
 
-if ::Puma::HAS_SSL
+if ::Puma::HAS_SSL && ENV['PUMA_DEBUG']
   require "puma/minissl"
   require "net/http"
 


### PR DESCRIPTION
New output:

```
install -c -p -m 755 puma_http11.so /host/nateberkopec/Documents/Code.nosync/upstream/puma/lib/puma
Run options: --seed 52639

# Running:

SSS................................................................................................................................................................................................S...................................S...............................................S.S...S...........................................S..........................................................................................................................................................................................................

Fabulous run in 133.758721s, 3.9773 runs/s, 11.5731 assertions/s.

532 runs, 1548 assertions, 0 failures, 0 errors, 9 skips

You have skipped tests. Run with --verbose for details.
```

CI output remains the same.