### PR TITLE
Skip Windows UNIXSocket tests for now

### DIFF
--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -28,7 +28,7 @@ module Puma
   # not in minissl.rb
   HAS_SSL = const_defined?(:MiniSSL, false) && MiniSSL.const_defined?(:Engine, false)
 
-  HAS_UNIX_SOCKET = Object.const_defined? :UNIXSocket
+  HAS_UNIX_SOCKET = Object.const_defined?(:UNIXSocket) && !IS_WINDOWS
 
   if HAS_SSL
     require_relative 'puma/minissl'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -116,7 +116,7 @@ end
 module TestSkips
 
   HAS_FORK = ::Process.respond_to? :fork
-  UNIX_SKT_EXIST = Object.const_defined? :UNIXSocket
+  UNIX_SKT_EXIST = Object.const_defined?(:UNIXSocket) && !Puma::IS_WINDOWS
 
   MSG_FORK = "Kernel.fork isn't available on #{RUBY_ENGINE} on #{RUBY_PLATFORM}"
   MSG_UNIX = "UNIXSockets aren't available on the #{RUBY_PLATFORM} platform"


### PR DESCRIPTION
### Description

@ioquatix added UNIXSocket support for Windows in ruby/ruby.  Many thanks to him for that.

Windows file system is different that Unix/macOS, and the URI gem may need changes re Windows path syntax.

Both issues can be dealt with in Puma, but it will take changes to both lib and test files.

So, for now, disable UNIXSocket tests in Puma...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
