### PR TITLE
Add dsl method `supported_http_methods`

### DIFF
--- a/6.0-Upgrade.md
+++ b/6.0-Upgrade.md
@@ -45,7 +45,11 @@ Check the following list to see if you're depending on any of these behaviors:
 1. We've removed the following constants: `Puma::StateFile::FIELDS`, `Puma::CLI::KEYS_NOT_TO_PERSIST_IN_STATE` and `Puma::Launcher::KEYS_NOT_TO_PERSIST_IN_STATE`, and `Puma::ControlCLI::COMMANDS`.
 1. We no longer support Ruby 2.2, 2.3, or JRuby on Java 1.7 or below.
 1. The behavior of `remote_addr` has changed. When using the set_remote_address header: "header_name" functionality, if the header is not passed, REMOTE_ADDR is now set to the physical peeraddr instead of always being set to 127.0.0.1. When an error occurs preventing the physical peeraddr from being fetched, REMOTE_ADDR is now set to the unspecified source address ('0.0.0.0') instead of to '127.0.0.1'
-1. Previously, Puma supported anything as an HTTP method and passed it to the app. We now only accept the 8 HTTP methods defined in RFC 9110.
+1. Previously, Puma supported anything as an HTTP method and passed it to the app. We now only accept the following 8 HTTP methods, based on [RFC 9110, section 9.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1).  The [IANA HTTP Method Registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) contains a full list of HTTP methods.
+   ```
+   HEAD GET POST PUT DELETE OPTIONS TRACE PATCH
+   ```
+   As of Puma 6.2, these can be overridden by `supported_http_methods` in your config file, see `Puma::DSL#supported_http_methods`.
 
 Then, update your Gemfile:
 

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -152,6 +152,50 @@ module Puma
     # with CONNECT removed, and PATCH added
     SUPPORTED_HTTP_METHODS = %w[HEAD GET POST PUT DELETE OPTIONS TRACE PATCH].freeze
 
+    # list from https://www.iana.org/assignments/http-methods/http-methods.xhtml
+    # as of 04-May-23
+    IANA_HTTP_METHODS = %w[
+      ACL
+      BASELINE-CONTROL
+      BIND
+      CHECKIN
+      CHECKOUT
+      CONNECT
+      COPY
+      DELETE
+      GET
+      HEAD
+      LABEL
+      LINK
+      LOCK
+      MERGE
+      MKACTIVITY
+      MKCALENDAR
+      MKCOL
+      MKREDIRECTREF
+      MKWORKSPACE
+      MOVE
+      OPTIONS
+      ORDERPATCH
+      PATCH
+      POST
+      PRI
+      PROPFIND
+      PROPPATCH
+      PUT
+      REBIND
+      REPORT
+      SEARCH
+      TRACE
+      UNBIND
+      UNCHECKOUT
+      UNLINK
+      UNLOCK
+      UPDATE
+      UPDATEREDIRECTREF
+      VERSION-CONTROL
+    ].freeze
+
     # ETag is based on the apache standard of hex mtime-size-inode (inode is 0 on win32)
     LINE_END = "\r\n"
     REMOTE_ADDR = "REMOTE_ADDR"

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -147,7 +147,11 @@ module Puma
 
     REQUEST_METHOD = "REQUEST_METHOD"
     HEAD = "HEAD"
+
+    # based on https://www.rfc-editor.org/rfc/rfc9110.html#name-overview,
+    # with CONNECT removed, and PATCH added
     SUPPORTED_HTTP_METHODS = %w[HEAD GET POST PUT DELETE OPTIONS TRACE PATCH].freeze
+
     # ETag is based on the apache standard of hex mtime-size-inode (inode is 0 on win32)
     LINE_END = "\r\n"
     REMOTE_ADDR = "REMOTE_ADDR"

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1078,7 +1078,7 @@ module Puma
     #
     # @example Adds 'PROPFIND' to existing supported methods
     #   supported_http_methods(Puma::Const::SUPPORTED_HTTP_METHODS + ['PROPFIND'])
-    # @example Restricts methods to the array elemnts
+    # @example Restricts methods to the array elements
     #   supported_http_methods %w[HEAD GET POST PUT DELETE OPTIONS PROPFIND]
     # @example Restricts methods to the methods in the IANA Registry
     #   supported_http_methods Puma::Const::IANA_HTTP_METHODS

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1068,13 +1068,16 @@ module Puma
     end
 
     # Supported http methods, which will replace `Puma::Const::SUPPORTED_HTTP_METHODS`.
-    # Must be an array of strings.  Note that methods are all uppercase.
+    # The value of `:any` will allows all methods, otherwise, the value must be
+    # an array of strings.  Note that methods are all uppercase.
+    #
     # `Puma::Const::SUPPORTED_HTTP_METHODS` is conservative, if you want a
     # complete set of methods, the methods defined by the
     # [IANA Method Registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml)
     # are pre-defined as the constant `Puma::Const::IANA_HTTP_METHODS`.
-    # @note If the `methods` value is an empty array, no method check with be
-    #   performed, similar to Puma v5 and earlier.
+    #
+    # @note If the `methods` value is `:any`, no method check with be performed,
+    #   similar to Puma v5 and earlier.
     #
     # @example Adds 'PROPFIND' to existing supported methods
     #   supported_http_methods(Puma::Const::SUPPORTED_HTTP_METHODS + ['PROPFIND'])
@@ -1083,13 +1086,16 @@ module Puma
     # @example Restricts methods to the methods in the IANA Registry
     #   supported_http_methods Puma::Const::IANA_HTTP_METHODS
     # @example Allows any method
-    #   supported_http_methods []
+    #   supported_http_methods :any
     #
     def supported_http_methods(methods)
-      if Array === methods && methods == (ary = methods.grep(String).uniq)
+      if methods == :any
+        @options[:supported_http_methods] = :any
+      elsif Array === methods && methods == (ary = methods.grep(String).uniq) &&
+        !ary.empty?
         @options[:supported_http_methods] = ary
       else
-        raise "supported_http_methods must be a unique array of strings"
+        raise "supported_http_methods must be ':any' or a unique array of strings"
       end
     end
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1067,12 +1067,23 @@ module Puma
       @options[:http_content_length_limit] = limit
     end
 
-    # Supported http methods, which will replace SUPPORTED_HTTP_METHODS.
+    # Supported http methods, which will replace `Puma::Const::SUPPORTED_HTTP_METHODS`.
     # Must be an array of strings.  Note that methods are all uppercase.
-    # @example
-    #   supported_http_methods(Puma::Const:SUPPORTED_HTTP_METHODS + ['PROPFIND'])
-    # @example
+    # `Puma::Const::SUPPORTED_HTTP_METHODS` is conservative, if you want a
+    # complete set of methods, the methods defined by the
+    # [IANA Method Registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml)
+    # are pre-defined as the constant `Puma::Const::IANA_HTTP_METHODS`.
+    # @note If the `methods` value is an empty array, no method check with be
+    #   performed, similar to Puma v5 and earlier.
+    #
+    # @example Adds 'PROPFIND' to existing supported methods
+    #   supported_http_methods(Puma::Const::SUPPORTED_HTTP_METHODS + ['PROPFIND'])
+    # @example Restricts methods to the array elemnts
     #   supported_http_methods %w[HEAD GET POST PUT DELETE OPTIONS PROPFIND]
+    # @example Restricts methods to the methods in the IANA Registry
+    #   supported_http_methods Puma::Const::IANA_HTTP_METHODS
+    # @example Allows any method
+    #   supported_http_methods []
     #
     def supported_http_methods(methods)
       if Array === methods && methods == (ary = methods.grep(String).uniq)

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1067,6 +1067,21 @@ module Puma
       @options[:http_content_length_limit] = limit
     end
 
+    # Supported http methods, which will replace SUPPORTED_HTTP_METHODS.
+    # Must be an array of strings.  Note that methods are all uppercase.
+    # @example
+    #   supported_http_methods(Puma::Const:SUPPORTED_HTTP_METHODS + ['PROPFIND'])
+    # @example
+    #   supported_http_methods %w[HEAD GET POST PUT DELETE OPTIONS PROPFIND]
+    #
+    def supported_http_methods(methods)
+      if Array === methods && methods == (ary = methods.grep(String).uniq)
+        @options[:supported_http_methods] = ary
+      else
+        raise "supported_http_methods must be a unique array of strings"
+      end
+    end
+
     private
 
     # To avoid adding cert_pem and key_pem as URI params, we store them on the

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -93,7 +93,7 @@ module Puma
       env[RACK_AFTER_REPLY] ||= []
 
       begin
-        if SUPPORTED_HTTP_METHODS.include?(env[REQUEST_METHOD])
+        if @supported_http_methods.key?(env[REQUEST_METHOD])
           status, headers, app_body = @thread_pool.with_force_shutdown do
             @app.call(env)
           end

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -93,7 +93,7 @@ module Puma
       env[RACK_AFTER_REPLY] ||= []
 
       begin
-        if @supported_http_methods.key?(env[REQUEST_METHOD])
+        if @do_not_check_http_methods || @supported_http_methods.key?(env[REQUEST_METHOD])
           status, headers, app_body = @thread_pool.with_force_shutdown do
             @app.call(env)
           end

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -93,7 +93,7 @@ module Puma
       env[RACK_AFTER_REPLY] ||= []
 
       begin
-        if @do_not_check_http_methods || @supported_http_methods.key?(env[REQUEST_METHOD])
+        if @supported_http_methods == :any || @supported_http_methods.key?(env[REQUEST_METHOD])
           status, headers, app_body = @thread_pool.with_force_shutdown do
             @app.call(env)
           end

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -97,6 +97,14 @@ module Puma
       @io_selector_backend = @options[:io_selector_backend]
       @http_content_length_limit = @options[:http_content_length_limit]
 
+      # make this a hash, since we prefer `key?` over `include?`
+      @supported_http_methods =
+        if (ary = @options[:supported_http_methods])
+          ary
+        else
+           SUPPORTED_HTTP_METHODS
+        end.sort.product([nil]).to_h.freeze
+
       temp = !!(@options[:environment] =~ /\A(development|test)\z/)
       @leak_stack_on_error = @options[:environment] ? temp : true
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -105,6 +105,8 @@ module Puma
            SUPPORTED_HTTP_METHODS
         end.sort.product([nil]).to_h.freeze
 
+      @do_not_check_http_methods = @supported_http_methods.keys.empty?
+
       temp = !!(@options[:environment] =~ /\A(development|test)\z/)
       @leak_stack_on_error = @options[:environment] ? temp : true
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -99,13 +99,15 @@ module Puma
 
       # make this a hash, since we prefer `key?` over `include?`
       @supported_http_methods =
-        if (ary = @options[:supported_http_methods])
-          ary
+        if @options[:supported_http_methods] == :any
+          :any
         else
-           SUPPORTED_HTTP_METHODS
-        end.sort.product([nil]).to_h.freeze
-
-      @do_not_check_http_methods = @supported_http_methods.keys.empty?
+          if (ary = @options[:supported_http_methods])
+            ary
+          else
+            SUPPORTED_HTTP_METHODS
+          end.sort.product([nil]).to_h.freeze
+        end
 
       temp = !!(@options[:environment] =~ /\A(development|test)\z/)
       @leak_stack_on_error = @options[:environment] ? temp : true

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1651,13 +1651,23 @@ EOF
   end
 
   def test_supported_http_methods_accept_all
-    server_run(supported_http_methods: []) do |env|
+    server_run(supported_http_methods: :any) do |env|
       body = [env['REQUEST_METHOD']]
       [200, {}, body]
     end
     resp = send_http_and_read "YOUR_SPECIAL_METHOD / HTTP/1.0\r\n\r\n"
     assert_match 'YOUR_SPECIAL_METHOD', resp
   end
+
+  def test_supported_http_methods_empty
+    server_run(supported_http_methods: []) do |env|
+      body = [env['REQUEST_METHOD']]
+      [200, {}, body]
+    end
+    resp = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+    assert_match(/\AHTTP\/1\.0 501 Not Implemented/, resp)
+  end
+
 
   def spawn_cmd(env = {}, cmd)
     opts = {}

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1632,6 +1632,24 @@ EOF
     assert_equal out_r.read.bytesize, req_body.bytesize
   end
 
+  def test_supported_http_methods_match
+    server_run(supported_http_methods: ['PROPFIND', 'PROPPATCH']) do |env|
+      body = [env['REQUEST_METHOD']]
+      [200, {}, body]
+    end
+    resp = send_http_and_read "PROPFIND / HTTP/1.0\r\n\r\n"
+    assert_match 'PROPFIND', resp
+  end
+
+  def test_supported_http_methods_no_match
+    server_run(supported_http_methods: ['PROPFIND', 'PROPPATCH']) do |env|
+      body = [env['REQUEST_METHOD']]
+      [200, {}, body]
+    end
+    resp = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+    assert_match "Not Implemented", resp
+  end
+
   def spawn_cmd(env = {}, cmd)
     opts = {}
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1647,7 +1647,16 @@ EOF
       [200, {}, body]
     end
     resp = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
-    assert_match "Not Implemented", resp
+    assert_match 'Not Implemented', resp
+  end
+
+  def test_supported_http_methods_accept_all
+    server_run(supported_http_methods: []) do |env|
+      body = [env['REQUEST_METHOD']]
+      [200, {}, body]
+    end
+    resp = send_http_and_read "YOUR_SPECIAL_METHOD / HTTP/1.0\r\n\r\n"
+    assert_match 'YOUR_SPECIAL_METHOD', resp
   end
 
   def spawn_cmd(env = {}, cmd)

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -79,14 +79,14 @@ class WebServerTest < Minitest::Test
     socket.close
   end
 
-  def test_unsupported_method
-    socket = do_test("CONNECT www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
+  def test_supported_http_method
+    socket = do_test("PATCH www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
     response = socket.read
-    assert_match "Not Implemented", response
+    assert_match "hello", response
     socket.close
   end
 
-  def test_nonexistent_method
+  def test_nonexistent_http_method
     socket = do_test("FOOBARBAZ www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
     response = socket.read
     assert_match "Not Implemented", response


### PR DESCRIPTION
### Description

Adds `Puma::DSL#supported_http_methods`, which allows overriding defaults in `Puma::Const::SUPPORTED_HTTP_METHODS`.

Turbo-Rails CI is currently broken.

Closes #3014

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
