### PR TITLE
Remove unused KEYS_NOT_TO_PERSIST_IN_STATE for Puma 6

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -21,9 +21,6 @@ module Puma
   # Handles invoke a Puma::Server in a command line style.
   #
   class CLI
-    # @deprecated 6.0.0
-    KEYS_NOT_TO_PERSIST_IN_STATE = Launcher::KEYS_NOT_TO_PERSIST_IN_STATE
-
     # Create a new CLI object using +argv+ as the command line
     # arguments.
     #

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -18,12 +18,6 @@ module Puma
   class Launcher
     autoload :BundlePruner, 'puma/launcher/bundle_pruner'
 
-    # @deprecated 6.0.0
-    KEYS_NOT_TO_PERSIST_IN_STATE = [
-       :logger, :lowlevel_error_handler,
-       :before_worker_shutdown, :before_worker_boot, :before_worker_fork,
-       :after_worker_boot, :before_fork, :on_restart
-     ]
     # Returns an instance of Launcher
     #
     # +conf+ A Puma::Configuration object indicating how to run the server.


### PR DESCRIPTION
### Description

Remove unused `KEYS_NOT_TO_PERSIST_IN_STATE` for Puma 6.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
