### PR TITLE
commonlogger.rb - fix HIJACK time format, use constants, not strings

### DIFF
--- a/lib/puma/commonlogger.rb
+++ b/lib/puma/commonlogger.rb
@@ -25,10 +25,17 @@ module Puma
 
     HIJACK_FORMAT = %{%s - %s [%s] "%s %s%s %s" HIJACKED -1 %0.4f\n}
 
-    CONTENT_LENGTH = 'Content-Length'.freeze
-    PATH_INFO      = 'PATH_INFO'.freeze
-    QUERY_STRING   = 'QUERY_STRING'.freeze
-    REQUEST_METHOD = 'REQUEST_METHOD'.freeze
+    LOG_TIME_FORMAT = '%d/%b/%Y:%H:%M:%S %z'
+
+    CONTENT_LENGTH       = 'Content-Length' # should be lower case from app,
+                                            # Util::HeaderHash allows mixed
+    HTTP_VERSION         = Const::HTTP_VERSION
+    HTTP_X_FORWARDED_FOR = Const::HTTP_X_FORWARDED_FOR
+    PATH_INFO            = Const::PATH_INFO
+    QUERY_STRING         = Const::QUERY_STRING
+    REMOTE_ADDR          = Const::REMOTE_ADDR
+    REMOTE_USER          = 'REMOTE_USER'
+    REQUEST_METHOD       = Const::REQUEST_METHOD
 
     def initialize(app, logger=nil)
       @app = app
@@ -57,13 +64,13 @@ module Puma
       now = Time.now
 
       msg = HIJACK_FORMAT % [
-        env['HTTP_X_FORWARDED_FOR'] || env["REMOTE_ADDR"] || "-",
-        env["REMOTE_USER"] || "-",
-        now.strftime("%d/%b/%Y %H:%M:%S"),
+        env[HTTP_X_FORWARDED_FOR] || env[REMOTE_ADDR] || "-",
+        env[REMOTE_USER] || "-",
+        now.strftime(LOG_TIME_FORMAT),
         env[REQUEST_METHOD],
         env[PATH_INFO],
         env[QUERY_STRING].empty? ? "" : "?#{env[QUERY_STRING]}",
-        env["HTTP_VERSION"],
+        env[HTTP_VERSION],
         now - began_at ]
 
       write(msg)
@@ -74,13 +81,13 @@ module Puma
       length = extract_content_length(header)
 
       msg = FORMAT % [
-        env['HTTP_X_FORWARDED_FOR'] || env["REMOTE_ADDR"] || "-",
-        env["REMOTE_USER"] || "-",
-        now.strftime("%d/%b/%Y:%H:%M:%S %z"),
+        env[HTTP_X_FORWARDED_FOR] || env[REMOTE_ADDR] || "-",
+        env[REMOTE_USER] || "-",
+        now.strftime(LOG_TIME_FORMAT),
         env[REQUEST_METHOD],
         env[PATH_INFO],
         env[QUERY_STRING].empty? ? "" : "?#{env[QUERY_STRING]}",
-        env["HTTP_VERSION"],
+        env[HTTP_VERSION],
         status.to_s[0..3],
         length,
         now - began_at ]

--- a/lib/puma/commonlogger.rb
+++ b/lib/puma/commonlogger.rb
@@ -3,7 +3,7 @@
 module Puma
   # Rack::CommonLogger forwards every request to the given +app+, and
   # logs a line in the
-  # {Apache common log format}[https://httpd.apache.org/docs/1.3/logs.html#common]
+  # {Apache common log format}[https://httpd.apache.org/docs/2.4/logs.html#common]
   # to the +logger+.
   #
   # If +logger+ is nil, CommonLogger will fall back +rack.errors+, which is
@@ -16,7 +16,7 @@ module Puma
   # (which is called without arguments in order to make the error appear for
   # sure)
   class CommonLogger
-    # Common Log Format: https://httpd.apache.org/docs/1.3/logs.html#common
+    # Common Log Format: https://httpd.apache.org/docs/2.4/logs.html#common
     #
     #   lilith.local - - [07/Aug/2006 23:58:02 -0400] "GET / HTTP/1.1" 500 -
     #


### PR DESCRIPTION
### Description
Current log output from a request and a 'full-hijacked' request:
```
127.0.0.1 - - [08/Feb/2023:18:47:21 -0600] "GET /users/profiles HTTP/1.1" 200 - 0.1126
127.0.0.1 - - [08/Feb/2023 18:47:22] "GET /cable HTTP/1.1" HIJACKED -1 0.6079
```
Note the hijack log line doesn't have a time zone offset...

Fixed and used constants for the env keys instead of strings.  Not sure if local constants are better than using one from `Puma::Const`?

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
