### PR TITLE
CI: add Ruby 3.2.0 jobs

### DIFF
--- a/.github/workflows/rack2.yaml
+++ b/.github/workflows/rack2.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04 ]
-        ruby: [ 2.4, 3.1 ]
+        ruby: [ 2.4, 3.2 ]
 
     steps:
       - name: repo checkout

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, macos-11, macos-12, windows-2022 ]
-        ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, head ]
+        ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head ]
         no-ssl: ['']
         yjit: ['']
         include:
@@ -49,6 +49,7 @@ jobs:
           - { os: ubuntu-20.04 , ruby: head , yjit: ' yjit' }
           - { os: ubuntu-20.04 , ruby: 2.7  , no-ssl: ' no SSL' }
           - { os: ubuntu-22.04 , ruby: 3.1  }
+          - { os: ubuntu-22.04 , ruby: 3.2  }
           - { os: ubuntu-22.04 , ruby: head }
 
         exclude:

--- a/.github/workflows/turbo-rails.yml
+++ b/.github/workflows/turbo-rails.yml
@@ -27,6 +27,7 @@ jobs:
         include:
           - { os: ubuntu-20.04 , ruby: '3.1', rails-version: '6.1', abi: '3.1.0'   }
           - { os: ubuntu-20.04 , ruby: '3.1', rails-version: '7.0', abi: '3.1.0'   }
+          - { os: ubuntu-20.04 , ruby: '3.2', rails-version: '7.0', abi: '3.2.0'   }
           - { os: ubuntu-22.04 , ruby: head , rails-version: '7.0', abi: '3.2.0+3' }
     env:
       CI: true


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/