### PR TITLE
[CI] test_puma_server.rb - running parallel, fixup tests that stub

### DIFF
--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1282,16 +1282,16 @@ EOF
   def stub_accept_nonblock(error)
     @port = (@server.add_tcp_listener @host, 0).addr[1]
     io = @server.binder.ios.last
+
     accept_old = io.method(:accept_nonblock)
-    accept_stub = -> do
+    io.singleton_class.send :define_method, :accept_nonblock do
       accept_old.call.close
       raise error
     end
-    io.stub(:accept_nonblock, accept_stub) do
-      @server.run
-      new_connection
-      sleep 0.01
-    end
+
+    @server.run
+    new_connection
+    sleep 0.01
   end
 
   # System-resource errors such as EMFILE should not be silently swallowed by accept loop.


### PR DESCRIPTION
### Description

Minitest stub is generic, we have the object we need to stub, so use singleton_class.

Fixes intermittent errors like:
```
  1) Failure:
TestPumaServer#test_accept_emfile [test/test_puma_server.rb:1292]:
Expected EMFILE error not logged.
Expected "" to not be empty.
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
