### PR TITLE
Log loaded extensions when `PUMA_DEBUG` is set

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -467,6 +467,7 @@ module Puma
                   @events.fire(:ping!, w)
                   if !booted && @workers.none? {|worker| worker.last_status.empty?}
                     @events.fire_on_booted!
+                    debug_loaded_extensions("────────────────────────────────── Loaded Extensions - master:") if @log_writer.debug?
                     booted = true
                   end
                 end
@@ -476,6 +477,7 @@ module Puma
             end
             if in_phased_restart && workers_not_booted.zero?
               @events.fire_on_booted!
+              debug_loaded_extensions("────────────────────────────────── Loaded Extensions - master:") if @log_writer.debug?
               in_phased_restart = false
             end
 

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -467,7 +467,7 @@ module Puma
                   @events.fire(:ping!, w)
                   if !booted && @workers.none? {|worker| worker.last_status.empty?}
                     @events.fire_on_booted!
-                    debug_loaded_extensions("────────────────────────────────── Loaded Extensions - master:") if @log_writer.debug?
+                    debug_loaded_extensions("Loaded Extensions - master:") if @log_writer.debug?
                     booted = true
                   end
                 end
@@ -477,7 +477,7 @@ module Puma
             end
             if in_phased_restart && workers_not_booted.zero?
               @events.fire_on_booted!
-              debug_loaded_extensions("────────────────────────────────── Loaded Extensions - master:") if @log_writer.debug?
+              debug_loaded_extensions("Loaded Extensions - master:") if @log_writer.debug?
               in_phased_restart = false
             end
 

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -117,7 +117,7 @@ module Puma
           server_thread = server.run
 
           if @log_writer.debug? && index == 0
-            debug_loaded_extensions "────────────────────────────────── Loaded Extensions - worker 0:"
+            debug_loaded_extensions "Loaded Extensions - worker 0:"
           end
 
           stat_thread ||= Thread.new(@worker_write) do |io|

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -115,6 +115,11 @@ module Puma
 
         while restart_server.pop
           server_thread = server.run
+
+          if @log_writer.debug? && index == 0
+            debug_loaded_extensions "────────────────────────────────── Loaded Extensions - worker 0:"
+          end
+
           stat_thread ||= Thread.new(@worker_write) do |io|
             Puma.set_thread_name "stat pld"
             base_payload = "p#{Process.pid}"

--- a/lib/puma/log_writer.rb
+++ b/lib/puma/log_writer.rb
@@ -80,6 +80,10 @@ module Puma
     end
     private :internal_write
 
+    def debug?
+      @debug
+    end
+
     def debug(str)
       log("% #{str}") if @debug
     end

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -201,7 +201,7 @@ module Puma
 
     # this method call should always be guarded by `@log_writer.debug?`
     def debug_loaded_extensions(str)
-      @log_writer.debug str
+      @log_writer.debug "────────────────────────────────── #{str}"
       re_ext = /\.#{RbConfig::CONFIG['DLEXT']}\z/i
       $LOADED_FEATURES.grep(re_ext).each { |f| @log_writer.debug("    #{f}") }
     end

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -198,5 +198,12 @@ module Puma
         }
       }
     end
+
+    # this method call should always be guarded by `@log_writer.debug?`
+    def debug_loaded_extensions(str)
+      @log_writer.debug str
+      re_ext = /\.#{RbConfig::CONFIG['DLEXT']}\z/i
+      $LOADED_FEATURES.grep(re_ext).each { |f| @log_writer.debug("    #{f}") }
+    end
   end
 end

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -57,6 +57,8 @@ module Puma
 
       @events.fire_on_booted!
 
+      debug_loaded_extensions("────────────────────────────────── Loaded Extensions:") if @log_writer.debug?
+
       begin
         server_thread.join
       rescue Interrupt

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -57,7 +57,7 @@ module Puma
 
       @events.fire_on_booted!
 
-      debug_loaded_extensions("────────────────────────────────── Loaded Extensions:") if @log_writer.debug?
+      debug_loaded_extensions("Loaded Extensions:") if @log_writer.debug?
 
       begin
         server_thread.join

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -83,9 +83,9 @@ class TestIntegration < Minitest::Test
     env = puma_debug ? {'PUMA_DEBUG' => 'true' } : {}
 
     if merge_err
-      @server = IO.popen(env, cmd, "r", :err=>[:child, :out])
+      @server = IO.popen(env, cmd, :err=>[:child, :out])
     else
-      @server = IO.popen(env, cmd, "r")
+      @server = IO.popen(env, cmd)
     end
     wait_for_server_to_boot(log: log) unless no_wait
     @pid = @server.pid

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -448,6 +448,14 @@ RUBY
     File.unlink file1 if File.file? file1
   end
 
+  def test_puma_debug_loaded_exts
+    cli_server "-w #{workers} test/rackup/hello.ru", puma_debug: true
+
+    assert wait_for_server_to_include('Loaded Extensions - worker 0:')
+    assert wait_for_server_to_include('Loaded Extensions - master:')
+    @pid = @server.pid
+  end
+
   private
 
   def worker_timeout(timeout, iterations, details, config)

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -9,15 +9,14 @@ class TestIntegrationPumactl < TestIntegration
 
   def setup
     super
-
-    @state_path   = tmp_path('.state')
-    @control_path = tmp_path('.sock')
+    @control_path = nil
+    @state_path = tmp_path('.state')
   end
 
   def teardown
     super
 
-    refute File.exist?(@control_path), "Control path must be removed after stop"
+    refute @control_path && File.exist?(@control_path), "Control path must be removed after stop"
   ensure
     [@state_path, @control_path].each { |p| File.unlink(p) rescue nil }
   end
@@ -25,7 +24,7 @@ class TestIntegrationPumactl < TestIntegration
   def test_stop_tcp
     skip_if :jruby, :truffleruby # Undiagnose thread race. TODO fix
     @control_tcp_port = UniquePort.call
-    cli_server "-q test/rackup/sleep.ru --control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN} -S #{@state_path}"
+    cli_server "-q test/rackup/sleep.ru #{set_pumactl_args} -S #{@state_path}"
 
     cli_pumactl "stop"
 
@@ -46,7 +45,8 @@ class TestIntegrationPumactl < TestIntegration
   def ctl_unix(signal='stop')
     skip_unless :unix
     stderr = Tempfile.new(%w(stderr .log))
-    cli_server "-q test/rackup/sleep.ru --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}",
+
+    cli_server "-q test/rackup/sleep.ru #{set_pumactl_args unix: true} -S #{@state_path}",
       config: "stdout_redirect nil, '#{stderr.path}'",
       unix: true
 
@@ -60,7 +60,7 @@ class TestIntegrationPumactl < TestIntegration
 
   def test_phased_restart_cluster
     skip_unless :fork
-    cli_server "-q -w #{workers} test/rackup/sleep.ru --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}", unix: true
+    cli_server "-q -w #{workers} test/rackup/sleep.ru #{set_pumactl_args unix: true} -S #{@state_path}", unix: true
 
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
@@ -96,7 +96,7 @@ class TestIntegrationPumactl < TestIntegration
   def test_refork_cluster
     skip_unless :fork
     wrkrs = 3
-    cli_server "-q -w #{wrkrs} test/rackup/sleep.ru --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}",
+    cli_server "-q -w #{wrkrs} test/rackup/sleep.ru #{set_pumactl_args unix: true} -S #{@state_path}",
       config: 'fork_worker 50',
       unix: true
 
@@ -133,7 +133,7 @@ class TestIntegrationPumactl < TestIntegration
   def test_prune_bundler_with_multiple_workers
     skip_unless :fork
 
-    cli_server "-q -C test/config/prune_bundler_with_multiple_workers.rb --control-url unix://#{@control_path} --control-token #{TOKEN} -S #{@state_path}", unix: true
+    cli_server "-q -C test/config/prune_bundler_with_multiple_workers.rb #{set_pumactl_args unix: true} -S #{@state_path}", unix: true
 
     s = UNIXSocket.new @bind_path
     @ios_to_close << s

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -190,8 +190,7 @@ class TestIntegrationSingle < TestIntegration
   end
 
   def test_application_logs_are_flushed_on_write
-    @control_tcp_port = UniquePort.call
-    cli_server "--control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN} test/rackup/write_to_stdout.ru"
+    cli_server "#{set_pumactl_args} test/rackup/write_to_stdout.ru"
 
     read_body connect
 
@@ -236,5 +235,13 @@ class TestIntegrationSingle < TestIntegration
       assert false, "Process froze"
     end
     assert true
+  end
+
+  def test_puma_debug_loaded_exts
+    cli_server "#{set_pumactl_args} test/rackup/hello.ru", puma_debug: true
+
+    assert wait_for_server_to_include('Loaded Extensions:')
+
+    cli_pumactl 'stop'
   end
 end


### PR DESCRIPTION
### Description

This implements the feature requested in https://github.com/puma/puma/issues/3020, printing the loaded extensions if PUMA_DEBUG is set.

When Puma is running 'single' (no workers), the log is done in the main Puma process, after `Server#run` has been called, as some extensions maybe loaded in that call. For Puma running 'clustered' (workers used), the log is generated in Worker index 0, after `Server#run` is called and also in the master process.

Log is also generated on phased-restarts.

Added a test for both, small refactor (moved functionality to `intergration.rb`) for using a control server in CI.

Closes #3020

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
