### PR TITLE
puma.rb - autoload LogWriter for non-standard loading

### DIFF
--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -17,9 +17,12 @@ require_relative 'puma/detect'
 require_relative 'puma/json_serialization'
 
 module Puma
-  autoload :Const,    "#{__dir__}/puma/const"
-  autoload :Server,   "#{__dir__}/puma/server"
-  autoload :Launcher, "#{__dir__}/puma/launcher"
+  # when Puma is loaded via `Puma::CLI`, all files are loaded via
+  # `require_relative`.  The below are for non-standard loading
+  autoload :Const,     "#{__dir__}/puma/const"
+  autoload :Server,    "#{__dir__}/puma/server"
+  autoload :Launcher,  "#{__dir__}/puma/launcher"
+  autoload :LogWriter, "#{__dir__}/puma/log_writer"
 
   # at present, MiniSSL::Engine is only defined in extension code (puma_http11),
   # not in minissl.rb

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -24,9 +24,6 @@ module Puma
     # Create a new CLI object using +argv+ as the command line
     # arguments.
     #
-    # +stdout+ and +stderr+ can be set to IO-like objects which
-    # this object will report status on.
-    #
     def initialize(argv, log_writer = LogWriter.stdio, events = Events.new)
       @debug = false
       @argv = argv.dup


### PR DESCRIPTION
### Description

With the change in PR #2965, if a 'non-standard' (normally directly creating a `Server`) Puma use needs a specific type of LogWriter, it may be created before `Server.new` is called, as it's passed an option value.  In normal Puma initialization, the LogWriter is loaded earlier, and also in `Server`.  And for these applications, `Server` is autoloaded.

Hence, autoload `LogWriter` to cover 'non-standard' Puma uses.

Note that previous uses (before `Events` was 'split' into `LogWriter` and `Events`), with `Events` as a possible parameter, it was called as a parameter to `Server.new`, so `Events` was loaded by the autoloaded `Server`.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
