### PR TITLE
Allow ::Rack::Handler::Puma.run to work regardless of whether Rack/Rackup are loaded

### DIFF
--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -120,7 +120,8 @@ if Object.const_defined? :Rackup
       register :puma, Puma
     end
   end
-elsif Object.const_defined?(:Rack) && Rack::RELEASE < '3'
+else
+  do_register = Object.const_defined?(:Rack) && Rack::RELEASE < '3'
   module Rack
     module Handler
       module Puma
@@ -128,9 +129,7 @@ elsif Object.const_defined?(:Rack) && Rack::RELEASE < '3'
           include ::Puma::RackHandler
         end
       end
-      register :puma, Puma
     end
   end
-else
-  raise "You must install the rackup gem when using Rack 3"
+  ::Rack::Handler.register(:puma, ::Rack::Handler::Puma) if do_register
 end

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -1,24 +1,9 @@
 require_relative "helper"
 
+# Most tests check that ::Rack::Handler::Puma works by itself
+# RackUp#test_bin runs Puma using the rackup bin file
 module TestRackUp
-  if ENV.key? "PUMA_CI_RACK_2"
-    require "rack"
-    RACK_HANDLER_MOD = ::Rack::Handler
-  else
-    require "rackup"
-    RACK_HANDLER_MOD = ::Rackup::Handler
-  end
-
   require "rack/handler/puma"
-
-  class TestHandlerGetStrSym < Minitest::Test
-    def test_handler
-      handler = RACK_HANDLER_MOD.get(:puma)
-      assert_equal RACK_HANDLER_MOD::Puma, handler
-      handler = RACK_HANDLER_MOD.get('Puma')
-      assert_equal RACK_HANDLER_MOD::Puma, handler
-    end
-  end
 
   class TestPathHandler < Minitest::Test
     def app
@@ -35,7 +20,7 @@ module TestRackUp
 
       @launcher = nil
       thread = Thread.new do
-        RACK_HANDLER_MOD::Puma.run(app, **options) do |s, p|
+        ::Rack::Handler::Puma.run(app, **options) do |s, p|
           @launcher = s
         end
       end
@@ -79,7 +64,7 @@ module TestRackUp
           File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
           @options[:Port] = user_port
-          conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
+          conf = ::Rack::Handler::Puma.config(->{}, @options)
           conf.load
 
           assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
@@ -100,7 +85,7 @@ module TestRackUp
 
       @options[:Host] = user_host
       @options[:Port] = user_port
-      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.load
 
       assert_equal ["tcp://#{user_host}:#{user_port}"], conf.options[:binds]
@@ -108,7 +93,7 @@ module TestRackUp
 
     def test_ipv6_host_supplied_port_default
       @options[:Host] = "::1"
-      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.load
 
       assert_equal ["tcp://[::1]:9292"], conf.options[:binds]
@@ -131,7 +116,7 @@ module TestRackUp
           File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
           @options[:Port] = user_port
-          conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
+          conf = ::Rack::Handler::Puma.config(->{}, @options)
           conf.load
 
           assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
@@ -150,7 +135,7 @@ module TestRackUp
 
           @options[:Host] = "localhost"
           @options[:Port] = user_port
-          conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
+          conf = ::Rack::Handler::Puma.config(->{}, @options)
           conf.load
 
           assert_equal ["tcp://localhost:#{file_port}"], conf.options[:binds]
@@ -169,7 +154,7 @@ module TestRackUp
 
           @options[:Host] = "localhost"
           @options[:Port] = user_port
-          conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
+          conf = ::Rack::Handler::Puma.config(->{}, @options)
           conf.load
 
           assert_equal ["tcp://1.2.3.4:#{file_port}"], conf.options[:binds]
@@ -184,7 +169,7 @@ module TestRackUp
     end
 
     def test_default_port_when_no_config_file
-      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.load
 
       assert_equal ["tcp://0.0.0.0:9292"], conf.options[:binds]
@@ -198,7 +183,7 @@ module TestRackUp
           FileUtils.mkdir("config")
           File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
-          conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
+          conf = ::Rack::Handler::Puma.config(->{}, @options)
           conf.load
 
           assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
@@ -210,7 +195,7 @@ module TestRackUp
       user_port = 5001
       @options[:user_supplied_options] = []
       @options[:Port] = user_port
-      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.load
 
       assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
@@ -219,7 +204,7 @@ module TestRackUp
     def test_user_port_wins_over_default
       user_port = 5001
       @options[:Port] = user_port
-      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.load
 
       assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
@@ -235,7 +220,7 @@ module TestRackUp
           File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
           @options[:Port] = user_port
-          conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
+          conf = ::Rack::Handler::Puma.config(->{}, @options)
           conf.load
 
           assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
@@ -244,7 +229,7 @@ module TestRackUp
     end
 
     def test_default_log_request_when_no_config_file
-      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.load
 
       assert_equal false, conf.options[:log_requests]
@@ -257,7 +242,7 @@ module TestRackUp
         'test/config/t1_conf.rb'
       ]
 
-      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.load
 
       assert_equal file_log_requests_config, conf.options[:log_requests]
@@ -271,10 +256,34 @@ module TestRackUp
         'test/config/t1_conf.rb'
       ]
 
-      conf = RACK_HANDLER_MOD::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.load
 
       assert_equal user_log_requests_config, conf.options[:log_requests]
+    end
+  end
+
+  # Run using IO.popen so we don't load Rack and/or Rackup in the main process
+  class RackUp < Minitest::Test
+    def setup
+      FileUtils.copy_file 'test/rackup/hello.ru', 'config.ru'
+    end
+
+    def teardown
+      FileUtils.rm 'config.ru'
+    end
+
+    def test_bin
+      skip_if :windows
+      # JRuby & TruffleRuby take a long time using IO.popen
+      skip_unless :mri
+      io = IO.popen "rackup -p 0"
+      io.wait_readable 2
+      sleep 0.7
+      log = io.sysread 2_048
+      assert_includes log, 'Puma version'
+      assert_includes log, 'Use Ctrl-C to stop'
+      system "kill #{io.pid}"
     end
   end
 end

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -274,16 +274,21 @@ module TestRackUp
     end
 
     def test_bin
-      skip_if :windows
       # JRuby & TruffleRuby take a long time using IO.popen
       skip_unless :mri
       io = IO.popen "rackup -p 0"
       io.wait_readable 2
       sleep 0.7
       log = io.sysread 2_048
+      pid = log[/PID: (\d+)/, 1] || io.pid
       assert_includes log, 'Puma version'
       assert_includes log, 'Use Ctrl-C to stop'
-      system "kill #{io.pid}"
+    ensure
+      if Puma::IS_WINDOWS
+        `taskkill /F /PID #{pid}`
+      else
+        `kill #{pid}`
+      end
     end
   end
 end

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -2,8 +2,11 @@
 require_relative "helper"
 require "net/http"
 
-require "rack"
+# don't load Rack, as it autoloads everything
 require "rack/body_proxy"
+require "rack/lint"
+require "rack/version"
+require "rack/common_logger"
 
 # Rack::Chunked is loaded by Rack v2, needs to be required by Rack 3.0,
 # and is removed in Rack 3.1


### PR DESCRIPTION
### Description

PR #3061 fixed the use of the `rackup` bin file for use with either Rack 2 or Rack 3.  It broke the use of `::Rack::Handler::Puma.run` when used stand-alone, which is used to start Puma in some CI frameworks.

Fix the above issues, add a test for running the `rackup` bin file using `IO.popen`, which isolates it (and what it requires) from the main test process.  Note that the test only runs on MRI Ruby, as non-MRI Rubies take time when using `IO.popen`.

The 'Tests' workflow uses the Rackup (includes the rackup bin) & Rack v3 gems, and the 'Rack_v2' workflow uses Rack v2 gem (includes the rackup bin).

See https://github.com/puma/puma/pull/2990#issuecomment-1428060309

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
