### PR TITLE
Store Tempfiles in ./tmp

### DIFF
--- a/test/helpers/tmp_path.rb
+++ b/test/helpers/tmp_path.rb
@@ -8,7 +8,7 @@ module TmpPath
   private
 
   def tmp_path(extension=nil)
-    path = Tempfile.create(['', extension]) { |f| f.path }
+    path = Tempfile.create(['', extension], './tmp') { |f| f.path }
     tmp_paths << path
     path
   end


### PR DESCRIPTION
On my machine, tempfile directories end up being rather long, and tests actually fail!

```
/Users/nateberkopec/Documents/Code.nosync/upstream/puma/lib/puma/binder.rb:421:in `initialize': too long unix socket path (106bytes given but 104bytes max) (ArgumentError)

        s = UNIXServer.new path.sub(/\A@/, "\0") # check for abstract UNIXSocket
```

Storing in ./tmp solves the issue.