### PR TITLE
SECURITY: Puma 4.x no longer supported [ci skip]

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version       | Supported  |
 | :------------ | :--------: |
+| Latest release in 6.x | ✅ |
 | Latest release in 5.x | ✅ |
-| Latest release in 4.x | ✅ |
 | All other releases    | ❌ |
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
Puma 4.x no longer eligible for security fixes since the release of Puma 6.