### PR TITLE
[CI] - remove macOS 10.15 jobs, unsupported as of 01-Dec-2022

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, macos-11, macos-12, windows-2022 ]
+        os: [ ubuntu-20.04, ubuntu-18.04, macos-11, macos-12, windows-2022 ]
         ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, head ]
         no-ssl: ['']
         yjit: ['']
@@ -57,15 +57,9 @@ jobs:
 
         exclude:
           - { os: windows-2022 , ruby: head }
-          - { os: macos-10.15  , ruby: 2.7  }
-          - { os: macos-10.15  , ruby: '3.0'}
-          - { os: macos-10.15  , ruby: 3.1  }
-          - { os: macos-10.15  , ruby: head }
           - { os: macos-11     , ruby: 2.4  }
           - { os: macos-11     , ruby: 2.5  }
-          - { os: macos-12     , ruby: 2.4  }
-          - { os: macos-12     , ruby: 2.5  }
-          - { os: macos-12     , ruby: 2.6  }
+          - { os: macos-11     , ruby: head }
 
     steps:
       - name: repo checkout
@@ -131,10 +125,11 @@ jobs:
           - { os: ubuntu-20.04 , ruby: jruby-head, allow-failure: true }
           - { os: ubuntu-20.04 , ruby: truffleruby, allow-failure: true } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
           - { os: ubuntu-20.04 , ruby: truffleruby-head, allow-failure: true }
-          - { os: macos-10.15  , ruby: jruby }
-          - { os: macos-10.15  , ruby: truffleruby, allow-failure: true }
           - { os: macos-11     , ruby: jruby }
           - { os: macos-11     , ruby: truffleruby, allow-failure: true }
+          - { os: macos-12     , ruby: jruby }
+          - { os: macos-12     , ruby: truffleruby, allow-failure: true }
+
 
     steps:
       - name: repo checkout


### PR DESCRIPTION
### Description

Brownouts are occurring from now until then, CI shows failing.  See https://github.com/actions/runner-images/issues/5583

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
