### PR TITLE
minissl.c - immediate ruby_memcheck fixes

### DIFF
--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -275,8 +275,11 @@ sslctx_initialize(VALUE self, VALUE mini_ssl_ctx) {
     x509 = PEM_read_bio_X509(bio, NULL, NULL, NULL);
 
     if (SSL_CTX_use_certificate(ctx, x509) != 1) {
+      BIO_free(bio);
       raise_file_error("SSL_CTX_use_certificate", RSTRING_PTR(cert_pem));
     }
+    X509_free(x509);
+    BIO_free(bio);
   }
 
   if (!NIL_P(key_pem)) {
@@ -285,8 +288,11 @@ sslctx_initialize(VALUE self, VALUE mini_ssl_ctx) {
     pkey = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
 
     if (SSL_CTX_use_PrivateKey(ctx, pkey) != 1) {
+      BIO_free(bio);
       raise_file_error("SSL_CTX_use_PrivateKey", RSTRING_PTR(key_pem));
     }
+    EVP_PKEY_free(pkey);
+    BIO_free(bio);
   }
 
   verification_flags = rb_funcall(mini_ssl_ctx, rb_intern_const("verification_flags"), 0);


### PR DESCRIPTION
### Description

Spent most of this evening working with [ruby_memcheck](https://github.com/Shopify/ruby_memcheck).  Code in this PR fixes a few memory leaks, some of which occur when improper data is used to create an SSL connection/listener.

All of the other results were calling `rb_define_` functions, which may be false positives.  Or, these are Ruby functions that are called when one requires Puma, as they are the functions that allow Ruby to know that a `Puma` module, or a `Puma::Server` class exist.

Note that the changes fix leaks in an object that is created once for each SSL listener.  I believe there are no leaks on the client/ request/accepted socket level.

I need to spend some more time working with ruby_memcheck...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
