### PR TITLE
Prevent loading with rack 3

### DIFF
--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -14,6 +14,8 @@ require 'puma/puma_http11'
 require 'puma/detect'
 require 'puma/json_serialization'
 
+require 'rack/version_restriction'
+
 module Puma
   autoload :Const, 'puma/const'
   autoload :Server, 'puma/server'

--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -10,11 +10,11 @@ require 'stringio'
 
 require 'thread'
 
+# extension files should not be loaded with `require_relative`
 require 'puma/puma_http11'
-require 'puma/detect'
-require 'puma/json_serialization'
-
-require 'rack/version_restriction'
+require_relative 'puma/detect'
+require_relative 'puma/json_serialization'
+require_relative 'rack/version_restriction'
 
 module Puma
   autoload :Const, 'puma/const'

--- a/lib/rack/version_restriction.rb
+++ b/lib/rack/version_restriction.rb
@@ -1,6 +1,13 @@
 begin
-  require 'rack'
+  begin
+    # rack/version exists in Rack 2.2.0 and later, compatible with Ruby 2.3 and later
+    # we prefer to not load Rack
+    require 'rack/version'
+  rescue LoadError
+    require 'rack'
+  end
 
+  # Rack.release is needed for Rack v1, Rack::RELEASE was added in v2
   if Gem::Version.new(Rack.release) >= Gem::Version.new("3.0.0")
     raise StandardError.new "Puma 5 is not compatible with Rack 3, please upgrade to Puma 6 or higher."
   end

--- a/lib/rack/version_restriction.rb
+++ b/lib/rack/version_restriction.rb
@@ -1,0 +1,8 @@
+begin
+  require 'rack'
+
+  if Gem::Version.new(Rack.release) >= Gem::Version.new("3.0.0")
+    raise StandardError.new "Puma 5 is not compatible with Rack 3, please upgrade to Puma 6 or higher."
+  end
+rescue LoadError
+end

--- a/test/bundle_rack_3/Gemfile
+++ b/test/bundle_rack_3/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'rack', '>= 3.0.0'
+gem 'puma', path: '../..'

--- a/test/bundle_rack_3/config.ru
+++ b/test/bundle_rack_3/config.ru
@@ -1,0 +1,1 @@
+run lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Hello World"]] }

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -54,6 +54,15 @@ class TestIntegration < Minitest::Test
 
   private
 
+  def with_unbundled_env
+    bundler_ver = Gem::Version.new(Bundler::VERSION)
+    if bundler_ver < Gem::Version.new('2.1.0')
+      Bundler.with_clean_env { yield }
+    else
+      Bundler.with_unbundled_env { yield }
+    end
+  end
+
   def silent_and_checked_system_command(*args)
     assert(system(*args, out: File::NULL, err: File::NULL))
   end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -67,7 +67,7 @@ class TestIntegration < Minitest::Test
     assert(system(*args, out: File::NULL, err: File::NULL))
   end
 
-  def cli_server(argv, unix: false, config: nil, merge_err: false)
+  def cli_server(argv, unix: false, config: nil, merge_err: false, skip_waiting: false)
     if config
       config_file = Tempfile.new(%w(config .rb))
       config_file.write config
@@ -86,7 +86,7 @@ class TestIntegration < Minitest::Test
     else
       @server = IO.popen(cmd, "r")
     end
-    wait_for_server_to_boot
+    wait_for_server_to_boot unless skip_waiting
     @pid = @server.pid
     @server
   end

--- a/test/test_rack_version_restriction.rb
+++ b/test/test_rack_version_restriction.rb
@@ -1,34 +1,42 @@
 require_relative "helper"
 require_relative "helpers/integration"
 
-class TestWorkerGemIndependence < TestIntegration
+class TestRackVersionRestriction < TestIntegration
   class PumaBooted < Timeout::Error; end
 
   def setup
+    # Rack 3 minimum Ruby version is 2.4
+    skip if !::Puma::IS_MRI || RUBY_VERSION < '2.4'
     super
   end
 
   def teardown
+    return if skipped?
     FileUtils.rm_rf ["#{workdir}/vendor", "#{workdir}/Gemfile.lock"]
+    begin
+      # KILL works with all OS's
+      Process.kill(:KILL, @server.pid) if @server
+    rescue Errno::ESRCH
+    end
   end
 
   def test_prevent_booting_with_rack_3
+    msg = "Puma 5 is not compatible with Rack 3"
     puma_crashed = false
 
     Dir.chdir(workdir) do
       with_unbundled_env do
+        silent_and_checked_system_command("bundle config --local path vendor/bundle")
         silent_and_checked_system_command("bundle install")
-        Timeout.timeout(1, PumaBooted) do
+        Timeout.timeout(5, PumaBooted) do
           cli_server './config.ru', merge_err: true, skip_waiting: true
-          sleep 0.1 until puma_crashed = @server.gets["Puma 5 is not compatible with Rack 3, please upgrade to Puma 6 or higher."]
+          sleep 0.1 until puma_crashed = @server.gets[msg]
         end
       end
     end
 
   rescue PumaBooted
-    puma_crashed = false
   ensure
-    Process.kill :HUP, @server.pid
     assert puma_crashed, "Puma was expected to crash on boot, but it didn't! "
   end
 

--- a/test/test_version_restriction.rb
+++ b/test/test_version_restriction.rb
@@ -1,0 +1,40 @@
+require_relative "helper"
+require_relative "helpers/integration"
+
+class TestWorkerGemIndependence < TestIntegration
+  class PumaBooted < Timeout::Error; end
+
+  def setup
+    super
+  end
+
+  def teardown
+    FileUtils.rm_rf ["#{workdir}/vendor", "#{workdir}/Gemfile.lock"]
+  end
+
+  def test_prevent_booting_with_rack_3
+    puma_crashed = false
+
+    Dir.chdir(workdir) do
+      with_unbundled_env do
+        silent_and_checked_system_command("bundle install")
+        Timeout.timeout(1, PumaBooted) do
+          cli_server './config.ru', merge_err: true, skip_waiting: true
+          sleep 0.1 until puma_crashed = @server.gets["Puma 5 is not compatible with Rack 3, please upgrade to Puma 6 or higher."]
+        end
+      end
+    end
+
+  rescue PumaBooted
+    puma_crashed = false
+  ensure
+    Process.kill :HUP, @server.pid
+    assert puma_crashed, "Puma was expected to crash on boot, but it didn't! "
+  end
+
+  private
+
+  def workdir
+    File.expand_path("bundle_rack_3", __dir__)
+  end
+end

--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -133,13 +133,4 @@ class TestWorkerGemIndependence < TestIntegration
 
     true while @server.gets !~ /booted in [.0-9]+s, phase: 1/
   end
-
-  def with_unbundled_env
-    bundler_ver = Gem::Version.new(Bundler::VERSION)
-    if bundler_ver < Gem::Version.new('2.1.0')
-      Bundler.with_clean_env { yield }
-    else
-      Bundler.with_unbundled_env { yield }
-    end
-  end
 end


### PR DESCRIPTION
WIP tests are failing

### Description
See https://github.com/puma/puma/pull/3164

Puma 5 is not compatible with Rack 3. App generated with the default Rails 6.1 and 7.0 app template will hit [this error](https://github.com/rails/rails/issues/48195) when they  run `bundle update`.

This check ensures affected users will get a meaningful error message pointing them toward a fix. 


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
