### PR TITLE
Remove outdated entry from 6.0-Upgrade.md about server initialization signature [ci skip]

### DIFF
--- a/6.0-Upgrade.md
+++ b/6.0-Upgrade.md
@@ -45,7 +45,6 @@ Check the following list to see if you're depending on any of these behaviors:
 1. We've removed the following constants: `Puma::StateFile::FIELDS`, `Puma::CLI::KEYS_NOT_TO_PERSIST_IN_STATE` and `Puma::Launcher::KEYS_NOT_TO_PERSIST_IN_STATE`, and `Puma::ControlCLI::COMMANDS`.
 1. We no longer support Ruby 2.2, 2.3, or JRuby on Java 1.7 or below.
 1. The behavior of `remote_addr` has changed. When using the set_remote_address header: "header_name" functionality, if the header is not passed, REMOTE_ADDR is now set to the physical peeraddr instead of always being set to 127.0.0.1. When an error occurs preventing the physical peeraddr from being fetched, REMOTE_ADDR is now set to the unspecified source address ('0.0.0.0') instead of to '127.0.0.1'
-1. If you are creating your own Puma::Server objects, it's initialize signature has changed. In 5.x and below, it was `def initialize(app, events=Events.stdio, options={})`. Now it is `def initialize(app, log_writer=LogWriter.stdio, events=Events.new, options = {})`.
 
 Then, update your Gemfile:
 


### PR DESCRIPTION
### Description

Remove confusing note about non-existent change in server initialization method signature.

Change to `Puma::Server#initialize` signature was reverted in https://github.com/puma/puma/pull/2965, however entry about it was left in upgrading notes.

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature. (N/A)
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages. (N/A)
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop. (N/A)
