### PR TITLE
[CI] test_integration_ssl_session.rb - wait for session callback

### DIFF
--- a/test/test_integration_ssl_session.rb
+++ b/test/test_integration_ssl_session.rb
@@ -137,7 +137,7 @@ class TestIntegrationSSLSession < TestIntegration
     assert reused, 'TLSv1.3 session was not reused'
   end
 
-  def client_skt(tls_vers = nil, session_pems = [])
+  def client_skt(tls_vers = nil, session_pems = [], queue = nil)
     ctx = OSSL::SSLContext.new
     ctx.verify_mode = OSSL::VERIFY_NONE
     ctx.session_cache_mode = OSSL::SSLContext::SESSION_CACHE_CLIENT
@@ -149,7 +149,10 @@ class TestIntegrationSSLSession < TestIntegration
         ctx.ssl_version = tls_vers.to_s.sub('TLS', 'TLSv').to_sym
       end
     end
-    ctx.session_new_cb = ->(ary) { session_pems << ary.last.to_pem }
+    ctx.session_new_cb = ->(ary) {
+      queue << true if queue
+      session_pems << ary.last.to_pem
+    }
 
     skt = OSSL::SSLSocket.new TCPSocket.new(HOST, bind_port), ctx
     skt.sync_close = true
@@ -157,14 +160,16 @@ class TestIntegrationSSLSession < TestIntegration
   end
 
   def ssl_client(tls_vers: nil)
+    queue = Thread::Queue.new
     session_pems = []
-    skt = client_skt tls_vers, session_pems
+    skt = client_skt tls_vers, session_pems, queue
     skt.connect
 
     skt.syswrite GET
     skt.to_io.wait_readable 2
     assert_equal RESP, skt.sysread(1_024)
     skt.sysclose
+    queue.pop # wait for cb session to be added to first client
 
     skt = client_skt tls_vers, session_pems
     skt.session = OSSL::Session.new(session_pems[0])
@@ -173,6 +178,8 @@ class TestIntegrationSSLSession < TestIntegration
     skt.syswrite GET
     skt.to_io.wait_readable 2
     assert_equal RESP, skt.sysread(1_024)
+    queue.close
+    queue = nil
 
     skt.session_reused?
   ensure


### PR DESCRIPTION
### Description

I haven't seen any of these tests fail, but I have seen some retry.  All of the tests create two ssl requests, and the SSLSockets have `OpenSSL::SSL::SSLContext#session_new_cb` set.

This PR adds code so the second request waits for the callback.  The tests haven't failed/retried in the limited CI testing I've done.

Note that, like many of the tests involving 'retry', I've never had these tests fail locally.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
