### PR TITLE
Warn when clustered-only hooks are defined in single mode

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -157,6 +157,7 @@ module Puma
       reaping_time: 1,
       remote_address: :socket,
       silence_single_worker_warning: false,
+      silence_fork_callback_warning: false,
       tag: File.basename(Dir.getwd),
       tcp_host: '0.0.0.0'.freeze,
       tcp_port: 9292,

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -585,6 +585,11 @@ module Puma
       @options[:silence_single_worker_warning] = true
     end
 
+    # Disable warning message when running single mode with callback hook defined.
+    def silence_fork_callback_warning
+      @options[:silence_fork_callback_warning] = true
+    end
+
     # Code to run immediately before master process
     # forks workers (once on boot). These hooks can block if necessary
     # to wait for background operations unknown to Puma to finish before
@@ -600,6 +605,8 @@ module Puma
     #     puts "Starting workers..."
     #   end
     def before_fork(&block)
+      warn_if_in_single_mode('before_fork')
+
       @options[:before_fork] ||= []
       @options[:before_fork] << block
     end
@@ -615,6 +622,8 @@ module Puma
     #     puts 'Before worker boot...'
     #   end
     def on_worker_boot(key = nil, &block)
+      warn_if_in_single_mode('on_worker_boot')
+
       process_hook :before_worker_boot, key, block, 'on_worker_boot'
     end
 
@@ -631,6 +640,8 @@ module Puma
     #     puts 'On worker shutdown...'
     #   end
     def on_worker_shutdown(key = nil, &block)
+      warn_if_in_single_mode('on_worker_shutdown')
+
       process_hook :before_worker_shutdown, key, block, 'on_worker_shutdown'
     end
 
@@ -645,6 +656,8 @@ module Puma
     #     puts 'Before worker fork...'
     #   end
     def on_worker_fork(&block)
+      warn_if_in_single_mode('on_worker_fork')
+
       process_hook :before_worker_fork, nil, block, 'on_worker_fork'
     end
 
@@ -659,6 +672,8 @@ module Puma
     #     puts 'After worker fork...'
     #   end
     def after_worker_fork(&block)
+      warn_if_in_single_mode('after_worker_fork')
+
       process_hook :after_worker_fork, nil, block, 'after_worker_fork'
     end
 
@@ -1073,7 +1088,20 @@ module Puma
       elsif key.nil?
         @options[options_key] << block
       else
-        raise "'#{method}' key must be String or Symbol"
+        raise "'#{meth}' key must be String or Symbol"
+      end
+    end
+
+    def warn_if_in_single_mode(hook_name)
+      return if @options[:silence_fork_callback_warning]
+
+      if (@options[:workers] || 0) == 0
+        log_string =
+          "Warning: You specified code to run in a `#{hook_name}` block, " \
+          "but Puma is configured to run in cluster mode, " \
+          "so your `#{hook_name}` block did not run"
+
+        LogWriter.stdio.log(log_string)
       end
     end
   end


### PR DESCRIPTION
### Description

Address https://github.com/puma/puma/issues/2950
- Add a default warning log when clustered-only hooks are defined but puma is booted in single mode.
- Add an config option to opt-out the default warning

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
