### PR TITLE
Reduce memory usage for large file uploads

### DIFF
--- a/benchmarks/local/sinatra/Gemfile
+++ b/benchmarks/local/sinatra/Gemfile
@@ -1,0 +1,13 @@
+source "http://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+ruby "3.2.0"
+
+gem "sinatra"
+gem "puma_worker_killer"
+
+# current puma release
+gem "puma"
+
+# PR to reduce memory of large file uploads
+# gem "puma", github: "willkoehler/puma", branch: "reduce_read_body_memory"

--- a/benchmarks/local/sinatra/README.md
+++ b/benchmarks/local/sinatra/README.md
@@ -1,0 +1,92 @@
+# Large file upload demo
+
+This is a simple app to demonstrate memory used by Puma for large file uploads and
+compare it to proposed changes in PR https://github.com/puma/puma/pull/3062
+
+### Steps to test memory improvements in https://github.com/puma/puma/pull/3062
+
+- Run the app with puma_worker_killer: `bundle exec puma -p 9090 --config puma.rb`
+- Make a POST request with curl: `curl --form "data=@some_large_file.mp4" --limit-rate 10M http://localhost:9090/`
+- Puma will log memory usage in the console
+
+Below is example of the results uploading a 115MB video.
+
+### Puma 6.0.2
+
+```
+[11820] Puma starting in cluster mode...
+[11820] * Puma version: 6.0.2 (ruby 3.2.0-p0) ("Sunflower")
+[11820] *  Min threads: 0
+[11820] *  Max threads: 5
+[11820] *  Environment: development
+[11820] *   Master PID: 11820
+[11820] *      Workers: 1
+[11820] *     Restarts: (✔) hot (✔) phased
+[11820] * Listening on http://0.0.0.0:3000
+[11820] Use Ctrl-C to stop
+[11820] - Worker 0 (PID: 11949) booted in 0.06s, phase: 0
+[11820] PumaWorkerKiller: Consuming 70.984375 mb with master and 1 workers.
+[11820] PumaWorkerKiller: Consuming 70.984375 mb with master and 1 workers.
+
+...curl request made - memory increases as file is received
+
+[11820] PumaWorkerKiller: Consuming 72.796875 mb with master and 1 workers.
+[11820] PumaWorkerKiller: Consuming 75.921875 mb with master and 1 workers.
+[11820] PumaWorkerKiller: Consuming 78.953125 mb with master and 1 workers.
+[11820] PumaWorkerKiller: Consuming 82.15625 mb with master and 1 workers.
+[11820] PumaWorkerKiller: Consuming 85.265625 mb with master and 1 workers.
+[11820] PumaWorkerKiller: Consuming 88.046875 mb with master and 1 workers.
+
+...(clipped out lines) memory keeps increasing while request is received
+
+[11820] PumaWorkerKiller: Consuming 121.53125 mb with master and 1 workers.
+[11820] PumaWorkerKiller: Consuming 122.75 mb with master and 1 workers.
+[11820] PumaWorkerKiller: Consuming 125.40625 mb with master and 1 workers.
+
+...request handed off from Puma to Rack/Sinatra
+
+[11820] PumaWorkerKiller: Consuming 220.6875 mb with master and 1 workers.
+127.0.0.1 - - [26/Jan/2023:20:09:56 -0500] "POST /upload HTTP/1.1" 200 162 0.0553
+[11820] PumaWorkerKiller: Consuming 228.96875 mb with master and 1 workers.
+[11820] PumaWorkerKiller: Consuming 228.96875 mb with master and 1 workers.
+```
+
+### With PR https://github.com/puma/puma/pull/3062
+
+```
+[20815] Puma starting in cluster mode...
+[20815] * Puma version: 6.0.2 (ruby 3.2.0-p0) ("Sunflower")
+[20815] *  Min threads: 0
+[20815] *  Max threads: 5
+[20815] *  Environment: development
+[20815] *   Master PID: 20815
+[20815] *      Workers: 1
+[20815] *     Restarts: (✔) hot (✔) phased
+[20815] * Listening on http://0.0.0.0:3000
+[20815] Use Ctrl-C to stop
+[20815] - Worker 0 (PID: 20944) booted in 0.1s, phase: 0
+[20815] PumaWorkerKiller: Consuming 73.25 mb with master and 1 workers.
+[20815] PumaWorkerKiller: Consuming 73.25 mb with master and 1 workers.
+
+...curl request made - memory stays level as file is received
+
+[20815] PumaWorkerKiller: Consuming 73.28125 mb with master and 1 workers.
+[20815] PumaWorkerKiller: Consuming 73.296875 mb with master and 1 workers.
+[20815] PumaWorkerKiller: Consuming 73.34375 mb with master and 1 workers.
+[20815] PumaWorkerKiller: Consuming 73.359375 mb with master and 1 workers.
+[20815] PumaWorkerKiller: Consuming 73.359375 mb with master and 1 workers.
+[20815] PumaWorkerKiller: Consuming 73.359375 mb with master and 1 workers.
+
+...(clipped out lines) memory continues to stay level
+
+[20815] PumaWorkerKiller: Consuming 73.703125 mb with master and 1 workers.
+[20815] PumaWorkerKiller: Consuming 73.703125 mb with master and 1 workers.
+[20815] PumaWorkerKiller: Consuming 73.703125 mb with master and 1 workers.
+
+...request handed off from Puma to Rack/Sinatra
+
+[20815] PumaWorkerKiller: Consuming 181.96875 mb with master and 1 workers.
+127.0.0.1 - - [26/Jan/2023:20:27:16 -0500] "POST /upload HTTP/1.1" 200 162 0.0585
+[20815] PumaWorkerKiller: Consuming 183.78125 mb with master and 1 workers.
+[20815] PumaWorkerKiller: Consuming 183.78125 mb with master and 1 workers.
+```

--- a/benchmarks/local/sinatra/config.ru
+++ b/benchmarks/local/sinatra/config.ru
@@ -1,0 +1,7 @@
+require "sinatra"
+
+post "/" do
+  204
+end
+
+run Sinatra::Application

--- a/benchmarks/local/sinatra/puma.rb
+++ b/benchmarks/local/sinatra/puma.rb
@@ -1,0 +1,15 @@
+silence_single_worker_warning
+
+workers 1
+
+before_fork do
+  require "puma_worker_killer"
+
+  PumaWorkerKiller.config do |config|
+    config.ram = 1024 # mb
+    config.frequency = 0.3 # seconds
+    config.reaper_status_logs = true # Log memory: PumaWorkerKiller: Consuming 54.34765625 mb with master and 1 workers.
+  end
+
+  PumaWorkerKiller.start
+end

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -98,6 +98,8 @@ module Puma
       @body_remain = 0
 
       @in_last_chunk = false
+
+      @read_buffer = +""
     end
 
     attr_reader :env, :to_io, :body, :io, :timeout_at, :ready, :hijacked,
@@ -433,7 +435,7 @@ module Puma
       end
 
       begin
-        chunk = @io.read_nonblock(want)
+        chunk = @io.read_nonblock(want, @read_buffer)
       rescue IO::WaitReadable
         return false
       rescue SystemCallError, IOError
@@ -465,7 +467,7 @@ module Puma
     def read_chunked_body
       while true
         begin
-          chunk = @io.read_nonblock(4096)
+          chunk = @io.read_nonblock(4096, @read_buffer)
         rescue IO::WaitReadable
           return false
         rescue SystemCallError, IOError


### PR DESCRIPTION
The motivation for this change is to reduce memory used by a Rails application running on Heroku that handles large file uploads (~100Mb). In it's current state the application (running Puma 6.0.2 + Rails 5.2.8 + Ruby 2.7.6) starts using swap and triggering "memory quota exceeded errors" on the Heroku dyno after only a few file uploads.

This PR is a proof of concept that appears to significantly reduce the memory used by Puma during the data phase of the HTTP request. The change I made was to re-use a single read buffer in `Puma::Client#read_body` and `Puma::Client#read_chunked_body` vs allocating a new buffer on each call to `read_nonblock()`.

I proved this change worked locally by throttling the network speed in Chrome dev tools and watching application memory usage as Puma received the file upload request. I then reproduced this experiment on a Heroku dyno, uploading a 100 Mb file to my application while watching memory on the dyno with `top`. I grabbed screenshots just before Puma handed the request off to Rack to isolate any memory usage to Puma alone.

### Puma v6.0.2 - Initial memory
<img width="614" alt="memory13_at_idle_puma_6_0_2" src="https://user-images.githubusercontent.com/889420/213878203-b4ea291e-a5cc-474f-9b3e-d07dcd0d5f61.png">

### Puma v6.0.2 - Memory at 95% uploaded
<img width="618" alt="memory14_95percent_uploaded_puma_6_0_2" src="https://user-images.githubusercontent.com/889420/213878244-5ab18e93-66c0-4da1-bddb-84744c4dda55.png">

### This PR - Initial memory
<img width="615" alt="memory11_at_idle_with_fix" src="https://user-images.githubusercontent.com/889420/213878325-802b2bd8-483b-4ebf-9369-3a08e0b204cc.png">

### This PR - Memory at 95% uploaded
<img width="613" alt="memory12_95percent_uploaded_with_fix" src="https://user-images.githubusercontent.com/889420/213878352-b455b307-0674-472d-92d5-1fce007a362a.png">

To demonstrate this change had a positive impact on the application memory footprint overall (not just the Puma data phase), I watched Heroku's memory usage graph while uploading 5 large (100Mb) files. This PR reduced memory usage by ~100Mb (25% reduction) compared to Puma 6.0.2. See screenshot below.

<img width="476" alt="heroku_memory" src="https://user-images.githubusercontent.com/889420/213879740-1a385c8c-e256-4fc9-b24e-39f1a1ef17ee.png">

My biggest concern is that this solution may not be thread-safe. To test this, I ran Puma locally with `WEB_CONCURRENCY=0 bin/rails s` and performed 3 simultaneous 100Mb file uploads. Each of the files was received successfully.

One final note: I did not make a change to the `read_nonblock` call in `Puma::Client#try_to_finish` Doing so creates a shared memory conflict between `data` and `@buffer` and `@read_buffer` (they are all just references to the same thing). This would need to be fixed by duping `data` before assigning to `@buffer`.

```
if @buffer
  @buffer << data
else
  @buffer = data.dup
end
```

I felt that this additional complexity may be confusing and easily broken in the future.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
