### PR TITLE
[CI] - Update client socket methods, fix intermittent failures

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -20,6 +20,7 @@ require "minitest/proveit"
 require "minitest/stub_const"
 require "net/http"
 require_relative "helpers/apps"
+require_relative "helpers/sockets"
 
 Thread.abort_on_exception = true
 

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -106,9 +106,9 @@ class TestIntegration < Minitest::Test
   def restart_server_and_listen(argv)
     cli_server argv
     connection = connect
-    initial_reply = read_body(connection)
+    initial_reply = connection.read_body
     restart_server connection
-    [initial_reply, read_body(connect)]
+    [initial_reply, connect.read_body]
   end
 
   # reuses an existing connection to make sure that works
@@ -143,7 +143,7 @@ class TestIntegration < Minitest::Test
       else
         true until (@server.gets || '').include?(str)
       end
-    rescue NoMethodError. Errno::EBADF, Errno::ECONNREFUSED, Errno::ECONNRESET, IOError => e
+    rescue NoMethodError, Errno::EBADF, Errno::ECONNREFUSED, Errno::ECONNRESET, IOError => e
       retry_cntr += 1
       raise e if retry_cntr > 10
       sleep 0.1
@@ -170,7 +170,7 @@ class TestIntegration < Minitest::Test
       else
         true until (line = @server.gets || '').match?(re)
       end
-    rescue NoMethodError. Errno::EBADF, Errno::ECONNREFUSED, Errno::ECONNRESET, IOError => e
+    rescue NoMethodError, Errno::EBADF, Errno::ECONNREFUSED, Errno::ECONNRESET, IOError => e
       retry_cntr += 1
       raise e if retry_cntr > 10
       sleep 0.1
@@ -180,7 +180,7 @@ class TestIntegration < Minitest::Test
   end
 
   def connect(path = nil, unix: false)
-    s = unix ? UNIXSocket.new(@bind_path) : TCPSocket.new(HOST, @tcp_port)
+    s = unix ? TestPuma::SktUNIX.new(@bind_path) : TestPuma::SktTCP.new(HOST, @tcp_port)
     @ios_to_close << s
     s << "GET /#{path} HTTP/1.1\r\n\r\n"
     s
@@ -189,10 +189,9 @@ class TestIntegration < Minitest::Test
   # use only if all socket writes are fast
   # does not wait for a read
   def fast_connect(path = nil, unix: false)
-    s = unix ? UNIXSocket.new(@bind_path) : TCPSocket.new(HOST, @tcp_port)
+    s = unix ? TestPuma::SktUNIX.new(@bind_path) : TestPuma::SktTCP.new(HOST, @tcp_port)
     @ios_to_close << s
-    fast_write s, "GET /#{path} HTTP/1.1\r\n\r\n"
-    s
+    s << "GET /#{path} HTTP/1.1\r\n\r\n"
   end
 
   def fast_write(io, str)
@@ -212,61 +211,6 @@ class TestIntegration < Minitest::Test
 
       return if n == str.bytesize
       str = str.byteslice(n..-1)
-    end
-  end
-
-  def read_body(connection, timeout = nil)
-    read_response(connection, timeout).last
-  end
-
-  def read_response(connection, timeout = nil)
-    timeout ||= RESP_READ_TIMEOUT
-    content_length = nil
-    chunked = nil
-    response = +''
-    t_st = Process.clock_gettime Process::CLOCK_MONOTONIC
-    if connection.to_io.wait_readable timeout
-      loop do
-        begin
-          part = connection.read_nonblock(RESP_READ_LEN, exception: false)
-          case part
-          when String
-            unless content_length || chunked
-              chunked ||= part.include? "\r\nTransfer-Encoding: chunked\r\n"
-              content_length = (t = part[/^Content-Length: (\d+)/i , 1]) ? t.to_i : nil
-            end
-
-            response << part
-            hdrs, body = response.split RESP_SPLIT, 2
-            unless body.nil?
-              # below could be simplified, but allows for debugging...
-              ret =
-                if content_length
-                  body.bytesize == content_length
-                elsif chunked
-                  body.end_with? "\r\n0\r\n\r\n"
-                elsif !hdrs.empty? && !body.empty?
-                  true
-                else
-                  false
-                end
-              if ret
-                return [hdrs, body]
-              end
-            end
-            sleep 0.000_1
-          when :wait_readable, :wait_writable # :wait_writable for ssl
-            sleep 0.000_2
-          when nil
-            raise EOFError
-          end
-          if timeout < Process.clock_gettime(Process::CLOCK_MONOTONIC) - t_st
-            raise Timeout::Error, 'Client Read Timeout'
-          end
-        end
-      end
-    else
-      raise Timeout::Error, 'Client Read Timeout'
     end
   end
 
@@ -344,13 +288,13 @@ class TestIntegration < Minitest::Test
         num_requests.times do |req_num|
           begin
             begin
-              socket = TCPSocket.new HOST, @tcp_port
+              socket = TestPuma::SktTCP.new HOST, @tcp_port
               fast_write socket, "POST / HTTP/1.1\r\nContent-Length: #{message.bytesize}\r\n\r\n#{message}"
             rescue => e
               replies[:write_error] += 1
               raise e
             end
-            body = read_body(socket, 10)
+            body = socket.read_body 10
             if body == "Hello World"
               mutex.synchronize {
                 replies[:success] += 1

--- a/test/helpers/sockets.rb
+++ b/test/helpers/sockets.rb
@@ -48,13 +48,13 @@ module TestPuma
       while n < byte_size
         begin
           n += syswrite(n.zero? ? str : str.byteslice(n..-1))
-        rescue Errno::EAGAIN, Errno::EWOULDBLOCK
+        rescue Errno::EAGAIN, Errno::EWOULDBLOCK => e
           unless wait_writable WRITE_TIMEOUT
-            raise ConnectionError, SKT_WRITE_ERR_MSG
+            raise e
           end
           retry
-        rescue  Errno::EPIPE, SystemCallError, IOError
-          raise ConnectionError, SKT_WRITE_ERR_MSG
+        rescue => e
+          raise e
         end
       end
     end

--- a/test/helpers/sockets.rb
+++ b/test/helpers/sockets.rb
@@ -1,0 +1,171 @@
+require 'socket'
+
+module TestPuma
+
+  # @!macro [new] req
+  #   @param [String] path request uri path
+  #   @param [Float] dly: delay in app when using 'ci' rackups
+  #   @param [Integer, String] body_conf: response body type and size in kB when using 'ci' rackups
+
+  # @!macro [new] tout
+  #   @param [Float] timeout: read timeout for socket
+
+  # @!macro [new] ret_skt
+  #   @return [SktSSL, SktTCP, SktUNIX] the opened socket
+
+
+  RESP_READ_TIMEOUT = 10
+
+  module SktPrepend
+
+    RESP_READ_LEN = 1_024 * 64
+    RESP_SPLIT = "\r\n\r\n"
+
+    WRITE_TIMEOUT = 5
+
+    # Writes a string to the socket using `syswrite`.
+    # @param [String] str
+    # @return [Integer] number of bytes written
+    def write(str)
+      fast_write str
+    end
+
+    # Writes a string to the socket using `syswrite`.
+    # @param [String] str
+    # @return [self]
+    def <<(str)
+      fast_write str
+      self
+    end
+
+    # Writes a string to the socket using `syswrite`.
+    # @param [String] str the string to write
+    # @return [Integer] the number of bytes written
+    def fast_write(str)
+      return unless str.is_a? String
+      n = 0
+      byte_size = str.bytesize
+      while n < byte_size
+        begin
+          n += syswrite(n.zero? ? str : str.byteslice(n..-1))
+        rescue Errno::EAGAIN, Errno::EWOULDBLOCK
+          unless wait_writable WRITE_TIMEOUT
+            raise ConnectionError, SKT_WRITE_ERR_MSG
+          end
+          retry
+        rescue  Errno::EPIPE, SystemCallError, IOError
+          raise ConnectionError, SKT_WRITE_ERR_MSG
+        end
+      end
+    end
+
+    # Returns the response body
+    # @!macro tout
+    # @return [String] response body
+    def read_body(timeout = nil)
+      read_response(timeout).last
+    end
+
+    # Reads the response as a two element array
+    # @note Cannot be used with responses without bodies, like 'HEAD' requests
+    # @!macro tout
+    # @return [Array<String, String>] array is [header string, body]
+    def read_response(timeout = nil)
+      timeout ||= RESP_READ_TIMEOUT
+      content_length = nil
+      chunked = nil
+      response = +''
+      timeout_end = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      while to_io.wait_readable timeout
+        timeout = timeout_end - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        begin
+          # part = sysread RESP_READ_LEN
+          part = read_nonblock(RESP_READ_LEN, exception: false)
+          case part
+          when String
+            unless content_length || chunked
+              chunked ||= part.include? "\r\nTransfer-Encoding: chunked\r\n"
+              content_length = (t = part[/^Content-Length: (\d+)/i , 1]) ? t.to_i : nil
+            end
+
+            response << part
+            hdrs, body = response.split RESP_SPLIT, 2
+            unless body.nil?
+              # below could be simplified, but allows for debugging...
+              ret =
+                if content_length
+                  # STDOUT.puts "body.bytesize #{body.bytesize} content length #{content_length}"
+                  body.bytesize == content_length
+                elsif chunked
+                  # STDOUT.puts "#{body.bytesize} chunked"
+                  body.end_with? "\r\n0\r\n\r\n"
+                elsif !hdrs.empty? && !body.empty?
+                  true
+                else
+                  false
+                end
+              if ret
+                @connection_close = hdrs.include? "\nConnection: close"
+                return [hdrs, body]
+              end
+            end
+            sleep 0.000_1
+          when :wait_readable, :wait_writable # :wait_writable for ssl
+            sleep 0.000_2
+          when nil
+            @connection_close = true
+            raise EOFError
+          end
+        end
+      end
+      raise Timeout::Error, 'Client Read Timeout'
+    end
+
+    # Reads the raw response as string
+    # @!macro tout
+    # @return <String>
+    def read_raw(timeout = nil)
+      timeout ||= RESP_READ_TIMEOUT
+      response = +''
+      timeout_end = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      while to_io.wait_readable timeout
+        timeout = timeout_end - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+        part = read_nonblock(RESP_READ_LEN, exception: false)
+        case part
+        when String
+          response << part
+          sleep 0.000_1
+        when :wait_readable, :wait_writable # :wait_writable for ssl
+          sleep 0.000_2
+        when nil
+          return response
+        end
+      end
+      raise Timeout::Error, 'Client Read Timeout'
+    end
+  end
+
+  unless Object.const_defined?(:Puma) && ::Puma.const_defined?(:HAS_SSL) && !Puma::HAS_SSL
+    require 'openssl'
+    # The SSLSocket class used by the TestPuma framework.  The `SktPrepend` module
+    # is prepended.  The socket is opened with parameters set by `bind_type`.
+    class SktSSL < ::OpenSSL::SSL::SSLSocket
+      prepend SktPrepend
+    end
+  end
+
+  # The TCPSocket class used by the TestPuma framework.  The `SktPrepend` module
+  # is prepended.  The socket is opened with parameters set by `bind_type`.
+  class SktTCP < ::TCPSocket
+    prepend SktPrepend
+  end
+
+  if Object.const_defined? :UNIXSocket
+    # The UNIXSocket class used by the TestPuma framework.  The `SktPrepend` module
+    # is prepended.  The socket is opened with parameters set by `bind_type`.
+    class SktUNIX < ::UNIXSocket
+      prepend SktPrepend
+    end
+  end
+end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -246,7 +246,7 @@ RUBY
       sleep 0.004
     }
 
-    socks.each { |s| read_body s }
+    socks.each { |s| s.read_body }
 
     refute_includes pids, get_worker_pids(1, wrkrs - 1)
   end
@@ -262,12 +262,12 @@ app do |_|
   [200, {}, [exitstatus.to_s]]
 end
 RUBY
-    assert_equal '0', read_body(connect)
+    assert_equal '0', connect.read_body
   end
 
   def test_prune_bundler_with_multiple_workers
     cli_server "-C test/config/prune_bundler_with_multiple_workers.rb"
-    reply = read_body(connect)
+    reply = connect.read_body
 
     assert reply, "embedded app"
   end
@@ -533,7 +533,7 @@ RUBY
     mutex = Mutex.new
 
     s = connect "sleep1", unix: unix
-    replies << read_body(s)
+    replies << s.read_body
 
     Process.kill :USR1, @pid
 
@@ -641,7 +641,7 @@ RUBY
     begin
       sleep delay
       s = fast_connect "sleep#{sleep_time}", unix: unix
-      body = read_body(s, 20)
+      body = s.read_body 20
       mutex.synchronize { replies << body }
     rescue Errno::ECONNRESET
       # connection was accepted but then closed
@@ -659,7 +659,7 @@ RUBY
     begin
       sleep delay
       s = connect "sleep#{sleep_time}-#{step}", unix: unix
-      body = read_body(s, 20)
+      body = s.read_body 20
       if body[/\ASlept /]
         mutex.synchronize { replies[step] = :success }
       else

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -64,7 +64,7 @@ class TestIntegrationPumactl < TestIntegration
 
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-    s = UNIXSocket.new @bind_path
+    s = TestPuma::SktUNIX.new @bind_path
     @ios_to_close << s
     s << "GET /sleep1 HTTP/1.0\r\n\r\n"
 
@@ -102,7 +102,7 @@ class TestIntegrationPumactl < TestIntegration
 
     start = Time.now
 
-    s = UNIXSocket.new @bind_path
+    s = TestPuma::SktUNIX.new @bind_path
     @ios_to_close << s
     s << "GET /sleep1 HTTP/1.0\r\n\r\n"
 
@@ -135,7 +135,7 @@ class TestIntegrationPumactl < TestIntegration
 
     cli_server "-q -C test/config/prune_bundler_with_multiple_workers.rb --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}", unix: true
 
-    s = UNIXSocket.new @bind_path
+    s = TestPuma::SktUNIX.new @bind_path
     @ios_to_close << s
     s << "GET / HTTP/1.0\r\n\r\n"
 

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -63,7 +63,7 @@ class TestIntegrationSingle < TestIntegration
 
     cli_server("test/rackup/url_scheme.ru")
 
-    reply = read_body(connect)
+    reply = connect.read_body
     stop_server
 
     assert_match("http", reply)
@@ -74,7 +74,7 @@ class TestIntegrationSingle < TestIntegration
 
     cli_server("-C test/config/rack_url_scheme.rb test/rackup/url_scheme.ru")
 
-    reply = read_body(connect)
+    reply = connect.read_body
     stop_server
 
     assert_match("https", reply)
@@ -84,7 +84,7 @@ class TestIntegrationSingle < TestIntegration
     skip_unless_signal_exist? :TERM
 
     cli_server "-C test/config/with_rackup_from_dsl.rb test/rackup/hello.ru"
-    reply = read_body(connect)
+    reply = connect.read_body
     stop_server
 
     assert_match("Hello World", reply)
@@ -125,7 +125,7 @@ class TestIntegrationSingle < TestIntegration
 
     cli_server 'test/rackup/hello.ru'
     begin
-      sock = TCPSocket.new(HOST, @tcp_port)
+      sock = TestPuma::SktTCP.new(HOST, @tcp_port)
       sock.close
     rescue => ex
       fail("Port didn't open properly: #{ex.message}")
@@ -134,7 +134,7 @@ class TestIntegrationSingle < TestIntegration
     Process.kill :INT, @pid
     Process.wait @pid
 
-    assert_raises(Errno::ECONNREFUSED) { TCPSocket.new(HOST, @tcp_port) }
+    assert_raises(Errno::ECONNREFUSED) { TestPuma::SktTCP.new(HOST, @tcp_port) }
   end
 
   def test_siginfo_thread_print
@@ -193,7 +193,7 @@ class TestIntegrationSingle < TestIntegration
     @control_tcp_port = UniquePort.call
     cli_server "--control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN} test/rackup/write_to_stdout.ru"
 
-    read_body connect
+    connect.read_body
 
     cli_pumactl 'stop'
 
@@ -213,11 +213,11 @@ class TestIntegrationSingle < TestIntegration
 
     if DARWIN && RUBY_VERSION < '2.5'
       begin
-        read_body connection
+        connection.read_body
       rescue EOFError
       end
     else
-      read_body connection
+      connection.read_body
     end
 
     begin

--- a/test/test_integration_ssl.rb
+++ b/test/test_integration_ssl.rb
@@ -48,7 +48,7 @@ class TestIntegrationSSL < TestIntegration
     yield http
 
     # stop server
-    sock = TCPSocket.new HOST, control_tcp_port
+    sock = TestPuma::SktTCP.new HOST, control_tcp_port
     @ios_to_close << sock
     sock.syswrite "GET /stop?token=#{TOKEN} HTTP/1.1\r\n\r\n"
     sock.read

--- a/test/test_integration_ssl_session.rb
+++ b/test/test_integration_ssl_session.rb
@@ -73,7 +73,7 @@ RUBY
 
   ensure
     # stop server
-    sock = TCPSocket.new HOST, control_tcp_port
+    sock = TestPuma::SktTCP.new HOST, control_tcp_port
     @ios_to_close << sock
     sock.syswrite "GET /stop?token=#{TOKEN} HTTP/1.1\r\n\r\n"
     sock.read

--- a/test/test_preserve_bundler_env.rb
+++ b/test/test_preserve_bundler_env.rb
@@ -32,10 +32,10 @@ class TestPreserveBundlerEnv < TestIntegration
     wait_for_server_to_boot
     @pid = @server.pid
     connection = connect
-    initial_reply = read_body(connection)
+    initial_reply = connection.read_body
     assert_match("Gemfile.bundle_env_preservation_test", initial_reply)
     restart_server connection
-    new_reply = read_body(connection)
+    new_reply = connection.read_body
     assert_match("Gemfile.bundle_env_preservation_test", new_reply)
   end
 
@@ -56,7 +56,7 @@ class TestPreserveBundlerEnv < TestIntegration
     end
     wait_for_server_to_boot
     @pid = @server.pid
-    reply = read_body(connect)
+    reply = connect.read_body
     assert_equal("Hello World", reply)
   end
 
@@ -78,7 +78,7 @@ class TestPreserveBundlerEnv < TestIntegration
     connection = connect
 
     # Bundler itself sets ENV['BUNDLE_GEMFILE'] to the Gemfile it finds if ENV['BUNDLE_GEMFILE'] was unspecified
-    initial_reply = read_body(connection)
+    initial_reply = connection.read_body
     expected_gemfile = File.expand_path("bundle_preservation_test/version1/Gemfile", __dir__).inspect
     assert_equal(expected_gemfile, initial_reply)
 
@@ -86,7 +86,7 @@ class TestPreserveBundlerEnv < TestIntegration
     start_phased_restart
 
     connection = connect
-    new_reply = read_body(connection)
+    new_reply = connection.read_body
     expected_gemfile = File.expand_path("bundle_preservation_test/version2/Gemfile", __dir__).inspect
     assert_equal(expected_gemfile, new_reply)
   end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -7,6 +7,11 @@ require "net/http"
 require "nio"
 require "ipaddr"
 
+class WithoutBacktraceError < StandardError
+  def backtrace; nil; end
+  def message; "no backtrace error"; end
+end
+
 class TestPumaServer < Minitest::Test
   parallelize_me!
 
@@ -428,12 +433,6 @@ EOF
 
     assert_match(/HTTP\/1.0 500 Internal Server Error/, data)
     assert_match(/Puma caught this error: Oh no an error.*\(NoMethodError\).*test\/test_puma_server.rb/m, data)
-  end
-
-  class WithoutBacktraceError < StandardError
-    def backtrace; nil; end
-    def message; "no backtrace error"; end
-    def class; "WithoutBacktraceError"; end
   end
 
   def test_lowlevel_error_message_without_backtrace

--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -100,7 +100,7 @@ class TestWorkerGemIndependence < TestIntegration
     end
 
     connection = connect
-    initial_reply = read_body(connection)
+    initial_reply = connection.read_body
     assert_equal old_version, initial_reply
 
     before_restart&.call
@@ -115,7 +115,7 @@ class TestWorkerGemIndependence < TestIntegration
     start_phased_restart
 
     connection = connect
-    new_reply = read_body(connection)
+    new_reply = connection.read_body
     assert_equal new_version, new_reply
   end
 


### PR DESCRIPTION
### Description

1. Implement a new file `test/helpers/sockets.rb`, which collects methods for creating client connections in tests.  Seems to increase CI speed and reliability.  Begin conversion of existing files to use the new methods.

2. `hot_restart_does_not_drop_connections` tests are run in both single and clustered integration tests.  There are intermittent failures when checking for whether the server has been restarted.  Most involve errors with the IO provided by `IO.popen`.  The main purpose of the tests are to verify that client connections are handled correctly.  So, add more error handling to the server checks.  Note that the there are mutliple restarts, and the client connections behave as expected.

3. Fix a TruffleRuby issue.  If an added error class is within the test class, the tests fail.  Moving it outside the class (so it's defined at root) solves the problem.

Locally, I noticed that test_puma_server.rb ran faster with this patch.  Interested in whether others find the same.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
