### PR TITLE
null_io.rb - add external_encoding, set_encoding, binmode, binmode?

### DIFF
--- a/lib/puma/null_io.rb
+++ b/lib/puma/null_io.rb
@@ -80,5 +80,14 @@ module Puma
     def closed?
       false
     end
+
+    def set_encoding(enc)
+      self
+    end
+
+    # per rack spec
+    def external_encoding
+      Encoding::ASCII_8BIT
+    end
   end
 end

--- a/lib/puma/null_io.rb
+++ b/lib/puma/null_io.rb
@@ -89,5 +89,13 @@ module Puma
     def external_encoding
       Encoding::ASCII_8BIT
     end
+
+    def binmode
+      self
+    end
+
+    def binmode?
+      true
+    end
   end
 end

--- a/test/test_null_io.rb
+++ b/test/test_null_io.rb
@@ -149,13 +149,22 @@ class TestNullIO < Minitest::Test
   def test_closed_returns_false
     assert_equal false, nio.closed?
   end
+
+  def test_set_encoding
+    assert_equal nio, nio.set_encoding(Encoding::BINARY)
+  end
+
+  def test_external_encoding
+    assert_equal Encoding::ASCII_8BIT, nio.external_encoding
+  end
 end
 
 # Run the same tests but against an empty file to
 # ensure all the test behavior is accurate
 class TestNullIOConformance < TestNullIO
   def setup
-    self.nio = ::Tempfile.create
+    # client.rb sets 'binmode` on all Tempfiles
+    self.nio = ::Tempfile.create.binmode
     nio.sync = true
   end
 

--- a/test/test_null_io.rb
+++ b/test/test_null_io.rb
@@ -157,6 +157,14 @@ class TestNullIO < Minitest::Test
   def test_external_encoding
     assert_equal Encoding::ASCII_8BIT, nio.external_encoding
   end
+
+  def test_binmode
+    assert_equal nio, nio.binmode
+  end
+
+  def test_binmode?
+    assert nio.binmode?
+  end
 end
 
 # Run the same tests but against an empty file to


### PR DESCRIPTION
### Description

See https://github.com/rack/rack/pull/2115, which identifies a bug that occurs with `Rack::MockRequest.env_for`.

See also [Rack Spec: The Input Stream](https://msp-greg.github.io/rack/file.SPEC.html#label-The+Input+Stream).

More IO instance methods may need to be added to `Puma::NullIO`.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
