### PR TITLE
Remove use of etc and time gems in Puma

### DIFF
--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -3,7 +3,6 @@
 # Standard libraries
 require 'socket'
 require 'tempfile'
-require 'time'
 require 'etc'
 require 'uri'
 require 'stringio'

--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -3,7 +3,6 @@
 # Standard libraries
 require 'socket'
 require 'tempfile'
-require 'etc'
 require 'uri'
 require 'stringio'
 

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -6,8 +6,6 @@ require_relative 'plugin'
 require_relative 'cluster/worker_handle'
 require_relative 'cluster/worker'
 
-require 'time'
-
 module Puma
   # This class is instantiated by the `Puma::Launcher` and used
   # to boot and serve a Ruby application when puma "workers" are needed
@@ -252,18 +250,18 @@ module Puma
       old_worker_count = @workers.count { |w| w.phase != @phase }
       worker_status = @workers.map do |w|
         {
-          started_at: w.started_at.utc.iso8601,
+          started_at: utc_iso8601(w.started_at),
           pid: w.pid,
           index: w.index,
           phase: w.phase,
           booted: w.booted?,
-          last_checkin: w.last_checkin.utc.iso8601,
+          last_checkin: utc_iso8601(w.last_checkin),
           last_status: w.last_status,
         }
       end
 
       {
-        started_at: @started_at.utc.iso8601,
+        started_at: utc_iso8601(@started_at),
         workers: @workers.size,
         phase: @phase,
         booted_workers: worker_status.count { |w| w[:booted] },

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -182,6 +182,10 @@ module Puma
       end
     end
 
+    def utc_iso8601(val)
+      "#{val.utc.strftime '%FT%T'}Z"
+    end
+
     def stats
       {
         versions: {

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -16,7 +16,7 @@ module Puma
     # @!attribute [r] stats
     def stats
       {
-        started_at: @started_at.utc.iso8601
+        started_at: utc_iso8601(@started_at)
       }.merge(@server.stats).merge(super)
     end
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -167,16 +167,22 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_worker_check_interval
+    # iso8601 2022-12-14T00:05:49Z
+    re_8601 = /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\z/
     @control_tcp_port = UniquePort.call
     worker_check_interval = 1
 
     cli_server "-w 1 -t 1:1 --control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN} test/rackup/hello.ru", config: "worker_check_interval #{worker_check_interval}"
 
     sleep worker_check_interval + 1
-    last_checkin_1 = Time.parse(get_stats["worker_status"].first["last_checkin"])
+    checkin_1 = get_stats["worker_status"].first["last_checkin"]
+    assert_match re_8601, checkin_1
+    last_checkin_1 = Time.parse checkin_1
 
     sleep worker_check_interval + 1
-    last_checkin_2 = Time.parse(get_stats["worker_status"].first["last_checkin"])
+    checkin_2 = get_stats["worker_status"].first["last_checkin"]
+    assert_match re_8601, checkin_2
+    last_checkin_2 = Time.parse checkin_2
 
     assert(last_checkin_2 > last_checkin_1)
   end


### PR DESCRIPTION
### Description

Several years ago the `etc` and `time` gems were added to Puma's requirements.  They are no longer needed, as a small code change replaces `time`, and I can't find any reference to `etc`.

Closes #3033.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
