### PR TITLE
Fix and update 5-6-stable CI, two backports

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,9 +22,22 @@ jobs:
       - name: rubocop
         run: bundle exec rake rubocop
 
+#      macOS MRI jobs
+#       11   12   13
+# 2.2    x
+# 2.3    x
+# 2.4    x    x
+# 2.5    x    x
+# 2.6    x         x
+# 2.7    x         x
+# 3.0              x
+# 3.1              x
+# 3.2    x         x
+# head        x    x
+
   test_mri:
     name: >-
-      MRI: ${{ matrix.os }} ${{ matrix.ruby }}${{ matrix.no-ssl }}${{ matrix.yjit }}
+      MRI: ${{ matrix.os }} ${{ matrix.ruby }}${{ matrix.no-ssl }}${{ matrix.yjit }}${{ matrix.rack-v }}
     needs: rubocop
     env:
       CI: true
@@ -38,34 +51,46 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-18.04, macos-10.15, macos-11, windows-2022 ]
-        ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, head ]
+        os: [ ubuntu-20.04, macos-11, macos-12, macos-13, windows-2022 ]
+        ruby: [ 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head ]
         no-ssl: ['']
         yjit: ['']
+        rack-v: ['']
         include:
+          - { os: ubuntu-20.04 , ruby: 2.4  , rack-v: ' rack1' }
+          - { os: ubuntu-20.04 , ruby: 2.7  , no-ssl: ' no SSL' }
+          - { os: ubuntu-22.04 , ruby: 3.1  }
+          - { os: ubuntu-22.04 , ruby: 3.2  }
+          - { os: ubuntu-22.04 , ruby: head }
+          - { os: ubuntu-22.04 , ruby: head , yjit: ' yjit' }
           - { os: windows-2022 , ruby: ucrt }
           - { os: windows-2022 , ruby: mswin }
           - { os: windows-2022 , ruby: 2.7  , no-ssl: ' no SSL' }
-          - { os: ubuntu-20.04 , ruby: head , yjit: ' yjit' }
-          - { os: ubuntu-20.04 , ruby: 2.7  , no-ssl: ' no SSL' }
-          - { os: ubuntu-22.04 , ruby: 3.1  }
-          - { os: ubuntu-22.04 , ruby: head }
 
         exclude:
-          - { os: ubuntu-20.04 , ruby: 2.2  }
-          - { os: ubuntu-20.04 , ruby: 2.3  }
+          - { os: macos-11     , ruby: 3.0  }
+          - { os: macos-11     , ruby: 3.1  }
+          - { os: macos-11     , ruby: head }
+          - { os: macos-12     , ruby: 2.2  }
+          - { os: macos-12     , ruby: 2.3  }
+          - { os: macos-12     , ruby: 2.6  }
+          - { os: macos-12     , ruby: 2.7  }
+          - { os: macos-12     , ruby: 3.0  }
+          - { os: macos-12     , ruby: 3.1  }
+          - { os: macos-12     , ruby: 3.2  }
+          - { os: macos-13     , ruby: 2.2  }
+          - { os: macos-13     , ruby: 2.3  }
+          - { os: macos-13     , ruby: 2.4  }
+          - { os: macos-13     , ruby: 2.5  }
           - { os: windows-2022 , ruby: head }
-          - { os: macos-10.15  , ruby: 2.6  }
-          - { os: macos-10.15  , ruby: 2.7  }
-          - { os: macos-10.15  , ruby: '3.0'}
-          - { os: macos-10.15  , ruby: 3.1  }
-          - { os: macos-11     , ruby: 2.2  }
-          - { os: macos-11     , ruby: 2.3  }
-          - { os: macos-11     , ruby: 2.4  }
 
     steps:
       - name: repo checkout
         uses: actions/checkout@v3
+
+      - name: Set Rack version, see Gemfile
+        shell: bash
+        run: echo 'PUMA_CI_RACK=${{ matrix.rack-v }}' >> $GITHUB_ENV
 
       - name: load ruby
         uses: ruby/setup-ruby-pkgs@v1
@@ -80,15 +105,24 @@ jobs:
 
       # Windows error thrown, doesn't affect CI
       - name: update rubygems for Ruby 2.2
-        if: matrix.ruby < '2.3'
+        if: matrix.ruby == '2.2'
         run: gem update --system 2.7.11 --no-document
         continue-on-error: true
         timeout-minutes: 5
 
       # fixes 'has a bug that prevents `required_ruby_version`'
-      - name: update rubygems for Ruby 2.3 - 2.5
-        if: contains('2.3 2.4 2.5', matrix.ruby)
+      - name: update rubygems for Ruby 2.3
+        if: matrix.ruby == '2.3'
         run: gem update --system 3.3.14 --no-document
+        continue-on-error: true
+        timeout-minutes: 5
+
+      # fixes 'has a bug that prevents `required_ruby_version`'
+      - name: update rubygems for Ruby 2.4 - 2.6
+        if: |
+          contains('2.4 2.5 2.6', matrix.ruby) &&
+          (needs.skip_duplicate_runs.outputs.should_skip != 'true')
+        run: gem update --system 3.3.26 --no-document
         continue-on-error: true
         timeout-minutes: 5
 
@@ -132,12 +166,12 @@ jobs:
           - { os: ubuntu-20.04 , ruby: jruby }
           - { os: ubuntu-20.04 , ruby: jruby, no-ssl: ' no SSL' }
           - { os: ubuntu-20.04 , ruby: jruby-head, allow-failure: true }
-          - { os: ubuntu-20.04 , ruby: truffleruby }
+          - { os: ubuntu-20.04 , ruby: truffleruby, allow-failure: true }
           - { os: ubuntu-20.04 , ruby: truffleruby-head, allow-failure: true }
-          - { os: macos-10.15  , ruby: jruby }
-          - { os: macos-10.15  , ruby: truffleruby }
-          - { os: macos-11     , ruby: jruby }
-          - { os: macos-11     , ruby: truffleruby }
+          - { os: macos-11 , ruby: jruby }
+          - { os: macos-11 , ruby: truffleruby, allow-failure: true }
+          - { os: macos-12 , ruby: jruby }
+          - { os: macos-12 , ruby: truffleruby, allow-failure: true }
 
     steps:
       - name: repo checkout

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,17 @@ gem "rake-compiler", "~> 1.1.1"
 
 gem "json", "~> 2.3"
 gem "nio4r", "~> 2.0"
-gem "rack", ">= 1.6.13"
+
+rack_vers =
+  case ENV.key?('PUMA_CI_RACK') && ENV['PUMA_CI_RACK'].strip
+  when 'rack1'
+    '~> 1.6'
+  else
+    '>= 2.1'
+  end
+
+gem "rack", rack_vers, "< 3.0.0"
+
 gem "minitest", "~> 5.11"
 gem "minitest-retry"
 gem "minitest-proveit"
@@ -16,7 +26,10 @@ gem "sd_notify"
 
 gem "jruby-openssl", :platform => "jruby"
 
-gem "rubocop", "~> 0.64.0"
+unless ENV['PUMA_NO_RUBOCOP'] || RUBY_PLATFORM.include?('mswin')
+  gem "rubocop", "~> 0.64.0"
+  gem 'rubocop-performance', require: false
+end
 
 if %w(2.2.7 2.2.8 2.2.9 2.2.10 2.3.4 2.4.1).include? RUBY_VERSION
   gem "stopgap_13632", "~> 1.0", :platforms => ["mri", "mingw", "x64_mingw"]

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,7 @@
-require "bundler/setup"
-require "rake/testtask"
-require "rake/extensiontask"
-require "rake/javaextensiontask"
-require "rubocop/rake_task"
+require 'bundler/setup'
+require 'rake/testtask'
+require 'rake/extensiontask'
+require 'rake/javaextensiontask'
 require_relative 'lib/puma/detect'
 require 'rubygems/package_task'
 require 'bundler/gem_tasks'
@@ -10,8 +9,12 @@ require 'bundler/gem_tasks'
 gemspec = Gem::Specification.load("puma.gemspec")
 Gem::PackageTask.new(gemspec).define
 
-# Add rubocop task
-RuboCop::RakeTask.new
+begin
+  # Add rubocop task
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new
+rescue LoadError
+end
 
 # generate extension code using Ragel (C and Java)
 desc "Generate extension code (C and Java) using Ragel"

--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -23,7 +23,7 @@ module Puma
   # not in minissl.rb
   HAS_SSL = const_defined?(:MiniSSL, false) && MiniSSL.const_defined?(:Engine, false)
 
-  HAS_UNIX_SOCKET = Object.const_defined? :UNIXSocket
+  HAS_UNIX_SOCKET = Object.const_defined?(:UNIXSocket) && !IS_WINDOWS
 
   if HAS_SSL
     require 'puma/minissl'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -110,7 +110,7 @@ end
 module TestSkips
 
   HAS_FORK = ::Process.respond_to? :fork
-  UNIX_SKT_EXIST = Object.const_defined? :UNIXSocket
+  UNIX_SKT_EXIST = Object.const_defined?(:UNIXSocket) && !Puma::IS_WINDOWS
 
   MSG_FORK = "Kernel.fork isn't available on #{RUBY_ENGINE} on #{RUBY_PLATFORM}"
   MSG_UNIX = "UNIXSockets aren't available on the #{RUBY_PLATFORM} platform"

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -85,7 +85,7 @@ class TestIntegrationSingle < TestIntegration
     rejected_curl_wait_thread.join
 
     assert_match(/Slept 10/, curl_stdout.read)
-    assert_match(/Connection refused/, rejected_curl_stderr.read)
+    assert_match(/Connection refused|Couldn't connect to server/, rejected_curl_stderr.read)
 
     Process.wait(@server.pid)
     @server.close unless @server.closed?


### PR DESCRIPTION
### Description

See commit comments.

Takes quite a while to run, but we won't be running that often, and there are a lot of Ruby versions.

The time is due to all the macos jobs.  Not sure if macos is used much in production, but I'm sure it's used in development.  I set the CI matrix up so no Ruby version is run on all three macos versions (11,12,13).

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
