### PR TITLE
CI: always run RuboCop lint job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,9 +10,7 @@ jobs:
     uses: ./.github/workflows/skip_duplicate_workflow_runs.yaml
 
   rubocop:
-    name: 'Rubocop linting'
-    needs: skip_duplicate_runs
-    if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
+    name: RuboCop linting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -101,7 +101,7 @@ module Puma
 
     PUMA_VERSION = VERSION = "6.0.1"
     CODE_NAME = "Sunflower"
-    
+
     PUMA_SERVER_STRING = ["puma", PUMA_VERSION, CODE_NAME].join(" ").freeze
 
     FAST_TRACK_KA_TIMEOUT = 0.2


### PR DESCRIPTION
Related to https://github.com/puma/puma/issues/3046

Also fix the lint offense that slipped through.