### PR TITLE
[CI] Use <<~ for heredocs

### DIFF
--- a/test/test_integration_ssl.rb
+++ b/test/test_integration_ssl.rb
@@ -56,33 +56,34 @@ class TestIntegrationSSL < TestIntegration
   end
 
   def test_ssl_run
-    config = <<RUBY
-if ::Puma.jruby?
-  keystore =  '#{File.expand_path '../examples/puma/keystore.jks', __dir__}'
-  keystore_pass = 'jruby_puma'
+    config = <<~RUBY
+      if ::Puma.jruby?
+        keystore =  '#{File.expand_path '../examples/puma/keystore.jks', __dir__}'
+        keystore_pass = 'jruby_puma'
 
-  ssl_bind '#{HOST}', '#{bind_port}', {
-    keystore: keystore,
-    keystore_pass:  keystore_pass,
-    verify_mode: 'none'
-  }
-else
-  key  = '#{File.expand_path '../examples/puma/puma_keypair.pem', __dir__}'
-  cert = '#{File.expand_path '../examples/puma/cert_puma.pem', __dir__}'
+        ssl_bind '#{HOST}', '#{bind_port}', {
+          keystore: keystore,
+          keystore_pass:  keystore_pass,
+          verify_mode: 'none'
+        }
+      else
+        key  = '#{File.expand_path '../examples/puma/puma_keypair.pem', __dir__}'
+        cert = '#{File.expand_path '../examples/puma/cert_puma.pem', __dir__}'
 
-  ssl_bind '#{HOST}', '#{bind_port}', {
-    cert: cert,
-    key:  key,
-    verify_mode: 'none'
-  }
-end
+        ssl_bind '#{HOST}', '#{bind_port}', {
+          cert: cert,
+          key:  key,
+          verify_mode: 'none'
+        }
+      end
 
-activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
+      activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
 
-app do |env|
-  [200, {}, [env['rack.url_scheme']]]
-end
-RUBY
+      app do |env|
+        [200, {}, [env['rack.url_scheme']]]
+      end
+    RUBY
+
     with_server(config) do |http|
       body = nil
       http.start do
@@ -138,22 +139,22 @@ RUBY
   def test_ssl_run_with_pem
     skip_if :jruby
 
-    config = <<RUBY
-  key_path  = '#{File.expand_path '../examples/puma/puma_keypair.pem', __dir__}'
-  cert_path = '#{File.expand_path '../examples/puma/cert_puma.pem', __dir__}'
+    config = <<~RUBY
+      key_path  = '#{File.expand_path '../examples/puma/puma_keypair.pem', __dir__}'
+      cert_path = '#{File.expand_path '../examples/puma/cert_puma.pem', __dir__}'
 
-  ssl_bind '#{HOST}', '#{bind_port}', {
-    cert_pem: File.read(cert_path),
-    key_pem:  File.read(key_path),
-    verify_mode: 'none'
-  }
+      ssl_bind '#{HOST}', '#{bind_port}', {
+        cert_pem: File.read(cert_path),
+        key_pem:  File.read(key_path),
+        verify_mode: 'none'
+      }
 
-activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
+      activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
 
-app do |env|
-  [200, {}, [env['rack.url_scheme']]]
-end
-RUBY
+      app do |env|
+        [200, {}, [env['rack.url_scheme']]]
+      end
+    RUBY
 
     with_server(config) do |http|
       body = nil
@@ -168,16 +169,16 @@ RUBY
   def test_ssl_run_with_localhost_authority
     skip_if :jruby
 
-    config = <<RUBY
-  require 'localhost'
-  ssl_bind '#{HOST}', '#{bind_port}'
+    config = <<~RUBY
+      require 'localhost'
+      ssl_bind '#{HOST}', '#{bind_port}'
 
-activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
+      activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
 
-app do |env|
-  [200, {}, [env['rack.url_scheme']]]
-end
-RUBY
+      app do |env|
+        [200, {}, [env['rack.url_scheme']]]
+      end
+    RUBY
 
     with_server(config) do |http|
       body = nil
@@ -192,25 +193,25 @@ RUBY
   def test_ssl_run_with_encrypted_key
     skip_if :jruby
 
-    config = <<RUBY
-  key_path  = '#{File.expand_path '../examples/puma/encrypted_puma_keypair.pem', __dir__}'
-  cert_path = '#{File.expand_path '../examples/puma/cert_puma.pem', __dir__}'
-  key_command = ::Puma::IS_WINDOWS ? 'echo hello world' :
-    '#{File.expand_path '../examples/puma/key_password_command.sh', __dir__}'
+    config = <<~RUBY
+      key_path  = '#{File.expand_path '../examples/puma/encrypted_puma_keypair.pem', __dir__}'
+      cert_path = '#{File.expand_path '../examples/puma/cert_puma.pem', __dir__}'
+      key_command = ::Puma::IS_WINDOWS ? 'echo hello world' :
+        '#{File.expand_path '../examples/puma/key_password_command.sh', __dir__}'
 
-  ssl_bind '#{HOST}', '#{bind_port}', {
-    cert: cert_path,
-    key: key_path,
-    verify_mode: 'none',
-    key_password_command: key_command
-  }
+      ssl_bind '#{HOST}', '#{bind_port}', {
+        cert: cert_path,
+        key: key_path,
+        verify_mode: 'none',
+        key_password_command: key_command
+      }
 
-activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
+      activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
 
-app do |env|
-  [200, {}, [env['rack.url_scheme']]]
-end
-RUBY
+      app do |env|
+        [200, {}, [env['rack.url_scheme']]]
+      end
+    RUBY
 
     with_server(config) do |http|
       body = nil
@@ -225,25 +226,25 @@ RUBY
   def test_ssl_run_with_encrypted_pem
     skip_if :jruby
 
-    config = <<RUBY
-  key_path  = '#{File.expand_path '../examples/puma/encrypted_puma_keypair.pem', __dir__}'
-  cert_path = '#{File.expand_path '../examples/puma/cert_puma.pem', __dir__}'
-  key_command = ::Puma::IS_WINDOWS ? 'echo hello world' :
-    '#{File.expand_path '../examples/puma/key_password_command.sh', __dir__}'
+    config = <<~RUBY
+      key_path  = '#{File.expand_path '../examples/puma/encrypted_puma_keypair.pem', __dir__}'
+      cert_path = '#{File.expand_path '../examples/puma/cert_puma.pem', __dir__}'
+      key_command = ::Puma::IS_WINDOWS ? 'echo hello world' :
+        '#{File.expand_path '../examples/puma/key_password_command.sh', __dir__}'
 
-  ssl_bind '#{HOST}', '#{bind_port}', {
-    cert_pem: File.read(cert_path),
-    key_pem: File.read(key_path),
-    verify_mode: 'none',
-    key_password_command: key_command
-  }
+      ssl_bind '#{HOST}', '#{bind_port}', {
+        cert_pem: File.read(cert_path),
+        key_pem: File.read(key_path),
+        verify_mode: 'none',
+        key_password_command: key_command
+      }
 
-activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
+      activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
 
-app do |env|
-  [200, {}, [env['rack.url_scheme']]]
-end
-RUBY
+      app do |env|
+        [200, {}, [env['rack.url_scheme']]]
+      end
+    RUBY
 
     with_server(config) do |http|
       body = nil

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -326,16 +326,15 @@ class TestPumaServer < Minitest::Test
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
-    expected_data = (<<EOF
-HTTP/1.1 103 Early Hints
-Link: </style.css>; rel=preload; as=style
-Link: </script.js>; rel=preload
+    expected_data = <<~EOF.gsub("\n", "\r\n") + "\r\n"
+      HTTP/1.1 103 Early Hints
+      Link: </style.css>; rel=preload; as=style
+      Link: </script.js>; rel=preload
 
-HTTP/1.0 200 OK
-X-Hello: World
-Content-Length: 12
-EOF
-).split("\n").join("\r\n") + "\r\n\r\n"
+      HTTP/1.0 200 OK
+      X-Hello: World
+      Content-Length: 12
+    EOF
 
     assert_equal true, @server.early_hints
     assert_equal expected_data, data
@@ -370,12 +369,11 @@ EOF
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
-    expected_data = (<<EOF
-HTTP/1.0 200 OK
-X-Hello: World
-Content-Length: 12
-EOF
-).split("\n").join("\r\n") + "\r\n\r\n"
+    expected_data = <<~EOF.gsub("\n", "\r\n") + "\r\n"
+      HTTP/1.0 200 OK
+      X-Hello: World
+      Content-Length: 12
+    EOF
 
     assert_nil @server.early_hints
     assert_equal expected_data, data


### PR DESCRIPTION
### Description

Ruby 2.2 did not support `<<~` for heredocs, so many used in the test files are indented all the way to the left.

Call me AR, but I hate that, as I often place debug code on the left margin.

So, this PR replace heredocs with `<<~`, and indents them.  If on uses the 'Hide whitespace' option in the 'diff/patch' view, it makes things much clearer...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
