### PR TITLE
[CI] test files - use unlink in ensure when appropriate

### DIFF
--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -215,14 +215,14 @@ RUBY
 
     stop_server(Integer(File.read("t3-pid")))
 
+    assert(worker_pid_was_present)
+    assert(worker_index_within_number_of_workers)
+  ensure
     File.unlink "t3-pid" if File.file? "t3-pid"
     File.unlink "t3-worker-0-pid" if File.file? "t3-worker-0-pid"
     File.unlink "t3-worker-1-pid" if File.file? "t3-worker-1-pid"
     File.unlink "t3-worker-2-pid" if File.file? "t3-worker-2-pid"
     File.unlink "t3-worker-3-pid" if File.file? "t3-worker-3-pid"
-
-    assert(worker_pid_was_present)
-    assert(worker_index_within_number_of_workers)
   end
 
   # use three workers to keep accepting clients

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -163,20 +163,18 @@ class TestIntegrationSingle < TestIntegration
 
     log = File.read('t1-stdout')
 
-    File.unlink 't1-stdout' if File.file? 't1-stdout'
-    File.unlink 't1-pid' if File.file? 't1-pid'
-
     assert_match(%r!GET / HTTP/1\.1!, log)
+  ensure
+    File.unlink 't1-stdout' if File.file? 't1-stdout'
+    File.unlink 't1-pid'    if File.file? 't1-pid'
   end
 
   def test_puma_started_log_writing
     skip_unless_signal_exist? :TERM
 
-    suppress_output = '> /dev/null 2>&1'
-
     cli_server '-C test/config/t2_conf.rb test/rackup/hello.ru'
 
-    system "curl http://localhost:#{@tcp_port}/ #{suppress_output}"
+    system "curl http://localhost:#{@tcp_port}/ > /dev/null 2>&1"
 
     out=`#{BASE} bin/pumactl -F test/config/t2_conf.rb status`
 
@@ -184,11 +182,11 @@ class TestIntegrationSingle < TestIntegration
 
     log = File.read('t2-stdout')
 
-    File.unlink 't2-stdout' if File.file? 't2-stdout'
-
     assert_match(%r!GET / HTTP/1\.1!, log)
     assert(!File.file?("t2-pid"))
     assert_equal("Puma is started\n", out)
+  ensure
+    File.unlink 't2-stdout' if File.file? 't2-stdout'
   end
 
   def test_application_logs_are_flushed_on_write

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -23,7 +23,7 @@ class TestLauncher < Minitest::Test
     launcher(conf).write_state
 
     assert_equal File.read(pid_path).strip.to_i, Process.pid
-
+  ensure
     File.unlink pid_path
   end
 

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -44,6 +44,7 @@ class TestPumaControlCli < TestConfigFileBase
   def test_config_file
     control_cli = Puma::ControlCLI.new ["--config-file", "test/config/state_file_testing_config.rb", "halt"]
     assert_equal "t3-pid", control_cli.instance_variable_get(:@pidfile)
+  ensure
     File.unlink "t3-pid" if File.file? "t3-pid"
   end
 


### PR DESCRIPTION
### Description

Some of the tests requiring disk files will intermittently fail, and code may stop before `unlink` calls.  This may hinder test 'retry'.

Place all `File.unlink` calls in an ensure section of the test method.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
