### PR TITLE
require securerandom for all tests

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,6 +11,8 @@ if RUBY_VERSION == '2.4.1'
   end
 end
 
+require "securerandom"
+
 require_relative "minitest/verbose"
 require "minitest/autorun"
 require "minitest/pride"

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1,4 +1,6 @@
 require_relative "helper"
+
+require "securerandom"
 require "puma/events"
 require "puma/server"
 require "net/http"

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1,6 +1,4 @@
 require_relative "helper"
-
-require "securerandom"
 require "puma/events"
 require "puma/server"
 require "net/http"

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -7,7 +7,6 @@ require "rack/body_proxy"
 require "rack/chunked" if Rack::RELEASE >= '3'
 
 require "nio"
-require "securerandom"
 require "open3"
 
 class TestRackServer < Minitest::Test


### PR DESCRIPTION
### Description

I found test errored with missing `require` of `SecureRandom`.

```
  1) Error:
TestPumaServer#test_file_to_path:
NameError: uninitialized constant TestPumaServer::SecureRandom

    random_bytes = SecureRandom.random_bytes(4096 * 32)
                   ^^^^^^^^^^^^
Did you mean?  SecurityError
    test/test_puma_server.rb:162:in `test_file_to_path'
    /Users/hhh/dev/puma/test/helper.rb:89:in `block (4 levels) in run'
    /Users/hhh/.rubies/ruby-3.1.0/lib/ruby/3.1.0/timeout.rb:107:in `block in timeout'
    /Users/hhh/.rubies/ruby-3.1.0/lib/ruby/3.1.0/timeout.rb:117:in `timeout'
    /Users/hhh/dev/puma/test/helper.rb:87:in `block (3 levels) in run'

  2) Error:
TestPumaServer#test_file_body:
NameError: uninitialized constant TestPumaServer::SecureRandom

    random_bytes = SecureRandom.random_bytes(4096 * 32)
                   ^^^^^^^^^^^^
Did you mean?  SecurityError
    test/test_puma_server.rb:147:in `test_file_body'
    /Users/hhh/dev/puma/test/helper.rb:89:in `block (4 levels) in run'
    /Users/hhh/.rubies/ruby-3.1.0/lib/ruby/3.1.0/timeout.rb:107:in `block in timeout'
    /Users/hhh/.rubies/ruby-3.1.0/lib/ruby/3.1.0/timeout.rb:117:in `timeout'
    /Users/hhh/dev/puma/test/helper.rb:87:in `block (3 levels) in run'

95 runs, 330 assertions, 0 failures, 2 errors, 0 skips
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
