### PR TITLE
RuboCop updates

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 3.1
           bundler-cache: true # `bundle install` and cache
       - name: rubocop
         run: bundle exec rake rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,12 +12,11 @@ AllCops:
     - 'pkg/**/*'
     - 'Rakefile'
   SuggestExtensions: false
-  NewCops: disable
+  NewCops: enable
 
 # ————————————————————————————————————————— disabled cops
 
 # ————————————————————————————————————————— enabled cops
-
 Layout/AccessModifierIndentation:
   EnforcedStyle: indent
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "rackup" unless ENV['PUMA_CI_RACK_2']
 gem "jruby-openssl", :platform => "jruby"
 
 unless ENV['PUMA_NO_RUBOCOP'] || RUBY_PLATFORM.include?('mswin')
-  gem "rubocop", "1.12.1"
+  gem "rubocop"
   gem 'rubocop-performance', require: false
 end
 

--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -80,7 +80,7 @@ module Puma
 
       def authenticate(env)
         return true unless @auth_token
-        env['QUERY_STRING'].to_s.split(/&;/).include?("token=#{@auth_token}")
+        env['QUERY_STRING'].to_s.split('&;').include? "token=#{@auth_token}"
       end
 
       def rack_response(status, body, content_type='application/json')

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -68,7 +68,7 @@ module Puma
       @to_io = io.to_io
       @io_buffer = IOBuffer.new
       @proto_env = env
-      @env = env ? env.dup : nil
+      @env = env&.dup
 
       @parser = HttpParser.new
       @parsed_bytes = 0

--- a/lib/puma/log_writer.rb
+++ b/lib/puma/log_writer.rb
@@ -125,7 +125,7 @@ module Puma
     def ssl_error(error, ssl_socket)
       peeraddr = ssl_socket.peeraddr.last rescue "<unknown>"
       peercert = ssl_socket.peercert
-      subject = peercert ? peercert.subject : nil
+      subject = peercert&.subject
       @error_logger.info(error: error, text: "SSL error, peer: #{peeraddr}, peer cert: #{subject}")
     end
 

--- a/lib/puma/rack/builder.rb
+++ b/lib/puma/rack/builder.rb
@@ -173,7 +173,7 @@ module Puma::Rack
         TOPLEVEL_BINDING, file, 0
     end
 
-    def initialize(default_app = nil,&block)
+    def initialize(default_app = nil, &block)
       @use, @map, @run, @warmup = [], nil, default_app, nil
 
       # Conditionally load rack now, so that any rack middlewares,
@@ -183,7 +183,7 @@ module Puma::Rack
       rescue LoadError
       end
 
-      instance_eval(&block) if block_given?
+      instance_eval(&block) if block
     end
 
     def self.app(default_app = nil, &block)

--- a/test/test_bundle_pruner.rb
+++ b/test/test_bundle_pruner.rb
@@ -4,6 +4,8 @@ require 'puma/events'
 
 class TestBundlePruner < Minitest::Test
 
+  RE_PUMA_VERS = /puma-#{Puma::Const::PUMA_VERSION}$/o
+
   def test_paths_to_require_after_prune_is_correctly_built_for_no_extra_deps
     skip_if :no_bundler
 
@@ -11,7 +13,7 @@ class TestBundlePruner < Minitest::Test
 
     assert_equal(2, dirs.length)
     assert_equal(File.join(PROJECT_ROOT, "lib"), dirs[0]) # lib dir
-    assert_match(%r{puma-#{Puma::Const::PUMA_VERSION}$}, dirs[1]) # native extension dir
+    assert_match(RE_PUMA_VERS, dirs[1]) # native extension dir
     refute_match(%r{gems/minitest-[\d.]+/lib$}, dirs[2])
   end
 
@@ -22,7 +24,7 @@ class TestBundlePruner < Minitest::Test
 
     assert_equal(3, dirs.length)
     assert_equal(File.join(PROJECT_ROOT, "lib"), dirs[0]) # lib dir
-    assert_match(%r{puma-#{Puma::Const::PUMA_VERSION}$}, dirs[1]) # native extension dir
+    assert_match(RE_PUMA_VERS, dirs[1]) # native extension dir
     assert_match(%r{gems/minitest-[\d.]+/lib$}, dirs[2]) # minitest dir
   end
 

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -35,7 +35,7 @@ class TestThreadPool < Minitest::Test
       work = [work] unless work.is_a?(Array)
       with_mutex do
         work.each {|arg| super arg}
-        yield if block_given?
+        yield if block
         @not_full.wait(@mutex)
       end
     end


### PR DESCRIPTION
### Description

RuboCop can run with a newer Rubies, but the [`.rubocop.yml`](https://github.com/puma/puma/blob/master/.rubocop.yml) file sets the minimum Ruby version to analyze.  Currently, RuboCop "Targets Ruby 2.0+ code analysis."

Hence, we can run RuboCop with Ruby 3.1, but analyze based on Ruby 2.4 syntax.

Update RuboCop configuration and fix 7 errors.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.