### PR TITLE
Add `supported_http_methods` option

### DIFF
--- a/6.0-Upgrade.md
+++ b/6.0-Upgrade.md
@@ -45,7 +45,16 @@ Check the following list to see if you're depending on any of these behaviors:
 1. We've removed the following constants: `Puma::StateFile::FIELDS`, `Puma::CLI::KEYS_NOT_TO_PERSIST_IN_STATE` and `Puma::Launcher::KEYS_NOT_TO_PERSIST_IN_STATE`, and `Puma::ControlCLI::COMMANDS`.
 1. We no longer support Ruby 2.2, 2.3, or JRuby on Java 1.7 or below.
 1. The behavior of `remote_addr` has changed. When using the set_remote_address header: "header_name" functionality, if the header is not passed, REMOTE_ADDR is now set to the physical peeraddr instead of always being set to 127.0.0.1. When an error occurs preventing the physical peeraddr from being fetched, REMOTE_ADDR is now set to the unspecified source address ('0.0.0.0') instead of to '127.0.0.1'
-1. Previously, Puma supported anything as an HTTP method and passed it to the app. We now only accept the 8 HTTP methods defined in RFC 9110.
+1. Previously, Puma supported anything as an HTTP method and passed it to the app. We now only accept the 8 HTTP methods defined in RFC 9110. If you want to override which HTTP methods are accepted, you may use the `supported_http_methods` option:
+    ```ruby
+      supported_http_methods %w[
+        ACL BASELINE-CONTROL BIND CHECKIN CHECKOUT CONNECT COPY DELETE
+        GET HEAD LABEL LINK LOCK MERGE MKACTIVITY MKCALENDAR MKCOL
+        MKREDIRECTREF MKWORKSPACE MOVE OPTIONS ORDERPATCH PATCH POST
+        PRI PROPFIND PROPPATCH PUT REBIND REPORT SEARCH TRACE UNBIND
+        UNCHECKOUT UNLINK UNLOCK UPDATE UPDATEREDIRECTREF VERSION-CONTROL
+      ].to_set.freeze
+    ```
 
 Then, update your Gemfile:
 

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -133,6 +133,7 @@ module Puma
       debug: false,
       early_hints: nil,
       environment: 'development'.freeze,
+      supported_http_methods: Puma::Const::DEFAULT_SUPPORTED_HTTP_METHODS,
       # Number of seconds to wait until we get the first data for the request
       first_data_timeout: 30,
       io_selector_backend: :auto,

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -1,6 +1,8 @@
 #encoding: utf-8
 # frozen_string_literal: true
 
+require "set"
+
 module Puma
   class UnsupportedOption < RuntimeError
   end
@@ -147,15 +149,7 @@ module Puma
     MAX_BODY = MAX_HEADER
 
     REQUEST_METHOD = "REQUEST_METHOD".freeze
-    HEAD = "HEAD".freeze
-    GET = "GET".freeze
-    POST = "POST".freeze
-    PUT = "PUT".freeze
-    DELETE = "DELETE".freeze
-    OPTIONS = "OPTIONS".freeze
-    TRACE = "TRACE".freeze
-    PATCH = "PATCH".freeze
-    SUPPORTED_HTTP_METHODS = [HEAD, GET, POST, PUT, DELETE, OPTIONS, TRACE, PATCH].freeze
+    DEFAULT_SUPPORTED_HTTP_METHODS = %w[HEAD GET POST PUT DELETE OPTIONS TRACE PATCH].to_set.freeze
     # ETag is based on the apache standard of hex mtime-size-inode (inode is 0 on win32)
     LINE_END = "\r\n".freeze
     REMOTE_ADDR = "REMOTE_ADDR".freeze

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -396,6 +396,26 @@ module Puma
       @options[:restart_cmd] = cmd.to_s
     end
 
+    # List of HTTP methods that will be considered valid.
+    # Any other method will raise "501 Not Implemented".
+    #
+    # The default is %w[HEAD GET POST PUT DELETE OPTIONS TRACE PATCH].to_set.freeze
+    #
+    # @example
+    #   # If you need to support all extended HTTP methods (as described in
+    #   #  https://www.iana.org/assignments/http-methods/http-methods.xhtml)
+    #
+    #   supported_http_methods %w[
+    #     ACL BASELINE-CONTROL BIND CHECKIN CHECKOUT CONNECT COPY DELETE
+    #     GET HEAD LABEL LINK LOCK MERGE MKACTIVITY MKCALENDAR MKCOL
+    #     MKREDIRECTREF MKWORKSPACE MOVE OPTIONS ORDERPATCH PATCH POST
+    #     PRI PROPFIND PROPPATCH PUT REBIND REPORT SEARCH TRACE UNBIND
+    #     UNCHECKOUT UNLINK UNLOCK UPDATE UPDATEREDIRECTREF VERSION-CONTROL
+    #   ].to_set.freeze
+    def supported_http_methods(methods)
+      @options[:supported_http_methods] = methods
+    end
+
     # Store the pid of the server in the file at "path".
     #
     # @example

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -88,7 +88,7 @@ module Puma
       env[RACK_AFTER_REPLY] ||= []
 
       begin
-        if SUPPORTED_HTTP_METHODS.include?(env[REQUEST_METHOD])
+        if @supported_http_methods.include?(env[REQUEST_METHOD])
           status, headers, app_body = @thread_pool.with_force_shutdown do
             @app.call(env)
           end
@@ -547,7 +547,7 @@ module Puma
       colon = COLON
 
       resp_info = {}
-      resp_info[:no_body] = env[REQUEST_METHOD] == HEAD
+      resp_info[:no_body] = env[REQUEST_METHOD] == "HEAD"
 
       http_11 = env[SERVER_PROTOCOL] == HTTP_11
       if http_11

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -86,15 +86,16 @@ module Puma
         UserFileDefaultOptions.new(options, Configuration::DEFAULTS)
       end
 
-      @log_writer          = @options.fetch :log_writer, LogWriter.stdio
-      @early_hints         = @options[:early_hints]
-      @first_data_timeout  = @options[:first_data_timeout]
-      @min_threads         = @options[:min_threads]
-      @max_threads         = @options[:max_threads]
-      @persistent_timeout  = @options[:persistent_timeout]
-      @queue_requests      = @options[:queue_requests]
-      @max_fast_inline     = @options[:max_fast_inline]
-      @io_selector_backend = @options[:io_selector_backend]
+      @log_writer              = @options.fetch :log_writer, LogWriter.stdio
+      @early_hints             = @options[:early_hints]
+      @first_data_timeout      = @options[:first_data_timeout]
+      @min_threads             = @options[:min_threads]
+      @max_threads             = @options[:max_threads]
+      @persistent_timeout      = @options[:persistent_timeout]
+      @queue_requests          = @options[:queue_requests]
+      @max_fast_inline         = @options[:max_fast_inline]
+      @io_selector_backend     = @options[:io_selector_backend]
+      @supported_http_methods  = @options[:supported_http_methods]
 
       temp = !!(@options[:environment] =~ /\A(development|test)\z/)
       @leak_stack_on_error = @options[:environment] ? temp : true

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -473,6 +473,15 @@ class TestConfigFile < TestConfigFileBase
     assert_equal true, conf.options[:silence_single_worker_warning]
   end
 
+  def test_supported_http_methods_overwrite
+    conf = Puma::Configuration.new do |c|
+      c.supported_http_methods %w[PROPFIND PROPPATCH].to_set.freeze
+    end
+    conf.load
+
+    assert_equal %w[PROPFIND PROPPATCH].to_set.freeze, conf.options[:supported_http_methods]
+  end
+
   private
 
   def assert_run_hooks(hook_name, options = {})

--- a/test/test_supported_http_methods.rb
+++ b/test/test_supported_http_methods.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+
+require "puma/server"
+
+class TestHandler
+  attr_reader :ran_test
+
+  def call(env)
+    @ran_test = true
+
+    [200, {"Content-Type" => "text/plain"}, ["hello!"]]
+  end
+end
+
+class WebServerTest < Minitest::Test
+  parallelize_me!
+
+  def run_server(options: {})
+    @tester = TestHandler.new
+    @server = Puma::Server.new @tester, nil, options
+    @port = (@server.add_tcp_listener "127.0.0.1", 0).addr[1]
+    @tcp = "http://127.0.0.1:#{@port}"
+    @server.run
+  end
+
+  def teardown
+    @server.stop(true)
+  end
+
+  def test_unsupported_method
+    run_server
+    socket = do_test("CONNECT www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
+    response = socket.read
+    assert_match "501 Not Implemented", response
+    socket.close
+  end
+
+  def test_nonexistent_method
+    run_server
+    socket = do_test("FOOBARBAZ www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
+    response = socket.read
+    assert_match "501 Not Implemented", response
+    socket.close
+  end
+
+  def test_custom_declared_method
+    run_server(options: { supported_http_methods: ["FOOBARBAZ"] })
+    socket = do_test("FOOBARBAZ www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
+    response = socket.read
+    assert_match "HTTP/1.1 200 OK", response
+    socket.close
+  end
+
+  private
+
+  def do_test(string, chunk)
+    # Do not use instance variables here, because it needs to be thread safe
+    socket = TCPSocket.new("127.0.0.1", @port)
+    request = StringIO.new(string)
+    chunks_out = 0
+
+    while data = request.read(chunk)
+      chunks_out += socket.write(data)
+      socket.flush
+    end
+    socket
+  end
+end

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -79,20 +79,6 @@ class WebServerTest < Minitest::Test
     socket.close
   end
 
-  def test_unsupported_method
-    socket = do_test("CONNECT www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
-    response = socket.read
-    assert_match "Not Implemented", response
-    socket.close
-  end
-
-  def test_nonexistent_method
-    socket = do_test("FOOBARBAZ www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
-    response = socket.read
-    assert_match "Not Implemented", response
-    socket.close
-  end
-
   private
 
   def do_test(string, chunk)


### PR DESCRIPTION
### Description

Closes #3014

This pr adds an option called `supported_http_methods`. This option allows puma users to specify which HTTP methods

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [X] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed, including Rubocop.
