### PR TITLE
[CI] test_redirect_io.rb - fixup for intermittent failures

### DIFF
--- a/test/test_redirect_io.rb
+++ b/test/test_redirect_io.rb
@@ -1,8 +1,12 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/integration"
 
 class TestRedirectIO < TestIntegration
   parallelize_me!
+
+  FILE_STR = 'puma startup'
 
   def setup
     skip_unless_signal_exist? :HUP
@@ -13,6 +17,12 @@ class TestRedirectIO < TestIntegration
     @err_file = Tempfile.new('puma-err')
     @out_file_path = @out_file.path
     @err_file_path = @err_file.path
+
+    @cli_args = ['--redirect-stdout', @out_file_path,
+      '--redirect-stderr', @err_file_path,
+      'test/rackup/hello.ru'
+    ]
+
   end
 
   def teardown
@@ -30,56 +40,17 @@ class TestRedirectIO < TestIntegration
   def test_sighup_redirects_io_single
     skip_if :jruby # Server isn't coming up in CI, TODO Fix
 
-    cli_args = [
-      '--redirect-stdout', @out_file_path,
-      '--redirect-stderr', @err_file_path,
-      'test/rackup/hello.ru'
-    ]
-    cli_server cli_args.join ' '
+    cli_server @cli_args.join ' '
 
-    wait_until_file_has_content @out_file_path
-    assert_match 'puma startup', File.read(@out_file_path)
-
-    wait_until_file_has_content @err_file_path
-    assert_match 'puma startup', File.read(@err_file_path)
-
-    log_rotate_output_files
-
-    Process.kill :HUP, @server.pid
-
-    wait_until_file_has_content @out_file_path
-    assert_match 'puma startup', File.read(@out_file_path)
-
-    wait_until_file_has_content @err_file_path
-    assert_match 'puma startup', File.read(@err_file_path)
+    rotate_check_logs
   end
 
   def test_sighup_redirects_io_cluster
     skip_unless :fork
 
-    cli_args = [
-      '-w', '1',
-      '--redirect-stdout', @out_file_path,
-      '--redirect-stderr', @err_file_path,
-      'test/rackup/hello.ru'
-    ]
-    cli_server cli_args.join ' '
+    cli_server (['-w', '1'] + @cli_args).join ' '
 
-    wait_until_file_has_content @out_file_path
-    assert_match 'puma startup', File.read(@out_file_path)
-
-    wait_until_file_has_content @err_file_path
-    assert_match 'puma startup', File.read(@err_file_path)
-
-    log_rotate_output_files
-
-    Process.kill :HUP, @server.pid
-
-    wait_until_file_has_content @out_file_path
-    assert_match 'puma startup', File.read(@out_file_path)
-
-    wait_until_file_has_content @err_file_path
-    assert_match 'puma startup', File.read(@err_file_path)
+    rotate_check_logs
   end
 
   private
@@ -88,6 +59,7 @@ class TestRedirectIO < TestIntegration
     # rename both files to .old
     @old_out_file_path = "#{@out_file_path}.old"
     @old_err_file_path = "#{@err_file_path}.old"
+
     File.rename @out_file_path, @old_out_file_path
     File.rename @err_file_path, @old_err_file_path
 
@@ -95,14 +67,35 @@ class TestRedirectIO < TestIntegration
     File.new(@err_file_path, File::CREAT).close
   end
 
-  def wait_until_file_has_content(path)
+  def rotate_check_logs
+    assert_file_contents @out_file_path
+    assert_file_contents @err_file_path
+
+    log_rotate_output_files
+
+    Process.kill :HUP, @pid
+
+    assert_file_contents @out_file_path
+    assert_file_contents @err_file_path
+  end
+
+  def assert_file_contents(path, include = FILE_STR)
+    retries = 0
+    retries_max = 50 # 5 seconds
     File.open(path) do |file|
       begin
         file.read_nonblock 1
         file.seek 0
+        assert_includes file.read, include,
+          "File #{File.basename(path)} does not include #{include}"
       rescue EOFError
         sleep 0.1
-        retry
+        retries += 1
+        if retries < retries_max
+          retry
+        else
+          flunk 'File read took too long'
+        end
       end
     end
   end


### PR DESCRIPTION
### Description

Puma's test suite runs with 'retry', which is helpful when CI systems are not 'resource robust'.  Recent additions to CI log all test 'retry' failures.  `test_redirect_io.rb` appears intermittently in these logs.

Hence, fixup with the hope of reducing or eliminating 'retry' failures.

1. This file is about log files.  Currently, it opens the file, checks if it can be read, then closes it, only to perform a `File.read` later.  The `read` operation should be contained in the `File.open` block.
2. The current `File.open` block may run forever, as it has no limit on the retry count.
3. Reduce redundant code.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
