### PR TITLE
Fixup response processing, enumerable bodies

### DIFF
--- a/.github/workflows/turbo-rails.yml
+++ b/.github/workflows/turbo-rails.yml
@@ -1,0 +1,92 @@
+name: turbo-rails
+
+# Note: turbo-rails often returns an ActionDispatch::Response::RackBody for the
+# body.  Also, Rack::BodyProxy or Sprockets::Asset
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  skip_duplicate_runs:
+    uses: ./.github/workflows/skip_duplicate_workflow_runs.yaml
+
+  turbo-rails:
+    name: >-
+      ${{ matrix.os }} Ruby ${{ matrix.ruby }} Rails ${{ matrix.rails-version }}
+    needs: skip_duplicate_runs
+    runs-on: ${{ matrix.os }}
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]')
+        || (needs.skip_duplicate_runs.outputs.should_skip == 'true'))
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-20.04 , ruby: '3.1', rails-version: '6.1', abi: '3.1.0'   }
+          - { os: ubuntu-20.04 , ruby: '3.1', rails-version: '7.0', abi: '3.1.0'   }
+          - { os: ubuntu-22.04 , ruby: head , rails-version: '7.0', abi: '3.2.0+3' }
+    env:
+      CI: true
+      PUMA_NO_RUBOCOP: true
+      RAILS_VERSION: "${{ matrix.rails-version }}"
+      RUBY_ABI: ${{ matrix.abi }}
+      PUMA_VERS: 6.0.0
+
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v3
+
+      - name: load ruby
+        uses: ruby/setup-ruby-pkgs@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          apt-get: ragel
+          bundler-cache: true
+        timeout-minutes: 10
+
+      - name: compile
+        run:  bundle exec rake compile
+
+      - name: turbo-rails git clone
+        run: |
+          git clone -q --depth=1 --no-tags --branch=main https://github.com/hotwired/turbo-rails.git $GITHUB_WORKSPACE/../../turbo-rails
+
+      - name: turbo-rails bundle install
+        working-directory: ../../turbo-rails
+        run: |
+          # fix Puma version, copying files from repo lib later
+          SRC="gem 'puma'"
+          DST="gem 'puma', '$PUMA_VERS'"
+          sed -i "s/$SRC/$DST/" Gemfile
+          # use `stdio` for log_writer, always have one thread existing
+          SRC="Silent: true"
+          DST="Silent: false, Threads: '1:4'"
+          sed -i "s/$SRC/$DST/" test/application_system_test_case.rb
+          SRC="visit echo_messages_path"
+          DST="visit echo_messages_path; sleep 0.001"
+          sed -i "s/$SRC/$DST/" test/system/broadcasts_test.rb
+          bundle config set --local path vendor/bundle
+          bundle config set --local with test
+          bundle install --jobs 4 --retry 3
+          # copy Puma lib files
+          rm -rf vendor/bundle/ruby/$RUBY_ABI/gems/puma-$PUMA_VERS/lib/*
+          cp -r $GITHUB_WORKSPACE/lib/* vendor/bundle/ruby/$RUBY_ABI/gems/puma-$PUMA_VERS/lib
+
+      - name: Puma version check
+        working-directory: ../../turbo-rails
+        run: bundle exec puma --version
+
+      - name: turbo-rails test
+        id: test
+        working-directory: ../../turbo-rails
+        run: bin/test test/**/*_test.rb -v
+        continue-on-error: true
+        if: success()
+
+      - name: >-
+          Test outcome: ${{ steps.test.outcome }}
+        # every step must define a `uses` or `run` key
+        run: echo NOOP

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -100,7 +100,7 @@ module Puma
   # too taxing on performance.
   module Const
 
-    PUMA_VERSION = VERSION = "6.0.0".freeze
+    PUMA_VERSION = VERSION = "6.0.1.dev".freeze
     CODE_NAME = "Sunflower".freeze
 
     PUMA_SERVER_STRING = ['puma', PUMA_VERSION, CODE_NAME].join(' ').freeze

--- a/lib/puma/io_buffer.rb
+++ b/lib/puma/io_buffer.rb
@@ -22,6 +22,16 @@ module Puma
       read
     end
 
+    # Read & Reset - returns contents and resets
+    # @return [String] StringIO contents
+    def read_and_reset
+      rewind
+      str = read
+      truncate 0
+      rewind
+      str
+    end
+
     alias_method :clear, :reset
 
     # before Ruby 2.5, `write` would only take one argument

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -14,15 +14,18 @@ module Puma
   #
   module Request # :nodoc:
 
-    # determines whether to write body to io_buffer first, or straight to socket
-    # also fixes max size of chunked body read when bosy is an IO.
-    BODY_LEN_MAX   = 1_024 * 256
+    # Single element array body: smaller bodies are written to io_buffer first,
+    # then a single write from io_buffer. Larger sizes are written separately.
+    # Also fixes max size of chunked file body read.
+    BODY_LEN_MAX = 1_024 * 256
 
-    # size divide for using copy_stream on body
+    # File body: smaller bodies are combined with io_buffer, then written to
+    # socket.  Larger bodies are written separately using `copy_stream`
     IO_BODY_MAX = 1_024 * 64
 
-    # max size for io_buffer, force write when exceeded
-    IO_BUFFER_LEN_MAX = 1_024 * 1_024 * 4
+    # Array body: elements are collected in io_buffer.  When io_buffer's size
+    # exceeds value, they are written to the socket.
+    IO_BUFFER_LEN_MAX = 1_024 * 512
 
     SOCKET_WRITE_ERR_MSG = "Socket timeout writing data"
 
@@ -134,15 +137,15 @@ module Puma
     end
 
     # Assembles the headers and prepares the body for actually sending the
-    # response via #fast_write_response.
+    # response via `#fast_write_response`.
     #
     # @param status [Integer] the status returned by the Rack application
     # @param headers [Hash] the headers returned by the Rack application
     # @param res_body [Array] the body returned by the Rack application or
-    #   a call to `lowlevel_error`
+    #   a call to `Server#lowlevel_error`
     # @param requests [Integer] number of inline requests handled
     # @param client [Puma::Client]
-    # @return [Boolean,:async]
+    # @return [Boolean,:async] keep-alive status or `:async`
     def prepare_response(status, headers, res_body, requests, client)
       env = client.env
       socket = client.io
@@ -160,27 +163,22 @@ module Puma
 
       resp_info = str_headers(env, status, headers, res_body, io_buffer, force_keep_alive)
 
+      close_body = false
+
       # below converts app_body into body, dependent on app_body's characteristics, and
       # resp_info[:content_length] will be set if it can be determined
       if !resp_info[:content_length] && !resp_info[:transfer_encoding] && status != 204
-        if res_body.respond_to?(:to_ary)
-          length = 0
-          if array_body = res_body.to_ary
-            body = array_body.map { |part| length += part.bytesize; part }
-          elsif res_body.is_a?(::File) && res_body.respond_to?(:size)
-            length = res_body.size
-          elsif res_body.respond_to?(:each)
-            body = []
-            res_body.each { |part| length += part.bytesize; body << part }
-          end
-          resp_info[:content_length] = length
+        if res_body.respond_to?(:to_ary) && (array_body = res_body.to_ary)
+          body = array_body
+          resp_info[:content_length] = body.sum(&:bytesize)
         elsif res_body.is_a?(File) && res_body.respond_to?(:size)
-          resp_info[:content_length] = res_body.size
           body = res_body
+          resp_info[:content_length] = body.size
         elsif res_body.respond_to?(:to_path) && res_body.respond_to?(:each) &&
             File.readable?(fn = res_body.to_path)
           body = File.open fn, 'rb'
           resp_info[:content_length] = body.size
+          close_body = true
         else
           body = res_body
         end
@@ -188,6 +186,17 @@ module Puma
           File.readable?(fn = res_body.to_path)
         body = File.open fn, 'rb'
         resp_info[:content_length] = body.size
+        close_body = true
+      elsif !res_body.is_a?(::File) && res_body.respond_to?(:filename) && res_body.respond_to?(:each) &&
+          res_body.respond_to?(:bytesize) && File.readable?(fn = res_body.filename)
+        # Sprockets::Asset
+        resp_info[:content_length] = res_body.bytesize unless resp_info[:content_length]
+        if res_body.to_hash[:source]   # use each to return @source
+          body = res_body
+        else                           # avoid each and use a File object
+          body = File.open fn, 'rb'
+          close_body = true
+        end
       else
         body = res_body
       end
@@ -211,7 +220,8 @@ module Puma
         end
 
         io_buffer << LINE_END
-        fast_write_str socket, io_buffer.to_s
+        fast_write_str socket, io_buffer.read_and_reset
+        socket.flush
         return keep_alive
       end
       if content_length
@@ -225,12 +235,13 @@ module Puma
       io_buffer << line_ending
 
       if response_hijack
-        fast_write_str socket, io_buffer.to_s
+        fast_write_str socket, io_buffer.read_and_reset
         response_hijack.call socket
         return :async
       end
 
       fast_write_response socket, body, io_buffer, chunked, content_length.to_i
+      body.close if close_body
       keep_alive
     end
 
@@ -247,10 +258,10 @@ module Puma
 
     # Used to write 'early hints', 'no body' responses, 'hijacked' responses,
     # and body segments (called by `fast_write_response`).
-    # Writes a string to an io (normally `Client#io`) using `write_nonblock`.
+    # Writes a string to a socket (normally `Client#io`) using `write_nonblock`.
     # Large strings may not be written in one pass, especially if `io` is a
     # `MiniSSL::Socket`.
-    # @param io [#write_nonblock] the io to write to
+    # @param socket [#write_nonblock] the request/response socket
     # @param str [String] the string written to the io
     # @raise [ConnectionError]
     #
@@ -259,7 +270,7 @@ module Puma
       byte_size = str.bytesize
       while n < byte_size
         begin
-          n += socket.syswrite(n.zero? ? str : str.byteslice(n..-1))
+          n += socket.write_nonblock(n.zero? ? str : str.byteslice(n..-1))
         rescue Errno::EAGAIN, Errno::EWOULDBLOCK
           unless socket.wait_writable WRITE_TIMEOUT
             raise ConnectionError, SOCKET_WRITE_ERR_MSG
@@ -277,39 +288,41 @@ module Puma
     # @param socket [#write] the response socket
     # @param body [Enumerable, File] the body object
     # @param io_buffer [Puma::IOBuffer] contains headers
-    # @param chunk [Boolean]
+    # @param chunked [Boolean]
+    # @paramn content_length [Integer
     # @raise [ConnectionError]
     #
     def fast_write_response(socket, body, io_buffer, chunked, content_length)
-      if body.is_a?(::File) || body.respond_to?(:read) || body.respond_to?(:readpartial)
+      if body.is_a?(::File) && body.respond_to?(:read)
         if chunked  # would this ever happen?
           while part = body.read(BODY_LEN_MAX)
             io_buffer.append part.bytesize.to_s(16), LINE_END, part, LINE_END
           end
-          io_buffer << CLOSE_CHUNKED
-          fast_write_str socket, io_buffer.to_s
+          fast_write_str socket, CLOSE_CHUNKED
         else
           if content_length <= IO_BODY_MAX
-            io_buffer.write body.sysread(content_length)
-            fast_write_str socket, io_buffer.to_s
+            io_buffer.write body.read(content_length)
+            fast_write_str socket, io_buffer.read_and_reset
           else
-            fast_write_str socket, io_buffer.to_s
+            fast_write_str socket, io_buffer.read_and_reset
             IO.copy_stream body, socket
           end
         end
-        body.close
       elsif body.is_a?(::Array) && body.length == 1
-        body_first = body.first
-        if body_first.is_a?(::String) && body_first.bytesize >= BODY_LEN_MAX
-          # large body, write both header & body to socket
-          fast_write_str socket, io_buffer.to_s
-          fast_write_str socket, body_first
-        else
-          # smaller body, write to stream first
+        body_first = nil
+        # using body_first = body.first causes issues?
+        body.each { |str| body_first ||= str }
+
+        if body_first.is_a?(::String) && body_first.bytesize < BODY_LEN_MAX
+          # smaller body, write to io_buffer first
           io_buffer.write body_first
-          fast_write_str socket, io_buffer.to_s
+          fast_write_str socket, io_buffer.read_and_reset
+        else
+          # large body, write both header & body to socket
+          fast_write_str socket, io_buffer.read_and_reset
+          fast_write_str socket, body_first
         end
-      else
+      elsif body.is_a?(::Array)
         # for array bodies, flush io_buffer to socket when size is greater than
         # IO_BUFFER_LEN_MAX
         if chunked
@@ -317,8 +330,7 @@ module Puma
             next if (byte_size = part.bytesize).zero?
             io_buffer.append byte_size.to_s(16), LINE_END, part, LINE_END
             if io_buffer.length > IO_BUFFER_LEN_MAX
-              fast_write_str socket, io_buffer.to_s
-              io_buffer.reset
+              fast_write_str socket, io_buffer.read_and_reset
             end
           end
           io_buffer.write CLOSE_CHUNKED
@@ -327,13 +339,31 @@ module Puma
             next if part.bytesize.zero?
             io_buffer.write part
             if io_buffer.length > IO_BUFFER_LEN_MAX
-              fast_write_str socket, io_buffer.to_s
-              io_buffer.reset
+              fast_write_str socket, io_buffer.read_and_reset
             end
           end
         end
-        fast_write_str(socket, io_buffer.to_s) unless io_buffer.length.zero?
+        # may write last body part for non-chunked, also headers if array is empty
+        fast_write_str(socket, io_buffer.read_and_reset) unless io_buffer.length.zero?
+      else
+        # for enum bodies
+        fast_write_str socket, io_buffer.read_and_reset
+        if chunked
+          body.each do |part|
+            next if (byte_size = part.bytesize).zero?
+             fast_write_str socket, (byte_size.to_s(16) << LINE_END)
+             fast_write_str socket, part
+             fast_write_str socket, LINE_END
+          end
+          fast_write_str socket, CLOSE_CHUNKED
+        else
+          body.each do |part|
+            next if part.bytesize.zero?
+            fast_write_str socket, part
+          end
+        end
       end
+      socket.flush
     rescue Errno::EAGAIN, Errno::EWOULDBLOCK
       raise ConnectionError, SOCKET_WRITE_ERR_MSG
     rescue  Errno::EPIPE, SystemCallError, IOError
@@ -512,6 +542,7 @@ module Puma
     # @version 5.0.3
     #
     def str_headers(env, status, headers, res_body, io_buffer, force_keep_alive)
+
       line_ending = LINE_END
       colon = COLON
 
@@ -565,7 +596,8 @@ module Puma
         case k.downcase
         when CONTENT_LENGTH2
           next if illegal_header_value?(vs)
-          resp_info[:content_length] = vs
+          # nil.to_i is 0, nil&.to_i is nil
+          resp_info[:content_length] = vs&.to_i
           next
         when TRANSFER_ENCODING
           resp_info[:allow_chunked] = false

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -25,6 +25,8 @@ class TestCLI < Minitest::Test
 
     @events = Puma::Events.new
     @events.on_booted { @ready << "!" }
+
+    @puma_version_pattern = "\\d+.\\d+.\\d+(\\.[a-z\\d]+)?"
   end
 
   def wait_booted
@@ -65,7 +67,7 @@ class TestCLI < Minitest::Test
     assert_equal Puma.stats_hash, JSON.parse(Puma.stats, symbolize_names: true)
 
     dmt = Puma::Configuration::DEFAULTS[:max_threads]
-    assert_match(/\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"\d+.\d+.\d+","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/, body.split(/\r?\n/).last)
+    assert_match(/\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/, body.split(/\r?\n/).last)
 
   ensure
     cli.launcher.stop
@@ -145,7 +147,7 @@ class TestCLI < Minitest::Test
     body = s.read
     s.close
 
-    assert_match(/\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","workers":2,"phase":0,"booted_workers":2,"old_workers":0,"worker_status":\[\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":0,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\},\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":1,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\}\],"versions":\{"puma":"\d+.\d+.\d+","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/, body.split("\r\n").last)
+    assert_match(/\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","workers":2,"phase":0,"booted_workers":2,"old_workers":0,"worker_status":\[\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":0,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\},\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":1,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\}\],"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/, body.split("\r\n").last)
   ensure
     if UNIX_SKT_EXIST && HAS_FORK
       cli.launcher.stop
@@ -181,7 +183,7 @@ class TestCLI < Minitest::Test
     s.close
 
     dmt = Puma::Configuration::DEFAULTS[:max_threads]
-    assert_match(/{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"\d+.\d+.\d+","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/, body.split(/\r?\n/).last)
+    assert_match(/{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/, body.split(/\r?\n/).last)
   ensure
     if UNIX_SKT_EXIST
       cli.launcher.stop


### PR DESCRIPTION
### Description

PR #2896 added code to collect members of response bodies that are Arrays or Enums, and allow a size threshold that waits to send the collected bytes only when they exceed it.  Previously, if the response body consisted of many small strings, each string was written.  #2896 collects them, and only writes when they exceed the threshold.  This may affect TTFB (time-to-first-byte).  The limit value was also too high in #2896.

This causes issues with Enum bodies that mimic a streaming body.  The size threshold has been removed for Enum bodies, but remains for true Array bodies.

Previously, due to the handling of Enum bodies, test code in Sinatra failed.  The code is checked in an added test, `test_streaming_enum_body'.

Using the benchmarks in benchmark/local, this PR shows:
```
Puma repo branch 00-size-to-first-byte
benchmarks/local/response_time_wrk.sh -w2 -t5:5 -s tcp6 -Y
Body    ────────── req/sec ──────────   ─────── req 50% times ───────
 KB     array   chunk  string      io   array   chunk  string      io
1       19071   18666   19072   12774   0.152   0.149   0.150   0.263
10      18478   17246   18540   12424   0.159   0.177   0.152   0.260
100     13450    8179   14821    9467   0.324   0.369   0.284   1.160
256      9702    4183   14501    9481   0.545   0.782   0.317   1.170
512      6549    2340   12380    9304   1.080   1.150   0.518   1.170
1024     4216    1253    7418    8804   2.100   2.020   0.764   1.190
2048     2564     652    6372    8782   3.930   4.060   1.590   1.170
─────────────────────────────────────────────────────────────────────
```

Using 5.6.5 and configuring `wait_for_less_busy_worker` to match current master:
```
Puma repo branch 5-6-stable-bench
benchmarks/local/response_time_wrk.sh -w2 -t5:5 -s tcp6 -Y -C test/config/wflbw_dflt.rb
Body    ────────── req/sec ──────────   ─────── req 50% times ───────
 KB     array   chunk  string      io   array   chunk  string      io
1       11002   10865   10502   10135    1.42    1.42    1.47    1.52
10      10614   10609   10838    9739    1.46    1.45    1.42    1.59
100      7113    7011   10047    5449    2.18    2.21    1.53    2.86
256      4609    4560    8923    3359    3.39    3.41    1.73    4.67
512      3135    3110    8304    2107    5.01    5.05    1.87    7.47
1024     1919    1909    6108      74    8.21    8.25    2.55  214.25
2048     1090    1082    4530      39   14.49   14.64    3.42  406.58
─────────────────────────────────────────────────────────────────────
```

'Requests per second' has greatly increased for body sizes below 100kB, above increases are smaller.

Closes #3000.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
