### PR TITLE
Refactor const.rb - freeze

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -5,7 +5,6 @@ module Puma
   class UnsupportedOption < RuntimeError
   end
 
-
   # Every standard HTTP code mapped to the appropriate message.  These are
   # used so frequently that they are placed directly in Puma for easy
   # access rather than Puma::Const itself.
@@ -100,8 +99,8 @@ module Puma
   # too taxing on performance.
   module Const
 
-    PUMA_VERSION = VERSION = "6.0.0".freeze
-    CODE_NAME = "Sunflower".freeze
+    PUMA_VERSION = VERSION = "6.0.0"
+    CODE_NAME = "Sunflower"
 
     PUMA_SERVER_STRING = ['puma', PUMA_VERSION, CODE_NAME].join(' ').freeze
 
@@ -112,28 +111,28 @@ module Puma
     WRITE_TIMEOUT = 10
 
     # The original URI requested by the client.
-    REQUEST_URI= 'REQUEST_URI'.freeze
-    REQUEST_PATH = 'REQUEST_PATH'.freeze
-    QUERY_STRING = 'QUERY_STRING'.freeze
-    CONTENT_LENGTH = "CONTENT_LENGTH".freeze
+    REQUEST_URI= 'REQUEST_URI'
+    REQUEST_PATH = 'REQUEST_PATH'
+    QUERY_STRING = 'QUERY_STRING'
+    CONTENT_LENGTH = "CONTENT_LENGTH"
 
-    PATH_INFO = 'PATH_INFO'.freeze
+    PATH_INFO = 'PATH_INFO'
 
-    PUMA_TMP_BASE = "puma".freeze
+    PUMA_TMP_BASE = "puma"
 
     ERROR_RESPONSE = {
       # Indicate that we couldn't parse the request
-      400 => "HTTP/1.1 400 Bad Request\r\n\r\n".freeze,
+      400 => "HTTP/1.1 400 Bad Request\r\n\r\n",
       # The standard empty 404 response for bad requests.  Use Error4040Handler for custom stuff.
-      404 => "HTTP/1.1 404 Not Found\r\nConnection: close\r\nServer: Puma #{PUMA_VERSION}\r\n\r\nNOT FOUND".freeze,
+      404 => "HTTP/1.1 404 Not Found\r\nConnection: close\r\nServer: Puma #{PUMA_VERSION}\r\n\r\nNOT FOUND",
       # The standard empty 408 response for requests that timed out.
-      408 => "HTTP/1.1 408 Request Timeout\r\nConnection: close\r\nServer: Puma #{PUMA_VERSION}\r\n\r\n".freeze,
+      408 => "HTTP/1.1 408 Request Timeout\r\nConnection: close\r\nServer: Puma #{PUMA_VERSION}\r\n\r\n",
       # Indicate that there was an internal error, obviously.
-      500 => "HTTP/1.1 500 Internal Server Error\r\n\r\n".freeze,
+      500 => "HTTP/1.1 500 Internal Server Error\r\n\r\n",
       # Incorrect or invalid header value
-      501 => "HTTP/1.1 501 Not Implemented\r\n\r\n".freeze,
+      501 => "HTTP/1.1 501 Not Implemented\r\n\r\n",
       # A common header for indicating the server is too busy.  Not used yet.
-      503 => "HTTP/1.1 503 Service Unavailable\r\n\r\nBUSY".freeze
+      503 => "HTTP/1.1 503 Service Unavailable\r\n\r\nBUSY"
     }.freeze
 
     # The basic max request size we'll try to read.
@@ -146,95 +145,95 @@ module Puma
     # Maximum request body size before it is moved out of memory and into a tempfile for reading.
     MAX_BODY = MAX_HEADER
 
-    REQUEST_METHOD = "REQUEST_METHOD".freeze
-    HEAD = "HEAD".freeze
-    GET = "GET".freeze
-    POST = "POST".freeze
-    PUT = "PUT".freeze
-    DELETE = "DELETE".freeze
-    OPTIONS = "OPTIONS".freeze
-    TRACE = "TRACE".freeze
-    PATCH = "PATCH".freeze
+    REQUEST_METHOD = "REQUEST_METHOD"
+    HEAD = "HEAD"
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    DELETE = "DELETE"
+    OPTIONS = "OPTIONS"
+    TRACE = "TRACE"
+    PATCH = "PATCH"
     SUPPORTED_HTTP_METHODS = [HEAD, GET, POST, PUT, DELETE, OPTIONS, TRACE, PATCH].freeze
     # ETag is based on the apache standard of hex mtime-size-inode (inode is 0 on win32)
-    LINE_END = "\r\n".freeze
-    REMOTE_ADDR = "REMOTE_ADDR".freeze
-    HTTP_X_FORWARDED_FOR = "HTTP_X_FORWARDED_FOR".freeze
-    HTTP_X_FORWARDED_SSL = "HTTP_X_FORWARDED_SSL".freeze
-    HTTP_X_FORWARDED_SCHEME = "HTTP_X_FORWARDED_SCHEME".freeze
-    HTTP_X_FORWARDED_PROTO = "HTTP_X_FORWARDED_PROTO".freeze
+    LINE_END = "\r\n"
+    REMOTE_ADDR = "REMOTE_ADDR"
+    HTTP_X_FORWARDED_FOR = "HTTP_X_FORWARDED_FOR"
+    HTTP_X_FORWARDED_SSL = "HTTP_X_FORWARDED_SSL"
+    HTTP_X_FORWARDED_SCHEME = "HTTP_X_FORWARDED_SCHEME"
+    HTTP_X_FORWARDED_PROTO = "HTTP_X_FORWARDED_PROTO"
 
-    SERVER_NAME = "SERVER_NAME".freeze
-    SERVER_PORT = "SERVER_PORT".freeze
-    HTTP_HOST = "HTTP_HOST".freeze
-    PORT_80 = "80".freeze
-    PORT_443 = "443".freeze
-    LOCALHOST = "localhost".freeze
-    LOCALHOST_IPV4 = "127.0.0.1".freeze
-    LOCALHOST_IPV6 = "::1".freeze
-    UNSPECIFIED_IPV4 = "0.0.0.0".freeze
-    UNSPECIFIED_IPV6 = "::".freeze
+    SERVER_NAME = "SERVER_NAME"
+    SERVER_PORT = "SERVER_PORT"
+    HTTP_HOST = "HTTP_HOST"
+    PORT_80 = "80"
+    PORT_443 = "443"
+    LOCALHOST = "localhost"
+    LOCALHOST_IPV4 = "127.0.0.1"
+    LOCALHOST_IPV6 = "::1"
+    UNSPECIFIED_IPV4 = "0.0.0.0"
+    UNSPECIFIED_IPV6 = "::"
 
-    SERVER_PROTOCOL = "SERVER_PROTOCOL".freeze
-    HTTP_11 = "HTTP/1.1".freeze
+    SERVER_PROTOCOL = "SERVER_PROTOCOL"
+    HTTP_11 = "HTTP/1.1"
 
-    SERVER_SOFTWARE = "SERVER_SOFTWARE".freeze
-    GATEWAY_INTERFACE = "GATEWAY_INTERFACE".freeze
-    CGI_VER = "CGI/1.2".freeze
+    SERVER_SOFTWARE = "SERVER_SOFTWARE"
+    GATEWAY_INTERFACE = "GATEWAY_INTERFACE"
+    CGI_VER = "CGI/1.2"
 
-    STOP_COMMAND = "?".freeze
-    HALT_COMMAND = "!".freeze
-    RESTART_COMMAND = "R".freeze
+    STOP_COMMAND = "?"
+    HALT_COMMAND = "!"
+    RESTART_COMMAND = "R"
 
-    RACK_INPUT = "rack.input".freeze
-    RACK_URL_SCHEME = "rack.url_scheme".freeze
-    RACK_AFTER_REPLY = "rack.after_reply".freeze
-    PUMA_SOCKET = "puma.socket".freeze
-    PUMA_CONFIG = "puma.config".freeze
-    PUMA_PEERCERT = "puma.peercert".freeze
+    RACK_INPUT = "rack.input"
+    RACK_URL_SCHEME = "rack.url_scheme"
+    RACK_AFTER_REPLY = "rack.after_reply"
+    PUMA_SOCKET = "puma.socket"
+    PUMA_CONFIG = "puma.config"
+    PUMA_PEERCERT = "puma.peercert"
 
-    HTTP = "http".freeze
-    HTTPS = "https".freeze
+    HTTP = "http"
+    HTTPS = "https"
 
-    HTTPS_KEY = "HTTPS".freeze
+    HTTPS_KEY = "HTTPS"
 
-    HTTP_VERSION = "HTTP_VERSION".freeze
-    HTTP_CONNECTION = "HTTP_CONNECTION".freeze
-    HTTP_EXPECT = "HTTP_EXPECT".freeze
-    CONTINUE = "100-continue".freeze
+    HTTP_VERSION = "HTTP_VERSION"
+    HTTP_CONNECTION = "HTTP_CONNECTION"
+    HTTP_EXPECT = "HTTP_EXPECT"
+    CONTINUE = "100-continue"
 
-    HTTP_11_100 = "HTTP/1.1 100 Continue\r\n\r\n".freeze
-    HTTP_11_200 = "HTTP/1.1 200 OK\r\n".freeze
-    HTTP_10_200 = "HTTP/1.0 200 OK\r\n".freeze
+    HTTP_11_100 = "HTTP/1.1 100 Continue\r\n\r\n"
+    HTTP_11_200 = "HTTP/1.1 200 OK\r\n"
+    HTTP_10_200 = "HTTP/1.0 200 OK\r\n"
 
-    CLOSE = "close".freeze
-    KEEP_ALIVE = "keep-alive".freeze
+    CLOSE = "close"
+    KEEP_ALIVE = "keep-alive"
 
-    CONTENT_LENGTH2 = "content-length".freeze
-    CONTENT_LENGTH_S = "Content-Length: ".freeze
-    TRANSFER_ENCODING = "transfer-encoding".freeze
-    TRANSFER_ENCODING2 = "HTTP_TRANSFER_ENCODING".freeze
+    CONTENT_LENGTH2 = "content-length"
+    CONTENT_LENGTH_S = "Content-Length: "
+    TRANSFER_ENCODING = "transfer-encoding"
+    TRANSFER_ENCODING2 = "HTTP_TRANSFER_ENCODING"
 
-    CONNECTION_CLOSE = "Connection: close\r\n".freeze
-    CONNECTION_KEEP_ALIVE = "Connection: Keep-Alive\r\n".freeze
+    CONNECTION_CLOSE = "Connection: close\r\n"
+    CONNECTION_KEEP_ALIVE = "Connection: Keep-Alive\r\n"
 
-    TRANSFER_ENCODING_CHUNKED = "Transfer-Encoding: chunked\r\n".freeze
-    CLOSE_CHUNKED = "0\r\n\r\n".freeze
+    TRANSFER_ENCODING_CHUNKED = "Transfer-Encoding: chunked\r\n"
+    CLOSE_CHUNKED = "0\r\n\r\n"
 
-    CHUNKED = "chunked".freeze
+    CHUNKED = "chunked"
 
-    COLON = ": ".freeze
+    COLON = ": "
 
-    NEWLINE = "\n".freeze
+    NEWLINE = "\n"
 
-    HIJACK_P = "rack.hijack?".freeze
-    HIJACK = "rack.hijack".freeze
-    HIJACK_IO = "rack.hijack_io".freeze
+    HIJACK_P = "rack.hijack?"
+    HIJACK = "rack.hijack"
+    HIJACK_IO = "rack.hijack_io"
 
-    EARLY_HINTS = "rack.early_hints".freeze
+    EARLY_HINTS = "rack.early_hints"
 
     # Illegal character in the key or value of response header
-    DQUOTE = "\"".freeze
+    DQUOTE = "\""
     HTTP_HEADER_DELIMITER = Regexp.escape("(),/:;<=>?@[]{}\\").freeze
     ILLEGAL_HEADER_KEY_REGEX = /[\x00-\x20#{DQUOTE}#{HTTP_HEADER_DELIMITER}]/.freeze
     # header values can contain HTAB?

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -102,7 +102,7 @@ module Puma
     PUMA_VERSION = VERSION = "6.0.0"
     CODE_NAME = "Sunflower"
 
-    PUMA_SERVER_STRING = ['puma', PUMA_VERSION, CODE_NAME].join(' ').freeze
+    PUMA_SERVER_STRING = ["puma", PUMA_VERSION, CODE_NAME].join(" ").freeze
 
     FAST_TRACK_KA_TIMEOUT = 0.2
 
@@ -111,12 +111,12 @@ module Puma
     WRITE_TIMEOUT = 10
 
     # The original URI requested by the client.
-    REQUEST_URI= 'REQUEST_URI'
-    REQUEST_PATH = 'REQUEST_PATH'
-    QUERY_STRING = 'QUERY_STRING'
+    REQUEST_URI= "REQUEST_URI"
+    REQUEST_PATH = "REQUEST_PATH"
+    QUERY_STRING = "QUERY_STRING"
     CONTENT_LENGTH = "CONTENT_LENGTH"
 
-    PATH_INFO = 'PATH_INFO'
+    PATH_INFO = "PATH_INFO"
 
     PUMA_TMP_BASE = "puma"
 

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -147,14 +147,7 @@ module Puma
 
     REQUEST_METHOD = "REQUEST_METHOD"
     HEAD = "HEAD"
-    GET = "GET"
-    POST = "POST"
-    PUT = "PUT"
-    DELETE = "DELETE"
-    OPTIONS = "OPTIONS"
-    TRACE = "TRACE"
-    PATCH = "PATCH"
-    SUPPORTED_HTTP_METHODS = [HEAD, GET, POST, PUT, DELETE, OPTIONS, TRACE, PATCH].freeze
+    SUPPORTED_HTTP_METHODS = %w[HEAD GET POST PUT DELETE OPTIONS TRACE PATCH].freeze
     # ETag is based on the apache standard of hex mtime-size-inode (inode is 0 on win32)
     LINE_END = "\r\n"
     REMOTE_ADDR = "REMOTE_ADDR"


### PR DESCRIPTION
### Description

Ruby 2.3 implemented the magic comment `# frozen_string_literal: true`.  The below shows one interesting result, `join`:
```ruby
v1 = "Frozen?"
v2 = %w[HEAD GET POST PUT DELETE OPTIONS TRACE PATCH].freeze
v3 = v2.join ' '
v4 =  {501 => "HTTP/1.1 501 Not Implemented\r\n\r\n",
       503 => "HTTP/1.1 503 Service Unavailable\r\n\r\nBUSY"}

puts v1.frozen?      # -> true
puts v2[0].frozen?   # -> true
puts v3.frozen?      # -> false
puts v4[501].frozen? # -> true
```

So, remove `.freeze` when not needed in const.rb.  Also, remove extra constants (`GET POST PUT DELETE OPTIONS TRACE PATCH`) that were added in https://github.com/puma/puma/commit/1b6b8adfaeb4.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
