### PR TITLE
Puma error responses - remove fingerprints to indicate Puma

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -124,7 +124,7 @@ module Puma
       # Indicate that we couldn't parse the request
       400 => "HTTP/1.1 400 Bad Request\r\n\r\n",
       # The standard empty 404 response for bad requests.  Use Error4040Handler for custom stuff.
-      404 => "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\nNOT FOUND",
+      404 => "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n",
       # The standard empty 408 response for requests that timed out.
       408 => "HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n",
       # Indicate that there was an internal error, obviously.
@@ -132,7 +132,7 @@ module Puma
       # Incorrect or invalid header value
       501 => "HTTP/1.1 501 Not Implemented\r\n\r\n",
       # A common header for indicating the server is too busy.  Not used yet.
-      503 => "HTTP/1.1 503 Service Unavailable\r\n\r\nBUSY"
+      503 => "HTTP/1.1 503 Service Unavailable\r\n\r\n"
     }.freeze
 
     # The basic max request size we'll try to read.

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -124,9 +124,9 @@ module Puma
       # Indicate that we couldn't parse the request
       400 => "HTTP/1.1 400 Bad Request\r\n\r\n",
       # The standard empty 404 response for bad requests.  Use Error4040Handler for custom stuff.
-      404 => "HTTP/1.1 404 Not Found\r\nConnection: close\r\nServer: Puma #{PUMA_VERSION}\r\n\r\nNOT FOUND",
+      404 => "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\nNOT FOUND",
       # The standard empty 408 response for requests that timed out.
-      408 => "HTTP/1.1 408 Request Timeout\r\nConnection: close\r\nServer: Puma #{PUMA_VERSION}\r\n\r\n",
+      408 => "HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n",
       # Indicate that there was an internal error, obviously.
       500 => "HTTP/1.1 500 Internal Server Error\r\n\r\n",
       # Incorrect or invalid header value


### PR DESCRIPTION
### Description

Puma may generate error responses both before and after the app is called, some of which are contained in the `Puma::Const::ERROR_RESPONSE` hash.  Some use a `Server` header whose value is 'Puma \<version\>'.  Some also contain a brief body.

Both of these may 'fingerprint' the response as being generated by Puma.  One commit removes the `Server` header, another removes the body text.

These error responses are for request errors and also server errors.  Request error handing is contained in a few places, and could be moved to `Puma::Client` code, as the request is received in full before calling code outside of `Client`.

Another issue is how to log request errors.  I suspect most would prefer them in the request/response logging, but whether additional error info should be logged is possibly an issue that could be controlled by a DSL method...

Closes #3037
Closes #3141

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
