### PR TITLE
Don't use the systemd plugin on JRuby

### DIFF
--- a/lib/puma/detect.rb
+++ b/lib/puma/detect.rb
@@ -17,6 +17,8 @@ module Puma
   IS_WINDOWS = !!(RUBY_PLATFORM =~ /mswin|ming|cygwin/) ||
     IS_JRUBY && RUBY_DESCRIPTION.include?('mswin')
 
+  IS_LINUX = !(IS_OSX || IS_WINDOWS)
+
   # @version 5.2.0
   IS_MRI = (RUBY_ENGINE == 'ruby' || RUBY_ENGINE.nil?)
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -59,7 +59,10 @@ module Puma
 
       @environment = conf.environment
 
-      if ENV["NOTIFY_SOCKET"] && RUBY_PLATFORM != "java"
+      # Load the systemd integration if we detect systemd's NOTIFY_SOCKET.
+      # Skip this on JRuby though, because it is incompatible with the systemd
+      # integration due to https://github.com/jruby/jruby/issues/6504
+      if ENV["NOTIFY_SOCKET"] && !Puma.jruby?
         @config.plugins.create('systemd')
       end
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -59,7 +59,7 @@ module Puma
 
       @environment = conf.environment
 
-      if ENV["NOTIFY_SOCKET"]
+      if ENV["NOTIFY_SOCKET"] && RUBY_PLATFORM != "java"
         @config.plugins.create('systemd')
       end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -145,6 +145,7 @@ module TestSkips
   def skip_if(*engs, suffix: '', bt: caller)
     engs.each do |eng|
       skip_msg = case eng
+        when :linux       then "Skipped if Linux#{suffix}"       if Puma::IS_LINUX
         when :darwin      then "Skipped if darwin#{suffix}"      if Puma::IS_OSX
         when :jruby       then "Skipped if JRuby#{suffix}"       if Puma::IS_JRUBY
         when :truffleruby then "Skipped if TruffleRuby#{suffix}" if TRUFFLE
@@ -165,6 +166,7 @@ module TestSkips
   # called with only one param
   def skip_unless(eng, bt: caller)
     skip_msg = case eng
+      when :linux   then "Skip unless Linux"            unless Puma::IS_LINUX
       when :darwin  then "Skip unless darwin"           unless Puma::IS_OSX
       when :jruby   then "Skip unless JRuby"            unless Puma::IS_JRUBY
       when :windows then "Skip unless Windows"          unless Puma::IS_WINDOWS

--- a/test/test_jruby_skip_plugin_systemd.rb
+++ b/test/test_jruby_skip_plugin_systemd.rb
@@ -1,0 +1,27 @@
+require_relative "helper"
+require_relative "helpers/integration"
+
+class TestJrubySkipPluginSystemd < TestIntegration
+
+  THREAD_LOG = TRUFFLE ? "{ 0/16 threads, 16 available, 0 backlog }" :
+    "{ 0/5 threads, 5 available, 0 backlog }"
+
+  def setup
+    skip "Skipped because Systemd support is linux-only" if windows? || osx?
+    skip_unless :unix
+    skip_unless_signal_exist? :TERM
+    skip_unless :jruby
+
+    super
+
+    ENV["NOTIFY_SOCKET"] = "/tmp/doesntmatter"
+  end
+
+  def test_systemd_skipped
+    cli_server "test/rackup/hello.ru"
+    
+    assert_nil Puma::Plugins.instance_variable_get(:@plugins)["systemd"]
+
+    stop_server
+  end
+end

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -7,7 +7,7 @@ class TestPluginSystemd < TestIntegration
     "{ 0/5 threads, 5 available, 0 backlog }"
 
   def setup
-    skip "Skipped because Systemd support is linux-only" if windows? || osx?
+    skip_unless :linux
     skip_unless :unix
     skip_unless_signal_exist? :TERM
     skip_if :jruby

--- a/test/test_plugin_systemd_jruby.rb
+++ b/test/test_plugin_systemd_jruby.rb
@@ -17,7 +17,7 @@ class TestPluginSystemdJruby < TestIntegration
     ENV["NOTIFY_SOCKET"] = "/tmp/doesntmatter"
   end
 
-  def test_systemd_skipped
+  def test_systemd_plugin_not_loaded
     cli_server "test/rackup/hello.ru"
 
     assert_nil Puma::Plugins.instance_variable_get(:@plugins)["systemd"]

--- a/test/test_plugin_systemd_jruby.rb
+++ b/test/test_plugin_systemd_jruby.rb
@@ -7,7 +7,7 @@ class TestPluginSystemdJruby < TestIntegration
     "{ 0/5 threads, 5 available, 0 backlog }"
 
   def setup
-    skip "Skipped because Systemd support is linux-only" if windows? || osx?
+    skip_unless :linux
     skip_unless :unix
     skip_unless_signal_exist? :TERM
     skip_unless :jruby

--- a/test/test_plugin_systemd_jruby.rb
+++ b/test/test_plugin_systemd_jruby.rb
@@ -1,7 +1,7 @@
 require_relative "helper"
 require_relative "helpers/integration"
 
-class TestJrubySkipPluginSystemd < TestIntegration
+class TestPluginSystemdJruby < TestIntegration
 
   THREAD_LOG = TRUFFLE ? "{ 0/16 threads, 16 available, 0 backlog }" :
     "{ 0/5 threads, 5 available, 0 backlog }"
@@ -19,7 +19,7 @@ class TestJrubySkipPluginSystemd < TestIntegration
 
   def test_systemd_skipped
     cli_server "test/rackup/hello.ru"
-    
+
     assert_nil Puma::Plugins.instance_variable_get(:@plugins)["systemd"]
 
     stop_server


### PR DESCRIPTION
The systemd integration will fail for JRuby at https://github.com/puma/puma/blob/e3d5794a7ebe47577ced4d4dfdd6a6cc969ded01/lib/puma/sd_notify.rb#L140, because JRuby doesn't support UNIX datagram sockets yet, and won't for a while. See https://github.com/jruby/jruby/issues/6504. So turning it off here, so that JRuby users can integrate with systemd on their own if they wish without errors.
