### PR TITLE
Fixup code for use with rackup gem (may be used with rack 3)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "minitest-proveit"
 gem "minitest-stub-const"
 
 gem "rack", (ENV['PUMA_CI_RACK_2'] ? "~> 2.2" : ">= 2.2")
+gem "rackup" unless ENV['PUMA_CI_RACK_2']
 
 gem "jruby-openssl", :platform => "jruby"
 

--- a/lib/puma/rack_default.rb
+++ b/lib/puma/rack_default.rb
@@ -2,8 +2,20 @@
 
 require_relative '../rack/handler/puma'
 
-module Rack::Handler
-  def self.default(options = {})
-    Rack::Handler::Puma
+if Object.const_defined? :Rackup
+  module Rackup
+    module Handler
+      def self.default(options = {})
+        ::Rackup::Handler::Puma
+      end
+    end
+  end
+else
+  module Rack
+    module Handler
+      def self.default(options = {})
+        ::Rack::Handler::Puma
+      end
+    end
   end
 end

--- a/lib/puma/rack_default.rb
+++ b/lib/puma/rack_default.rb
@@ -2,6 +2,7 @@
 
 require_relative '../rack/handler/puma'
 
+# rackup was removed in Rack 3, it is now a separate gem
 if Object.const_defined? :Rackup
   module Rackup
     module Handler
@@ -10,7 +11,7 @@ if Object.const_defined? :Rackup
       end
     end
   end
-else
+elsif Object.const_defined?(:Rack) && Rack::RELEASE < '3'
   module Rack
     module Handler
       def self.default(options = {})
@@ -18,4 +19,6 @@ else
       end
     end
   end
+else
+  raise "Rack 3 must be used with the Rackup gem"
 end

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -132,5 +132,5 @@ elsif Object.const_defined?(:Rack) && Rack::RELEASE < '3'
     end
   end
 else
-  raise "Rack 3 must be used with the Rackup gem"
+  raise "You must install the rackup gem when using Rack 3"
 end

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -1,114 +1,118 @@
 # frozen_string_literal: true
 
-require 'rack/handler'
+# Code below is 'odd', but don't want to define a top level constant
 
-module Rack
-  module Handler
-    module Puma
-      DEFAULT_OPTIONS = {
-        :Verbose => false,
-        :Silent  => false
-      }
+if Object.const_defined? :Rackup
+  require 'rackup/handler'
+  ::Rackup::Handler
+else
+  require 'rack/handler'
+  ::Rack::Handler
+end.module_eval <<'HEREDOC'
+  module Puma
+    DEFAULT_OPTIONS = {
+      :Verbose => false,
+      :Silent  => false
+    }
 
-      def self.config(app, options = {})
-        require_relative '../../puma'
-        require_relative '../../puma/configuration'
-        require_relative '../../puma/log_writer'
-        require_relative '../../puma/launcher'
+    def self.config(app, options = {})
+      # `require_relative` won't work with `module_eval`
+      require 'puma'
+      require 'puma/configuration'
+      require 'puma/log_writer'
+      require 'puma/launcher'
 
-        default_options = DEFAULT_OPTIONS.dup
+      default_options = DEFAULT_OPTIONS.dup
 
-        # Libraries pass in values such as :Port and there is no way to determine
-        # if it is a default provided by the library or a special value provided
-        # by the user. A special key `user_supplied_options` can be passed. This
-        # contains an array of all explicitly defined user options. We then
-        # know that all other values are defaults
-        if user_supplied_options = options.delete(:user_supplied_options)
-          (options.keys - user_supplied_options).each do |k|
-            default_options[k] = options.delete(k)
-          end
-        end
-
-        conf = ::Puma::Configuration.new(options, default_options) do |user_config, file_config, default_config|
-          if options.delete(:Verbose)
-            require 'rack/common_logger'
-            app = Rack::CommonLogger.new(app, STDOUT)
-          end
-
-          if options[:environment]
-            user_config.environment options[:environment]
-          end
-
-          if options[:Threads]
-            min, max = options.delete(:Threads).split(':', 2)
-            user_config.threads min, max
-          end
-
-          if options[:Host] || options[:Port]
-            host = options[:Host] || default_options[:Host]
-            port = options[:Port] || default_options[:Port]
-            self.set_host_port_to_config(host, port, user_config)
-          end
-
-          if default_options[:Host]
-            file_config.set_default_host(default_options[:Host])
-          end
-          self.set_host_port_to_config(default_options[:Host], default_options[:Port], default_config)
-
-          user_config.app app
-        end
-        conf
-      end
-
-      def self.run(app, **options)
-        conf   = self.config(app, options)
-
-        log_writer = options.delete(:Silent) ? ::Puma::LogWriter.strings : ::Puma::LogWriter.stdio
-
-        launcher = ::Puma::Launcher.new(conf, :log_writer => log_writer)
-
-        yield launcher if block_given?
-        begin
-          launcher.run
-        rescue Interrupt
-          puts "* Gracefully stopping, waiting for requests to finish"
-          launcher.stop
-          puts "* Goodbye!"
+      # Libraries pass in values such as :Port and there is no way to determine
+      # if it is a default provided by the library or a special value provided
+      # by the user. A special key `user_supplied_options` can be passed. This
+      # contains an array of all explicitly defined user options. We then
+      # know that all other values are defaults
+      if user_supplied_options = options.delete(:user_supplied_options)
+        (options.keys - user_supplied_options).each do |k|
+          default_options[k] = options.delete(k)
         end
       end
 
-      def self.valid_options
-        {
-          "Host=HOST"       => "Hostname to listen on (default: localhost)",
-          "Port=PORT"       => "Port to listen on (default: 8080)",
-          "Threads=MIN:MAX" => "min:max threads to use (default 0:16)",
-          "Verbose"         => "Don't report each request (default: false)"
-        }
-      end
-
-      def self.set_host_port_to_config(host, port, config)
-        config.clear_binds! if host || port
-
-        if host && (host[0,1] == '.' || host[0,1] == '/')
-          config.bind "unix://#{host}"
-        elsif host && host =~ /^ssl:\/\//
-          uri = URI.parse(host)
-          uri.port ||= port || ::Puma::Configuration::DEFAULTS[:tcp_port]
-          config.bind uri.to_s
-        else
-
-          if host
-            port ||= ::Puma::Configuration::DEFAULTS[:tcp_port]
-          end
-
-          if port
-            host ||= ::Puma::Configuration::DEFAULTS[:tcp_host]
-            config.port port, host
-          end
+      conf = ::Puma::Configuration.new(options, default_options) do |user_config, file_config, default_config|
+        if options.delete(:Verbose)
+          require 'rack/common_logger'
+          app = Rack::CommonLogger.new(app, STDOUT)
         end
+
+        if options[:environment]
+          user_config.environment options[:environment]
+        end
+
+        if options[:Threads]
+          min, max = options.delete(:Threads).split(':', 2)
+          user_config.threads min, max
+        end
+
+        if options[:Host] || options[:Port]
+          host = options[:Host] || default_options[:Host]
+          port = options[:Port] || default_options[:Port]
+          self.set_host_port_to_config(host, port, user_config)
+        end
+
+        if default_options[:Host]
+          file_config.set_default_host(default_options[:Host])
+        end
+        self.set_host_port_to_config(default_options[:Host], default_options[:Port], default_config)
+
+        user_config.app app
+      end
+      conf
+    end
+
+    def self.run(app, **options)
+      conf   = self.config(app, options)
+
+      log_writer = options.delete(:Silent) ? ::Puma::LogWriter.strings : ::Puma::LogWriter.stdio
+
+      launcher = ::Puma::Launcher.new(conf, :log_writer => log_writer)
+
+      yield launcher if block_given?
+      begin
+        launcher.run
+      rescue Interrupt
+        puts "* Gracefully stopping, waiting for requests to finish"
+        launcher.stop
+        puts "* Goodbye!"
       end
     end
 
-    register :puma, Puma
+    def self.valid_options
+      {
+        "Host=HOST"       => "Hostname to listen on (default: localhost)",
+        "Port=PORT"       => "Port to listen on (default: 8080)",
+        "Threads=MIN:MAX" => "min:max threads to use (default 0:16)",
+        "Verbose"         => "Don't report each request (default: false)"
+      }
+    end
+
+    def self.set_host_port_to_config(host, port, config)
+      config.clear_binds! if host || port
+
+      if host && (host[0,1] == '.' || host[0,1] == '/')
+        config.bind "unix://#{host}"
+      elsif host && host =~ /^ssl:\/\//
+        uri = URI.parse(host)
+        uri.port ||= port || ::Puma::Configuration::DEFAULTS[:tcp_port]
+        config.bind uri.to_s
+      else
+
+        if host
+          port ||= ::Puma::Configuration::DEFAULTS[:tcp_port]
+        end
+
+        if port
+          host ||= ::Puma::Configuration::DEFAULTS[:tcp_host]
+          config.port port, host
+        end
+      end
+    end
   end
-end
+  register :puma, Puma
+HEREDOC

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -1,16 +1,15 @@
 require_relative "helper"
 
-require "rack"
-
 module TestRackUp
-  if Rack::RELEASE < '3'
-    require "rack/handler/puma"
+  if ENV.key? "PUMA_CI_RACK_2"
+    require "rack"
     RACK_HANDLER_MOD = ::Rack::Handler
   else
     require "rackup"
-    require "rack/handler/puma"
     RACK_HANDLER_MOD = ::Rackup::Handler
   end
+
+  require "rack/handler/puma"
 
   class TestHandlerGetStrSym < Minitest::Test
     def test_handler

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -2,16 +2,22 @@ require_relative "helper"
 
 require "rack"
 
-if Rack::RELEASE < '3'
-
-  require "rack/handler/puma"
+module TestRackUp
+  if Rack::RELEASE < '3'
+    require "rack/handler/puma"
+    RACK_HANDLER_MOD = ::Rack::Handler
+  else
+    require "rackup"
+    require "rack/handler/puma"
+    RACK_HANDLER_MOD = ::Rackup::Handler
+  end
 
   class TestHandlerGetStrSym < Minitest::Test
     def test_handler
-      handler = Rack::Handler.get(:puma)
-      assert_equal Rack::Handler::Puma, handler
-      handler = Rack::Handler.get('Puma')
-      assert_equal Rack::Handler::Puma, handler
+      handler = RACK_HANDLER_MOD.get(:puma)
+      assert_equal RACK_HANDLER_MOD::Puma, handler
+      handler = RACK_HANDLER_MOD.get('Puma')
+      assert_equal RACK_HANDLER_MOD::Puma, handler
     end
   end
 
@@ -30,7 +36,7 @@ if Rack::RELEASE < '3'
 
       @launcher = nil
       thread = Thread.new do
-        Rack::Handler::Puma.run(app, **options) do |s, p|
+        RACK_HANDLER_MOD::Puma.run(app, **options) do |s, p|
           @launcher = s
         end
       end
@@ -74,7 +80,7 @@ if Rack::RELEASE < '3'
           File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
           @options[:Port] = user_port
-          conf = Rack::Handler::Puma.config(->{}, @options)
+          conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
           conf.load
 
           assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
@@ -95,7 +101,7 @@ if Rack::RELEASE < '3'
 
       @options[:Host] = user_host
       @options[:Port] = user_port
-      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
       conf.load
 
       assert_equal ["tcp://#{user_host}:#{user_port}"], conf.options[:binds]
@@ -103,7 +109,7 @@ if Rack::RELEASE < '3'
 
     def test_ipv6_host_supplied_port_default
       @options[:Host] = "::1"
-      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
       conf.load
 
       assert_equal ["tcp://[::1]:9292"], conf.options[:binds]
@@ -126,7 +132,7 @@ if Rack::RELEASE < '3'
           File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
           @options[:Port] = user_port
-          conf = Rack::Handler::Puma.config(->{}, @options)
+          conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
           conf.load
 
           assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
@@ -145,7 +151,7 @@ if Rack::RELEASE < '3'
 
           @options[:Host] = "localhost"
           @options[:Port] = user_port
-          conf = Rack::Handler::Puma.config(->{}, @options)
+          conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
           conf.load
 
           assert_equal ["tcp://localhost:#{file_port}"], conf.options[:binds]
@@ -164,7 +170,7 @@ if Rack::RELEASE < '3'
 
           @options[:Host] = "localhost"
           @options[:Port] = user_port
-          conf = Rack::Handler::Puma.config(->{}, @options)
+          conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
           conf.load
 
           assert_equal ["tcp://1.2.3.4:#{file_port}"], conf.options[:binds]
@@ -179,7 +185,7 @@ if Rack::RELEASE < '3'
     end
 
     def test_default_port_when_no_config_file
-      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
       conf.load
 
       assert_equal ["tcp://0.0.0.0:9292"], conf.options[:binds]
@@ -193,7 +199,7 @@ if Rack::RELEASE < '3'
           FileUtils.mkdir("config")
           File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
-          conf = Rack::Handler::Puma.config(->{}, @options)
+          conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
           conf.load
 
           assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
@@ -205,7 +211,7 @@ if Rack::RELEASE < '3'
       user_port = 5001
       @options[:user_supplied_options] = []
       @options[:Port] = user_port
-      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
       conf.load
 
       assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
@@ -214,7 +220,7 @@ if Rack::RELEASE < '3'
     def test_user_port_wins_over_default
       user_port = 5001
       @options[:Port] = user_port
-      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
       conf.load
 
       assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
@@ -230,7 +236,7 @@ if Rack::RELEASE < '3'
           File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
           @options[:Port] = user_port
-          conf = Rack::Handler::Puma.config(->{}, @options)
+          conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
           conf.load
 
           assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
@@ -239,7 +245,7 @@ if Rack::RELEASE < '3'
     end
 
     def test_default_log_request_when_no_config_file
-      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
       conf.load
 
       assert_equal false, conf.options[:log_requests]
@@ -252,7 +258,7 @@ if Rack::RELEASE < '3'
         'test/config/t1_conf.rb'
       ]
 
-      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
       conf.load
 
       assert_equal file_log_requests_config, conf.options[:log_requests]
@@ -266,10 +272,10 @@ if Rack::RELEASE < '3'
         'test/config/t1_conf.rb'
       ]
 
-      conf = Rack::Handler::Puma.config(->{}, @options)
+      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
       conf.load
 
       assert_equal user_log_requests_config, conf.options[:log_requests]
     end
   end
-end # if Rack::RELEASE < '3'
+end


### PR DESCRIPTION
### Description

Rack v2 included the files needed to use `rackup` from the command line.  With Rack v3, it is now a separate gem, and the namespace has changed.

Re tests, when Rack v3 was released, we (ok, I) blocked  [test/test_rack_handler](https://github.com/puma/puma/blame/3f4e3c8ca689e39218459836b939c39fa81e2692/test/test_rack_handler.rb#L5) from running with Rack v3, so tests do exist.  This PR unblocks the tests.

The changes to `lib/rack/handler/puma.rb` look excessive.  This PR is taking the previous code, and turning it into a HEREDOC, so it can be used in `module_eval`.  This is the work-around to allow it to be placed in either the `Rack::Handler` or the `Rackup::Handler` namespace.

Adjust code to work with both.

**Note:** labeled as a 'bug', not sure...

Closes #3057 

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
