### PR TITLE
Introduce the ability to return 413: payload too large for requests

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -156,6 +156,7 @@ module Puma
       @peerip = nil if @remote_addr_header
       @in_last_chunk = false
       @http_content_length_size = 0
+      @http_content_length_limit_exceeded = false
 
       if @buffer
         return false unless try_to_parse_proxy_protocol

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -214,8 +214,8 @@ module Puma
     end
 
     def try_to_finish
-      if env[CONTENT_LENGTH] && @http_content_length_limit
-        @http_content_length_limit_exceeded = env[CONTENT_LENGTH].to_i > @http_content_length_limit
+      if env[CONTENT_LENGTH] && above_http_content_limit(env[CONTENT_LENGTH].to_i)
+        @http_content_length_limit_exceeded = true
       end
 
       if @http_content_length_limit_exceeded
@@ -254,7 +254,7 @@ module Puma
 
       @parsed_bytes = @parser.execute(@env, @buffer, @parsed_bytes)
 
-      if @parser.finished? && @http_content_length_limit && (@parser.body.bytesize > @http_content_length_limit)
+      if @parser.finished? && above_http_content_limit(@parser.body.bytesize)
         @http_content_length_limit_exceeded = true
       end
 
@@ -612,6 +612,10 @@ module Puma
       end
       @requests_served += 1
       @ready = true
+    end
+
+    def above_http_content_limit(value)
+      @http_content_length_limit&.< value
     end
   end
 end

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -88,7 +88,6 @@ module Puma
 
       @http_content_length_limit = nil
       @http_content_length_limit_exceeded = false
-      @http_content_length_size = 0
 
       @peerip = nil
       @peer_family = nil
@@ -155,7 +154,6 @@ module Puma
       @body_remain = 0
       @peerip = nil if @remote_addr_header
       @in_last_chunk = false
-      @http_content_length_size = 0
       @http_content_length_limit_exceeded = false
 
       if @buffer

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -167,6 +167,7 @@ module Puma
       worker_shutdown_timeout: 30,
       worker_timeout: 60,
       workers: 0,
+      http_content_length_limit: nil
     }
 
     def initialize(user_options={}, default_options = {}, &block)

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1022,6 +1022,16 @@ module Puma
       @options[:mutate_stdout_and_stderr_to_sync_on_write] = enabled
     end
 
+    # Specify how big the request payload should be.
+    # This limit is compared against CONTENT_LENGTH HTTP header.
+    # If the payload size (CONTENT_LENGTH) is larger than http_content_length_limit,
+    # HTTP 413 status code is returned.
+    #
+    # The default value for http_content_length_limit is nil.
+    def http_content_length_limit(limit)
+      @options[:http_content_length_limit] = limit
+    end
+
     private
 
     # To avoid adding cert_pem and key_pem as URI params, we store them on the

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1022,7 +1022,7 @@ module Puma
       @options[:mutate_stdout_and_stderr_to_sync_on_write] = enabled
     end
 
-    # Specify how big the request payload should be.
+    # Specify how big the request payload should be, in bytes.
     # This limit is compared against Content-Length HTTP header.
     # If the payload size (CONTENT_LENGTH) is larger than http_content_length_limit,
     # HTTP 413 status code is returned.

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1023,10 +1023,13 @@ module Puma
     end
 
     # Specify how big the request payload should be.
-    # This limit is compared against CONTENT_LENGTH HTTP header.
+    # This limit is compared against Content-Length HTTP header.
     # If the payload size (CONTENT_LENGTH) is larger than http_content_length_limit,
     # HTTP 413 status code is returned.
     #
+    # When no Content-Length http header is present, it is compared against the
+    # size of the body of the request.
+     #
     # The default value for http_content_length_limit is nil.
     def http_content_length_limit(limit)
       @options[:http_content_length_limit] = limit

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -53,7 +53,12 @@ module Puma
       socket  = client.io   # io may be a MiniSSL::Socket
       app_body = nil
 
+
       return false if closed_socket?(socket)
+
+      if client.http_content_length_limit_exceeded
+        return prepare_response(413, {}, ["Payload Too Large"], requests, client)
+      end
 
       normalize_env env, client
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -95,6 +95,7 @@ module Puma
       @queue_requests      = @options[:queue_requests]
       @max_fast_inline     = @options[:max_fast_inline]
       @io_selector_backend = @options[:io_selector_backend]
+      @http_content_length_limit = @options[:http_content_length_limit]
 
       temp = !!(@options[:environment] =~ /\A(development|test)\z/)
       @leak_stack_on_error = @options[:environment] ? temp : true
@@ -334,6 +335,7 @@ module Puma
                 drain += 1 if shutting_down?
                 pool << Client.new(io, @binder.env(sock)).tap { |c|
                   c.listener = sock
+                  c.http_content_length_limit = @http_content_length_limit
                   c.send(addr_send_name, addr_value) if addr_value
                 }
               end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -473,6 +473,14 @@ class TestConfigFile < TestConfigFileBase
     assert_equal true, conf.options[:silence_single_worker_warning]
   end
 
+  def test_http_content_length_limit
+    assert_nil Puma::Configuration.new.options.default_options[:http_content_length_limit]
+
+    conf = Puma::Configuration.new({ http_content_length_limit: 10000})
+
+    assert_equal 10000, conf.final_options[:http_content_length_limit]
+  end
+
   private
 
   def assert_run_hooks(hook_name, options = {})

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -394,6 +394,17 @@ EOF
     assert_equal "HTTP/1.1 413 Payload Too Large\r\n", data
   end
 
+  def test_http_11_keep_alive_with_large_payload
+    server_run(http_content_length_limit: 10) { [204, {}, []] }
+
+    sock = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nContent-Length: 17\r\n\r\n"
+    sock << "hello world foo bar"
+    h = header sock
+
+    assert_equal ["HTTP/1.1 413 Payload Too Large", "Content-Length: 17"], h
+
+  end
+
   def test_GET_with_no_body_has_sane_chunking
     server_run { [200, {}, []] }
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -387,10 +387,7 @@ EOF
     server_run(http_content_length_limit: 10)
 
     sock = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 19\r\n\r\n"
-    sleep 0.5
-
     sock << "hello world foo bar"
-    sleep 0.5
 
     data = sock.gets
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -383,6 +383,20 @@ EOF
     assert_equal expected_data, data
   end
 
+  def test_request_payload_too_large
+    server_run(http_content_length_limit: 10)
+
+    sock = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 19\r\n\r\n"
+    sleep 0.5
+
+    sock << "hello world foo bar"
+    sleep 0.5
+
+    data = sock.gets
+
+    assert_equal "HTTP/1.1 413 Payload Too Large\r\n", data
+  end
+
   def test_GET_with_no_body_has_sane_chunking
     server_run { [200, {}, []] }
 


### PR DESCRIPTION
### Description

When receiving large payload objects, the server can often slowdown or get fully exhausted if bunch of requests with large payload body size come in. When request with large payload comes in, lot of the time is spent reading the body into buffer, writing it to the IO for rack, before the request is passed to the rails app for further processing.

While there are some workarounds around limiting large request sizes, like at nginx layer by setting `client_max_body_size`, which would return a `413` back to the client, today that is not possible with puma.

This would be a very nice feature to have, especially when there is no reverse proxy in between client and server.

This approach - allows a user to set `http_content_length_limit` via  a config variable (defaults to `nil`). This value is then compared against `Content-Length` http header (when present) before reading the body into buffer. If the user value is higher than the header value, the request body is not loaded and an immediate `413` (`Payload too large`) http response is returned, from `Puma::Request.handle_request`.

Without having to buffer in the huge request and return the `413` immediately to the clients that send a `Content-Length` - could be a nice feature and helpful protection to have.

Additionally, when no `Content-Length` http header is present, it is compared against the size of the body of the request.
During this time, the body is already loaded, so there isn't much we can do, but it still respects the limit and
returns the `413` status from puma itself, before passing down the request to the app. 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
