### PR TITLE
[CI] fixup test_plugin.rb, change IO.select to IO#wait_*

### DIFF
--- a/test/config/plugin1.rb
+++ b/test/config/plugin1.rb
@@ -1,1 +1,0 @@
-plugin 'tmp_restart'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -30,6 +30,10 @@ end.to_i
 require "puma"
 require "puma/detect"
 
+unless ::Puma::HAS_NATIVE_IO_WAIT
+  require "io/wait"
+end
+
 # used in various ssl test files, see test_puma_server_ssl.rb and
 # test_puma_localhost_authority.rb
 if Puma::HAS_SSL

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -200,7 +200,7 @@ class TestIntegration < Minitest::Test
       begin
         n = io.syswrite str
       rescue Errno::EAGAIN, Errno::EWOULDBLOCK => e
-        if !IO.select(nil, [io], nil, 5)
+        unless io.wait_writable 5
           raise e
         end
 

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -237,10 +237,7 @@ class TestPersistent < Minitest::Test
     c2 = TCPSocket.new HOST, @port
     c2 << @valid_request
 
-    out = IO.select([c2], nil, nil, 1)
-
-    assert out, "select returned nil"
-    assert_equal c2, out.first.first
+    assert c2.wait_readable(1), "2nd request starved"
 
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4, c2)
     assert_equal "Hello", c2.read(5)

--- a/test/test_plugin.rb
+++ b/test/test_plugin.rb
@@ -4,35 +4,24 @@ require_relative "helpers/integration"
 class TestPlugin < TestIntegration
   def test_plugin
     skip "Skipped on Windows Ruby < 2.5.0, Ruby bug" if windows? && RUBY_VERSION < '2.5.0'
-    @tcp_bind = UniquePort.call
-    @tcp_ctrl = UniquePort.call
+    @control_tcp_port = UniquePort.call
 
     Dir.mkdir("tmp") unless Dir.exist?("tmp")
 
-    cli_server "-b tcp://#{HOST}:#{@tcp_bind} --control-url tcp://#{HOST}:#{@tcp_ctrl} --control-token #{TOKEN} -C test/config/plugin1.rb test/rackup/hello.ru"
+    cli_server "--control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN} test/rackup/hello.ru",
+      config: "plugin 'tmp_restart'"
+
     File.open('tmp/restart.txt', mode: 'wb') { |f| f.puts "Restart #{Time.now}" }
 
     assert wait_for_server_to_include('Restarting...')
 
     assert wait_for_server_to_boot
 
-    out = StringIO.new
-
-    cli_pumactl "-C tcp://#{HOST}:#{@tcp_ctrl} -T #{TOKEN} stop"
+    cli_pumactl "stop"
 
     assert wait_for_server_to_include('Goodbye')
 
     @server.close
     @server = nil
-    out.close
-  end
-
-  private
-
-  def cli_pumactl(argv)
-    pumactl = IO.popen("#{BASE} bin/pumactl #{argv}", "r")
-    @ios_to_close << pumactl
-    Process.wait pumactl.pid
-    pumactl
   end
 end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -525,7 +525,7 @@ EOF
 
     sock = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\n"
 
-    sock << "Hello" unless IO.select([sock], nil, nil, 1.15)
+    sock << "Hello" unless sock.wait_readable(1.15)
 
     data = sock.gets
 
@@ -1209,9 +1209,9 @@ EOF
     assert_match(s1_response, s1.gets) if s1_response
 
     # Send s2 after shutdown begins
-    s2 << "\r\n" unless IO.select([s2], nil, nil, 0.2)
+    s2 << "\r\n" unless s2.wait_readable(0.2)
 
-    assert IO.select([s2], nil, nil, 10), 'timeout waiting for response'
+    assert s2.wait_readable(10), 'timeout waiting for response'
     s2_result = begin
       s2.gets
     rescue Errno::ECONNABORTED, Errno::ECONNRESET
@@ -1350,7 +1350,7 @@ EOF
     sleep 0.5 # give enough time for new connection to enter reactor
     @server.stop false
 
-    assert IO.select([sock], nil, nil, 1), 'Unexpected timeout'
+    assert sock.wait_readable(1), 'Unexpected timeout'
     assert_raises EOFError do
       sock.read_nonblock(256)
     end


### PR DESCRIPTION
### Description

The last CI run failed in a JRuby job. `test_plugin.rb` uses a control server, and it was being started via `IO.popen`.  We should keep the calls to `IO.popen` to a minimum, as they're slow.  `integration.rb` has code to start the control server in the test process, and grabs the output with a pipe.  Fixed up the file.

Also, changed several instances of `IO.select` that were operating on a single io to use `IO#wait_*`.

### Your checklist for this pull request
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
