### PR TITLE
Loggers - internal_write - catch Errno::EINVAL

### DIFF
--- a/lib/puma/error_logger.rb
+++ b/lib/puma/error_logger.rb
@@ -102,7 +102,8 @@ module Puma
           @ioerr.is_a?(IO) and @ioerr.wait_writable(1)
           @ioerr.write "#{w_str}\n"
           @ioerr.flush unless @ioerr.sync
-        rescue Errno::EPIPE, Errno::EBADF, IOError
+        rescue Errno::EPIPE, Errno::EBADF, IOError, Errno::EINVAL
+        # 'Invalid argument' (Errno::EINVAL) may be raised by flush
         end
       end
     rescue ThreadError

--- a/lib/puma/log_writer.rb
+++ b/lib/puma/log_writer.rb
@@ -73,7 +73,8 @@ module Puma
           @stdout.is_a?(IO) and @stdout.wait_writable(1)
           @stdout.write w_str
           @stdout.flush unless @stdout.sync
-        rescue Errno::EPIPE, Errno::EBADF, IOError
+        rescue Errno::EPIPE, Errno::EBADF, IOError, Errno::EINVAL
+        # 'Invalid argument' (Errno::EINVAL) may be raised by flush
         end
       end
     rescue ThreadError


### PR DESCRIPTION
### Description

The following appeared in a recent CI job:
```
D:/a/puma/puma/lib/puma/log_writer.rb:75:in `flush': Invalid argument (Errno::EINVAL)
  from D:/a/puma/puma/lib/puma/log_writer.rb:75:in `internal_write'
  from D:/a/puma/puma/lib/puma/log_writer.rb:62:in `log'
  from D:/a/puma/puma/lib/puma/launcher.rb:321:in `log'
  from D:/a/puma/puma/lib/puma/launcher.rb:414:in `rescue in setup_signals'
```

The error raised can happen in the `internal_write` method of both `LogWriter` & `ErrorLogger`.  Error should be caught...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
