### PR TITLE
CI: remove ubuntu-18.04 jobs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-18.04, macos-11, macos-12, windows-2022 ]
+        os: [ ubuntu-20.04, macos-11, macos-12, windows-2022 ]
         ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, head ]
         no-ssl: ['']
         yjit: ['']


### PR DESCRIPTION
The image has been deprecated and the brownout period have started
already: https://github.com/actions/runner-images/issues/6002

Close https://github.com/puma/puma/issues/3045