### PR TITLE
[CI] Fix hot-restart issue and TruffleRuby

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -126,6 +126,11 @@ class TestIntegration < Minitest::Test
 
   # Returns true if and when server log includes str.
   # Will timeout or raise an error otherwise
+  # @note Integration tests read server output via the IO returned by `IO.popen`.
+  #   When hot-restarting a server, sometimes (maybe a very short time) the IO
+  #   may be `nil`.  Not sure, but there have been infrequent intermittent
+  #   failures due it.
+  #
   def wait_for_server_to_include(str, log: false)
     sleep 0.05 until @server.is_a?(IO)
     retry_cntr = 0
@@ -140,7 +145,7 @@ class TestIntegration < Minitest::Test
       else
         true until (@server.gets || '').include?(str)
       end
-    rescue Errno::EBADF, Errno::ECONNREFUSED, Errno::ECONNRESET, IOError => e
+    rescue NoMethodError, Errno::EBADF, Errno::ECONNREFUSED, Errno::ECONNRESET, IOError => e
       retry_cntr += 1
       raise e if retry_cntr > 10
       sleep 0.1
@@ -152,6 +157,11 @@ class TestIntegration < Minitest::Test
   # Returns line if and when server log matches re, unless idx is specified,
   # then returns regex match.
   # Will timeout or raise an error otherwise
+  # @note Integration tests read server output via the IO returned by `IO.popen`.
+  #   When hot-restarting a server, sometimes (maybe a very short time) the IO
+  #   may be `nil`.  Not sure, but there have been infrequent intermittent
+  #   failures due it.
+  #
   def wait_for_server_to_match(re, idx = nil, log: false)
     sleep 0.05 until @server.is_a?(IO)
     retry_cntr = 0
@@ -167,7 +177,7 @@ class TestIntegration < Minitest::Test
       else
         true until (line = @server.gets || '').match?(re)
       end
-    rescue Errno::EBADF, Errno::ECONNREFUSED, Errno::ECONNRESET, IOError => e
+    rescue NoMethodError, Errno::EBADF, Errno::ECONNREFUSED, Errno::ECONNRESET, IOError => e
       retry_cntr += 1
       raise e if retry_cntr > 10
       sleep 0.1


### PR DESCRIPTION
### Description

1. With hot-restart integration tests, intermittent failures occur with the popen server IO being nil.  Add `NoMethodError` to allowed errors, as the `wait_for_server_to_*` methods will timeout quicker than the test timeout.

2. TruffleRuby has consistent failures on `TestPumaServer#test_lowlevel_error_message_without_backtrace`.  Add a small delay, and importantly, use `sysread` for the client socket.  This allows tests to pass, and also shortens the time needed.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
