### PR TITLE
Support rack 3 cookies

### DIFF
--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -450,8 +450,15 @@ module Puma
           next
         end
 
-        if vs.respond_to?(:to_s) && !vs.to_s.empty?
-          vs.to_s.split(NEWLINE).each do |v|
+        ary = if vs.is_a?(::Array) && !vs.empty?
+          vs
+        elsif vs.respond_to?(:to_s) && !vs.to_s.empty?
+          vs.to_s.split NEWLINE
+        else
+          nil
+        end
+        if ary
+          ary.each do |v|
             next if illegal_header_value?(v)
             lines.append k, colon, v, line_ending
           end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -165,6 +165,7 @@ module TestSkips
       when :fork    then MSG_FORK                       unless HAS_FORK
       when :unix    then MSG_UNIX                       unless Puma::HAS_UNIX_SOCKET
       when :aunix   then MSG_AUNIX                      unless Puma.abstract_unix_socket?
+      when :rack3   then "Skipped unless Rack >= 3.x"   unless ::Rack::RELEASE >= '3'
       else false
     end
     skip skip_msg, bt if skip_msg

--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -1,9 +1,13 @@
 require_relative "helper"
 require "puma/events"
 require "net/http"
+require "nio"
 
 class TestResponseHeader < Minitest::Test
   parallelize_me!
+
+  # this file has limited response length, so 10kB works.
+  CLIENT_SYSREAD_LENGTH = 10_240
 
   def setup
     @host = "127.0.0.1"
@@ -29,7 +33,7 @@ class TestResponseHeader < Minitest::Test
   end
 
   def send_http_and_read(req)
-    send_http(req).read
+    send_http(req).sysread CLIENT_SYSREAD_LENGTH
   end
 
   def send_http(req)
@@ -140,5 +144,13 @@ class TestResponseHeader < Minitest::Test
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
     refute_match("X-header: First\000 line\r\nX-header: Second Lin\037e\r\n", data)
+  end
+
+  def test_header_value_array
+    server_run app: ->(env) { [200, {'set-cookie' => ['z=1', 'a=2']}, ['Hello']] }
+    data = send_http_and_read "GET / HTTP/1.1\r\n\r\n"
+
+    resp = "HTTP/1.1 200 OK\r\nset-cookie: z=1\r\nset-cookie: a=2\r\nContent-Length: 5\r\n\r\n"
+    assert_includes data, resp
   end
 end


### PR DESCRIPTION
This is a cherry pick of e2ef83b4ee37399d880f6465706e349e327889ce

### Description
Rack 3 switched to arrays for cookies. Puma 6 already supports it  (e2ef83b4ee37399d880f6465706e349e327889ce).

The problem if we don't backport this to Puma 5 is that a whole lot of people are about to hit [this error](https://github.com/rails/rails/issues/48195).

I built a minimal repro of the issue [here](https://gist.github.com/JoeDupuis/1d219656f4d9d6dd3421e98b4eb00eea). 

 [Since Rails 6.1](https://github.com/rails/rails/blob/6-1-stable/railties/lib/rails/generators/app_base.rb#L209), Rails has `gem "puma", "~> 5.0"` as the default web server. 

This means  that anyone who started a Rails app since 6.1 will hit the issue if they run `bundle update` after Rails 7.1 releases as [Rails main removed the upper bound for rack](https://github.com/rails/rails/commit/859b526c5b9f1e516df3fc1b388c949da3fa9c4e) 

If they run `bundle update rails` there is not much we can do as it won't update Puma, but if we can mitigate the issue for anyone running `bundle update` this could solve a lot headache. 

I doubt this is the only incompatibility with Rack 3. It might be too much to cherry pick everything, so I made [this PR](https://github.com/JoeDupuis/puma/pull/1/files) as an alternative. This alternative PR would prevent Puma 5 from starting if Rack 3 is loaded. I didn't open it on this repo (lives in my fork), I'll switch it if this approach is preferred. 


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
