### PR TITLE
fix java 8 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake-compiler", "~> 1.1.1"
+gem "rake-compiler", "~> 1.1.9"
 
 gem "json", "~> 2.3"
 gem "nio4r", "~> 2.0"

--- a/Rakefile
+++ b/Rakefile
@@ -76,8 +76,7 @@ else
 
   Rake::JavaExtensionTask.new("puma_http11", gemspec) do |ext|
     ext.lib_dir = "lib/puma"
-    ext.source_version = '1.8'
-    ext.target_version = '1.8'
+    ext.release = '8'
   end
 end
 


### PR DESCRIPTION
### Description
it's a similar issue as https://github.com/puma/puma/issues/1772 unfortunately, that PR didn't fix all usage of buffers

since https://github.com/rake-compiler/rake-compiler/issues/200 does support the ```--release``` flag for compatibility with older java versions, it's cleaner and safer to fix it this way instead of explicitly casting buffer methods as `(Buffer) buffer`

the downside is, it requires at least Java 9 for building the extension, but I guess it won't be a problem.

closes https://github.com/puma/puma/issues/3108

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.

the only way to test it would be to build the extension with Java 9+, but run tests with Java 8.
