### PR TITLE
[CI] - fixup various test suite issues

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -37,7 +37,7 @@ class TestIntegration < Minitest::Test
     if @ios_to_close
       @ios_to_close.each do |io|
         begin
-          io.close if io.is_a?(IO) && !io.closed?
+          io.close if io.respond_to?(:close) && !io.closed?
         rescue
         ensure
           io = nil

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -428,6 +428,9 @@ RUBY
     get_worker_pids 0, 2
     stop_server
 
+    # helpful for mon MRI Rubies
+    assert wait_for_server_to_include('puma shutdown')
+
     file = 'hook_data-0.txt'
     assert_equal 'index 0 data 0', File.read(file, mode: 'rb:UTF-8')
     File.unlink file if File.file? file

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -100,7 +100,7 @@ class TestIntegrationSingle < TestIntegration
     sleep 1 # ensure curl send a request
 
     Process.kill :TERM, @pid
-    true while @server.gets !~ /Gracefully stopping/ # wait for server to begin graceful shutdown
+    assert wait_for_server_to_include('Gracefully stopping') # wait for server to begin graceful shutdown
 
     # Invoke a request which must be rejected
     _stdin, _stdout, rejected_curl_stderr, rejected_curl_wait_thread = Open3.popen3("curl #{HOST}:#{@tcp_port}")
@@ -199,7 +199,7 @@ class TestIntegrationSingle < TestIntegration
 
     cli_pumactl 'stop'
 
-    assert_equal "hello\n", @server.gets
+    assert wait_for_server_to_include("hello\n")
     assert_includes @server.read, 'Goodbye!'
 
     @server.close unless @server.closed?

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -7,11 +7,16 @@ class TestIntegrationSingle < TestIntegration
   def workers ; 0 ; end
 
   def test_hot_restart_does_not_drop_connections_threads
-    hot_restart_does_not_drop_connections num_threads: 5, total_requests: 1_000
+    ttl_reqs = Puma.windows? ? 500 : 1_000
+    hot_restart_does_not_drop_connections num_threads: 5, total_requests: ttl_reqs
   end
 
   def test_hot_restart_does_not_drop_connections
-    hot_restart_does_not_drop_connections
+    if Puma.windows?
+      hot_restart_does_not_drop_connections total_requests: 300
+    else
+      hot_restart_does_not_drop_connections
+    end
   end
 
   def test_usr2_restart

--- a/test/test_plugin.rb
+++ b/test/test_plugin.rb
@@ -12,16 +12,15 @@ class TestPlugin < TestIntegration
     cli_server "-b tcp://#{HOST}:#{@tcp_bind} --control-url tcp://#{HOST}:#{@tcp_ctrl} --control-token #{TOKEN} -C test/config/plugin1.rb test/rackup/hello.ru"
     File.open('tmp/restart.txt', mode: 'wb') { |f| f.puts "Restart #{Time.now}" }
 
-    true while (l = @server.gets) !~ /Restarting\.\.\./
-    assert_match(/Restarting\.\.\./, l)
+    assert wait_for_server_to_include('Restarting...')
 
-    true while (l = @server.gets) !~ /Ctrl-C/
-    assert_match(/Ctrl-C/, l)
+    assert wait_for_server_to_boot
 
     out = StringIO.new
 
     cli_pumactl "-C tcp://#{HOST}:#{@tcp_ctrl} -T #{TOKEN} stop"
-    true while (l = @server.gets) !~ /Goodbye/
+
+    assert wait_for_server_to_include('Goodbye')
 
     @server.close
     @server = nil

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -22,7 +22,15 @@ class TestPumaServer < Minitest::Test
 
   def teardown
     @server.stop(true)
-    @ios.each { |io| io.close if io && !io.closed? }
+    # Errno::EBADF raised on macOS
+    @ios.each do |io|
+      begin
+        io.close if io.respond_to?(:close) && !io.closed?
+      rescue Errno::EBADF
+      ensure
+        io = nil
+      end
+    end
   end
 
   def server_run(**options, &block)

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -3,6 +3,7 @@ require_relative "helper"
 require "net/http"
 
 require "rack"
+require "rack/body_proxy"
 require "rack/chunked" if Rack::RELEASE >= '3'
 
 require "nio"


### PR DESCRIPTION
### Description

1. **'Fix wait_for_server_to_boot failures when restarting'** - Most CI failures (excluding platform failures) seem to be due to logging issues (see #2967) or issues with reading the log when booting, often when restarting.  Add code to better account for IO issues when restarting.
2. **'[CI] Update hot_restart tests for Windows'**
3. **'[CI] test_rack_server.rb - require "rack/body_proxy"'** - Rack autoloads the file, issues when run parallel in tests.
4. **'[CI] fixups for test teardown code'** - teardown code closes IO objects, add better error handling if they've been closed or destroyed.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
'