### PR TITLE
Test system update

### DIFF
--- a/test/config/event_on_booted_exit.rb
+++ b/test/config/event_on_booted_exit.rb
@@ -1,5 +1,8 @@
 on_booted do
   pid = Process.pid
   Process.kill :TERM, pid
-  Process.wait pid
+  begin
+    Process.wait2 pid
+  rescue Errno::ECHILD
+  end
 end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -317,12 +317,12 @@ class TestIntegration < Minitest::Test
   # used to define correct 'refused' errors
   def thread_run_refused(unix: false)
     if unix
-      DARWIN ? [IOError, Errno::ENOENT, Errno::EPIPE] :
-               [IOError, Errno::ENOENT]
+      DARWIN ? [IOError, Errno::ENOENT, Errno::EPIPE, Errno::ENOTSOCK] :
+               [IOError, Errno::ENOENT, Errno::ENOTSOCK]
     else
       # Errno::ECONNABORTED is thrown intermittently on TCPSocket.new
-      DARWIN ? [IOError, Errno::ECONNREFUSED, Errno::EPIPE, Errno::EBADF, EOFError, Errno::ECONNABORTED] :
-               [IOError, Errno::ECONNREFUSED, Errno::EPIPE, Errno::EBADF]
+      DARWIN ? [IOError, Errno::ECONNREFUSED, Errno::EPIPE, Errno::EBADF, EOFError, Errno::ECONNABORTED, Errno::ENOTSOCK] :
+               [IOError, Errno::ECONNREFUSED, Errno::EPIPE, Errno::EBADF, Errno::ENOTSOCK]
     end
   end
 
@@ -407,7 +407,7 @@ class TestIntegration < Minitest::Test
           # client would see an empty response
           # Errno::EBADF Windows may not be able to make a connection
           mutex.synchronize { replies[:reset] += 1 }
-        rescue *refused, IOError
+        rescue *refused
           # IOError intermittently thrown by Ubuntu, add to allow retry
           mutex.synchronize { replies[:refused] += 1 }
         rescue ::Timeout::Error

--- a/test/helpers/puma_socket.rb
+++ b/test/helpers/puma_socket.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+module PumaTest
+
+  # Note: no setup or teardown, make sure to initialize @ios = []
+  #
+  module PumaSocket
+    HOST = '127.0.0.1'
+    RESP_READ_LEN = 65_536
+    RESP_READ_TIMEOUT = 10
+    RESP_SPLIT = "\r\n\r\n"
+    NO_ENTITY_BODY = Puma::STATUS_WITH_NO_ENTITY_BODY
+
+    def before_setup
+      @ios_to_close ||= []
+      @tcp_port = nil
+      @bind_path = nil
+      @port = nil
+      super
+    end
+
+    def after_teardown
+      return if skipped?
+      # Errno::EBADF raised on macOS
+      @ios_to_close.each do |io|
+        begin
+          io.close if io.respond_to?(:close) && !io.closed?
+          File.unlink io.path if io.is_a? File
+        rescue Errno::EBADF
+        ensure
+          io = nil
+        end
+      end
+      super
+    end
+
+    def header(skt)
+      headers = []
+      while true
+        skt.wait_readable 1
+        line = skt.gets
+        break if line == "\r\n"
+        headers << line.strip
+      end
+
+      headers
+    end
+
+    def send_http_read_resp_body(req, port: nil, path: nil, len: nil)
+      skt = send_http req, port: port, path: path
+      skt.read_body len: len
+    end
+
+    def send_http_read_response(req, port: nil, path: nil, len: nil)
+      skt = send_http req, port: port, path: path
+      skt.read_response len: len
+    end
+
+    def send_http(req, port: nil, path: nil)
+      skt = new_connection port: port, path: path
+      skt.syswrite req
+      skt
+    end
+
+    READ_BODY = -> (timeout = nil, len: nil) {
+      self.read_response(timeout, len: len).split(RESP_SPLIT, 2).last
+    }
+
+    READ_RESPONSE = -> (timeout = nil, len: nil) do
+      timeout ||= RESP_READ_TIMEOUT
+      content_length = nil
+      chunked = nil
+      status = nil
+      no_body = nil
+      response = +''
+      t_st = Process.clock_gettime Process::CLOCK_MONOTONIC
+      read_len = len || RESP_READ_LEN
+      if self.to_io.wait_readable timeout
+        loop do
+          begin
+            part = self.read_nonblock(read_len, exception: false)
+            case part
+            when String
+              status ||= part[/\AHTTP\/1\.[01] (\d{3})/, 1]
+              if status
+                no_body ||= NO_ENTITY_BODY.key? status.to_i || status.to_i < 200
+              end
+              if no_body && part.end_with?(RESP_SPLIT)
+                return response << part
+              end
+
+              unless content_length || chunked
+                chunked ||= part.include? "\r\nTransfer-Encoding: chunked\r\n"
+                content_length = (t = part[/^Content-Length: (\d+)/i , 1]) ? t.to_i : nil
+              end
+
+              response << part
+              hdrs, body = response.split RESP_SPLIT, 2
+              unless body.nil?
+                # below could be simplified, but allows for debugging...
+                ret =
+                  if content_length
+                    body.bytesize == content_length
+                  elsif chunked
+                    body.end_with? "0\r\n\r\n"
+                  elsif !hdrs.empty? && !body.empty?
+                    true
+                  else
+                    false
+                  end
+                if ret
+                  return response
+                end
+              end
+              sleep 0.000_1
+            when :wait_readable, :wait_writable # :wait_writable for ssl
+              sleep 0.000_2
+            when nil
+              if response.empty?
+                raise EOFError
+              else
+                return response
+              end
+            end
+            if timeout < Process.clock_gettime(Process::CLOCK_MONOTONIC) - t_st
+              raise Timeout::Error, 'Client Read Timeout'
+            end
+          end
+        end
+      else
+        raise Timeout::Error, 'Client Read Timeout'
+      end
+    end
+
+    REQ_WRITE = -> (str) { self.syswrite str }
+
+    def new_connection(port: nil, path: nil)
+      port  ||= @port || @tcp_port
+      path  ||= @bind_path
+      @host ||= HOST
+      skt = if path && !port
+        UNIXSocket.new path.sub(/\A@/, "\0")
+      elsif port && !path
+        TCPSocket.new @host, port
+      else
+        raise 'port or path must be set!'
+      end
+      skt.define_singleton_method :read_response, READ_RESPONSE
+      skt.define_singleton_method :read_body, READ_BODY
+      skt.define_singleton_method :<<, REQ_WRITE
+      @ios_to_close << skt
+      skt
+    end
+
+    private
+    def no_body(status)
+
+    end
+  end
+end

--- a/test/helpers/tmp_path.rb
+++ b/test/helpers/tmp_path.rb
@@ -13,6 +13,16 @@ module TmpPath
     path
   end
 
+  def tmp_path_write(basename, data, mode: File::BINARY)
+    fio = Tempfile.create basename, mode: mode
+    path = fio.path
+    fio.write data
+    fio.flush
+    fio.close
+    tmp_paths << path
+    path
+  end
+
   def tmp_paths
     @tmp_paths ||= []
   end

--- a/test/test_bundle_pruner.rb
+++ b/test/test_bundle_pruner.rb
@@ -5,6 +5,7 @@ require 'puma/events'
 class TestBundlePruner < Minitest::Test
 
   PUMA_VERS = "puma-#{Puma::Const::PUMA_VERSION}"
+  PUMA_TTO = true # use Timeout.timeout on each test
 
   def test_paths_to_require_after_prune_is_correctly_built_for_no_extra_deps
     skip_if :no_bundler

--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -1,34 +1,29 @@
 require_relative "helper"
+require_relative "helpers/puma_socket"
 
 class TestBusyWorker < Minitest::Test
+  parallelize_me! if ::Puma.mri?
+
+  include PumaTest::PumaSocket
+
   def setup
     skip_unless :mri # This feature only makes sense on MRI
-    @ios = []
+
+    @host = '127.0.0.1'
+    @app = -> (env) {
+      sleep 0.1
+      [200, {}, ["Hello World"]]
+    }
+
     @server = nil
   end
 
   def teardown
     return if skipped?
     @server&.stop true
-    @ios.each {|i| i.close unless i.closed?}
   end
 
-  def new_connection
-    TCPSocket.new('127.0.0.1', @port).tap {|s| @ios << s}
-  rescue IOError
-    Puma::Util.purge_interrupt_queue
-    retry
-  end
-
-  def send_http(req)
-    new_connection << req
-  end
-
-  def send_http_and_read(req)
-    send_http(req).read
-  end
-
-  def with_server(**options, &app)
+  def with_server(**options)
     @requests_count = 0 # number of requests processed
     @requests_running = 0 # current number of requests running
     @requests_max_running = 0 # max number of requests running in parallel
@@ -44,7 +39,7 @@ class TestBusyWorker < Minitest::Test
       end
 
       begin
-        yield(env)
+        @app.call env
       ensure
         @mutex.synchronize do
           @requests_running -= 1
@@ -52,29 +47,46 @@ class TestBusyWorker < Minitest::Test
       end
     end
 
-    options[:min_threads] ||= 0
-    options[:max_threads] ||= 10
-    options[:log_writer]  ||= Puma::LogWriter.strings
+    options[:min_threads] = 4
+    options[:max_threads] = 4
+    options[:log_writer] = log_writer ||= Puma::LogWriter.strings
 
     @server = Puma::Server.new request_handler, nil, **options
     @port = (@server.add_tcp_listener '127.0.0.1', 0).addr[1]
     @server.run
+    # server is running in thread, and creating threads
+    sleep 0.1 until @server.running == 4
+  end
+
+  def run_requests(n)
+    # send all requests first, read later
+    skts = Array.new(n) {
+      max_retries = 5
+      retries = 0
+      begin
+        send_http "GET / HTTP/1.0\r\n\r\n"
+      rescue Errno::ECONNREFUSED => e
+        retries += 1
+        if retries < max_retries
+          retry
+        else
+          flunk "TestBusyWorker#run_requests failed via #{e.class}"
+        end
+      end
+    }
+
+    Array.new(n) do |i|
+      # using read_body seems to intermittently fail
+      Thread.new { skts[i].sysread 1_024 }
+    end.each(&:join)
   end
 
   # Multiple concurrent requests are not processed
   # sequentially as a small delay is introduced
   def test_multiple_requests_waiting_on_less_busy_worker
-    with_server(wait_for_less_busy_worker: 1.0) do |_|
-      sleep(0.1)
-
-      [200, {}, [""]]
-    end
-
-    n = 2
-
-    Array.new(n) do
-      Thread.new { send_http_and_read "GET / HTTP/1.0\r\n\r\n" }
-    end.each(&:join)
+    with_server(wait_for_less_busy_worker: 1.0)
+    n = 4
+    run_requests n
 
     assert_equal n, @requests_count, "number of requests needs to match"
     assert_equal 0, @requests_running, "none of requests needs to be running"
@@ -84,17 +96,9 @@ class TestBusyWorker < Minitest::Test
   # Multiple concurrent requests are processed
   # in parallel as a delay is disabled
   def test_multiple_requests_processing_in_parallel
-    with_server(wait_for_less_busy_worker: 0.0) do |_|
-      sleep(0.1)
-
-      [200, {}, [""]]
-    end
-
+    with_server(wait_for_less_busy_worker: 0.0)
     n = 4
-
-    Array.new(n) do
-      Thread.new { send_http_and_read "GET / HTTP/1.0\r\n\r\n" }
-    end.each(&:join)
+    run_requests n
 
     assert_equal n, @requests_count, "number of requests needs to match"
     assert_equal 0, @requests_running, "none of requests needs to be running"

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -586,9 +586,7 @@ class TestConfigFile < TestConfigFileBase
 
   def assert_warning_for_hooks_defined_in_single_mode(hook_name)
     out, _ = capture_io do
-      Puma::Configuration.new do |c|
-        c.send(hook_name)
-      end
+      Puma::Configuration.new { |c| c.send hook_name }
     end
 
     assert_match "your `#{hook_name}` block did not run\n", out

--- a/test/test_http10.rb
+++ b/test/test_http10.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 
 require "puma/puma_http11"
 
-class Http10ParserTest < Minitest::Test
+class TestHttp10Parser < Minitest::Test
   def test_parse_simple
     parser = Puma::HttpParser.new
     req = {}

--- a/test/test_http11.rb
+++ b/test/test_http11.rb
@@ -6,7 +6,7 @@ require "digest"
 
 require "puma/puma_http11"
 
-class Http11ParserTest < Minitest::Test
+class TestHttp11Parser < Minitest::Test
 
   parallelize_me!
 

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -143,7 +143,7 @@ class TestIntegrationPumactl_S < TestIntegrationPumactlBase
     send_http_read_response "GET /sleep1 HTTP/1.0\r\n\r\n"
 
     # Get the PIDs of the phase 0 workers.
-    phase0_worker_pids = get_worker_pids 0, log: false
+    phase0_worker_pids = get_worker_pids 0
 
     assert File.exist? @bind_path
 
@@ -151,7 +151,7 @@ class TestIntegrationPumactl_S < TestIntegrationPumactlBase
     cli_pumactl 'phased-restart', unix: true
 
     # Get the PIDs of the phase 1 workers.
-    phase1_worker_pids = get_worker_pids 1, log: false
+    phase1_worker_pids = get_worker_pids 1
 
     msg = "phase 0 pids #{phase0_worker_pids.inspect}  phase 1 pids #{phase1_worker_pids.inspect}"
 

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -72,7 +72,7 @@ class TestIntegrationSingle < TestIntegration
     reply = read_body(connect)
     stop_server
 
-    assert_match("http", reply)
+    assert_equal 'http', reply
   end
 
   def test_conf_is_loaded_before_passing_it_to_binder
@@ -83,7 +83,7 @@ class TestIntegrationSingle < TestIntegration
     reply = read_body(connect)
     stop_server
 
-    assert_match("https", reply)
+    assert_equal 'https', reply
   end
 
   def test_prefer_rackup_file_specified_by_cli
@@ -93,7 +93,7 @@ class TestIntegrationSingle < TestIntegration
     reply = read_body(connect)
     stop_server
 
-    assert_match("Hello World", reply)
+    assert_equal 'Hello World', reply
   end
 
   def test_term_not_accepts_new_connections
@@ -148,7 +148,7 @@ class TestIntegrationSingle < TestIntegration
     Process.kill :INT , @pid
     t.join
 
-    assert_match "Thread: TID", output.join
+    assert_includes output.join, 'Thread: TID'
   end
 
   def test_write_to_log
@@ -164,7 +164,7 @@ class TestIntegrationSingle < TestIntegration
 
     log = File.read('t1-stdout')
 
-    assert_match(%r!GET / HTTP/1\.1!, log)
+    assert_includes log, '"GET / HTTP/1.1"'
   ensure
     File.unlink 't1-stdout' if File.file? 't1-stdout'
     File.unlink 't1-pid'    if File.file? 't1-pid'
@@ -183,7 +183,7 @@ class TestIntegrationSingle < TestIntegration
 
     log = File.read('t2-stdout')
 
-    assert_match(%r!GET / HTTP/1\.1!, log)
+    assert_includes log, '"GET / HTTP/1.1"'
     assert(!File.file?("t2-pid"))
     assert_equal("Puma is started\n", out)
   ensure

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -109,7 +109,11 @@ class TestPersistent < Minitest::Test
     @client << HTTP10_REQUEST
 
     expected = "HTTP/1.0 200 OK\r\nX-Header: Works\r\n\r\nHelloChunked"
-    Thread.pass if Puma::IS_JRUBY # may only receive the first element ('Hello')
+
+    # may only receive the first element ('Hello')
+    Thread.pass if Puma::IS_JRUBY
+    sleep 0.01
+
     assert_equal expected, @client.read_response
   end
 

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -1,103 +1,92 @@
 require_relative "helper"
+require_relative "helpers/puma_socket"
 
 class TestPersistent < Minitest::Test
+  parallelize_me!
+  include PumaTest::PumaSocket
 
-  HOST = "127.0.0.1"
+  VALID_REQUEST  = "GET / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
+  CLOSE_REQUEST  = "GET / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n"
+  HTTP10_REQUEST = "GET / HTTP/1.0\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
+  KEEP_REQUEST   = "GET / HTTP/1.0\r\nHost: test.com\r\nContent-Type: text/plain\r\nConnection: Keep-Alive\r\n\r\n"
+
+  VALID_POST     = "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello"
+  VALID_NO_BODY  = "GET / HTTP/1.1\r\nHost: test.com\r\nX-Status: 204\r\nContent-Type: text/plain\r\n\r\n"
 
   def setup
-    @valid_request  = "GET / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
-    @close_request  = "GET / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n"
-    @http10_request = "GET / HTTP/1.0\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
-    @keep_request   = "GET / HTTP/1.0\r\nHost: test.com\r\nContent-Type: text/plain\r\nConnection: Keep-Alive\r\n\r\n"
-
-    @valid_post    = "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello"
-    @valid_no_body  = "GET / HTTP/1.1\r\nHost: test.com\r\nX-Status: 204\r\nContent-Type: text/plain\r\n\r\n"
-
     @headers = { "X-Header" => "Works" }
     @body = ["Hello"]
-    @inputs = []
+    @cl = @body[0].bytesize
 
-    @simple = lambda do |env|
-      @inputs << env['rack.input']
+    app = ->(env) do
       status = Integer(env['HTTP_X_STATUS'] || 200)
       [status, @headers, @body]
     end
 
-    opts = {max_threads: 1}
-    @server = Puma::Server.new @simple, nil, opts
+    opts = {min_threads: 1, max_threads: 1}
+    @server = Puma::Server.new app, nil, opts
     @port = (@server.add_tcp_listener HOST, 0).addr[1]
     @server.run
-    sleep 0.15 if Puma.jruby?
-    @client = TCPSocket.new HOST, @port
+    sleep 0.1 until @server.running == opts[:min_threads]
+    @client = new_connection
   end
 
   def teardown
-    @client.close
     @server.stop(true)
   end
 
-  def lines(count, s=@client)
-    str = +''
-    Timeout.timeout(5) do
-      count.times { str << (s.gets || "") }
-    end
-    str
-  end
-
   def test_one_with_content_length
-    @client << @valid_request
-    sz = @body[0].size.to_s
+    @client << VALID_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    expected = "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{@cl}\r\n\r\n#{@body[0]}"
+
+    assert_equal expected, @client.read_response
   end
 
   def test_two_back_to_back
-    @client << @valid_request
-    sz = @body[0].size.to_s
+    expected = "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{@cl}\r\n\r\n#{@body[0]}"
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    @client << VALID_REQUEST
 
-    @client << @valid_request
-    sz = @body[0].size.to_s
+    assert_equal expected, @client.read_response
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    @client << VALID_REQUEST
+
+    assert_equal expected, @client.read_response
   end
 
   def test_post_then_get
-    @client << @valid_post
-    sz = @body[0].size.to_s
+    expected = "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{@cl}\r\n\r\n#{@body[0]}"
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    @client << VALID_POST
+    assert_equal expected, @client.read_response
 
-    @client << @valid_request
-    sz = @body[0].size.to_s
-
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    @client << VALID_REQUEST
+    assert_equal expected, @client.read_response
   end
 
   def test_no_body_then_get
-    @client << @valid_no_body
-    assert_equal "HTTP/1.1 204 No Content\r\nX-Header: Works\r\n\r\n", lines(3)
+    @client << VALID_NO_BODY
 
-    @client << @valid_request
-    sz = @body[0].size.to_s
+    assert_equal "HTTP/1.1 204 No Content\r\nX-Header: Works\r\n\r\n", @client.read_response
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    @client << VALID_REQUEST
+
+    expected = "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{@cl}\r\n\r\n#{@body[0]}"
+
+    assert_equal expected, @client.read_response
   end
 
   def test_chunked
     @body << "Chunked"
     @body = @body.to_enum
 
-    @client << @valid_request
+    @client << VALID_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n7\r\nChunked\r\n0\r\n\r\n", lines(10)
+    expected = "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n" \
+      "5\r\nHello\r\n7\r\nChunked\r\n0\r\n\r\n"
+
+    assert_equal expected, @client.read_response
   end
 
   def test_chunked_with_empty_part
@@ -105,19 +94,23 @@ class TestPersistent < Minitest::Test
     @body << "Chunked"
     @body = @body.to_enum
 
-    @client << @valid_request
+    @client << VALID_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n7\r\nChunked\r\n0\r\n\r\n", lines(10)
+    expected = "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n" \
+      "5\r\n#{@body.to_a[0]}\r\n7\r\nChunked\r\n0\r\n\r\n"
+
+    assert_equal expected, @client.read_response
   end
 
   def test_no_chunked_in_http10
     @body << "Chunked"
     @body = @body.to_enum
 
-    @client << @http10_request
+    @client << HTTP10_REQUEST
 
-    assert_equal "HTTP/1.0 200 OK\r\nX-Header: Works\r\n\r\n", lines(3)
-    assert_equal "HelloChunked", @client.read
+    expected = "HTTP/1.0 200 OK\r\nX-Header: Works\r\n\r\nHelloChunked"
+    Thread.pass if Puma::IS_JRUBY # may only receive the first element ('Hello')
+    assert_equal expected, @client.read_response
   end
 
   def test_hex
@@ -125,43 +118,44 @@ class TestPersistent < Minitest::Test
     @body << str
     @body = @body.to_enum
 
-    @client << @valid_request
+    @client << VALID_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n#{str.size.to_s(16)}\r\n#{str}\r\n0\r\n\r\n", lines(10)
+    expected = "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n" \
+      "5\r\nHello\r\n#{str.size.to_s(16)}\r\n#{str}\r\n0\r\n\r\n"
 
+    assert_equal expected, @client.read_response
   end
 
   def test_client11_close
-    @client << @close_request
-    sz = @body[0].size.to_s
+    @client << CLOSE_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nConnection: close\r\nContent-Length: #{sz}\r\n\r\n", lines(5)
-    assert_equal "Hello", @client.read(5)
+    expected = "HTTP/1.1 200 OK\r\nX-Header: Works\r\nConnection: close\r\nContent-Length: #{@cl}\r\n\r\n#{@body[0]}"
+
+    assert_equal expected, @client.read_response
   end
 
   def test_client10_close
-    @client << @http10_request
-    sz = @body[0].size.to_s
+    @client << HTTP10_REQUEST
 
-    assert_equal "HTTP/1.0 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    expected = "HTTP/1.0 200 OK\r\nX-Header: Works\r\nContent-Length: #{@cl}\r\n\r\n#{@body[0]}"
+
+    assert_equal expected, @client.read_response
   end
 
   def test_one_with_keep_alive_header
-    @client << @keep_request
-    sz = @body[0].size.to_s
+    @client << KEEP_REQUEST
 
-    assert_equal "HTTP/1.0 200 OK\r\nX-Header: Works\r\nConnection: Keep-Alive\r\nContent-Length: #{sz}\r\n\r\n", lines(5)
-    assert_equal "Hello", @client.read(5)
+    expected = "HTTP/1.0 200 OK\r\nX-Header: Works\r\nConnection: Keep-Alive\r\nContent-Length: #{@cl}\r\n\r\n#{@body[0]}"
+
+    assert_equal expected, @client.read_response
   end
 
   def test_persistent_timeout
     @server.instance_variable_set(:@persistent_timeout, 1)
-    @client << @valid_request
-    sz = @body[0].size.to_s
+    @client << VALID_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    expected = "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{@cl}\r\n\r\n#{@body[0]}"
+    assert_equal expected, @client.read_response
 
     sleep 2
 
@@ -174,11 +168,11 @@ class TestPersistent < Minitest::Test
     @body = ["hello", " world"]
     @headers['Content-Length'] = "11"
 
-    @client << @valid_request
+    @client << VALID_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: 11\r\n\r\n",
-                 lines(4)
-    assert_equal "hello world", @client.read(11)
+    expected = "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: 11\r\n\r\nhello world"
+
+    assert_equal expected, @client.read_response
   end
 
   def test_allow_app_to_chunk_itself
@@ -186,63 +180,54 @@ class TestPersistent < Minitest::Test
 
     @body = ["5\r\nhello\r\n0\r\n\r\n"]
 
-    @client << @valid_request
+    @client << VALID_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n", lines(7)
+    expected = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n"
+
+    assert_equal expected, @client.read_response
   end
 
 
   def test_two_requests_in_one_chunk
     @server.instance_variable_set(:@persistent_timeout, 3)
 
-    req = @valid_request.to_s
-    req += "GET /second HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
+    req = "#{VALID_REQUEST}GET /second HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
 
     @client << req
 
-    sz = @body[0].size.to_s
+    expected = "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{@cl}\r\n\r\n#{@body[0]}"
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
-
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    assert_equal expected, @client.read_response(len: expected.bytesize)
+    assert_equal expected, @client.read_response
   end
 
   def test_second_request_not_in_first_req_body
     @server.instance_variable_set(:@persistent_timeout, 3)
 
-    req = @valid_request.to_s
-    req += "GET /second HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
+    req = "#{VALID_REQUEST}GET /second HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
 
     @client << req
 
-    sz = @body[0].size.to_s
+    expected = "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{@cl}\r\n\r\n#{@body[0]}"
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
-
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
-
-    assert_kind_of Puma::NullIO, @inputs[0]
-    assert_kind_of Puma::NullIO, @inputs[1]
+    assert_equal expected, @client.read_response(len: expected.bytesize)
+    assert_equal expected, @client.read_response
   end
 
   def test_keepalive_doesnt_starve_clients
-    sz = @body[0].size.to_s
 
-    @client << @valid_request
+    @client << VALID_REQUEST
 
-    c2 = TCPSocket.new HOST, @port
-    c2 << @valid_request
+    c2 = send_http VALID_REQUEST
 
     assert c2.wait_readable(1), "2nd request starved"
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4, c2)
-    assert_equal "Hello", c2.read(5)
+    expected = "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{@cl}\r\n\r\n#{@body[0]}"
+
+    assert_equal expected, @client.read_response
+
+    assert_equal expected, c2.read_response
   ensure
     c2.close
   end
-
 end

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestPluginSystemd < TestIntegration
-  parallelize_me! if ::Puma.mri?
+  parallelize_me! if ::Puma::IS_MRI && ::Puma::IS_LINUX
 
   THREAD_LOG = TRUFFLE ? "{ 0/16 threads, 16 available, 0 backlog }" :
     "{ 0/5 threads, 5 available, 0 backlog }"
@@ -12,8 +12,6 @@ class TestPluginSystemd < TestIntegration
     skip_unless :unix
     skip_unless_signal_exist? :TERM
     skip_if :jruby
-
-    super
 
     ::Dir::Tmpname.create("puma_socket") do |sockaddr|
       @sockaddr = sockaddr
@@ -26,6 +24,7 @@ class TestPluginSystemd < TestIntegration
 
   def teardown
     return if skipped?
+
     @socket&.close
     File.unlink(@sockaddr) if @sockaddr
     @socket = nil

--- a/test/test_redirect_io.rb
+++ b/test/test_redirect_io.rb
@@ -45,7 +45,7 @@ class TestRedirectIO < TestIntegration
 
     log_rotate_output_files
 
-    Process.kill :HUP, @server.pid
+    Process.kill :HUP, @pid
 
     wait_until_file_has_content @out_file_path
     assert_match 'puma startup', File.read(@out_file_path)
@@ -73,7 +73,7 @@ class TestRedirectIO < TestIntegration
 
     log_rotate_output_files
 
-    Process.kill :HUP, @server.pid
+    Process.kill :HUP, @pid
 
     wait_until_file_has_content @out_file_path
     assert_match 'puma startup', File.read(@out_file_path)

--- a/test/test_request_invalid.rb
+++ b/test/test_request_invalid.rb
@@ -1,4 +1,5 @@
 require_relative "helper"
+require_relative "helpers/puma_socket"
 
 # These tests check for invalid request headers and metadata.
 # Content-Length, Transfer-Encoding, and chunked body size
@@ -14,13 +15,13 @@ class TestRequestInvalid < Minitest::Test
   # running parallel seems to take longer...
   # parallelize_me! unless JRUBY_HEAD
 
+  include PumaTest::PumaSocket
+
   GET_PREFIX = "GET / HTTP/1.1\r\nConnection: close\r\n"
   CHUNKED = "1\r\nH\r\n4\r\nello\r\n5\r\nWorld\r\n0\r\n\r\n"
 
   def setup
     @host = '127.0.0.1'
-
-    @ios = []
 
     # this app should never be called, used for debugging
     app = ->(env) {
@@ -43,19 +44,6 @@ class TestRequestInvalid < Minitest::Test
 
   def teardown
     @server.stop(true)
-    @ios.each { |io| io.close if io && !io.closed? }
-  end
-
-  def send_http_and_read(req)
-    send_http(req).read
-  end
-
-  def send_http(req)
-    new_connection << req
-  end
-
-  def new_connection
-    TCPSocket.new(@host, @port).tap {|sock| @ios << sock}
   end
 
   def assert_status(str, status = 400)
@@ -70,33 +58,33 @@ class TestRequestInvalid < Minitest::Test
       'Content-Length: 5'
     ].join "\r\n"
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
 
-    assert_status data
+    assert_status resp
   end
 
   def test_content_length_bad_characters_1
     te = 'Content-Length: 5.01'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
 
-    assert_status data
+    assert_status resp
   end
 
   def test_content_length_bad_characters_2
     te = 'Content-Length: +5'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
 
-    assert_status data
+    assert_status resp
   end
 
   def test_content_length_bad_characters_3
     te = 'Content-Length: 5 test'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
 
-    assert_status data
+    assert_status resp
   end
 
   # ──────────────────────────────────── below are invalid Transfer-Encoding
@@ -107,9 +95,9 @@ class TestRequestInvalid < Minitest::Test
       'Transfer-Encoding: gzip'
     ].join "\r\n"
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
 
-    assert_status data
+    assert_status resp
   end
 
   def test_transfer_encoding_chunked_multiple
@@ -119,17 +107,17 @@ class TestRequestInvalid < Minitest::Test
       'Transfer-Encoding: chunked'
     ].join "\r\n"
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
 
-    assert_status data
+    assert_status resp
   end
 
   def test_transfer_encoding_invalid_single
     te = 'Transfer-Encoding: xchunked'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
 
-    assert_status data, 501
+    assert_status resp, 501
   end
 
   def test_transfer_encoding_invalid_multiple
@@ -139,17 +127,17 @@ class TestRequestInvalid < Minitest::Test
       'Transfer-Encoding: chunked'
     ].join "\r\n"
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
 
-    assert_status data, 501
+    assert_status resp, 501
   end
 
   def test_transfer_encoding_single_not_chunked
     te = 'Transfer-Encoding: gzip'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
 
-    assert_status data
+    assert_status resp
   end
 
   # ──────────────────────────────────── below are invalid chunked size
@@ -158,36 +146,36 @@ class TestRequestInvalid < Minitest::Test
     te = 'Transfer-Encoding: chunked'
     chunked ='5.01'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
 
-    assert_status data
+    assert_status resp
   end
 
   def test_chunked_size_bad_characters_2
     te = 'Transfer-Encoding: chunked'
     chunked ='+5'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
 
-    assert_status data
+    assert_status resp
   end
 
   def test_chunked_size_bad_characters_3
     te = 'Transfer-Encoding: chunked'
     chunked ='5 bad'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
 
-    assert_status data
+    assert_status resp
   end
 
   def test_chunked_size_bad_characters_4
     te = 'Transfer-Encoding: chunked'
     chunked ='0xA'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHelloHello\r\n0\r\n\r\n"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHelloHello\r\n0\r\n\r\n"
 
-    assert_status data
+    assert_status resp
   end
 
   # size is less than bytesize
@@ -198,9 +186,9 @@ class TestRequestInvalid < Minitest::Test
       "4\r\nWorld\r\n" \
       "0"
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n#{chunked}\r\n\r\n"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\n#{chunked}\r\n\r\n"
 
-    assert_status data
+    assert_status resp
   end
 
   # size is greater than bytesize
@@ -211,8 +199,8 @@ class TestRequestInvalid < Minitest::Test
       "6\r\nWorld\r\n" \
       "0"
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n#{chunked}\r\n\r\n"
+    resp = send_http_read_response "#{GET_PREFIX}#{te}\r\n\r\n#{chunked}\r\n\r\n"
 
-    assert_status data
+    assert_status resp
   end
 end

--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -2,15 +2,16 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestWorkerGemIndependence < TestIntegration
+
+  PUMA_TTO = true # use Timeout.timeout on each test
+
   def setup
     skip_unless :fork
-    super
   end
 
   def teardown
     return if skipped?
     FileUtils.rm current_release_symlink, force: true
-    super
   end
 
   def test_changing_nio4r_version_during_phased_restart

--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -131,7 +131,7 @@ class TestWorkerGemIndependence < TestIntegration
   def start_phased_restart
     Process.kill :USR1, @pid
 
-    true while @server.gets !~ /booted in [.0-9]+s, phase: 1/
+    assert wait_for_server_to_match(/booted in [.0-9]+s, phase: 1/)
   end
 
   def with_unbundled_env


### PR DESCRIPTION
### Description

1. Currently, all tests are wrapped by `::Timeout.timeout`.  Switched to using a constant defined in each test class.  This PR changes so that only test classes that use some form of `bundle install` are using the timeout.

2. Created `test/helpers/puma_socket.rb`, which allows removal of duplicated code in several test files. This will also make it easier to re-arrange and/or split test files into more (smaller) files.

3. Made minor updates to some library files, most of which related to error handling.

4. Currently, some of the tests fail if a client socket raises `Errno::ECONNRESET`.  I've got some code that queries the GitHub API with `Net::HTTP`, and it threw the same error, as GitHub has had network issues.  Using the same URI, I tried several browsers, and they all retry on `Errno::ECONNRESET`.  Changed test code to allow a small percentage of `Errno::ECONNRESET` errors.

5. CI is often running a full allocation of macos jobs at the end.  Removed a few macos jobs to quicken the test time.  This may be needed again, as GitHub will be supporting macos-13 and also `arm64` macos.

Creating as a draft, not sure whether to break it up into lib file changes and test file changes, etc...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
