### PR TITLE
Correctly close app body for all code paths

### DIFF
--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -59,6 +59,11 @@ class TestPumaServer < Minitest::Test
     header
   end
 
+  # only for shorter bodies!
+  def send_http_and_sysread(req)
+    send_http(req).sysread 2_048
+  end
+
   def send_http_and_read(req)
     send_http(req).read
   end
@@ -420,29 +425,25 @@ EOF
   end
 
   def test_lowlevel_error_message
-    @server = Puma::Server.new @app, @events, {log_writer: @log_writer, :force_shutdown_after => 2}
-
-    server_run do
+    server_run(log_writer: @log_writer, :force_shutdown_after => 2) do
       raise NoMethodError, "Oh no an error"
     end
 
-    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+    data = send_http_and_sysread "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.0 500 Internal Server Error/, data)
+    assert_includes data, 'HTTP/1.0 500 Internal Server Error'
     assert_match(/Puma caught this error: Oh no an error.*\(NoMethodError\).*test\/test_puma_server.rb/m, data)
   end
 
   def test_lowlevel_error_message_without_backtrace
-    @server = Puma::Server.new @app, @events, {log_writer: @log_writer, :force_shutdown_after => 2}
-
-    server_run do
+    server_run(log_writer: @log_writer, :force_shutdown_after => 2) do
       raise WithoutBacktraceError.new
     end
 
-    data = send_http_and_read "GET / HTTP/1.1\r\n\r\n"
-    assert_match(/HTTP\/1.1 500 Internal Server Error/, data)
-    assert_match(/Puma caught this error: no backtrace error.*\(WithoutBacktraceError\)/, data)
-    assert_match(/<no backtrace available>/, data)
+    data = send_http_and_sysread "GET / HTTP/1.1\r\n\r\n"
+    assert_includes data, 'HTTP/1.1 500 Internal Server Error'
+    assert_includes data, 'Puma caught this error: no backtrace error (WithoutBacktraceError)'
+    assert_includes data, '<no backtrace available>'
   end
 
   def test_force_shutdown_error_default
@@ -1439,7 +1440,7 @@ EOF
 
     # TODO: it would be great to test a connection from a non-localhost IP, but we can't really do that. For
     # now, at least test that it doesn't return garbage.
-    remote_addr = send_http_and_read("GET / HTTP/1.1\r\n\r\n").split("\r\n").last
+    remote_addr = send_http_and_sysread("GET / HTTP/1.1\r\n\r\n").split("\r\n").last
     assert_equal @host, remote_addr
   end
 end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -448,7 +448,7 @@ EOF
     assert_includes data, 'HTTP/1.0 500 Internal Server Error'
     assert_includes data, "Puma caught this error: undefined method `to_i' for [0, 1]:Array"
     refute_includes data, 'lowlevel_error'
-    sleep 0.1 if TRUFFLE
+    sleep 0.1 unless ::Puma::IS_MRI
     assert app_body.closed?
   end
 

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -233,6 +233,8 @@ class TestRackServer < Minitest::Test
     sleep 0.25 if Puma::IS_WINDOWS || !Puma::IS_MRI
     resp1 = socket1.sysread 1_024
 
+    sleep 0.01 # time for close block to be called ?
+
     socket2 = TCPSocket.new "127.0.0.1", @port
     socket2.syswrite "GET / HTTP/1.1\r\n\r\n"
     sleep 0.25 if Puma::IS_WINDOWS || !Puma::IS_MRI

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -210,6 +210,41 @@ class TestRackServer < Minitest::Test
     assert_equal str_ary_bytes, content_length
   end
 
+  def test_hijack_body_close
+    available = true
+    @server.app = ->(env) {
+      if available
+        available = false
+        hijack_lambda = ->(io) {
+          io.syswrite 'hijacked'
+          io.close
+        }
+        [200, { 'Content-Type' => 'text/plain', 'rack.hijack' => hijack_lambda},
+          ::Rack::BodyProxy.new([]) { available = true }]
+      else
+        [500, { 'Content-Type' => 'text/plain' }, ['incorrect']]
+      end
+    }
+
+    @server.run
+
+    socket1 = TCPSocket.new "127.0.0.1", @port
+    socket1.syswrite "GET / HTTP/1.1\r\n\r\n"
+    sleep 0.25 if Puma::IS_WINDOWS || !Puma::IS_MRI
+    resp1 = socket1.sysread 1_024
+
+    socket2 = TCPSocket.new "127.0.0.1", @port
+    socket2.syswrite "GET / HTTP/1.1\r\n\r\n"
+    sleep 0.25 if Puma::IS_WINDOWS || !Puma::IS_MRI
+    resp2 = socket2.sysread 1_024
+
+    assert_operator resp1, :end_with?, 'hijacked'
+    assert_operator resp2, :end_with?, 'hijacked'
+
+    socket1.close
+    socket2.close
+  end
+
   def test_common_logger
     log = StringIO.new
 
@@ -259,5 +294,4 @@ class TestRackServer < Minitest::Test
     assert_includes headers.downcase, TRANSFER_ENCODING_CHUNKED
     assert_equal STR_1KB * 10, resp_body
   end
-
 end


### PR DESCRIPTION
### Description

1. At present, some code paths will not close the app body.  Add code to always hold a reference to the app body, so when code calling `lowlevel_error` is executed, the reference to the app body is maintained.

2. test_rack_server.rb - add test_hijack_body_close - test for above

3. Small refactor of test_puma_server.rb.  Takes too damn long.

4. test_puma_server.rb - add `test_lowlevel_error_body_close` to verify body close call when lowlevel_error

Closes #2999.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
