### PR TITLE
Set env['rack.hijack'] to client.method(:full_hijack) instead of client instance

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -122,9 +122,9 @@ module Puma
       "#<Puma::Client:0x#{object_id.to_s(16)} @ready=#{@ready.inspect}>"
     end
 
-    # For the hijack protocol (allows us to just put the Client object
-    # into the env)
-    def call
+    # For the full hijack protocol, `env['rack.hijack']` is set to
+    # `client.method :full_hijack`
+    def full_hijack
       @hijacked = true
       env[HIJACK_IO] ||= @io
     end

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -53,7 +53,6 @@ module Puma
       socket  = client.io   # io may be a MiniSSL::Socket
       app_body = nil
 
-
       return false if closed_socket?(socket)
 
       if client.http_content_length_limit_exceeded
@@ -69,7 +68,7 @@ module Puma
       end
 
       env[HIJACK_P] = true
-      env[HIJACK] = client
+      env[HIJACK] = client.method :full_hijack
 
       env[RACK_INPUT] = client.body
       env[RACK_URL_SCHEME] ||= default_server_port(env) == PORT_443 ? HTTPS : HTTP


### PR DESCRIPTION
### Description

Currently, `Puma::Request` sets `env['rack.hijack']` to the `Puma::Client` instance.  Instead of using the client instance, pass a method object that responds to `call`.

The Rack spec for the object passed in `env['rack.hijack']` is that it must respond to `call`.  Also, `Puma::Client` is a ':nodoc:` class, so it shouldn't be considered part of Puma's public API.  Hence, there is no reason to pass it to the app.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
