### PR TITLE
Misc lib file fixes - trapping additional errors, CI helper

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -48,7 +48,6 @@ module Puma
 
       @envs = {}
       @ios = []
-      localhost_authority
     end
 
     attr_reader :ios

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -450,11 +450,14 @@ module Puma
 
     def close_listeners
       @listeners.each do |l, io|
-        io.close unless io.closed?
-        uri = URI.parse l
-        next unless uri.scheme == 'unix'
-        unix_path = "#{uri.host}#{uri.path}"
-        File.unlink unix_path if @unix_paths.include?(unix_path) && File.exist?(unix_path)
+        begin
+          io.close unless io.closed?
+          uri = URI.parse l
+          next unless uri.scheme == 'unix'
+          unix_path = "#{uri.host}#{uri.path}"
+          File.unlink unix_path if @unix_paths.include?(unix_path) && File.exist?(unix_path)
+        rescue Errno::EBADF
+        end
       end
     end
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -566,7 +566,7 @@ module Puma
 
     def notify_safely(message)
       @notify << message
-    rescue IOError, NoMethodError, Errno::EPIPE
+    rescue IOError, NoMethodError, Errno::EPIPE, Errno::EBADF
       # The server, in another thread, is shutting down
       Puma::Util.purge_interrupt_queue
     rescue RuntimeError => e

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -44,6 +44,10 @@ module Puma
       @name = name
       @min = Integer(options[:min_threads])
       @max = Integer(options[:max_threads])
+      # Not an 'exposed' option, options[:pool_shutdown_grace_time] is used in CI
+      # to shorten @shutdown_grace_time from SHUTDOWN_GRACE_TIME. Parallel CI
+      # makes stubbing constants difficult.
+      @shutdown_grace_time = Float(options[:pool_shutdown_grace_time] || SHUTDOWN_GRACE_TIME)
       @block = block
       @out_of_band = options[:out_of_band]
       @clean_thread_locals = options[:clean_thread_locals]
@@ -344,8 +348,8 @@ module Puma
 
     # Tell all threads in the pool to exit and wait for them to finish.
     # Wait +timeout+ seconds then raise +ForceShutdown+ in remaining threads.
-    # Next, wait an extra +grace+ seconds then force-kill remaining threads.
-    # Finally, wait +kill_grace+ seconds for remaining threads to exit.
+    # Next, wait an extra +@shutdown_grace_time+ seconds then force-kill remaining
+    # threads. Finally, wait 1 second for remaining threads to exit.
     #
     def shutdown(timeout=-1)
       threads = with_mutex do
@@ -382,7 +386,7 @@ module Puma
             t.raise ForceShutdown if t[:with_force_shutdown]
           end
         end
-        join.call(SHUTDOWN_GRACE_TIME)
+        join.call(@shutdown_grace_time)
 
         # If threads are _still_ running, forcefully kill them and wait to finish.
         threads.each(&:kill)


### PR DESCRIPTION
### Description

All files except `thread_pool.rb` have additional handling added.  These errors have intermittently been seen in CI.

`thread_pool.rb` allows setting `options[:pool_shutdown_grace_time]` during CI, as stubbing a constant is difficult when running parallel CI.  At present, it is not exposed via the DSL, but could be added in the future.

Hence, no API or functionality changes.

These commits were originally part of PR #3128.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
