### PR TITLE
Introduce support for fiber-per-request.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,10 +1,3 @@
-## Unreleased
-
-* Features
-  * Add `fiber_per_request` option (aliased as `clean_thread_locals`) to isolate fiber-local state per request using Ruby Fibers. Enable via config or `PUMA_FIBER_PER_REQUEST` env var. ([#3101])
-
-[#3101]: https://github.com/puma/puma/pull/3101
-
 ## 7.0.0.pre1 / 2025-07-31
 
 * Changed

--- a/History.md
+++ b/History.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+* Features
+  * Add `fiber_per_request` option (aliased as `clean_thread_locals`) to isolate fiber-local state per request using Ruby Fibers. Enable via config or `PUMA_FIBER_PER_REQUEST` env var. ([#3101])
+
+[#3101]: https://github.com/puma/puma/pull/3101
+
 ## 7.0.0.pre1 / 2025-07-31
 
 * Changed

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -128,7 +128,7 @@ module Puma
     DEFAULTS = {
       auto_trim_time: 30,
       binds: ['tcp://0.0.0.0:9292'.freeze],
-      clean_thread_locals: false,
+      fiber_per_request: ENV["PUMA_FIBER_PER_REQUEST"] == "true",
       debug: false,
       enable_keep_alives: true,
       early_hints: nil,

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -128,7 +128,7 @@ module Puma
     DEFAULTS = {
       auto_trim_time: 30,
       binds: ['tcp://0.0.0.0:9292'.freeze],
-      fiber_per_request: ENV["PUMA_FIBER_PER_REQUEST"] == "true",
+      fiber_per_request: !!ENV.fetch("PUMA_FIBER_PER_REQUEST", false),
       debug: false,
       enable_keep_alives: true,
       early_hints: nil,

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -370,17 +370,20 @@ module Puma
       @options[:idle_timeout] = Integer(seconds)
     end
 
-    # Work around leaky apps that leave garbage in Thread locals
-    # across requests.
+    # Use a clean fiber per request which ensures a clean slate for fiber
+    # locals and fiber storage. Also provides a cleaner backtrace with less
+    # Puma internal stack frames.
     #
     # The default is +false+.
     #
     # @example
-    #   clean_thread_locals
+    #   fiber_per_request
     #
-    def clean_thread_locals(which=true)
-      @options[:clean_thread_locals] = which
+    def fiber_per_request(which=true)
+      @options[:fiber_per_request] = which
     end
+
+    alias clean_thread_locals fiber_per_request
 
     # When shutting down, drain the accept socket of pending connections and
     # process them. This loops over the accept socket until there are no more

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -53,7 +53,6 @@ module Puma
       @block = block
       @out_of_band = options[:out_of_band]
       @out_of_band_running = false
-      @clean_thread_locals = options[:clean_thread_locals]
       @before_thread_start = options[:before_thread_start]
       @before_thread_exit = options[:before_thread_exit]
       @reaping_time = options[:reaping_time]
@@ -81,12 +80,6 @@ module Puma
     end
 
     attr_reader :spawned, :trim_requested, :waiting
-
-    def self.clean_thread_locals
-      Thread.current.keys.each do |key| # rubocop: disable Style/HashEachMethods
-        Thread.current[key] = nil unless key == :__recursive_key__
-      end
-    end
 
     # generate stats hash so as not to perform multiple locks
     # @return [Hash] hash containing stat info from ThreadPool
@@ -173,10 +166,6 @@ module Puma
             end
 
             work = todo.shift
-          end
-
-          if @clean_thread_locals
-            ThreadPool.clean_thread_locals
           end
 
           begin

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -181,6 +181,7 @@ module TestSkips
         when :unix        then "Skipped if UNIXSocket exists"    if Puma::HAS_UNIX_SOCKET
         when :aunix       then "Skipped if abstract UNIXSocket"  if Puma.abstract_unix_socket?
         when :rack3       then "Skipped if Rack 3.x"             if Rack.release >= '3'
+        when :oldwindows  then "Skipped if old Windows"          if Puma::IS_WINDOWS && RUBY_VERSION < '2.6'
         else false
       end
       skip skip_msg, bt if skip_msg

--- a/test/test_fiber_local_application.rb
+++ b/test/test_fiber_local_application.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023, by Samuel Williams.
+
+require_relative "helper"
+
+require "puma/server"
+
+class FiberLocalApplication
+  def call(env)
+    # Just in case you didn't know, this is fiber local...
+    count = (Thread.current[:request_count] ||= 0)
+    Thread.current[:request_count] += 1
+    [200, {"Content-Type" => "text/plain"}, [count.to_s]]
+  end
+end
+
+class FiberLocalApplicationTest < Minitest::Test
+  parallelize_me!
+
+  def setup
+    @tester = FiberLocalApplication.new
+    @server = Puma::Server.new @tester, nil, {log_writer: Puma::LogWriter.strings, fiber_per_request: true}
+    @port = (@server.add_tcp_listener "127.0.0.1", 0).addr[1]
+    @tcp = "http://127.0.0.1:#{@port}"
+    @server.run
+  end
+
+  def teardown
+    @server.stop(true)
+  end
+
+  def test_empty_locals
+    response = hit(["#{@tcp}/test"] * 3)
+    assert_equal ["0", "0", "0"], response
+  end
+end

--- a/test/test_fiber_local_application.rb
+++ b/test/test_fiber_local_application.rb
@@ -32,6 +32,8 @@ class FiberLocalApplicationTest < Minitest::Test
   end
 
   def test_empty_locals
+    skip_if :oldwindows
+
     response = hit(["#{@tcp}/test"] * 3)
     assert_equal ["0", "0", "0"], response
   end

--- a/test/test_fiber_local_application.rb
+++ b/test/test_fiber_local_application.rb
@@ -16,7 +16,7 @@ class FiberLocalApplication
   end
 end
 
-class FiberLocalApplicationTest < Minitest::Test
+class FiberLocalApplicationTest < PumaTest
   parallelize_me!
 
   def setup

--- a/test/test_fiber_storage_application.rb
+++ b/test/test_fiber_storage_application.rb
@@ -33,6 +33,8 @@ class FiberStorageApplicationTest < Minitest::Test
   end
 
   def test_empty_storage
+    skip_if :oldwindows
+
     response = hit(["#{@tcp}/test"] * 3)
     assert_equal ["0", "0", "0"], response
   end

--- a/test/test_fiber_storage_application.rb
+++ b/test/test_fiber_storage_application.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023, by Samuel Williams.
+
+require_relative "helper"
+
+require "puma/server"
+
+class FiberStorageApplication
+  def call(env)
+    count = (Fiber[:request_count] ||= 0)
+    Fiber[:request_count] += 1
+    [200, {"Content-Type" => "text/plain"}, [count.to_s]]
+  end
+end
+
+class FiberStorageApplicationTest < Minitest::Test
+  parallelize_me!
+
+  def setup
+    skip "Fiber Storage is not supported on this Ruby" unless Fiber.respond_to?(:[])
+
+    @tester = FiberStorageApplication.new
+    @server = Puma::Server.new @tester, nil, {log_writer: Puma::LogWriter.strings, fiber_per_request: true}
+    @port = (@server.add_tcp_listener "127.0.0.1", 0).addr[1]
+    @tcp = "http://127.0.0.1:#{@port}"
+    @server.run
+  end
+
+  def teardown
+    @server.stop(true)
+  end
+
+  def test_empty_storage
+    response = hit(["#{@tcp}/test"] * 3)
+    assert_equal ["0", "0", "0"], response
+  end
+end

--- a/test/test_fiber_storage_application.rb
+++ b/test/test_fiber_storage_application.rb
@@ -15,7 +15,7 @@ class FiberStorageApplication
   end
 end
 
-class FiberStorageApplicationTest < Minitest::Test
+class FiberStorageApplicationTest < PumaTest
   parallelize_me!
 
   def setup

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -233,24 +233,6 @@ class TestThreadPool < PumaTest
     assert_equal 1, pool.spawned
   end
 
-  def test_cleanliness
-    values = []
-    n = 100
-
-    pool = mutex_pool(1,1) {
-      values.push Thread.current[:foo]
-      Thread.current[:foo] = :hai
-    }
-
-    pool.instance_variable_set :@clean_thread_locals, true
-
-    pool << [1] * n
-
-    assert_equal n,  values.length
-
-    assert_equal [], values.compact
-  end
-
   def test_reap_only_dead_threads
     pool = mutex_pool(2,2) do
       th = Thread.current


### PR DESCRIPTION
This enables the correct scope of `Fiber.storage` per request.

`Fiber[]` and `Fiber[]=` are recently introduced features in Ruby 3.2. They are designed to provide per-operation or per-request state handling.

Using a thread pool, `Fiber.storage` is retained beyond a single request, which can leak information from one request into another. The simplest way to avoid this is to wrap each request itself in a fiber. The overhead should be minimal as these fibers are cached and reused, so once warm, the overhead is a single Ruby VALUE allocation per request.

The benefit is that code which uses `Fiber[]=` will be scoped correctly to a single request.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
