### PR TITLE
Allow setting TCP low_latency with SSL listener, minor fixes

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -158,10 +158,10 @@ module Puma
             ios_len = @ios.length
             params = Util.parse_query uri.query
 
-            opt = params.key?('low_latency') && params['low_latency'] != 'false'
+            low_latency = params.key?('low_latency') && params['low_latency'] != 'false'
             backlog = params.fetch('backlog', 1024).to_i
 
-            io = add_tcp_listener uri.host, uri.port, opt, backlog
+            io = add_tcp_listener uri.host, uri.port, low_latency, backlog
 
             @ios[ios_len..-1].each do |i|
               addr = loc_addr_str i
@@ -251,8 +251,8 @@ module Puma
           else
             ios_len = @ios.length
             backlog = params.fetch('backlog', 1024).to_i
-            opt = params.key?('low_latency') && params['low_latency'] != 'false'
-            io = add_ssl_listener uri.host, uri.port, ctx, opt, backlog
+            low_latency = params.key?('low_latency') && params['low_latency'] != 'false'
+            io = add_ssl_listener uri.host, uri.port, ctx, low_latency, backlog
 
             @ios[ios_len..-1].each do |i|
               addr = loc_addr_str i

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -251,7 +251,8 @@ module Puma
           else
             ios_len = @ios.length
             backlog = params.fetch('backlog', 1024).to_i
-            io = add_ssl_listener uri.host, uri.port, ctx, optimize_for_latency = true, backlog
+            opt = params.key?('low_latency') && params['low_latency'] != 'false'
+            io = add_ssl_listener uri.host, uri.port, ctx, opt, backlog
 
             @ios[ios_len..-1].each do |i|
               addr = loc_addr_str i

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -251,7 +251,7 @@ module Puma
           else
             ios_len = @ios.length
             backlog = params.fetch('backlog', 1024).to_i
-            low_latency = params.key?('low_latency') && params['low_latency'] != 'false'
+            low_latency = params['low_latency'] != 'false'
             io = add_ssl_listener uri.host, uri.port, ctx, low_latency, backlog
 
             @ios[ios_len..-1].each do |i|

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -65,6 +65,7 @@ module Puma
 
       ca_additions = "&ca=#{Puma::Util.escape(opts[:ca])}" if ['peer', 'force_peer'].include?(verify)
 
+      low_latency_str = opts.key?(:low_latency) ? "&low_latency=#{opts[:low_latency]}" : ''
       backlog_str = opts[:backlog] ? "&backlog=#{Integer(opts[:backlog])}" : ''
 
       if defined?(JRUBY_VERSION)
@@ -114,7 +115,7 @@ module Puma
           end
 
         "ssl://#{host}:#{port}?#{cert_flags}#{key_flags}#{ssl_cipher_filter}" \
-          "#{reuse_flag}&verify_mode=#{verify}#{tls_str}#{ca_additions}#{v_flags}#{backlog_str}"
+          "#{reuse_flag}&verify_mode=#{verify}#{tls_str}#{ca_additions}#{v_flags}#{backlog_str}#{low_latency_str}"
       end
     end
 

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -306,8 +306,8 @@ module Puma
     def fast_write_response(socket, body, io_buffer, chunked, content_length)
       if body.is_a?(::File) && body.respond_to?(:read)
         if chunked  # would this ever happen?
-          while part = body.read(BODY_LEN_MAX)
-            io_buffer.append part.bytesize.to_s(16), LINE_END, part, LINE_END
+          while chunk = body.read(BODY_LEN_MAX)
+            io_buffer.append chunk.bytesize.to_s(16), LINE_END, chunk, LINE_END
           end
           fast_write_str socket, CLOSE_CHUNKED
         else

--- a/test/rackup/hello-bind_rack3.ru
+++ b/test/rackup/hello-bind_rack3.ru
@@ -1,0 +1,1 @@
+run lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Hello World"]] }

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -192,6 +192,15 @@ class TestBinderParallel < TestBinderBase
     end
   end
 
+  def test_binder_defaults_to_low_latency_off
+    skip_if :jruby
+    @binder.parse ["tcp://0.0.0.0:0"], @log_writer
+
+    socket = @binder.listeners.first.last
+
+    refute socket.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY).bool
+  end
+
   def test_binder_parses_nil_low_latency
     skip_if :jruby
     @binder.parse ["tcp://0.0.0.0:0?low_latency"], @log_writer
@@ -217,6 +226,26 @@ class TestBinderParallel < TestBinderBase
     socket = @binder.listeners.first.last
 
     refute socket.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY).bool
+  end
+
+  def test_binder_defaults_to_low_latency_off_ssl
+    skip_unless :ssl
+    skip_if :jruby
+    @binder.parse ["ssl://0.0.0.0:0?#{ssl_query}"], @log_writer
+
+    socket = @binder.listeners.first.last
+
+    refute socket.to_io.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY).bool
+  end
+
+  def test_binder_parses_false_low_latency_ssl
+    skip_unless :ssl
+    skip_if :jruby
+    @binder.parse ["ssl://0.0.0.0:0?#{ssl_query}&low_latency=false"], @log_writer
+
+    socket = @binder.listeners.first.last
+
+    refute socket.to_io.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY).bool
   end
 
   def test_binder_parses_tlsv1_disabled

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -192,7 +192,7 @@ class TestBinderParallel < TestBinderBase
     end
   end
 
-  def test_binder_defaults_to_low_latency_off
+  def test_binder_tcp_defaults_to_low_latency_off
     skip_if :jruby
     @binder.parse ["tcp://0.0.0.0:0"], @log_writer
 
@@ -201,7 +201,7 @@ class TestBinderParallel < TestBinderBase
     refute socket.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY).bool
   end
 
-  def test_binder_parses_nil_low_latency
+  def test_binder_tcp_parses_nil_low_latency
     skip_if :jruby
     @binder.parse ["tcp://0.0.0.0:0?low_latency"], @log_writer
 
@@ -210,7 +210,7 @@ class TestBinderParallel < TestBinderBase
     assert socket.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY).bool
   end
 
-  def test_binder_parses_true_low_latency
+  def test_binder_tcp_parses_true_low_latency
     skip_if :jruby
     @binder.parse ["tcp://0.0.0.0:0?low_latency=true"], @log_writer
 
@@ -228,17 +228,17 @@ class TestBinderParallel < TestBinderBase
     refute socket.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY).bool
   end
 
-  def test_binder_defaults_to_low_latency_off_ssl
+  def test_binder_ssl_defaults_to_true_low_latency
     skip_unless :ssl
     skip_if :jruby
     @binder.parse ["ssl://0.0.0.0:0?#{ssl_query}"], @log_writer
 
     socket = @binder.listeners.first.last
 
-    refute socket.to_io.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY).bool
+    assert socket.to_io.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY).bool
   end
 
-  def test_binder_parses_false_low_latency_ssl
+  def test_binder_ssl_parses_false_low_latency
     skip_unless :ssl
     skip_if :jruby
     @binder.parse ["ssl://0.0.0.0:0?#{ssl_query}&low_latency=false"], @log_writer

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -147,6 +147,38 @@ class TestConfigFile < TestConfigFileBase
     assert ssl_binding.include?('&backlog=2048')
   end
 
+  def test_ssl_bind_with_low_latency_true
+    skip_unless :ssl
+    skip_if :jruby
+
+    conf = Puma::Configuration.new do |c|
+      c.ssl_bind "0.0.0.0", "9292", {
+        low_latency: true
+      }
+    end
+
+    conf.load
+
+    ssl_binding = conf.options[:binds].first
+    assert ssl_binding.include?('&low_latency=true')
+  end
+
+  def test_ssl_bind_with_low_latency_false
+    skip_unless :ssl
+    skip_if :jruby
+
+    conf = Puma::Configuration.new do |c|
+      c.ssl_bind "0.0.0.0", "9292", {
+        low_latency: false
+      }
+    end
+
+    conf.load
+
+    ssl_binding = conf.options[:binds].first
+    assert ssl_binding.include?('&low_latency=false')
+  end
+
   def test_ssl_bind_jruby
     skip_unless :jruby
     skip_unless :ssl

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -17,9 +17,16 @@ class TestConfigFile < TestConfigFileBase
   end
 
   def test_app_from_rackup
-    skip_if :rack3
+    if Rack::RELEASE >= '3'
+      fn = "test/rackup/hello-bind_rack3.ru"
+      bind = "tcp://0.0.0.0:9292"
+    else
+      fn = "test/rackup/hello-bind.ru"
+      bind = "tcp://127.0.0.1:9292"
+    end
+
     conf = Puma::Configuration.new do |c|
-      c.rackup "test/rackup/hello-bind.ru"
+      c.rackup fn
     end
     conf.load
 
@@ -29,7 +36,9 @@ class TestConfigFile < TestConfigFileBase
       conf.app
     end
 
-    assert_equal ["tcp://127.0.0.1:9292"], conf.options[:binds]
+    assert_equal [200, {"Content-Type"=>"text/plain"}, ["Hello World"]], conf.app.call({})
+
+    assert_equal [bind], conf.options[:binds]
   end
 
   def test_app_from_app_DSL


### PR DESCRIPTION
### Description

Started with the following warnings in Ruby 2.4:
```
lib/puma/binder.rb:254: warning: assigned but unused variable - optimize_for_latency
lib/puma/request.rb:334: warning: shadowing outer local variable - part
lib/puma/request.rb:343: warning: shadowing outer local variable - part
lib/puma/request.rb:357: warning: shadowing outer local variable - part
lib/puma/request.rb:365: warning: shadowing outer local variable - part
```

Fixed the above, rather trivial.

Then, while looking at the 'optimize_for_latency' warning, discovered that the TCPServer started for an SSL connection was not passed the 'low_latency' argument.

Fixed, and added tests to `test_binder.rb` & `test_config.rb`, which is the last commit.  Cherry-pick the test commits to master, it shows the following three failures:
```
  1) Failure:
TestBinderParallel#test_binder_ssl_parses_false_low_latency [/mnt/c/Greg/GitHub/puma/test/test_binder.rb:248]:
Expected true to not be truthy.

48 runs, 96 assertions, 1 failures, 0 errors, 0 skips


  1) Failure:
TestConfigFile#test_ssl_bind_with_low_latency_true [/mnt/c/Greg/GitHub/puma/test/test_config.rb:172]:
Expected false to be truthy.

  2) Failure:
TestConfigFile#test_ssl_bind_with_low_latency_false [/mnt/c/Greg/GitHub/puma/test/test_config.rb:188]:
Expected false to be truthy.

53 runs, 81 assertions, 2 failures, 0 errors, 3 skips
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
