### PR TITLE
[CI] temporary fix for Capybara, use recent commit

### DIFF
--- a/.github/workflows/turbo-rails.yml
+++ b/.github/workflows/turbo-rails.yml
@@ -42,9 +42,16 @@ jobs:
 
       - name: turbo-rails updates
         run: |
+          # use repo & commit being tested, $GITHUB_REPOSITORY allows forks to work
           SRC="gem ['\"]puma['\"].*"
           DST="gem 'puma', git: 'https://github.com/$GITHUB_REPOSITORY.git', ref: '$GITHUB_SHA'"
           sed -i "s#$SRC#$DST#" Gemfile
+          #
+          # allow using capybara from the repo, either a branch or a commit
+          SRC="gem ['\"]capybara['\"].*"
+          DST="kw =\n    if RUBY_VERSION.start_with? '3'\n      {git: 'https://github.com/teamcapybara/capybara.git', ref: '43e32a8495'}\n    else\n      {}\n    end\n  gem 'capybara', **kw"
+          sed -i "s#$SRC#$DST#" Gemfile
+          #
           # use `stdio` for log_writer, always have one thread existing
           SRC="Silent: true"
           DST="Silent: false, Threads: '1:4'"


### PR DESCRIPTION
### Description

We run a CI workflow using turbo-rails test suite, which uses Puma for sending websocket data.

It is currently failing, and I'm getting tired of receiving an email every time the workflow fails.

turbo-rails has a hierarchy of dependencies, so a change in one may affect others.  Recently, a change in selenium-webdriver broke release versions of capybara.  This has been fixed in capybara, but the fix hasn't been released.

This PR changes the line in turbo-rails Gemfile from
```ruby
gem 'capybara'
```
to
```ruby
kw =
  if RUBY_VERSION.start_with? '3'
    {git: 'https://github.com/teamcapybara/capybara.git', ref: '43e32a8495'}
  else
    {}
  end
gem 'capybara', **kw
```

When a new release of capybara is available, rather than reverting this PR, the following lines should be left but commented out:
```
          SRC="gem ['\"]capybara['\"].*"
          DST="kw =\n    if RUBY_VERSION.start_with? '3'\n      {git: 'https://github.com/teamcapybara/capybara.git', ref: '43e32a8495'}\n    else\n      {}\n    end\n  gem 'capybara', **kw"
          sed -i "s#$SRC#$DST#" Gemfile
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
