### PR TITLE
[CI] Modify test for PR #3118

### DIFF
--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -11,6 +11,8 @@ module TestRackUp
       Proc.new {|env| @input = env; [200, {}, ["hello world"]]}
     end
 
+    # `Verbose: true` is included for `NameError`,
+    # see https://github.com/puma/puma/pull/3118
     def test_on_booted
       on_booted = false
       events = Puma::Events.new
@@ -20,7 +22,7 @@ module TestRackUp
 
       launcher = nil
       thread = Thread.new do
-        Rack::Handler::Puma.run(app, events: events, Silent: true) do |l|
+        Rack::Handler::Puma.run(app, events: events, Verbose: true, Silent: true) do |l|
           launcher = l
         end
       end


### PR DESCRIPTION
### Description
PR #3118 did not include a test, probably best to check for the issue.

This PR doesn't add a test, but modifies one.  It raises `NameError` with #3118 reverted, as below:
```
  1) Error:
TestRackUp::TestOnBootedHandler#test_on_booted:
NameError: uninitialized constant Puma::Rack::CommonLogger
    /mnt/c/Greg/GitHub/puma/lib/rack/handler/puma.rb:35:in `block in config'
    /mnt/c/Greg/GitHub/puma/lib/puma/configuration.rb:195:in `configure'
    /mnt/c/Greg/GitHub/puma/lib/puma/configuration.rb:188:in `initialize'
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
