### PR TITLE
test/rackup/ci_*.ru files - fix frozen string issue

### DIFF
--- a/test/rackup/ci_select.ru
+++ b/test/rackup/ci_select.ru
@@ -25,9 +25,9 @@ body_types = %w[a c i s].freeze
 run lambda { |env|
   info = if (dly = env[hdr_dly])
     sleep dly.to_f
-    "#{Process.pid}\nHello World\nSlept #{dly}\n"
+    "#{Process.pid}\nHello World\nSlept #{dly}\n".dup
   else
-    "#{Process.pid}\nHello World\n"
+    "#{Process.pid}\nHello World\n".dup
   end
   info_len_adj = 1023 - info.bytesize
 

--- a/test/rackup/ci_string.ru
+++ b/test/rackup/ci_string.ru
@@ -24,9 +24,9 @@ env_len = (t = ENV['CI_BODY_CONF']) ? t[/\d+\z/].to_i : 10
 run lambda { |env|
   info = if (dly = env[hdr_dly])
     sleep dly.to_f
-    "#{Process.pid}\nHello World\nSlept #{dly}\n"
+    "#{Process.pid}\nHello World\nSlept #{dly}\n".dup
   else
-    "#{Process.pid}\nHello World\n"
+    "#{Process.pid}\nHello World\n".dup
   end
   info_len_adj = 1023 - info.bytesize
 


### PR DESCRIPTION
### Description

Interesting problem.  Ruby 3 doesn't throw a 'frozen string' error, but Ruby 2.7 does.  Fixed.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
