### PR TITLE
Correct date for Puma 6.0.1 in History

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,4 @@
-## 6.0.1 / 2022-12-12
+## 6.0.1 / 2022-12-20
  
 * Bugfixes
   * Handle waking up a closed selector in Reactor#add ([#3005])


### PR DESCRIPTION
[ci skip]
