### PR TITLE
Support request_body_wait metric with higher precision

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -315,7 +315,7 @@ module Puma
     private
 
     def setup_body
-      @body_read_start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+      @body_read_start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
 
       if @env[HTTP_EXPECT] == CONTINUE
         # TODO allow a hook here to check the headers before
@@ -587,7 +587,7 @@ module Puma
 
     def set_ready
       if @body_read_start
-        @env['puma.request_body_wait'] = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - @body_read_start
+        @env['puma.request_body_wait'] = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond) - @body_read_start
       end
       @requests_served += 1
       @ready = true

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1016,6 +1016,7 @@ EOF
 
     sock.gets
 
+    assert request_body_wait.is_a?(Float)
     # Could be 1000 but the tests get flaky. We don't care if it's extremely precise so much as that
     # it is set to a reasonable number.
     assert_operator request_body_wait, :>=, 900


### PR DESCRIPTION
### Description

Why? I was reading the `architecture` document and looked at `request_body_wait`. I remember concurrent-ruby has a change https://github.com/ruby-concurrency/concurrent-ruby/pull/915 that powers Rails to have float milliseconds in some places (https://github.com/rails/rails/pull/43502). 

Thought it will be useful for people to have better precision for this metric.

After this PR, People will get more precisions for this metric (3 more digits)

```ruby
> Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
=> 391179141

> Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
=> 391181147.258
```

This metric was first introduced at https://github.com/puma/puma/pull/1569.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
