### PR TITLE
Remove unused Puma::ControlCLI::COMMANDS for Puma 6

### DIFF
--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -33,9 +33,6 @@ module Puma
       'worker-count-up'   => 'SIGTTIN'
     }.freeze
 
-    # @deprecated 6.0.0
-    COMMANDS = CMD_PATH_SIG_MAP.keys.freeze
-
     # commands that cannot be used in a request
     NO_REQ_COMMANDS = %w[info reopen-log worker-count-down worker-count-up].freeze
 


### PR DESCRIPTION
### Description

Remove unused `Puma::ControlCLI::COMMANDS` for Puma 6.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
