### PR TITLE
Use the correct name for TruffleRuby

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Puma is a server for [Rack](https://github.com/rack/rack)-powered HTTP applicati
 
 Originally designed as a server for [Rubinius](https://github.com/rubinius/rubinius), Puma also works well with Ruby (MRI) and JRuby.
 
-On MRI, there is a Global VM Lock (GVL) that ensures only one thread can run Ruby code at a time. But if you're doing a lot of blocking IO (such as HTTP calls to external APIs like Twitter), Puma still improves MRI's throughput by allowing IO waiting to be done in parallel. Truly parallel Ruby implementations (Truffle, JRuby) don't have this limitation.
+On MRI, there is a Global VM Lock (GVL) that ensures only one thread can run Ruby code at a time. But if you're doing a lot of blocking IO (such as HTTP calls to external APIs like Twitter), Puma still improves MRI's throughput by allowing IO waiting to be done in parallel. Truly parallel Ruby implementations (TruffleRuby, JRuby) don't have this limitation.
 
 ## Quick Start
 


### PR DESCRIPTION
Searching the internet for "Truffle" vs "TruffleRuby" yields quite different results.

[ci skip]
