### PR TITLE
[CI] - update RubyGems for Ruby 2.6, eliminate warnings

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,7 +78,7 @@ jobs:
       # fixes 'has a bug that prevents `required_ruby_version`'
       - name: update rubygems for Ruby 2.4 - 2.5
         if: |
-          contains('2.4 2.5', matrix.ruby) && 
+          contains('2.4 2.5 2.6', matrix.ruby) && 
           (needs.skip_duplicate_runs.outputs.should_skip != 'true')
         run: gem update --system 3.3.14 --no-document
         continue-on-error: true


### PR DESCRIPTION
### Description

Current CI is showing warnings when using Ruby 2.6, update RubyGems

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
