### PR TITLE
Remove unused StateFile::FIELDS for Puma 6

### DIFF
--- a/lib/puma/state_file.rb
+++ b/lib/puma/state_file.rb
@@ -15,9 +15,6 @@ module Puma
 
     ALLOWED_FIELDS = %w!control_url control_auth_token pid running_from!
 
-    # @deprecated 6.0.0
-    FIELDS = ALLOWED_FIELDS
-
     def initialize
       @options = {}
     end


### PR DESCRIPTION
### Description

Remove unused `StateFile::FIELDS` for Puma 6.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
