### PR TITLE
[CI] Fix error message change in Ruby master

### DIFF
--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -467,7 +467,8 @@ EOF
     data = send_http_and_sysread "GET / HTTP/1.0\r\n\r\n"
 
     assert_includes data, 'HTTP/1.0 500 Internal Server Error'
-    assert_includes data, "Puma caught this error: undefined method `to_i' for [0, 1]:Array"
+    assert_includes data, "Puma caught this error: undefined method `to_i' for"
+    assert_includes data, "Array"
     refute_includes data, 'lowlevel_error'
     sleep 0.1 unless ::Puma::IS_MRI
     assert app_body.closed?


### PR DESCRIPTION
### Description

Ruby master has changed an error message, which causes TestPumaServer#test_lowlevel_error_body_close to fail.

Adjust the asserts checking that the error message is included in the log.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
