### PR TITLE
README.md - clarify use of localhost gem [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,8 @@ Bundler.require(:default, ENV["RACK_ENV"].to_sym)
 
 Alternatively, you can require the gem in your configuration file, either `config/puma/development.rb`, `config/puma.rb`, or set via the `-C` cli option:
 ```ruby
-require './app'
 require 'localhost'
-run Sinatra::Application
+# configuration methods (from Puma::DSL) as needed
 ```
 
 Additionally, Puma must be listening to an SSL socket:

--- a/README.md
+++ b/README.md
@@ -211,17 +211,21 @@ Puma supports the [`localhost`] gem for self-signed certificates. This is partic
 
 Puma automatically configures SSL when the [`localhost`] gem is loaded in a `development` environment:
 
+Add the gem to your Gemfile:
 ```ruby
-# Add the gem to your Gemfile
 group(:development) do
   gem 'localhost'
 end
+```
 
-# And require it implicitly using bundler
+And require it implicitly using bundler:
+```ruby
 require "bundler"
 Bundler.require(:default, ENV["RACK_ENV"].to_sym)
+```
 
-# Alternatively, you can require the gem in config.ru:
+Alternatively, you can require the gem in your configuration file, either `config/puma/development.rb`, `config/puma.rb`, or set via the `-C` cli option:
+```ruby
 require './app'
 require 'localhost'
 run Sinatra::Application
@@ -230,10 +234,10 @@ run Sinatra::Application
 Additionally, Puma must be listening to an SSL socket:
 
 ```shell
-$ puma -b 'ssl://localhost:9292' config.ru
+$ puma -b 'ssl://localhost:9292' -C config/use_local_host.rb
 
 # The following options allow you to reach Puma over HTTP as well:
-$ puma -b ssl://localhost:9292 -b tcp://localhost:9393 config.ru
+$ puma -b ssl://localhost:9292 -b tcp://localhost:9393 -C config/use_local_host.rb
 ```
 
 [`localhost`]: https://github.com/socketry/localhost


### PR DESCRIPTION
### Description

The current README.md describes how to use the localhost gem in development, but implies that one can require it in a rackup file.  That is incorrect, as it needs to be required in a configuration file.

Updated README.md to clarify.

Closes #2818
Closes #3068

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
