### PR TITLE
Revert change to Server#initialize (new) method signature from #2798

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -46,6 +46,8 @@ module Puma
       @original_argv = @argv.dup
       @config        = conf
 
+      @config.options[:log_writer] = @log_writer
+
       # Advertise the Configuration
       Puma.cli_config = @config if defined?(Puma.cli_config)
 

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -69,7 +69,7 @@ module Puma
 
       app = Puma::App::Status.new @launcher, token
 
-      control = Puma::Server.new app, @log_writer, @events,
+      control = Puma::Server.new app, @events,
         { min_threads: 0, max_threads: 1, queue_requests: false }
 
       control.binder.parse [str], self, 'Starting control server'
@@ -167,7 +167,7 @@ module Puma
     end
 
     def start_server
-      server = Puma::Server.new(app, @log_writer, @events, @options)
+      server = Puma::Server.new(app, @events, @options)
       server.inherit_binder(@launcher.binder)
       server
     end

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -67,10 +67,13 @@ module Puma
     #   and have default values set via +fetch+.  Normally the values are set via
     #   `::Puma::Configuration.puma_default_options`.
     #
-    def initialize(app, log_writer=LogWriter.stdio, events=Events.new, options = {})
+    # @note The `events` parameter is set to nil, and set to `Events.new` in code.
+    #   Often `options` needs to be passed, but `events` does not.  Using nil allows
+    #   calling code to not require events.rb.
+    #
+    def initialize(app, events = nil, options = {})
       @app = app
-      @log_writer = log_writer
-      @events = events
+      @events = events || Events.new
 
       @check, @notify = nil
       @status = :stop
@@ -84,6 +87,7 @@ module Puma
         UserFileDefaultOptions.new(options, Configuration::DEFAULTS)
       end
 
+      @log_writer          = @options.fetch :log_writer, LogWriter.stdio
       @early_hints         = @options[:early_hints]
       @first_data_timeout  = @options[:first_data_timeout]
       @min_threads         = @options[:min_threads]

--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -1,5 +1,4 @@
 require_relative "helper"
-require "puma/events"
 
 class TestBusyWorker < Minitest::Test
   def setup
@@ -55,8 +54,9 @@ class TestBusyWorker < Minitest::Test
 
     options[:min_threads] ||= 0
     options[:max_threads] ||= 10
+    options[:log_writer]  ||= Puma::LogWriter.strings
 
-    @server = Puma::Server.new request_handler, Puma::LogWriter.strings, Puma::Events.new, **options
+    @server = Puma::Server.new request_handler, nil, **options
     @port = (@server.add_tcp_listener '127.0.0.1', 0).addr[1]
     @server.run
   end

--- a/test/test_integration_ssl.rb
+++ b/test/test_integration_ssl.rb
@@ -1,6 +1,5 @@
 require_relative 'helper'
 require_relative "helpers/integration"
-require "puma/log_writer"
 
 # These tests are used to verify that Puma works with SSL sockets.  Only
 # integration tests isolate the server from the test environment, so there
@@ -99,7 +98,7 @@ RUBY
 
     app = lambda { |_| [200, { 'Content-Type' => 'text/plain' }, ["HELLO", ' ', "THERE"]] }
     opts = {max_threads: 1}
-    server = Puma::Server.new app, Puma::LogWriter.stdio, Puma::Events.new, opts
+    server = Puma::Server.new app, nil, opts
     if Puma.jruby?
       ssl_params = {
           'keystore'      => File.expand_path('../examples/puma/client-certs/keystore.jks', __dir__),

--- a/test/test_log_writer.rb
+++ b/test/test_log_writer.rb
@@ -1,3 +1,4 @@
+require 'puma/detect'
 require 'puma/log_writer'
 require_relative "helper"
 
@@ -124,7 +125,7 @@ class TestLogWriter < Minitest::Test
   def test_parse_error
     app = proc { |_env| [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
     log_writer = Puma::LogWriter.strings
-    server = Puma::Server.new app, log_writer
+    server = Puma::Server.new app, nil, {log_writer: log_writer}
 
     host = '127.0.0.1'
     port = (server.add_tcp_listener host, 0).addr[1]

--- a/test/test_out_of_band_server.rb
+++ b/test/test_out_of_band_server.rb
@@ -1,5 +1,4 @@
 require_relative "helper"
-require "puma/events"
 
 class TestOutOfBandServer < Minitest::Test
   parallelize_me!
@@ -69,8 +68,9 @@ class TestOutOfBandServer < Minitest::Test
 
     options[:min_threads] ||= 1
     options[:max_threads] ||= 1
+    options[:log_writer]  ||= Puma::LogWriter.strings
 
-    @server = Puma::Server.new app, Puma::LogWriter.strings, Puma::Events.new, out_of_band: [oob], **options
+    @server = Puma::Server.new app, nil, out_of_band: [oob], **options
     @port = (@server.add_tcp_listener '127.0.0.1', 0).addr[1]
     @server.run
     sleep 0.15 if Puma.jruby?

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -1,5 +1,4 @@
 require_relative "helper"
-require "puma/log_writer"
 
 class TestPersistent < Minitest::Test
 
@@ -25,7 +24,7 @@ class TestPersistent < Minitest::Test
     end
 
     opts = {max_threads: 1}
-    @server = Puma::Server.new @simple, Puma::LogWriter.stdio, Puma::Events.new, opts
+    @server = Puma::Server.new @simple, nil, opts
     @port = (@server.add_tcp_listener HOST, 0).addr[1]
     @server.run
     sleep 0.15 if Puma.jruby?

--- a/test/test_puma_localhost_authority.rb
+++ b/test/test_puma_localhost_authority.rb
@@ -31,9 +31,8 @@ class TestPumaLocalhostAuthority < Minitest::Test
     app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
 
     @log_writer = SSLLogWriterHelper.new STDOUT, STDERR
-    @server = Puma::Server.new app, @log_writer
-    @server.app = app
-    @server.add_ssl_listener @host, 0,nil
+    @server = Puma::Server.new app, nil, {log_writer: @log_writer}
+    @server.add_ssl_listener @host, 0, nil
     @http = Net::HTTP.new @host, @server.connected_ports[0]
 
     @http.use_ssl = true
@@ -63,7 +62,7 @@ class TestPumaSSLLocalhostAuthority < Minitest::Test
 
     @log_writer = SSLLogWriterHelper.new STDOUT, STDERR
 
-    @server = Puma::Server.new app, @log_writer
+    @server = Puma::Server.new app, nil, {log_writer: @log_writer}
     @server.app = app
 
     @server.add_ssl_listener @host, 0,nil

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -56,7 +56,7 @@ class TestPumaServerSSL < Minitest::Test
     yield ctx if block_given?
 
     @log_writer = SSLLogWriterHelper.new STDOUT, STDERR
-    @server = Puma::Server.new app, @log_writer
+    @server = Puma::Server.new app, nil, {log_writer: @log_writer}
     @port = (@server.add_ssl_listener @host, 0, ctx).addr[1]
     @server.run
 
@@ -315,7 +315,7 @@ class TestPumaServerSSLClient < Minitest::Test
     app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
 
     log_writer = SSLLogWriterHelper.new STDOUT, STDERR
-    server = Puma::Server.new app, log_writer
+    server = Puma::Server.new app, nil, {log_writer: log_writer}
     server.add_ssl_listener host, port, context
     host_addrs = server.binder.ios.map { |io| io.to_io.addr[2] }
     server.run
@@ -520,7 +520,7 @@ class TestPumaServerSSLWithCertPemAndKeyPem < Minitest::Test
 
     app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
     log_writer = SSLLogWriterHelper.new STDOUT, STDERR
-    server = Puma::Server.new app, log_writer
+    server = Puma::Server.new app, nil, {log_writer: log_writer}
     server.add_ssl_listener host, port, ctx
     server.run
 

--- a/test/test_request_invalid.rb
+++ b/test/test_request_invalid.rb
@@ -1,5 +1,4 @@
 require_relative "helper"
-require "puma/events"
 
 # These tests check for invalid request headers and metadata.
 # Content-Length, Transfer-Encoding, and chunked body size
@@ -36,8 +35,7 @@ class TestRequestInvalid < Minitest::Test
     }
 
     @log_writer = Puma::LogWriter.strings
-    events = Puma::Events.new
-    @server = Puma::Server.new app, @log_writer, events
+    @server = Puma::Server.new app, nil, {log_writer: @log_writer}
     @port = (@server.add_tcp_listener @host, 0).addr[1]
     @server.run
     sleep 0.15 if Puma.jruby?

--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -17,7 +17,7 @@ class TestResponseHeader < Minitest::Test
     @app = ->(env) { [200, {}, [env['rack.url_scheme']]] }
 
     @log_writer = Puma::LogWriter.strings
-    @server = Puma::Server.new @app, @log_writer, ::Puma::Events.new, {min_threads: 1}
+    @server = Puma::Server.new @app, ::Puma::Events.new, {log_writer: @log_writer, min_threads: 1}
   end
 
   def teardown

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -23,7 +23,7 @@ class WebServerTest < Minitest::Test
 
   def setup
     @tester = TestHandler.new
-    @server = Puma::Server.new @tester, Puma::LogWriter.strings
+    @server = Puma::Server.new @tester, nil, {log_writer: Puma::LogWriter.strings}
     @port = (@server.add_tcp_listener "127.0.0.1", 0).addr[1]
     @tcp = "http://127.0.0.1:#{@port}"
     @server.run


### PR DESCRIPTION
### Description

#2798 introduced a change to the paramenters passed to `Server#initialize`.  This may affect repo's using Puma for testing.

Revert the change and adjust other lib files & test files.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
