### PR TITLE
Handle waking up a closed selector in Reactor#add

### DIFF
--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -50,7 +50,7 @@ module Puma
       @input << client
       @selector.wakeup
       true
-    rescue ClosedQueueError
+    rescue ClosedQueueError, IOError # Ignore if selector is already closed
       false
     end
 


### PR DESCRIPTION
This Pull Request rescues `IOError` when we try to wake up a closed selector.

I noticed there are `IOError`s from this code path (see below). It may be auto-scaling scale up/down an instance. It does not seems to relate to during deployment / restart. I am not really sure. It only happens 4-5 times for the past 30 days in an app (with reasonable, constant traffic) I am working on.

```ruby
vendor/bundle/ruby/2.7.0/gems/puma-5.6.4/lib/puma/reactor.rb:51:in `wakeup': selector is closed (IOError)
    from vendor/bundle/ruby/2.7.0/gems/puma-5.6.4/lib/puma/reactor.rb:51:in `add'
    from vendor/bundle/ruby/2.7.0/gems/puma-5.6.4/lib/puma/server.rb:470:in `process_client'
    from vendor/bundle/ruby/2.7.0/gems/puma-5.6.4/lib/puma/thread_pool.rb:147:in `block in spawn_thread'
```

Seems like similar to `#shutdown` method, we should handle waking up a closed selector.

I am not sure how to add a test for this.

If needs, please let me know how could I add some instrument to the app I’m working on, so I could help report more details for helping with improving this area. Thanks!