### PR TITLE
Handle malformed request path

### DIFF
--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -418,7 +418,11 @@ module Puma
 
       unless env[REQUEST_PATH]
         # it might be a dumbass full host request header
-        uri = URI.parse(env[REQUEST_URI])
+        uri = begin
+          URI.parse(env[REQUEST_URI])
+        rescue URI::InvalidURIError
+          raise Puma::HttpParserError
+        end
         env[REQUEST_PATH] = uri.path
 
         # A nil env value will cause a LintError (and fatal errors elsewhere),

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -64,6 +64,12 @@ class WebServerTest < Minitest::Test
     socket.close
   end
 
+  def test_bad_path
+    socket = do_test("GET : HTTP/1.1\r\n\r\n", 3)
+    assert_match "HTTP/1.1 400 Bad Request\r\n\r\n", socket.read
+    socket.close
+  end
+
   def test_header_is_too_long
     long = "GET /test HTTP/1.1\r\n" + ("X-Big: stuff\r\n" * 15000) + "\r\n"
     assert_raises Errno::ECONNRESET, Errno::EPIPE, Errno::ECONNABORTED, Errno::EINVAL, IOError do


### PR DESCRIPTION
### Description

Bad Request is returned

```
$ printf 'GET :/ HTTP/1.1\r\n\r\n' | nc localhost 8080
HTTP/1.1 400 Bad Request
```

and it is logged like this

```
2023-05-14 11:54:28 +0200 HTTP parse error, malformed request ("GET " - (-)): #<Puma::HttpParserError: Puma::HttpParserError>
```

Close #3148

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
