### PR TITLE
Use Rack.release over Rack::RELEASE (rack 1..6.X compatibility)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
 
   test_mri:
     name: >-
-      MRI: ${{ matrix.os }} ${{ matrix.ruby }}${{ matrix.no-ssl }}${{ matrix.yjit }}${{ matrix.rack-2 }}
+      MRI: ${{ matrix.os }} ${{ matrix.ruby }}${{ matrix.no-ssl }}${{ matrix.yjit }}${{ matrix.rack-v }}
     needs: [rubocop, skip_duplicate_runs]
     env:
       CI: true
@@ -41,7 +41,7 @@ jobs:
         os: [ ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, macos-13, windows-2022 ]
         ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head ]
         no-ssl: ['']
-        rack-2: ['']
+        rack-v: ['']
         yjit: ['']
         include:
           - { os: windows-2022 , ruby: ucrt }
@@ -49,8 +49,9 @@ jobs:
           - { os: windows-2022 , ruby: 2.7  , no-ssl: ' no SSL' }
           - { os: ubuntu-20.04 , ruby: 2.7  , no-ssl: ' no SSL' }
           - { os: ubuntu-22.04 , ruby: head , yjit: ' yjit' }
-          - { os: ubuntu-22.04 , ruby: 2.4  , rack-2: ' rack2' }
-          - { os: ubuntu-22.04 , ruby: 3.2  , rack-2: ' rack2' }
+          - { os: ubuntu-22.04 , ruby: 2.4  , rack-v: ' rack2' }
+          - { os: ubuntu-22.04 , ruby: 3.2  , rack-v: ' rack2' }
+          - { os: ubuntu-22.04 , ruby: 2.4  , rack-v: ' rack1' }
 
         exclude:
           - { os: ubuntu-22.04 , ruby:  2.4  }
@@ -83,12 +84,9 @@ jobs:
         shell: bash
         run: echo 'PUMA_DISABLE_SSL=true' >> $GITHUB_ENV
 
-      - name: Test with Rack 2
-        if: |
-          (matrix.rack-2 == ' rack2') &&
-          (needs.skip_duplicate_runs.outputs.should_skip != 'true')
+      - name: Set Rack version, see Gemfile
         shell: bash
-        run: echo 'PUMA_CI_RACK_2=true' >> $GITHUB_ENV
+        run: echo 'PUMA_CI_RACK=${{ matrix.rack-v }}' >> $GITHUB_ENV
 
       - name: load ruby
         if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,20 @@ gem "minitest-retry"
 gem "minitest-proveit"
 gem "minitest-stub-const"
 
-gem "rack", (ENV['PUMA_CI_RACK_2'] ? "~> 2.2" : ">= 2.2")
-gem "rackup" unless ENV['PUMA_CI_RACK_2']
+use_rackup = false
+rack_vers =
+  case ENV['PUMA_CI_RACK']&.strip
+  when 'rack2'
+    '~> 2.2'
+  when 'rack1'
+    '~> 1.6'
+  else
+    use_rackup = true
+    '>= 2.2'
+  end
+
+gem "rack", rack_vers
+gem "rackup" if use_rackup
 
 gem "jruby-openssl", :platform => "jruby"
 

--- a/lib/puma/rack_default.rb
+++ b/lib/puma/rack_default.rb
@@ -11,7 +11,7 @@ if Object.const_defined? :Rackup
       end
     end
   end
-elsif Object.const_defined?(:Rack) && Rack::RELEASE < '3'
+elsif Object.const_defined?(:Rack) && Rack.release < '3'
   module Rack
     module Handler
       def self.default(options = {})

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -123,7 +123,7 @@ if Object.const_defined? :Rackup
     end
   end
 else
-  do_register = Object.const_defined?(:Rack) && Rack::RELEASE < '3'
+  do_register = Object.const_defined?(:Rack) && Rack.release < '3'
   module Rack
     module Handler
       module Puma

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -31,7 +31,11 @@ module Puma
 
       conf = ::Puma::Configuration.new(options, default_options.merge({events: @events})) do |user_config, file_config, default_config|
         if options.delete(:Verbose)
-          require 'rack/common_logger'
+          begin
+            require 'rack/commonlogger'  # Rack 1.x
+          rescue LoadError
+            require 'rack/common_logger' # Rack 2 and later
+          end
           app = ::Rack::CommonLogger.new(app, STDOUT)
         end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -182,7 +182,7 @@ module TestSkips
         when :fork        then "Skipped if Kernel.fork exists"   if HAS_FORK
         when :unix        then "Skipped if UNIXSocket exists"    if Puma::HAS_UNIX_SOCKET
         when :aunix       then "Skipped if abstract UNIXSocket"  if Puma.abstract_unix_socket?
-        when :rack3       then "Skipped if Rack 3.x"             if Rack::RELEASE >= '3'
+        when :rack3       then "Skipped if Rack 3.x"             if Rack.release >= '3'
         else false
       end
       skip skip_msg, bt if skip_msg
@@ -201,7 +201,7 @@ module TestSkips
       when :fork    then MSG_FORK                       unless HAS_FORK
       when :unix    then MSG_UNIX                       unless Puma::HAS_UNIX_SOCKET
       when :aunix   then MSG_AUNIX                      unless Puma.abstract_unix_socket?
-      when :rack3   then "Skipped unless Rack >= 3.x"   unless ::Rack::RELEASE >= '3'
+      when :rack3   then "Skipped unless Rack >= 3.x"   unless ::Rack.release >= '3'
       else false
     end
     skip skip_msg, bt if skip_msg

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -17,7 +17,7 @@ class TestConfigFile < TestConfigFileBase
   end
 
   def test_app_from_rackup
-    if Rack::RELEASE >= '3'
+    if Rack.release >= '3'
       fn = "test/rackup/hello-bind_rack3.ru"
       bind = "tcp://0.0.0.0:9292"
     else

--- a/test/test_puma_server_hijack.rb
+++ b/test/test_puma_server_hijack.rb
@@ -29,6 +29,7 @@ class TestPumaServerHijack < Minitest::Test
   end
 
   def teardown
+    return if skipped?
     @server.stop(true)
     assert_empty @log_writer.stdout.string
     assert_empty @log_writer.stderr.string
@@ -172,6 +173,7 @@ class TestPumaServerHijack < Minitest::Test
   end
 
   def test_partial_hijack_body_closes_body
+    skip 'Not supported with Rack 1.x' if Rack.release.start_with? '1.'
     @available = true
     hdrs = { 'Content-Type' => 'text/plain' }
     body = ::Rack::BodyProxy.new(HIJACK_LAMBDA) { @available = true }
@@ -179,6 +181,7 @@ class TestPumaServerHijack < Minitest::Test
   end
 
   def test_partial_hijack_header_closes_body_correct_precedence
+    skip 'Not supported with Rack 1.x' if Rack.release.start_with? '1.'
     @available = true
     incorrect_lambda = ->(io) {
       io.syswrite 'incorrect body.call'

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -10,7 +10,7 @@ require "rack/common_logger"
 
 # Rack::Chunked is loaded by Rack v2, needs to be required by Rack 3.0,
 # and is removed in Rack 3.1
-require "rack/chunked" if Rack::RELEASE.start_with? '3.0'
+require "rack/chunked" if Rack.release.start_with? '3.0'
 
 require "nio"
 
@@ -41,7 +41,7 @@ class TestRackServer < Minitest::Test
 
   class ServerLint < Rack::Lint
     def call(env)
-      if Rack::RELEASE < '3'
+      if Rack.release < '3'
         check_env env
       else
         Wrapper.new(@app, env).check_environment env
@@ -241,7 +241,7 @@ class TestRackServer < Minitest::Test
     resp = Net::HTTP.get_response URI(@tcp)
     assert_equal 'chunked', resp['transfer-encoding']
     assert_equal STR_1KB, resp.body.force_encoding(Encoding::UTF_8)
-  end if Rack::RELEASE < '3.1'
+  end if Rack.release < '3.1'
 
   def test_rack_chunked_array10
     body = Array.new 10, STR_1KB
@@ -253,7 +253,7 @@ class TestRackServer < Minitest::Test
     resp = Net::HTTP.get_response URI(@tcp)
     assert_equal 'chunked', resp['transfer-encoding']
     assert_equal STR_1KB * 10, resp.body.force_encoding(Encoding::UTF_8)
-  end if Rack::RELEASE < '3.1'
+  end if Rack.release < '3.1'
 
   def test_puma_enum
     body = Array.new(10, STR_1KB).to_enum


### PR DESCRIPTION
### Description

The constant `Rack::RELEASE` was introduced "only" (I know, it's a long time ago) in rack version 2 (specifically: https://github.com/rack/rack/commit/a2fe30a5e70371c89c1b29fdc2dc5f8027bc5fe6). Earlier versions provided the class method `Rack.release` which still exists.

https://github.com/puma/puma/pull/3061 has introduced usage of `Rack::RELEASE` and therefore broke compatibility with rack 1.6.X. Since this was released with a minor or patch version update of *puma* I feel it would be nice to fix and restore compatibility with rack 1.6.X.

So this PR changes usage of `Rack::RELEASE` to `Rack.release`. Since none of the occurrences seem to be in any code that is called per request I assume it's fine to introduce a potential tiny performance overhead of a method call vs. constant lookup.

Please let me know if this makes sense and let me know if I can/should change anything with this PR. 

I didn't add any tests since I didn't know how to best approach this: ~*rack* is not a dependency of *puma* and there does not seem to be any infrastructure in place to run tests against different versions of *rack*~ (I now see that there's a env var that controls rack version for tests). Since rack 1.6.X is very outdated I would say in this case it's "good enough" if the change does not introduce any regressions but let me know if you have any ideas on how to better test this!

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
