### PR TITLE
Don't send 103 early hints response when only invalid headers are used

### DIFF
--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -83,7 +83,11 @@ class TestResponseHeader < Minitest::Test
     server_run(app: app, early_hints: opts[:early_hints])
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    refute_match("#{name}: #{value}", data)
+    if opts[:early_hints]
+      refute_includes data, "HTTP/1.1 103 Early Hints"
+    end
+
+    refute_includes data, "#{name}: #{value}"
   end
 
   # The header must not contain a Status key.


### PR DESCRIPTION
### Description

While reviewing code in `test\test_response_header.rb`, I noticed that when invalid headers are returned by the app with 'early hints', the first line of an 'early hints' response (`HTTP/1.1 103 Early Hints`) is sent without any data/headers.

This PR modifies the code in `puma/request.rb` to only send the 'early hints' response if at least one header is valid.

Note that with the test changes, current master has the following errors:
```
TestResponseHeader#test_illegal_character_in_key_when_early_hints [test/test_response_header.rb:128]:
Expected # encoding: ASCII-8BIT
#    valid: true
"HTTP/1.1 103 Early Hints\r\n\r\n" to not include "HTTP/1.1 103 Early Hints".

  2) Failure:
TestResponseHeader#test_illegal_character_in_value_when_early_hints [test_response_header.rb:139]:
Expected # encoding: ASCII-8BIT
#    valid: true
"HTTP/1.1 103 Early Hints\r\n\r\nHTTP/1.0 200 OK\r\nContent-Length: 5\r\n\r\nHello" to not include "HTTP/1.1 103 Early Hints".
```


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
