### PR TITLE
control_cli.rb - add `require_relative 'log_writer'`

### DIFF
--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 require 'optparse'
-require_relative 'state_file'
+require_relative 'state_file'     # created in prepare_configuration
 require_relative 'const'
 require_relative 'detect'
-require_relative 'configuration'
+require_relative 'configuration'  # created in initialize
+require_relative 'log_writer'     # created in start
 require 'uri'
 require 'socket'
 

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 require 'optparse'
-require_relative 'state_file'     # created in prepare_configuration
 require_relative 'const'
 require_relative 'detect'
-require_relative 'configuration'  # created in initialize
-require_relative 'log_writer'     # created in start
 require 'uri'
 require 'socket'
 
@@ -127,6 +124,9 @@ module Puma
         end
 
         if @config_file
+          require_relative 'configuration'
+          require_relative 'log_writer'
+
           config = Puma::Configuration.new({ config_files: [@config_file] }, {})
           config.load
           @state              ||= config.options[:state]
@@ -149,6 +149,8 @@ module Puma
         unless File.exist? @state
           raise "State file not found: #{@state}"
         end
+
+        require_relative 'state_file'
 
         sf = Puma::StateFile.new
         sf.load @state


### PR DESCRIPTION
### Description

`control_cli.rb` may create Some Puma objects, dependent on the setup used (config, pid, or state file).

It may create a `Puma::Configuration`, which uses `Puma::DSL`, which may create a `Puma::LogWriter`,  a `Puma::LogWriter`is also created when using the `start` method.

When used in a 'Puma' process, `puma.rb` autoloads `Puma::LogWriter`, but that file isn't required in `control_cli.rb`.

Closes #3186.


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
