### PR TITLE
[CI] Integration tests - add parameter to allow TestIntegration#cli_server to change ENV

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -65,7 +65,14 @@ class TestIntegration < Minitest::Test
     assert(system(*args, out: File::NULL, err: File::NULL))
   end
 
-  def cli_server(argv, unix: false, config: nil, merge_err: false, log: false, no_wait: false, puma_debug: nil)
+  def cli_server(argv,  # rubocop:disable Metrics/ParameterLists
+      unix: false,      # uses a UNIXSocket for the server listener when true
+      config: nil,      # string to use for config file
+      merge_err: false, # merge STDERR into STDOUT
+      log: false,       # output server log to console (for debugging)
+      no_wait: false,   # don't wait for server to boot
+      puma_debug: nil,  # set env['PUMA_DEBUG'] = 'true'
+      env: {})          # pass env setting to Puma process in IO.popen
     if config
       config_file = Tempfile.new(%w(config .rb))
       config_file.write config
@@ -80,7 +87,7 @@ class TestIntegration < Minitest::Test
       cmd = "#{BASE} #{puma_path} #{config} -b tcp://#{HOST}:#{@tcp_port} #{argv}"
     end
 
-    env = puma_debug ? {'PUMA_DEBUG' => 'true' } : {}
+    env['PUMA_DEBUG'] = 'true' if puma_debug
 
     if merge_err
       @server = IO.popen(env, cmd, :err=>[:child, :out])

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -2,6 +2,7 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestPluginSystemd < TestIntegration
+  parallelize_me! if ::Puma.mri?
 
   THREAD_LOG = TRUFFLE ? "{ 0/16 threads, 16 available, 0 backlog }" :
     "{ 0/5 threads, 5 available, 0 backlog }"
@@ -19,7 +20,7 @@ class TestPluginSystemd < TestIntegration
       @socket = Socket.new(:UNIX, :DGRAM, 0)
       socket_ai = Addrinfo.unix(sockaddr)
       @socket.bind(socket_ai)
-      ENV["NOTIFY_SOCKET"] = sockaddr
+      @env = {"NOTIFY_SOCKET" => sockaddr }
     end
   end
 
@@ -29,8 +30,6 @@ class TestPluginSystemd < TestIntegration
     File.unlink(@sockaddr) if @sockaddr
     @socket = nil
     @sockaddr = nil
-    ENV["NOTIFY_SOCKET"] = nil
-    ENV["WATCHDOG_USEC"] = nil
   end
 
   def test_systemd_notify_usr1_phased_restart_cluster
@@ -48,9 +47,8 @@ class TestPluginSystemd < TestIntegration
   end
 
   def test_systemd_watchdog
-    ENV["WATCHDOG_USEC"] = "1_000_000"
-
-    cli_server "test/rackup/hello.ru"
+    wd_env = @env.merge({"WATCHDOG_USEC" => "1_000_000"})
+    cli_server "test/rackup/hello.ru", env: wd_env
     assert_message "READY=1"
 
     assert_message "WATCHDOG=1"
@@ -60,10 +58,10 @@ class TestPluginSystemd < TestIntegration
   end
 
   def test_systemd_notify
-    cli_server "test/rackup/hello.ru"
+    cli_server "test/rackup/hello.ru", env: @env
     assert_message "READY=1"
 
-    assert_message "STATUS=Puma #{Puma::Const::VERSION}: worker: #{THREAD_LOG}", 70
+    assert_message "STATUS=Puma #{Puma::Const::VERSION}: worker: #{THREAD_LOG}"
 
     stop_server
     assert_message "STOPPING=1"
@@ -71,10 +69,11 @@ class TestPluginSystemd < TestIntegration
 
   def test_systemd_cluster_notify
     skip_unless :fork
-    cli_server "-w2 test/rackup/hello.ru"
+    cli_server "-w2 test/rackup/hello.ru", env: @env
     assert_message "READY=1"
+
     assert_message(
-      "STATUS=Puma #{Puma::Const::VERSION}: cluster: 2/2, worker_status: [#{THREAD_LOG},#{THREAD_LOG}]", 130)
+      "STATUS=Puma #{Puma::Const::VERSION}: cluster: 2/2, worker_status: [#{THREAD_LOG},#{THREAD_LOG}]")
 
     stop_server
     assert_message "STOPPING=1"
@@ -84,7 +83,7 @@ class TestPluginSystemd < TestIntegration
 
   def assert_restarts_with_systemd(signal, workers: 2)
     skip_unless(:fork) unless workers.zero?
-    cli_server "-w#{workers} test/rackup/hello.ru"
+    cli_server "-w#{workers} test/rackup/hello.ru", env: @env
     assert_message 'READY=1'
 
     Process.kill signal, @pid
@@ -101,7 +100,8 @@ class TestPluginSystemd < TestIntegration
     assert_message 'STOPPING=1'
   end
 
-  def assert_message(msg, len = 15)
-    assert_equal msg, @socket.recvfrom(len)[0]
+  def assert_message(msg)
+    @socket.wait_readable 1
+    assert_equal msg, @socket.recvfrom(msg.bytesize)[0]
   end
 end


### PR DESCRIPTION
### Description

`test_plugin_systemd.rb` should be able to run parallel, except one test is setting `ENV["WATCHDOG_USEC"]` in the test process.

Add an `env` keyword parameter to `TestIntegration#cli_server` so it can set ENV values in the sub-process.

This allows `test_plugin_systemd.rb` to run parallel.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
