### PR TITLE
[CI] helpers/tmp_path - use './tmp' for temp file root only on macOS

### DIFF
--- a/test/helpers/tmp_path.rb
+++ b/test/helpers/tmp_path.rb
@@ -12,7 +12,16 @@ module TmpPath
   #
   # too long unix socket path (106 bytes given but 104 bytes max) (ArgumentError)
   #
-  PUMA_TMPDIR = RUBY_PLATFORM.include? 'darwin' ? './tmp' : nil
+  PUMA_TMPDIR =
+    begin
+      if RUBY_PLATFORM.include? 'darwin'
+        dir_temp = File.absolute_path("#{__dir__}/../../tmp")
+        Dir.mkdir dir_temp unless Dir.exist? dir_temp
+        './tmp'
+      else
+        nil
+      end
+    end
 
   def tmp_path(extension=nil)
     path = Tempfile.create(['', extension], PUMA_TMPDIR) { |f| f.path }

--- a/test/helpers/tmp_path.rb
+++ b/test/helpers/tmp_path.rb
@@ -7,8 +7,15 @@ module TmpPath
 
   private
 
+  # With some macOS configurations, the following error may be raised when
+  # creating a UNIXSocket:
+  #
+  # too long unix socket path (106 bytes given but 104 bytes max) (ArgumentError)
+  #
+  PUMA_TMPDIR = RUBY_PLATFORM.include? 'darwin' ? './tmp' : nil
+
   def tmp_path(extension=nil)
-    path = Tempfile.create(['', extension], './tmp') { |f| f.path }
+    path = Tempfile.create(['', extension], PUMA_TMPDIR) { |f| f.path }
     tmp_paths << path
     path
   end


### PR DESCRIPTION
### Description

See PR #3153, which is due to a macOS limitation causing an error:
```
too long unix socket path (106 bytes given but 104 bytes max) (ArgumentError)
```

The above is added to comments in `test/helpers/tmp_path.rb`

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
