### PR TITLE
Runner & subclasses - instance variable cleanup

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -96,7 +96,7 @@ module Puma
 
     # @version 5.0.0
     def spawn_worker(idx, master)
-      @launcher.config.run_hooks(:before_worker_fork, idx, @launcher.log_writer)
+      @config.run_hooks(:before_worker_fork, idx, @log_writer)
 
       pid = fork { worker(idx, master) }
       if !pid
@@ -105,7 +105,7 @@ module Puma
         exit! 1
       end
 
-      @launcher.config.run_hooks(:after_worker_fork, idx, @launcher.log_writer)
+      @config.run_hooks(:after_worker_fork, idx, @log_writer)
       pid
     end
 
@@ -294,7 +294,7 @@ module Puma
 
         # Auto-fork after the specified number of requests.
         if (fork_requests = @options[:fork_worker].to_i) > 0
-          @launcher.events.register(:ping!) do |w|
+          @events.register(:ping!) do |w|
             fork_worker! if w.index == 0 &&
               w.phase == 0 &&
               w.last_status[:requests_count] >= fork_requests
@@ -376,7 +376,7 @@ module Puma
       else
         log "*     Restarts: (\u2714) hot (\u2714) phased"
 
-        unless @launcher.config.app_configured?
+        unless @config.app_configured?
           error "No application configured, nothing to run"
           exit 1
         end
@@ -413,7 +413,7 @@ module Puma
 
       @master_read, @worker_write = read, @wakeup
 
-      @launcher.config.run_hooks(:before_fork, nil, @launcher.log_writer)
+      @config.run_hooks(:before_fork, nil, @log_writer)
 
       spawn_workers
 
@@ -466,9 +466,9 @@ module Puma
                   w.term unless w.term?
                 when "p"
                   w.ping!(result.sub(/^\d+/,'').chomp)
-                  @launcher.events.fire(:ping!, w)
+                  @events.fire(:ping!, w)
                   if !booted && @workers.none? {|worker| worker.last_status.empty?}
-                    @launcher.events.fire_on_booted!
+                    @events.fire_on_booted!
                     booted = true
                   end
                 end

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -16,8 +16,6 @@ module Puma
 
         @index = index
         @master = master
-        @launcher = launcher
-        @options = launcher.options
         @check_pipe = pipes[:check_pipe]
         @worker_write = pipes[:worker_write]
         @fork_pipe = pipes[:fork_pipe]
@@ -53,7 +51,7 @@ module Puma
 
         # Invoke any worker boot hooks so they can get
         # things in shape before booting the app.
-        @launcher.config.run_hooks(:before_worker_boot, index, @launcher.log_writer, @hook_data)
+        @config.run_hooks(:before_worker_boot, index, @log_writer, @hook_data)
 
         begin
         server = @server ||= start_server
@@ -85,7 +83,7 @@ module Puma
                 if restart_server.length > 0
                   restart_server.clear
                   server.begin_restart(true)
-                  @launcher.config.run_hooks(:before_refork, nil, @launcher.log_writer, @hook_data)
+                  @config.run_hooks(:before_refork, nil, @log_writer, @hook_data)
                 end
               elsif idx == 0 # restart server
                 restart_server << true << false
@@ -139,7 +137,7 @@ module Puma
 
         # Invoke any worker shutdown hooks so they can prevent the worker
         # exiting until any background operations are completed
-        @launcher.config.run_hooks(:before_worker_shutdown, index, @launcher.log_writer, @hook_data)
+        @config.run_hooks(:before_worker_shutdown, index, @log_writer, @hook_data)
       ensure
         @worker_write << "t#{Process.pid}\n" rescue nil
         @worker_write.close
@@ -148,7 +146,7 @@ module Puma
       private
 
       def spawn_worker(idx)
-        @launcher.config.run_hooks(:before_worker_fork, idx, @launcher.log_writer, @hook_data)
+        @config.run_hooks(:before_worker_fork, idx, @log_writer, @hook_data)
 
         pid = fork do
           new_worker = Worker.new index: idx,
@@ -166,7 +164,7 @@ module Puma
           exit! 1
         end
 
-        @launcher.config.run_hooks(:after_worker_fork, idx, @launcher.log_writer, @hook_data)
+        @config.run_hooks(:after_worker_fork, idx, @log_writer, @hook_data)
         pid
       end
     end

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -12,6 +12,7 @@ module Puma
       @launcher = launcher
       @log_writer = launcher.log_writer
       @events = launcher.events
+      @config = launcher.config
       @options = launcher.options
       @app = nil
       @control = nil
@@ -146,13 +147,13 @@ module Puma
     end
 
     def load_and_bind
-      unless @launcher.config.app_configured?
+      unless @config.app_configured?
         error "No application configured, nothing to run"
         exit 1
       end
 
       begin
-        @app = @launcher.config.app
+        @app = @config.app
       rescue Exception => e
         log "! Unable to load application: #{e.class}: #{e.message}"
         raise e
@@ -163,7 +164,7 @@ module Puma
 
     # @!attribute [r] app
     def app
-      @app ||= @launcher.config.app
+      @app ||= @config.app
     end
 
     def start_server

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -55,7 +55,7 @@ module Puma
       log "Use Ctrl-C to stop"
       redirect_io
 
-      @launcher.events.fire_on_booted!
+      @events.fire_on_booted!
 
       begin
         server_thread.join


### PR DESCRIPTION
### Description

Runner & subclasses - @launcher is duplicated, other instance variables in Runner are not used in subclasses and should be.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
