### PR TITLE
[CI] Log test retry information on workflow page

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -3,7 +3,6 @@
 require "puma/control_cli"
 require "json"
 require "open3"
-require "io/wait"
 require_relative 'tmp_path'
 
 # Only single mode tests go here. Cluster and pumactl tests


### PR DESCRIPTION
### Description

The test suite currently runs with [minitest-retry](https://rubygems.org/gems/minitest-retry).  Forty-five jobs are currently run against the test suite.  Detemining which tests were retried is very time consuming, as it involves opening the logs of each job and looking thru the test step log.

This PR adds logging the retried tests to the workflow summary page.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
