### PR TITLE
Make sure low level error response is sent to the client

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -476,7 +476,7 @@ module Puma
         end
         true
       rescue StandardError => e
-        client_error(e, client)
+        client_error(e, client, requests)
         # The ensure tries to close +client+ down
         requests > 0
       ensure
@@ -504,22 +504,22 @@ module Puma
     # :nocov:
 
     # Handle various error types thrown by Client I/O operations.
-    def client_error(e, client)
+    def client_error(e, client, requests = 1)
       # Swallow, do not log
       return if [ConnectionError, EOFError].include?(e.class)
 
-      lowlevel_error(e, client.env)
       case e
       when MiniSSL::SSLError
+        lowlevel_error(e, client.env)
         @log_writer.ssl_error e, client.io
       when HttpParserError
-        client.write_error(400)
+        response_to_error(client, requests, e, 400)
         @log_writer.parse_error e, client
       when HttpParserError501
-        client.write_error(501)
+        response_to_error(client, requests, e, 501)
         @log_writer.parse_error e, client
       else
-        client.write_error(500)
+        response_to_error(client, requests, e, 500)
         @log_writer.unknown_error e, nil, "Read"
       end
     end
@@ -541,9 +541,16 @@ module Puma
         backtrace = e.backtrace.nil? ? '<no backtrace available>' : e.backtrace.join("\n")
         [status, {}, ["Puma caught this error: #{e.message} (#{e.class})\n#{backtrace}"]]
       else
-        [status, {}, ["An unhandled lowlevel error occurred. The application logs may have details.\n"]]
+        [status, {}, [""]]
       end
     end
+
+    def response_to_error(client, requests, err, status_code)
+      status, headers, res_body = lowlevel_error(err, client.env, status_code)
+      prepare_response(status, headers, res_body, requests, client)
+      client.write_error(status_code)
+    end
+    private :response_to_error
 
     # Wait for all outstanding requests to finish.
     #

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1695,4 +1695,19 @@ class TestPumaServer < Minitest::Test
     [out_w, err_w].each(&:close)
     [out_r, err_r, pid]
   end
+
+  def test_lowlevel_error_handler_response
+    options = {
+      lowlevel_error_handler: ->(_error) do
+        [500, {}, ["something wrong happened"]]
+      end
+    }
+    broken_app = ->(_env) { [200, nil, []] }
+
+    server_run(**options, &broken_app)
+
+    data = send_http_and_read "GET / HTTP/1.1\r\n\r\n"
+
+    assert_match(/something wrong happened/, data)
+  end
 end

--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -49,7 +49,7 @@ class TestResponseHeader < Minitest::Test
     server_run app: ->(env) { [200, { 1 => 'Boo'}, []] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.1 500 Internal Server Error/, data)
+    assert_match(/Puma caught this error/, data)
   end
 
   # The header must respond to each
@@ -57,7 +57,7 @@ class TestResponseHeader < Minitest::Test
     server_run app: ->(env) { [200, nil, []] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.1 500 Internal Server Error/, data)
+    assert_match(/Puma caught this error/, data)
   end
 
   # The values of the header must be Strings


### PR DESCRIPTION
Closes #2341

### Description

Currently, when Client I/O operations raise any exceptions, we build a fallback rack response (either by `lowlevel_error_handler` or by default puma's hard-coded response), but doesn't do anything with it. This commit ensures that this response is sent back to client.

To verify:
1. `bundle exec puma -C test/config/lowlevel_error_handler.rb test/rackup/hello.ru`
2. `curl -i GET localhost:9292`

```
HTTP/1.1 500 Internal Server Error
Content-Length: 24

something wrong happened
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
