### PR TITLE
Add on_thread_start_hook

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -723,6 +723,23 @@ module Puma
       process_hook :before_refork, key, block, 'on_refork'
     end
 
+    # Code to run immediately before a thread starts. The worker does not
+    # start new threads until this code finishes.
+    #
+    # This hook is useful for doing something when a thread
+    # starts.
+    #
+    # This can be called multiple times to add several hooks.
+    #
+    # @example
+    #   on_thread_start do
+    #     puts 'On thread start...'
+    #   end
+    def on_thread_start(&block)
+      @options[:before_thread_start] ||= []
+      @options[:before_thread_start] << block
+    end
+
     # Code to run immediately before a thread exits. The worker does not
     # accept new requests until this code finishes.
     #

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -51,6 +51,7 @@ module Puma
       @block = block
       @out_of_band = options[:out_of_band]
       @clean_thread_locals = options[:clean_thread_locals]
+      @before_thread_start = options[:before_thread_start]
       @before_thread_exit = options[:before_thread_exit]
       @reaping_time = options[:reaping_time]
       @auto_trim_time = options[:auto_trim_time]
@@ -108,6 +109,7 @@ module Puma
     def spawn_thread
       @spawned += 1
 
+      trigger_before_thread_start_hooks
       th = Thread.new(@spawned) do |spawned|
         Puma.set_thread_name '%s tp %03i' % [@name, spawned]
         todo  = @todo
@@ -163,6 +165,21 @@ module Puma
     end
 
     private :spawn_thread
+
+    def trigger_before_thread_start_hooks
+      return unless @before_thread_start&.any?
+
+      @before_thread_start.each do |b|
+        begin
+          b.call
+        rescue Exception => e
+          STDERR.puts "WARNING before_thread_start hook failed with exception (#{e.class}) #{e.message}"
+        end
+      end
+      nil
+    end
+
+    private :trigger_before_thread_start_hooks
 
     def trigger_before_thread_exit_hooks
       return unless @before_thread_exit&.any?

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -483,6 +483,10 @@ class TestConfigFile < TestConfigFileBase
     assert_warning_for_hooks_defined_in_single_mode :before_fork
   end
 
+  def test_run_hooks_before_thread_start
+    assert_run_hooks :before_thread_start, configured_with: :on_thread_start
+  end
+
   def test_run_hooks_before_thread_exit
     assert_run_hooks :before_thread_exit, configured_with: :on_thread_exit
   end

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -117,6 +117,26 @@ class TestThreadPool < Minitest::Test
     assert_equal 3, pool.backlog
   end
 
+  def test_thread_start_hook
+    started = Queue.new
+    options = {
+      min_threads: 0,
+      max_threads: 1,
+      before_thread_start: [
+        proc do
+          started << 1
+        end
+      ]
+    }
+    block = proc { }
+    pool = MutexPool.new('tst', options, &block)
+
+    pool << 1
+
+    assert_equal 1, pool.spawned
+    assert_equal 1, started.length
+  end
+
   def test_trim
     pool = mutex_pool(0, 1)
 


### PR DESCRIPTION
### Description
This PR closes #3192

It provides a `before_thread_start` hook which can be used to execute code before a thread starts.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
