### PR TITLE
Add IOBuffer to Client, remove from ThreadPool thread instances

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -9,6 +9,7 @@ class IO
 end
 
 require_relative 'detect'
+require_relative 'io_buffer'
 require 'tempfile'
 require 'forwardable'
 
@@ -65,6 +66,7 @@ module Puma
     def initialize(io, env=nil)
       @io = io
       @to_io = io.to_io
+      @io_buffer = IOBuffer.new
       @proto_env = env
       @env = env ? env.dup : nil
 
@@ -96,7 +98,7 @@ module Puma
     end
 
     attr_reader :env, :to_io, :body, :io, :timeout_at, :ready, :hijacked,
-                :tempfile
+                :tempfile, :io_buffer
 
     attr_writer :peerip
 
@@ -138,6 +140,7 @@ module Puma
 
     def reset(fast_check=true)
       @parser.reset
+      @io_buffer.reset
       @read_header = true
       @read_proxy = !!@expect_proxy_proto
       @env = @proto_env.dup

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -45,7 +45,6 @@ module Puma
       @min = Integer(options[:min_threads])
       @max = Integer(options[:max_threads])
       @block = block
-      @extra = [::Puma::IOBuffer]
       @out_of_band = options[:out_of_band]
       @clean_thread_locals = options[:clean_thread_locals]
       @reaping_time = options[:reaping_time]
@@ -112,8 +111,6 @@ module Puma
         not_empty = @not_empty
         not_full = @not_full
 
-        extra = @extra.map { |i| i.new }
-
         while true
           work = nil
 
@@ -147,7 +144,7 @@ module Puma
           end
 
           begin
-            @out_of_band_pending = true if block.call(work, *extra)
+            @out_of_band_pending = true if block.call(work)
           rescue Exception => e
             STDERR.puts "Error reached top of thread-pool: #{e.message} (#{e.class})"
           end


### PR DESCRIPTION
### Description

Currently, an [IOBuffer](https://github.com/puma/puma/blob/f323d129bc16/lib/puma/io_buffer.rb) object is created in each thread in each ThreadPool (one per worker).  This object is used to assemble response headers, and also may contain parts or all of the response body.

It is shared among all clients/connections processed in the thread.  The data is cleared after every request.  But, given all the code paths, etc, if it was not cleared, it could leak headers between responses from different clients.

No one has reported this occurring.  Regardless, it is a relatively lightweight object subclassed from StringIO (a default gem in Ruby), so rather than share an instance with clients in a thread, remove it from the thread, and add it to the Client class.  Doing so makes it impossible for data to go to the wrong client.

Also, this allows changing/simplifying some method signatures.  Previously, there was a calculation in `Request#str_headers` that calculated whether to force a 'keep-alive' connection closed.  Moved the calculation to immediately before the call to `str_headers` in `Request#prepare_response`.  The calcuation is time sensitive, but there are no 'blocking' operations preceding the code using the calculation result.

Lastly, as improvements to Ruby and/or Puma allow more concurrency, this extra isolation may be needed in the future.

Moving IOBuffer has been discussed somewhere, don't recall when/where...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
