### PR TITLE
[CI] Cleanup turbo_rails.yml

### DIFF
--- a/.github/workflows/turbo-rails.yml
+++ b/.github/workflows/turbo-rails.yml
@@ -25,15 +25,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-20.04 , ruby: '3.1', rails-version: '6.1', abi: '3.1.0'   }
-          - { os: ubuntu-20.04 , ruby: '3.1', rails-version: '7.0', abi: '3.1.0'   }
-          - { os: ubuntu-20.04 , ruby: '3.2', rails-version: '7.0', abi: '3.2.0'   }
-          - { os: ubuntu-22.04 , ruby: head , rails-version: '7.0', abi: '3.2.0+3' }
+          - { os: ubuntu-20.04 , ruby: '3.1', rails-version: '6.1' }
+          - { os: ubuntu-20.04 , ruby: '3.1', rails-version: '7.0' }
+          - { os: ubuntu-20.04 , ruby: '3.2', rails-version: '7.0' }
+          - { os: ubuntu-22.04 , ruby: head , rails-version: '7.0' }
     env:
       CI: true
       PUMA_NO_RUBOCOP: true
       RAILS_VERSION: "${{ matrix.rails-version }}"
-      RUBY_ABI: ${{ matrix.abi }}
       # below needs to be a recent released gem version, code below copies
       # relevant Puma code into gem's install folder
       PUMA_VERS: 6.0.0
@@ -60,6 +59,7 @@ jobs:
       - name: turbo-rails bundle install
         working-directory: ../../turbo-rails
         run: |
+          RUBY_ABI=$(ruby -e 'STDOUT.write RbConfig::CONFIG["ruby_version"]')
           # fix Puma version, copying files from repo lib later
           SRC="gem 'puma'"
           DST="gem 'puma', '$PUMA_VERS'"


### PR DESCRIPTION
### Description

The turbo_rails workflow currently hardcodes the Ruby ABI version.  Compute the value in the bash script.  A fix for code I wrote...

Note that the tests will intermittently fail on the first test running a websocket connection.  Haven't found a good fix, it seems to be caused by all the assets not being loaded by the client before the test code sends client websocket data.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
