### PR TITLE
[CI] test_integration_ssl_session.rb - use SSLSockets instead of curl

### DIFF
--- a/test/test_plugin_systemd_jruby.rb
+++ b/test/test_plugin_systemd_jruby.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/integration"
 
@@ -15,6 +17,10 @@ class TestPluginSystemdJruby < TestIntegration
     super
 
     ENV["NOTIFY_SOCKET"] = "/tmp/doesntmatter"
+  end
+
+  def teardown
+    super unless skipped?
   end
 
   def test_systemd_plugin_not_loaded


### PR DESCRIPTION
### Description

test_integration_ssl_session.rb was originally committed about 8-1/2 months ago in PR #2846, which was my PR.  It used curl (via `IO.popen` with a block) to generate SSL requests, running asserts on the output.

I think it's preferred to not 'shell out' unless absolutely necessary, and I also started seeing intermittent failures while working on test updates.

This PR removes the use of curl, and uses SSLSockets.

test_plugin_systemd_jruby.rb has a small fix as teardown was running regardless of whether a test was skipped, which was throwing 'undefined' warnings.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
