### PR TITLE
test/rackup/ci_*.ru files - cache response bodies

### DIFF
--- a/test/rackup/ci_array.ru
+++ b/test/rackup/ci_array.ru
@@ -7,7 +7,7 @@
 require 'securerandom'
 
 headers = {}
-headers['Content-Type'] = 'text/plain; charset=utf-8'
+headers['Content-Type'] = 'text/plain; charset=utf-8'.freeze
 25.times { |i| headers["X-My-Header-#{i}"] = SecureRandom.hex(25) }
 
 hdr_dly = 'HTTP_DLY'
@@ -18,19 +18,28 @@ str_1kb = "──#{SecureRandom.hex 507}─\n".freeze
 
 env_len = (t = ENV['CI_BODY_CONF']) ? t[/\d+\z/].to_i : 10
 
+cache_array = {}
+
 run lambda { |env|
   info = if (dly = env[hdr_dly])
+    hash_key = "#{dly},".dup
     sleep dly.to_f
     "#{Process.pid}\nHello World\nSlept #{dly}\n"
   else
+    hash_key = ",".dup
     "#{Process.pid}\nHello World\n"
   end
   info_len_adj = 1023 - info.bytesize
 
   len = (t = env[hdr_body_conf]) ? t[/\d+\z/].to_i : env_len
 
-  body = Array.new len, str_1kb
-  body[0] = info + str_1kb.byteslice(0, info_len_adj) + "\n"
+  hash_key << len.to_s
+
   headers[hdr_content_length] = (1_024 * len).to_s
+  body = cache_array[hash_key] ||= begin
+    temp = Array.new len, str_1kb
+    temp[0] = info + str_1kb.byteslice(0, info_len_adj) + "\n"
+    temp
+  end
   [200, headers, body]
 }

--- a/test/rackup/ci_chunked.ru
+++ b/test/rackup/ci_chunked.ru
@@ -7,7 +7,7 @@
 require 'securerandom'
 
 headers = {}
-headers['Content-Type'] = 'text/plain; charset=utf-8'
+headers['Content-Type'] = 'text/plain; charset=utf-8'.freeze
 25.times { |i| headers["X-My-Header-#{i}"] = SecureRandom.hex(25) }
 
 hdr_dly = 'HTTP_DLY'
@@ -18,19 +18,27 @@ str_1kb = "──#{SecureRandom.hex 507}─\n".freeze
 
 env_len = (t = ENV['CI_BODY_CONF']) ? t[/\d+\z/].to_i : 10
 
+cache_chunked = {}
+
 run lambda { |env|
   info = if (dly = env[hdr_dly])
+    hash_key = "#{dly},".dup
     sleep dly.to_f
     "#{Process.pid}\nHello World\nSlept #{dly}\n"
   else
+    hash_key = ",".dup
     "#{Process.pid}\nHello World\n"
   end
   info_len_adj = 1023 - info.bytesize
 
   len = (t = env[hdr_body_conf]) ? t[/\d+\z/].to_i : env_len
 
-  temp = Array.new len, str_1kb
-  temp[0] = info + str_1kb.byteslice(0, info_len_adj) + "\n"
-  body = temp.to_enum
+  hash_key << len.to_s
+
+  body = cache_chunked[hash_key] ||= begin
+    temp = Array.new len, str_1kb
+    temp[0] = info + str_1kb.byteslice(0, info_len_adj) + "\n"
+    temp.to_enum
+  end
   [200, headers, body]
 }


### PR DESCRIPTION
### Description

When using the test/rackup/ci_*.ru files, previous (original) versions did not cache response bodies.  Larger bodies may use a lot of memory, causing gc issues, etc.  This affects performance benchmarks.

Hence, cache bodies so benchmark results are more accurate.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
