### PR TITLE
[CI] - Use RubyGems 3.3.26 for Ruby 2.4 thru 2.6 (was 3.3.14)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -109,7 +109,7 @@ jobs:
         if: |
           contains('2.4 2.5 2.6', matrix.ruby) &&
           (needs.skip_duplicate_runs.outputs.should_skip != 'true')
-        run: gem update --system 3.3.14 --no-document
+        run: gem update --system 3.3.26 --no-document
         continue-on-error: true
         timeout-minutes: 5
 


### PR DESCRIPTION
### Description

CI updates RubyGems/Bundler for Ruby versions 2.4 thru 2.6.  Currently it's pinned to 3.3.14, which was released May 18, 2022.

Update to version 3.3.26, which was released November 17, 2022.

Noticed this while working on test suite stability, and old Ruby versions were intermittently failing running `test_worker_gem_independence.rb`, which tests Gemfile changes when restarting Puma.

For those of you not following RubyGems/Bundler, @deivid-rodriguez and others have been doing a lot of good work there...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
