### PR TITLE
Fix using control server with IPv6 host

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -330,7 +330,7 @@ module Puma
         return
       end
 
-      host = host[1..-2] if host and host[0..0] == '['
+      host = host[1..-2] if host&.start_with? '['
       tcp_server = TCPServer.new(host, port)
 
       if optimize_for_latency
@@ -364,7 +364,7 @@ module Puma
         return
       end
 
-      host = host[1..-2] if host[0..0] == '['
+      host = host[1..-2] if host&.start_with? '['
       s = TCPServer.new(host, port)
       if optimize_for_latency
         s.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -69,8 +69,8 @@ def hit(uris)
 end
 
 module UniquePort
-  def self.call
-    TCPServer.open('127.0.0.1', 0) do |server|
+  def self.call(host = '127.0.0.1')
+    TCPServer.open(host, 0) do |server|
       server.connect_address.ip_port
     end
   end

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -224,11 +224,10 @@ class TestPumaControlCli < TestConfigFileBase
     refute_includes log, 'send_request'
   end
 
-  def test_control_ssl
+  def control_ssl(host)
     skip_unless :ssl
-
-    host = "127.0.0.1"
-    port = UniquePort.call
+    ip = host&.start_with?('[') ? host[1..-2] : host
+    port = UniquePort.call(ip)
     url = "ssl://#{host}:#{port}?#{ssl_query}"
 
     opts = [
@@ -250,10 +249,44 @@ class TestPumaControlCli < TestConfigFileBase
     assert_kind_of Thread, t.join, "server didn't stop"
   end
 
+
+  def test_control_ssl_ipv4
+    skip_unless :ssl
+    control_ssl '127.0.0.1'
+  end
+
+  def test_control_ssl_ipv6
+    skip_unless :ssl
+    control_ssl '[::1]'
+  end
+
   def test_control_aunix
     skip_unless :aunix
 
     url = "unix://@test_control_aunix.unix"
+
+    opts = [
+      "--control-url", url,
+      "--control-token", "ctrl",
+      "--config-file", "test/config/app.rb",
+    ]
+
+    control_cli = Puma::ControlCLI.new (opts + ["start"]), @ready, @ready
+    t = Thread.new do
+      control_cli.run
+    end
+
+    wait_booted
+
+    assert_command_cli_output opts + ["status"], "Puma is started"
+    assert_command_cli_output opts + ["stop"], "Command stop sent success"
+
+    assert_kind_of Thread, t.join, "server didn't stop"
+  end
+
+  def test_control_ipv6
+    port = UniquePort.call '::1'
+    url = "tcp://[::1]:#{port}"
 
     opts = [
       "--control-url", url,


### PR DESCRIPTION
### Description

Creating a server listener with an IPv6 host is working, but using an IPv6 host for the control server is not.

Fix, and add tests for both tcp & ssl connections.  This involves trimming the surrounding brackets from the URI format (eg `[::1]`) to the IP address format (eg `::1`).

See https://github.com/puma/puma/commit/097641274be50adee4b5764057959454197ece05 

Tests fail on current master.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
