### PR TITLE
Update handling of Server: header in Puma generated responses

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -120,21 +120,6 @@ module Puma
 
     PUMA_TMP_BASE = "puma"
 
-    ERROR_RESPONSE = {
-      # Indicate that we couldn't parse the request
-      400 => "HTTP/1.1 400 Bad Request\r\n\r\n",
-      # The standard empty 404 response for bad requests.  Use Error4040Handler for custom stuff.
-      404 => "HTTP/1.1 404 Not Found\r\nConnection: close\r\nServer: Puma #{PUMA_VERSION}\r\n\r\nNOT FOUND",
-      # The standard empty 408 response for requests that timed out.
-      408 => "HTTP/1.1 408 Request Timeout\r\nConnection: close\r\nServer: Puma #{PUMA_VERSION}\r\n\r\n",
-      # Indicate that there was an internal error, obviously.
-      500 => "HTTP/1.1 500 Internal Server Error\r\n\r\n",
-      # Incorrect or invalid header value
-      501 => "HTTP/1.1 501 Not Implemented\r\n\r\n",
-      # A common header for indicating the server is too busy.  Not used yet.
-      503 => "HTTP/1.1 503 Service Unavailable\r\n\r\nBUSY"
-    }.freeze
-
     # The basic max request size we'll try to read.
     CHUNK_SIZE = 16 * 1024
 

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1110,5 +1110,14 @@ module Puma
         LogWriter.stdio.log(log_string)
       end
     end
+
+    # Puma will write responses to requests that are invalid.  This is done
+    # before the app is called.  This setting allows specifying a response
+    #`Server:` header value in those responses.  Normally it is only used if the
+    # app specifies one.
+    #
+    def server_header_value(val = nil)
+      @options[:puma_server_header_value] = val.strip if val.is_a? String
+    end
   end
 end

--- a/test/helpers/request_server_header.rb
+++ b/test/helpers/request_server_header.rb
@@ -1,0 +1,25 @@
+require 'puma'
+
+# This file is just used with two tests in test/test_misc.rb.  Both tests check
+# setting the `Puma::Client::ERROR_RESPONSE` constant in `::Puma::Server.new`.
+#
+module SetReqServerHeader
+  APP = ->(env) { [200, {}, []] }
+
+  class << self
+
+    # Used to check if the constant is properly defined without
+    # a `Server:` header
+    def no_set_header
+      svr = ::Puma::Server.new APP
+      STDOUT.syswrite ::Puma::Client::ERROR_RESPONSE.values.join
+    end
+
+    # Used to check if the constant is properly defined when a `Server:` header
+    # is defined using `Puma::DSL#server_header_value`
+    def set_header
+      svr = ::Puma::Server.new APP, nil, {puma_server_header_value: 'Puma 6.2.2'}
+      STDOUT.syswrite ::Puma::Client::ERROR_RESPONSE.values.join
+    end
+  end
+end

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -1,0 +1,24 @@
+require_relative "helper"
+require 'open3'
+
+class TestMisc < Minitest::Test
+  parallelize_me! if ::Puma::IS_MRI
+
+  def test_puma_response_server_header_value_empty
+    responses, _, status = Open3.capture3(
+      'ruby -rbundler/setup -r./test/helpers/request_server_header -e "SetReqServerHeader.no_set_header"'
+    )
+    sleep 0.1 until status.success?
+    assert_includes responses, 'HTTP/1.1'
+    refute_includes responses, 'Puma'
+  end
+
+  def test_puma_response_server_header_value_set
+    responses, _, status = Open3.capture3(
+      'ruby -rbundler/setup -r./test/helpers/request_server_header -e "SetReqServerHeader.set_header"'
+    )
+    sleep 0.1 until status.success?
+    assert_includes responses, 'HTTP/1.1'
+    assert_includes responses, 'Puma 6.2.2'
+  end
+end


### PR DESCRIPTION
### Description

Puma generates responses for invalid requests, and these responses are sent before `app.call`.  Currently the response strings are the values of [`Const::ERROR_RESPONSE`](https://github.com/puma/puma/blob/c2ac2c4f7c9c0f3a8ba294350ee70990ff94598f/lib/puma/const.rb#L123-L136), and the constant is used in `Client#write_error`. That method is called three times in conditional code in `Server#client_error`, and once in `Client#timeout!`.  There are two responses sent in `Request#handle_request` (413, 501), but those responses do not use the string values from the constant.

1. Two of the constant values contain a `Server:` header, whose values are `'Puma #{PUMA_VERSION}'`. From a pen test standpoint these headers should not be included.  This PR removes them.

2. Some sites include a `Server:` header, often a non-informational value.  Most GitHub pages return `Server: GitHub.com`.  Since it would be best for Puma's reponses to mimic app responses, a DSL method `server_header_value(val = nil)` has been added, allowing sites using a response `Server:` header to let Puma responses use the same value.

Because `Const` simply defines constants on load/require, we cannot create a constant in it that depends on a Config (DSL) option.  So, the constant definition is removes from `Const`, and defined when `Server.new` is called.

Note that if `DSL#server_header_value` is not used in a config file, no `Server:` headers will be sent with any of Puma's error responses.  Also, since error responses do not have pre-defined bodies, again, from a pen test standpoint, none of the responses include body text.

Closes #3037

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
