### PR TITLE
update URLMap Regexp usage for Ruby v3.3

### DIFF
--- a/lib/puma/rack/urlmap.rb
+++ b/lib/puma/rack/urlmap.rb
@@ -34,7 +34,7 @@ module Puma::Rack
         end
 
         location = location.chomp('/')
-        match = Regexp.new("^#{Regexp.quote(location).gsub('/', '/+')}(.*)", nil, 'n')
+        match = Regexp.new("^#{Regexp.quote(location).gsub('/', '/+')}(.*)", Regexp::NOENCODING)
 
         [host, location, match, app]
       }.sort_by do |(host, location, _, _)|

--- a/test/test_url_map.rb
+++ b/test/test_url_map.rb
@@ -2,10 +2,6 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestURLMap < TestIntegration
-  def setup
-    skip_unless :fork
-    super
-  end
 
   def teardown
     return if skipped?
@@ -14,23 +10,15 @@ class TestURLMap < TestIntegration
 
   # make sure the mapping defined in url_map_test/config.ru works
   def test_basic_url_mapping
-    skip_unless_signal_exist? :USR2
-
-    @tcp_port = UniquePort.call
-    timeout = 1
-    env = {
-      "BUNDLE_GEMFILE" => File.join(File.expand_path("url_map_test/Gemfile", __dir__))
-    }
-    cmd = "bundle exec puma -q -w 1 --prune-bundler -b tcp://#{HOST}:#{@tcp_port}"
-    Dir.chdir(File.expand_path("url_map_test", __dir__)) do
-      @server = IO.popen(env, cmd.split, "r")
+    skip_if :jruby
+    env = { "BUNDLE_GEMFILE" => "#{__dir__}/url_map_test/Gemfile" }
+    Dir.chdir("#{__dir__}/url_map_test") do
+      cli_server set_pumactl_args, env: env
     end
-    wait_for_server_to_boot
-    @pid = @server.pid
     connection = connect("/ok")
     # Puma 6.2.2 and below will time out here with Ruby v3.3
     # see https://github.com/puma/puma/pull/3165
-    initial_reply = read_body(connection, timeout)
-    assert_match("OK", initial_reply)
+    body = read_body(connection, 1)
+    assert_equal("OK", body)
   end
 end

--- a/test/test_url_map.rb
+++ b/test/test_url_map.rb
@@ -1,0 +1,36 @@
+require_relative "helper"
+require_relative "helpers/integration"
+
+class TestURLMap < TestIntegration
+  def setup
+    skip_unless :fork
+    super
+  end
+
+  def teardown
+    return if skipped?
+    super
+  end
+
+  # make sure the mapping defined in url_map_test/config.ru works
+  def test_basic_url_mapping
+    skip_unless_signal_exist? :USR2
+
+    @tcp_port = UniquePort.call
+    timeout = 1
+    env = {
+      "BUNDLE_GEMFILE" => File.join(File.expand_path("url_map_test/Gemfile", __dir__))
+    }
+    cmd = "bundle exec puma -q -w 1 --prune-bundler -b tcp://#{HOST}:#{@tcp_port}"
+    Dir.chdir(File.expand_path("url_map_test", __dir__)) do
+      @server = IO.popen(env, cmd.split, "r")
+    end
+    wait_for_server_to_boot
+    @pid = @server.pid
+    connection = connect("/ok")
+    # Puma 6.2.2 and below will time out here with Ruby v3.3
+    # see https://github.com/puma/puma/pull/3165
+    initial_reply = read_body(connection, timeout)
+    assert_match("OK", initial_reply)
+  end
+end

--- a/test/url_map_test/Gemfile
+++ b/test/url_map_test/Gemfile
@@ -1,0 +1,1 @@
+gem 'puma', path: '../..'

--- a/test/url_map_test/config.ru
+++ b/test/url_map_test/config.ru
@@ -1,0 +1,3 @@
+map "/ok" do
+  run ->(env) { [200, {}, ["OK"]] }
+end

--- a/test/url_map_test/config.ru
+++ b/test/url_map_test/config.ru
@@ -1,3 +1,9 @@
 map "/ok" do
-  run ->(env) { [200, {}, ["OK"]] }
+  run ->(env) {
+    if Object.const_defined?(:Rack) && ::Rack.const_defined?(:URLMap)
+      [200, {}, ["::Rack::URLMap is loaded"]]
+    else
+      [200, {}, ["OK"]]
+    end
+  }
 end


### PR DESCRIPTION
Ruby v3.3.0-preview1 doesn't support passing 3 arguments to `Regexp.new`, so update `Puma::Rack::URLMap#remap` to use a 2 argument version instead.

I didn't notice where `Puma::Rack::URLMap#remap` was currently tested and could use some advice on the testing front. Syntactically, I've tested the change going back as far as the current minimum supported Ruby, v2.4.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
