### PR TITLE
Fixup req form data file upload with "r\n" line endings

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -99,7 +99,8 @@ module Puma
 
       @in_last_chunk = false
 
-      @read_buffer = +""
+      # need unfrozen ASCII-8BIT, +'' is UTF-8
+      @read_buffer = String.new # rubocop: disable Performance/UnfreezeString
     end
 
     attr_reader :env, :to_io, :body, :io, :timeout_at, :ready, :hijacked,


### PR DESCRIPTION
### Description

Current code breaks when a form uploads a file with "\r\n" line endings.

Currently `client.rb` uses a string buffer that is initialized as UTF-8, it should be initialized as ASCII-8BIT.  UTF-8 can be 'character/line-ending' sensitive, while ASCII-8BIT is just bytes...

Add two tests, both with "\r\n" line endings, one as BOM|UTF-8.

Closes Discussion #3131

Running the two new tests on master has the below errors:
```
  1) Error:
TestPumaServer#test_form_data_encoding_windows:
NoMethodError: undefined method `split' for nil
    puma/test/test_puma_server.rb:1629:in `test_form_data_encoding_windows'

  2) Error:
TestPumaServer#test_form_data_encoding_windows_bom:
NoMethodError: undefined method `split' for nil
    puma/test/test_puma_server.rb:1598:in `test_form_data_encoding_windows_bom'
```
### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
