### PR TITLE
[CI] two small CI fixes

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -121,7 +121,7 @@ class TestIntegration < Minitest::Test
   # wait for server to say it booted
   # @server and/or @server.gets may be nil on slow CI systems
   def wait_for_server_to_boot(log: false)
-    wait_for_server_to_include 'Ctrl-C'
+    wait_for_server_to_include 'Ctrl-C', log: log
   end
 
   # Returns true if and when server log includes str.

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -230,14 +230,14 @@ class TestRackServer < Minitest::Test
 
     socket1 = TCPSocket.new "127.0.0.1", @port
     socket1.syswrite "GET / HTTP/1.1\r\n\r\n"
-    sleep 0.25 if Puma::IS_WINDOWS || !Puma::IS_MRI
+    sleep (Puma::IS_WINDOWS || !Puma::IS_MRI ? 0.25 : 0.1)
     resp1 = socket1.sysread 1_024
 
     sleep 0.01 # time for close block to be called ?
 
     socket2 = TCPSocket.new "127.0.0.1", @port
     socket2.syswrite "GET / HTTP/1.1\r\n\r\n"
-    sleep 0.25 if Puma::IS_WINDOWS || !Puma::IS_MRI
+    sleep (Puma::IS_WINDOWS || !Puma::IS_MRI ? 0.25 : 0.1)
     resp2 = socket2.sysread 1_024
 
     assert_operator resp1, :end_with?, 'hijacked'


### PR DESCRIPTION
### Description

**Update test_rack_server.rb** - when working with `test_hijack_body_close` in my fork, it seemed that Window and non_MRI jobs needed a small delay.  Recently I saw the same error on a macOS job.  So, add a smaller delay for Ubuntu & macOS.

**test/helpers/integration.rb** - in several methods that read the `IO.popen` IO from the server, a log keyword parameter exists for debugging.  The parameter was not passed thru `wait_for_server_to_boot`. Fix.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
