### PR TITLE
[CI] PR #2976 - Fix RuboCop mistake - test/test_integration_cluster.rb

### DIFF
--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -626,13 +626,14 @@ RUBY
   # Process.kill should raise the Errno::ESRCH exception, indicating the
   # process is dead and has been reaped.
   def bad_exit_pids(pids)
-    pids.map do |pid|
+    t = pids.map do |pid|
       begin
         pid if Process.kill 0, pid
       rescue Errno::ESRCH
         nil
       end
-    end.compact!
+    end
+    t.compact!; t
   end
 
   # used in loop to create several 'requests'


### PR DESCRIPTION
### Description

Incorrect code in one of the 'Performance/ChainArrayAllocation' updates.

`#compact!` returns `nil` if no changes were made.

Or, several Array bang methods may not return the array operated on.  Hence, when rewriting chained array methods, never use the return value of a bang method call.

Sorry, I was working on #2976 intermittently yesterday, and should have waitied until this morning to check the code...

### Your checklist for this pull request
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
