### PR TITLE
Remove `Forwardable` dependency (possible conversion to bundled gem)

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -11,7 +11,6 @@ end
 require_relative 'detect'
 require_relative 'io_buffer'
 require 'tempfile'
-require 'forwardable'
 
 if Puma::IS_JRUBY
   # We have to work around some OpenSSL buffer/io-readiness bugs
@@ -61,7 +60,6 @@ module Puma
     EmptyBody = NullIO.new
 
     include Puma::Const
-    extend Forwardable
 
     def initialize(io, env=nil)
       @io = io
@@ -110,7 +108,10 @@ module Puma
 
     attr_accessor :remote_addr_header, :listener
 
-    def_delegators :@io, :closed?
+    # Remove in Puma 7?
+    def closed?
+      @to_io.closed?
+    end
 
     # Test to see if io meets a bare minimum of functioning, @to_io needs to be
     # used for MiniSSL::Socket

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -15,7 +15,6 @@ require_relative 'request'
 
 require 'socket'
 require 'io/wait' unless Puma::HAS_NATIVE_IO_WAIT
-require 'forwardable'
 
 module Puma
 
@@ -32,7 +31,6 @@ module Puma
   class Server
     include Puma::Const
     include Request
-    extend Forwardable
 
     attr_reader :thread
     attr_reader :log_writer
@@ -47,9 +45,6 @@ module Puma
 
     attr_accessor :app
     attr_accessor :binder
-
-    def_delegators :@binder, :add_tcp_listener, :add_ssl_listener,
-      :add_unix_listener, :connected_ports
 
     THREAD_LOCAL_KEY = :puma_server
 
@@ -622,6 +617,28 @@ module Puma
     # @!attribute [r] stats
     def stats
       STAT_METHODS.map {|name| [name, send(name) || 0]}.to_h
+    end
+
+    # below are 'delegations' to binder
+    # remove in Puma 7?
+
+
+    def add_tcp_listener(host, port, optimize_for_latency = true, backlog = 1024)
+      @binder.add_tcp_listener host, port, optimize_for_latency, backlog
+    end
+
+    def add_ssl_listener(host, port, ctx, optimize_for_latency = true,
+                         backlog = 1024)
+      @binder.add_ssl_listener host, port, ctx, optimize_for_latency, backlog
+    end
+
+    def add_unix_listener(path, umask = nil, mode = nil, backlog = 1024)
+      @binder.add_unix_listener path, umask, mode, backlog
+    end
+
+    # @!attribute [r] connected_ports
+    def connected_ports
+      @binder.connected_ports
     end
   end
 end


### PR DESCRIPTION
### Description

[Forwardable](https://github.com/ruby/forwardable) is currently used by server.rb & client.rb.

It is part of the standard library, but it's also available as a gem. Hence, it could be 'converted' to a bundled gem, especially since it's nor an extension gem.

Bundled gems need to be included as dependencies in gemspec files.

Since removing it is relatively trivial (5 methods are delegated), lets do so now.

Closes #3190
Closes https://github.com/puma/puma/issues/3218

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
