### PR TITLE
Always write io_buffer when in "enum bodies" branch.

### DIFF
--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -362,6 +362,7 @@ module Puma
         fast_write_str(socket, io_buffer.read_and_reset) unless io_buffer.length.zero?
       else
         # for enum bodies
+        fast_write_str socket, io_buffer.read_and_reset
         if chunked
           body.each do |part|
             next if (byte_size = part.bytesize).zero?
@@ -370,7 +371,6 @@ module Puma
           end
           fast_write_str socket, CLOSE_CHUNKED
         else
-          fast_write_str socket, io_buffer.read_and_reset
           body.each do |part|
             next if part.bytesize.zero?
             fast_write_str socket, part

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1545,4 +1545,25 @@ EOF
     assert_equal str * loops, resp_body
     assert_operator times.last - times.first, :>, 1.0
   end
+
+  def test_empty_body_array_content_length_0
+    server_run { |env| [404, {'Content-Length' => '0'}, []] }
+
+    resp = send_http_and_sysread "GET / HTTP/1.1\r\n\r\n"
+    assert_equal "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n", resp
+  end
+
+  def test_empty_body_array_no_content_length
+    server_run { |env| [404, {}, []] }
+
+    resp = send_http_and_sysread "GET / HTTP/1.1\r\n\r\n"
+    assert_equal "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n", resp
+  end
+
+  def test_empty_body_enum
+    server_run { |env| [404, {}, [].to_enum] }
+
+    resp = send_http_and_sysread "GET / HTTP/1.1\r\n\r\n"
+    assert_equal "HTTP/1.1 404 Not Found\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n", resp
+  end
 end


### PR DESCRIPTION
### Description

Root of the issue is that you can get into the `if chunked` branch when `body.each` has nothing in it, so the previously populated `io_buffer` is never written to the socket.

This used to be the case but was changed on [#3072](https://github.com/puma/puma/pull/3072/files#diff-b58a5aaef75ecf535b6fc4546c848b0f576f9cf27e37b27c59015251097d5736L361).  I'm just moving this line back.

Closes #3112. 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
