### PR TITLE
Fix warn_if_in_single_mode incorrect message

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1103,7 +1103,7 @@ module Puma
       if (@options[:workers] || 0) == 0
         log_string =
           "Warning: You specified code to run in a `#{hook_name}` block, " \
-          "but Puma is configured to run in cluster mode, " \
+          "but Puma is not configured to run in cluster mode (worker count > 0 ), " \
           "so your `#{hook_name}` block did not run"
 
         LogWriter.stdio.log(log_string)


### PR DESCRIPTION
The message could either be in the positive `but Puma is configured to run in single mode (worker count = 0 )` or the negative `but Puma is not configured to run in cluster mode (worker count > 0 )`. I went with negative because it explicitly instructs what is required in order for hooks to run.

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
