### PR TITLE
[CI] misc updates to test files

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -21,7 +21,7 @@ require_relative "helpers/apps"
 
 Thread.abort_on_exception = true
 
-$debugging_info = +''
+$debugging_info = []
 $debugging_hold = false   # needed for TestCLI#test_control_clustered
 $test_case_timeout = ENV.fetch("TEST_CASE_TIMEOUT") do
   RUBY_ENGINE == "ruby" ? 45 : 60
@@ -197,7 +197,8 @@ end
 Minitest.after_run do
   # needed for TestCLI#test_control_clustered
   if !$debugging_hold && ENV['PUMA_TEST_DEBUG']
-    out = $debugging_info.strip
+    $debugging_info.sort!
+    out = $debugging_info.join.strip
     unless out.empty?
       dash = "\u2500"
       wid = ENV['GITHUB_ACTIONS'] ? 88 : 90

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -513,10 +513,9 @@ class TestPumaServerSSLWithCertPemAndKeyPem < Minitest::Test
   def test_server_ssl_with_cert_pem_and_key_pem
     host = "localhost"
     port = 0
-    ctx = Puma::MiniSSL::Context.new.tap { |ctx|
-      ctx.cert_pem = File.read("#{CERT_PATH}/server.crt")
-      ctx.key_pem = File.read("#{CERT_PATH}/server.key")
-    }
+    ctx = Puma::MiniSSL::Context.new
+    ctx.cert_pem = File.read "#{CERT_PATH}/server.crt"
+    ctx.key_pem  = File.read "#{CERT_PATH}/server.key"
 
     app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
     log_writer = SSLLogWriterHelper.new STDOUT, STDERR


### PR DESCRIPTION
### Description

There are still intermittent failures in CI.  These changes may help.  There are also two file updates, one is just a refactor, the other changes the debug logging output.

Recent jobs in my fork, showing one job with a test step failure:
```
                    Load
Run  OS / Ruby      Ruby   Compile   Test
195  macOS-12 3.0   0:22      0:11    3:21 passed

196  macOS-12 3.0   7:31      3:30   10:12 failed (timed out)
196  macOS-12 3.1   0:21      0:12    3:20 passed
```

Notice the increased times in the failed job.

Tests are random and parallel, which can affect test time.  Conversely, the 'Load Ruby' and 'Compile' steps should have consistent times.  In the failing job, those times are well over an order of magnitude slower...

I don't think we can accommodate variances like that in CI.  Although everyone hates to see a red 'X', we'll just have to assume the failures are CI related, and not actual Puma problems...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
