### PR TITLE
Use :nodoc: to limit public API [ci skip]

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -25,6 +25,9 @@ module Puma
 
   class HttpParserError501 < IOError; end
 
+  #———————————————————————— DO NOT USE — this class is for internal use only ———
+
+
   # An instance of this class represents a unique request from a client.
   # For example, this could be a web request from a browser or from CURL.
   #
@@ -38,7 +41,7 @@ module Puma
   # the header and body are fully buffered via the `try_to_finish` method.
   # They can be used to "time out" a response via the `timeout_at` reader.
   #
-  class Client
+  class Client # :nodoc:
 
     # this tests all values but the last, which must be chunked
     ALLOWED_TRANSFER_ENCODING = %w[compress deflate gzip].freeze

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -2,13 +2,16 @@
 
 module Puma
   class Cluster < Puma::Runner
+    #—————————————————————— DO NOT USE — this class is for internal use only ———
+
+
     # This class is instantiated by the `Puma::Cluster` and represents a single
     # worker process.
     #
     # At the core of this class is running an instance of `Puma::Server` which
     # gets created via the `start_server` method from the `Puma::Runner` class
     # that this inherits from.
-    class Worker < Puma::Runner
+    class Worker < Puma::Runner # :nodoc:
       attr_reader :index, :master
 
       def initialize(index:, master:, launcher:, pipes:, server: nil)

--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -2,12 +2,15 @@
 
 module Puma
   class Cluster < Runner
+    #—————————————————————— DO NOT USE — this class is for internal use only ———
+
+
     # This class represents a worker process from the perspective of the puma
     # master process. It contains information about the process and its health
     # and it exposes methods to control the process via IPC. It does not
     # include the actual logic executed by the worker process itself. For that,
     # see Puma::Cluster::Worker.
-    class WorkerHandle
+    class WorkerHandle # :nodoc:
       def initialize(idx, pid, phase, options)
         @index = idx
         @pid = pid

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Puma
+  #———————————————————————— DO NOT USE — this class is for internal use only ———
+
 
   # The methods here are included in Server, but are separated into this file.
   # All the methods here pertain to passing the request to the app, then
@@ -10,7 +12,7 @@ module Puma
   # #handle_request, which is called in Server#process_client.
   # @version 5.0.3
   #
-  module Request
+  module Request # :nodoc:
 
     # determines whether to write body to io_buffer first, or straight to socket
     # also fixes max size of chunked body read when bosy is an IO.


### PR DESCRIPTION
### Description

Use `:nodoc:` and add a comment that isn't parsed (note the two blank lines after it) to the following classes/modules:
* Client
* Cluster::Worker
* Cluster::WorkerHandle
* Request

The comment is added to clarify the API status, especially if people are unfamiliar with `:nodoc:`.

Some classes/modules really shouldn't be part of the public API, as changes to the public API should only be done with major version updates.

A super top secret, double overtime folder exists at https://msp-greg.github.io/puma_test/ which shows how these changes would appear in docs.

Comments?  Add more classes/modules?

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
