### PR TITLE
Unlock support for the CONNECT HTTP method

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -147,7 +147,6 @@ module Puma
 
     REQUEST_METHOD = "REQUEST_METHOD"
     HEAD = "HEAD"
-    SUPPORTED_HTTP_METHODS = %w[HEAD GET POST PUT DELETE OPTIONS TRACE PATCH].freeze
     # ETag is based on the apache standard of hex mtime-size-inode (inode is 0 on win32)
     LINE_END = "\r\n"
     REMOTE_ADDR = "REMOTE_ADDR"

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -93,13 +93,8 @@ module Puma
       env[RACK_AFTER_REPLY] ||= []
 
       begin
-        if SUPPORTED_HTTP_METHODS.include?(env[REQUEST_METHOD])
-          status, headers, app_body = @thread_pool.with_force_shutdown do
-            @app.call(env)
-          end
-        else
-          @log_writer.log "Unsupported HTTP method used: #{env[REQUEST_METHOD]}"
-          status, headers, app_body = [501, {}, ["#{env[REQUEST_METHOD]} method is not supported"]]
+        status, headers, app_body = @thread_pool.with_force_shutdown do
+          @app.call(env)
         end
 
         # app_body needs to always be closed, hold value in case lowlevel_error

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -79,20 +79,6 @@ class WebServerTest < Minitest::Test
     socket.close
   end
 
-  def test_unsupported_method
-    socket = do_test("CONNECT www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
-    response = socket.read
-    assert_match "Not Implemented", response
-    socket.close
-  end
-
-  def test_nonexistent_method
-    socket = do_test("FOOBARBAZ www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
-    response = socket.read
-    assert_match "Not Implemented", response
-    socket.close
-  end
-
   private
 
   def do_test(string, chunk)


### PR DESCRIPTION
### Description
Unlock support for the CONNECT HTTP method by selectively reverting breaking changes from #2932.

Enhances #2932

Closes #3014

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
