### PR TITLE
Fix path could be nil in test_puma_server tests

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -259,3 +259,15 @@ module AggregatedResults
   end
 end
 Minitest::SummaryReporter.prepend AggregatedResults
+
+module TestTempFile
+  require "tempfile"
+  def tempfile_create(basename, data, mode: File::BINARY)
+    fio = Tempfile.create(basename, mode: mode)
+    fio.syswrite data
+    fio.rewind
+    @ios << fio
+    fio
+  end
+end
+Minitest::Test.include TestTempFile

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -264,7 +264,8 @@ module TestTempFile
   require "tempfile"
   def tempfile_create(basename, data, mode: File::BINARY)
     fio = Tempfile.create(basename, mode: mode)
-    fio.syswrite data
+    fio.write data
+    fio.flush
     fio.rewind
     @ios << fio
     fio

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -154,6 +154,8 @@ class TestPumaServer < Minitest::Test
     ary = data.split("\r\n\r\n", 2)
 
     assert_equal random_bytes, ary.last
+  ensure
+    tf.close
   end
 
   def test_file_to_path
@@ -161,7 +163,6 @@ class TestPumaServer < Minitest::Test
 
     tf = tempfile_create("test_file_to_path", random_bytes)
     path = tf.path
-    tf.close # for Windows
 
     obj = Object.new
     obj.singleton_class.send(:define_method, :to_path) { path }
@@ -173,6 +174,8 @@ class TestPumaServer < Minitest::Test
     ary = data.split("\r\n\r\n", 2)
 
     assert_equal random_bytes, ary.last
+  ensure
+    tf.close
   end
 
   def test_proper_stringio_body

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -26,6 +26,7 @@ class TestPumaServer < Minitest::Test
     @ios.each do |io|
       begin
         io.close if io.respond_to?(:close) && !io.closed?
+        File.unlink io.path if io.is_a? File
       rescue Errno::EBADF
       ensure
         io = nil
@@ -140,28 +141,27 @@ class TestPumaServer < Minitest::Test
 
     data = send_http_and_read "GET / HTTP/1.0\r\nConnection: close\r\n\r\n"
 
-    assert_equal "Hello World", data.split("\n").last
+    assert_equal "Hello World", data.split("\r\n\r\n", 2).last
   end
 
   def test_file_body
     random_bytes = SecureRandom.random_bytes(4096 * 32)
-    path = Tempfile.open { |f| f.path }
-    File.binwrite path, random_bytes
+    tf = tempfile_create("test_file_body", random_bytes)
 
-    server_run { |env| [200, {}, File.open(path, 'rb')] }
+    server_run { |env| [200, {}, tf] }
 
-    data = send_http_and_read "GET / HTTP/1.0\r\nHost: [::ffff:127.0.0.1]:9292\r\n\r\n"
+    data = send_http("GET / HTTP/1.1\r\nHost: [::ffff:127.0.0.1]:#{@port}\r\n\r\n").sysread(1_024)
     ary = data.split("\r\n\r\n", 2)
 
     assert_equal random_bytes, ary.last
-  ensure
-    File.delete(path) if File.exist?(path)
   end
 
   def test_file_to_path
     random_bytes = SecureRandom.random_bytes(4096 * 32)
-    path = Tempfile.open { |f| f.path }
-    File.binwrite path, random_bytes
+
+    tf = tempfile_create("test_file_to_path", random_bytes)
+    path = tf.path
+    tf.close # for Windows
 
     obj = Object.new
     obj.singleton_class.send(:define_method, :to_path) { path }
@@ -169,15 +169,11 @@ class TestPumaServer < Minitest::Test
 
     server_run { |env| [200, {}, obj] }
 
-    data = send_http_and_read "GET / HTTP/1.0\r\nHost: [::ffff:127.0.0.1]:9292\r\n\r\n"
+    data = send_http("GET / HTTP/1.1\r\nHost: [::ffff:127.0.0.1]:#{@port}\r\n\r\n").sysread(1_024)
     ary = data.split("\r\n\r\n", 2)
 
     assert_equal random_bytes, ary.last
-  ensure
-    File.delete(path) if File.exist?(path)
   end
-
-
 
   def test_proper_stringio_body
     data = nil


### PR DESCRIPTION

### Description

When I ran the test `bundle exec ruby test/test_puma_server.rb` locally with `ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [arm64-darwin21]` on macOS, I got two failing tests which complains path is `nil`<sup>[1]</sup>.

With the rewrite the use of `Tempfile`, now it works for my local dev env `for i in $(seq 1 10); do bundle exec ruby test/test_puma_server.rb; done` and CI seems happy, too. 



<details>
<summary>For references docs on <code>Tempfile</code> and <code>IO</code></summary>

- Ruby 2.4: [Tempfile](https://rubyapi.org/2.4/o/tempfile), [IO#binmode](https://rubyapi.org/2.4/o/io#method-i-binmode) and [IO#write](https://rubyapi.org/2.4/o/io#method-i-write)
- Ruby 2.5: [Tempfile](https://rubyapi.org/2.5/o/tempfile), [IO#binmode](https://rubyapi.org/2.5/o/io#method-i-binmode) and [IO#write](https://rubyapi.org/2.5/o/io#method-i-write)
- Ruby 2.6: [Tempfile](https://rubyapi.org/2.6/o/tempfile), [IO#binmode](https://rubyapi.org/2.6/o/io#method-i-binmode) and [IO#write](https://rubyapi.org/2.6/o/io#method-i-write)
- Ruby 2.7: [Tempfile](https://rubyapi.org/2.7/o/tempfile), [IO#binmode](https://rubyapi.org/2.7/o/io#method-i-binmode) and [IO#write](https://rubyapi.org/2.7/o/io#method-i-write)
- Ruby 3.0: [Tempfile](https://rubyapi.org/3.0/o/tempfile), [IO#binmode](https://rubyapi.org/3.0/o/io#method-i-binmode) and [IO#write](https://rubyapi.org/3.0/o/io#method-i-write)
- Ruby 3.1: [Tempfile](https://rubyapi.org/3.1/o/tempfile), [IO#binmode](https://rubyapi.org/3.1/o/io#method-i-binmode) and [IO#write](https://rubyapi.org/3.1/o/io#method-i-write)

</details>


<details>
<summary><sup>[1] Error I got</sup></summary>

```
  1) Error:
TestPumaServer#test_file_body:
TypeError: no implicit conversion of nil into String
    test/test_puma_server.rb:158:in `exist?'
    test/test_puma_server.rb:158:in `ensure in test_file_body'
    test/test_puma_server.rb:158:in `test_file_body'
    /Users/hhh/dev/puma/test/helper.rb:89:in `block (4 levels) in run'
    /Users/hhh/.rubies/ruby-3.1.0/lib/ruby/3.1.0/timeout.rb:107:in `block in timeout'
    /Users/hhh/.rubies/ruby-3.1.0/lib/ruby/3.1.0/timeout.rb:117:in `timeout'
    /Users/hhh/dev/puma/test/helper.rb:87:in `block (3 levels) in run'

  2) Error:
TestPumaServer#test_file_to_path:
TypeError: no implicit conversion of nil into String
    test/test_puma_server.rb:177:in `exist?'
    test/test_puma_server.rb:177:in `ensure in test_file_to_path'
    test/test_puma_server.rb:177:in `test_file_to_path'
    /Users/hhh/dev/puma/test/helper.rb:89:in `block (4 levels) in run'
    /Users/hhh/.rubies/ruby-3.1.0/lib/ruby/3.1.0/timeout.rb:107:in `block in timeout'
    /Users/hhh/.rubies/ruby-3.1.0/lib/ruby/3.1.0/timeout.rb:117:in `timeout'
    /Users/hhh/dev/puma/test/helper.rb:87:in `block (3 levels) in run'
```
</details>

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.

