### PR TITLE
[CI] test.yaml - update non-MRI Test Timeout - tto

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -144,9 +144,9 @@ jobs:
       matrix:
         include:
           # tto - test timeout
-          - { tto: 6 , os: ubuntu-22.04 , ruby: jruby }
-          - { tto: 6 , os: ubuntu-22.04 , ruby: jruby, no-ssl: ' no SSL' }
-          - { tto: 6 , os: ubuntu-22.04 , ruby: jruby-head, allow-failure: true }
+          - { tto: 8 , os: ubuntu-22.04 , ruby: jruby }
+          - { tto: 7 , os: ubuntu-22.04 , ruby: jruby, no-ssl: ' no SSL' }
+          - { tto: 8 , os: ubuntu-22.04 , ruby: jruby-head, allow-failure: true }
           - { tto: 8 , os: ubuntu-20.04 , ruby: truffleruby, allow-failure: true } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
           - { tto: 8 , os: ubuntu-20.04 , ruby: truffleruby-head, allow-failure: true }
           - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby, allow-failure: true } # Until https://github.com/oracle/truffleruby/issues/2700 is solved


### PR DESCRIPTION
### Description
Recently had a JRuby test timeout failure in Actions, as below.  This is rare, but it shows the tests finished, but essentially in the same time as the Actions test step timout.  So, all the tests passed, but the job failed.

Hence, increase the JRuby test step timouts just a bit....
```
TestRackServer#test_common_logger = 20.23 s = .

Finished in 344.920221s, 1.4525 runs/s, 3.3892 assertions/s.

Skips:

501 runs, 1169 assertions, 0 failures, 0 errors, 80 skips
Error: The action has timed out.
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
