### PR TITLE
Fix ActiveSupport deprecation warning being thrown on shutdown in Rails 7.0.7

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -217,7 +217,12 @@ module Puma
       @runner.close_control_listeners
       @binder.close_listeners
       unless @status == :restart
-        log "=== puma shutdown: #{Time.now} ==="
+        # Formatting the timestamp using .strftime so that we don't trigger
+        # an ActiveSupport deprecation warning "Using a :default format for
+        # Time#to_s is deprecated. Please use Time#to_fs instead." in 7.0.7
+        # and above Rails apps.
+        timestamp = Time.now.strftime("%Y-%m-%d %H:%M:%S %z")
+        log "=== puma shutdown: #{timestamp} ==="
         log "- Goodbye!"
       end
     end


### PR DESCRIPTION
### Description

Use `Time.now.strftime` to format the shutdown timestamp to stop the ActiveSupport deprecation warning "_Using a :default format for Time#to_s is deprecated. Please use Time#to_fs instead._" if Puma is being used in Rails 7.0.7 apps

Before:

```sh
[65598] - Gracefully shutting down workers...
DEPRECATION WARNING: Using a :default format for Time#to_s is deprecated. Please use Time#to_fs instead. (called from <main> at bin/rails:6)
[65598] === puma shutdown: 16/08/2023 13:52:35 ===
[65598] - Goodbye!
```

After:

```sh
[2284] - Gracefully shutting down workers...
[2284] === puma shutdown: 2023-08-17 05:15:22 +0100 ===
[2284] - Goodbye!
```
