### PR TITLE
TestBundlePruner: do not hard code directory name

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -184,7 +184,7 @@ Minitest::Test.include TestSkips
 
 class Minitest::Test
 
-  REPO_NAME = ENV['GITHUB_REPOSITORY'] ? ENV['GITHUB_REPOSITORY'][/[^\/]+\z/] : 'puma'
+  PROJECT_ROOT = File.dirname(__dir__)
 
   def self.run(reporter, options = {}) # :nodoc:
     prove_it!

--- a/test/test_bundle_pruner.rb
+++ b/test/test_bundle_pruner.rb
@@ -10,7 +10,7 @@ class TestBundlePruner < Minitest::Test
     dirs = bundle_pruner.send(:paths_to_require_after_prune)
 
     assert_equal(2, dirs.length)
-    assert_match(%r{#{REPO_NAME}/lib$}, dirs[0]) # lib dir
+    assert_equal(File.join(PROJECT_ROOT, "lib"), dirs[0]) # lib dir
     assert_match(%r{puma-#{Puma::Const::PUMA_VERSION}$}, dirs[1]) # native extension dir
     refute_match(%r{gems/minitest-[\d.]+/lib$}, dirs[2])
   end
@@ -21,7 +21,7 @@ class TestBundlePruner < Minitest::Test
     dirs = bundle_pruner([], ['minitest']).send(:paths_to_require_after_prune)
 
     assert_equal(3, dirs.length)
-    assert_match(%r{#{REPO_NAME}/lib$}, dirs[0]) # lib dir
+    assert_equal(File.join(PROJECT_ROOT, "lib"), dirs[0]) # lib dir
     assert_match(%r{puma-#{Puma::Const::PUMA_VERSION}$}, dirs[1]) # native extension dir
     assert_match(%r{gems/minitest-[\d.]+/lib$}, dirs[2]) # minitest dir
   end


### PR DESCRIPTION
These two test would fail when running tests from a directory not named "puma", e.g. running from docker/podman like this:

    podman run -it --rm -v $(pwd):/app -w /app ruby:3.1.2 bash

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
