### PR TITLE
Add workflow for ensuring PRs are labeled

### DIFF
--- a/.github/workflows/ensure_pull_requests_are_labeled.yml
+++ b/.github/workflows/ensure_pull_requests_are_labeled.yml
@@ -1,5 +1,4 @@
-
-name: Ensure pull requests are labeled
+name: Ensure pull requests are labelled
 on:
   pull_request:
     types: [opened, labeled, unlabeled]
@@ -13,16 +12,17 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            const {data: allLabels} = await github.rest.issues.listLabelsOnIssue({
+            const {data: labels} = await github.rest.issues.listLabelsOnIssue({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
             })
+
+            console.log(labels)
             
-            const labels = allLabels.filter(label => !label.name.includes("waiting"))
+            const requiredLabels = ["security", "feature", "bug", "perf", "refactor", "maintenance", "docs"]
+            const labelsPresent = labels.some((label) => requiredLabels.includes(label.name))
             
-            if (labels.length > 0) {
-              console.log(labels)
-            } else {
-              throw new Error("All pull requests require at least one label")
+            if (!labelsPresent) {
+              throw new Error(`All pull requests require at least one of the required labels ${requiredLabels}`)
             }

--- a/.github/workflows/ensure_pull_requests_are_labeled.yml
+++ b/.github/workflows/ensure_pull_requests_are_labeled.yml
@@ -1,0 +1,28 @@
+
+name: Ensure pull requests are labeled
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled]
+
+jobs:
+  label_pull_requests:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const {data: allLabels} = await github.rest.issues.listLabelsOnIssue({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+            
+            const labels = allLabels.filter(label => !label.name.includes("waiting"))
+            
+            if (labels.length > 0) {
+              console.log(labels)
+            } else {
+              throw new Error("All pull requests require at least one label")
+            }


### PR DESCRIPTION
### Description
Closes #3038

Attempt at ensuring PRs are labeled! Apologies for the generic branch name, I was creating the file via the github UI 🙈. 

Some additional thoughts:
- The workflow runs on PR opening, or if a label is added or removed. Are there other parts of the PR lifecycle I might be missing?
- It's a bit "ick" to have a big red ❌ on your PR just because you forgot to add a label, is there maybe a default label we could automatically add instead?


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
