### PR TITLE
[CI] test_rack_server.rb - remove use of Open3, set HOST constant

### DIFF
--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -4,15 +4,17 @@ require "net/http"
 
 require "rack"
 require "rack/body_proxy"
-require "rack/chunked" if Rack::RELEASE >= '3'
+
+# Rack::Chunked is loaded by Rack v2, needs to be required by Rack 3.0,
+# and is removed in Rack 3.1
+require "rack/chunked" if Rack::RELEASE.between?('3', '3.1')
 
 require "nio"
-require "open3"
 
 class TestRackServer < Minitest::Test
   parallelize_me!
 
-  TRANSFER_ENCODING_CHUNKED = 'transfer-encoding: chunked'
+  HOST = '127.0.0.1'
 
   STR_1KB = "──#{SecureRandom.hex 507}─\n".freeze
 
@@ -49,8 +51,8 @@ class TestRackServer < Minitest::Test
   def setup
     @simple = lambda { |env| [200, { "x-header" => "Works" }, ["Hello"]] }
     @server = Puma::Server.new @simple
-    @port = (@server.add_tcp_listener "127.0.0.1", 0).addr[1]
-    @tcp = "http://127.0.0.1:#{@port}"
+    @port = (@server.add_tcp_listener HOST, 0).addr[1]
+    @tcp = "http://#{HOST}:#{@port}"
     @stopped = false
   end
 
@@ -135,7 +137,7 @@ class TestRackServer < Minitest::Test
 
     @server.run
 
-    socket = TCPSocket.open "127.0.0.1", @port
+    socket = TCPSocket.open HOST, @port
     socket.puts "GET /test HTTP/1.1\r\n"
     socket.puts "Connection: Keep-Alive\r\n"
     socket.puts "\r\n"
@@ -194,7 +196,7 @@ class TestRackServer < Minitest::Test
 
     @server.run
 
-    socket = TCPSocket.open "127.0.0.1", @port
+    socket = TCPSocket.open HOST, @port
     socket.puts "GET /test HTTP/1.1\r\n"
     socket.puts "Connection: Keep-Alive\r\n"
     socket.puts "\r\n"
@@ -228,14 +230,14 @@ class TestRackServer < Minitest::Test
 
     @server.run
 
-    socket1 = TCPSocket.new "127.0.0.1", @port
+    socket1 = TCPSocket.new HOST, @port
     socket1.syswrite "GET / HTTP/1.1\r\n\r\n"
     sleep (Puma::IS_WINDOWS || !Puma::IS_MRI ? 0.25 : 0.1)
     resp1 = socket1.sysread 1_024
 
     sleep 0.01 # time for close block to be called ?
 
-    socket2 = TCPSocket.new "127.0.0.1", @port
+    socket2 = TCPSocket.new HOST, @port
     socket2.syswrite "GET / HTTP/1.1\r\n\r\n"
     sleep (Puma::IS_WINDOWS || !Puma::IS_MRI ? 0.25 : 0.1)
     resp2 = socket2.sysread 1_024
@@ -270,9 +272,9 @@ class TestRackServer < Minitest::Test
     @server.app = rack_app
     @server.run
 
-    resp_body, headers, _status = Open3.capture3 "curl -v #{@tcp}/"
-    assert_includes headers.downcase, TRANSFER_ENCODING_CHUNKED
-    assert_equal STR_1KB, resp_body
+    resp = Net::HTTP.get_response URI(@tcp)
+    assert_equal 'chunked', resp['transfer-encoding']
+    assert_equal STR_1KB, resp.body.force_encoding(Encoding::UTF_8)
   end if Rack::RELEASE < '3.1'
 
   def test_rack_chunked_array10
@@ -282,9 +284,9 @@ class TestRackServer < Minitest::Test
     @server.app = rack_app
     @server.run
 
-    resp_body, headers, _status = Open3.capture3 "curl -v #{@tcp}/"
-    assert_includes headers.downcase, TRANSFER_ENCODING_CHUNKED
-    assert_equal STR_1KB * 10, resp_body
+    resp = Net::HTTP.get_response URI(@tcp)
+    assert_equal 'chunked', resp['transfer-encoding']
+    assert_equal STR_1KB * 10, resp.body.force_encoding(Encoding::UTF_8)
   end if Rack::RELEASE < '3.1'
 
   def test_puma_enum
@@ -292,8 +294,8 @@ class TestRackServer < Minitest::Test
     @server.app = lambda { |env| [200, { 'content-type' => 'text/plain; charset=utf-8' }, body] }
     @server.run
 
-    resp_body, headers, _status = Open3.capture3 "curl -v #{@tcp}/"
-    assert_includes headers.downcase, TRANSFER_ENCODING_CHUNKED
-    assert_equal STR_1KB * 10, resp_body
+    resp = Net::HTTP.get_response URI(@tcp)
+    assert_equal 'chunked', resp['transfer-encoding']
+    assert_equal STR_1KB * 10, resp.body.force_encoding(Encoding::UTF_8)
   end
 end


### PR DESCRIPTION
### Description
Recently there was a failure (with IO), when using Open3 in test_rack_server.rb.  Remove use of Open3, use net/http instead.  Note that net/http ignores `content-type` encoding, so we have to force it.

'curl' was used with Open3, and it does recognize encoding.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
