### PR TITLE
[Fix #2786] Worker 0 timing out during phased restart

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -78,7 +78,7 @@ end
 
 require "timeout"
 module TimeoutEveryTestCase
-  # our own subclass so we never confused different timeouts
+  # our own subclass so we never confuse different timeouts
   class TestTookTooLong < Timeout::Error
   end
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -290,23 +290,24 @@ class TestIntegrationCluster < TestIntegration
   def test_fork_worker_phased_restart_with_high_worker_count
     cli_server "test/rackup/hello.ru", config: <<~RUBY
       fork_worker 0
+      worker_check_interval 1
+      # lower worker timeout from default (60) to avoid test timeout
+      worker_timeout 2
       # to simulate worker 0 timeout, total boot time for all workers
       # needs to exceed single worker timeout
-      workers 11
-      # lower worker timeout from default (60) to avoid test timeout
-      worker_timeout 6
+      workers 16
     RUBY
 
     while (line = @server.gets).include?("phase: 0")
       # wait till all the workers are up
-      break if line.include?("Worker 10")
+      break if line.include?("Worker 15")
     end
 
     Process.kill :USR1, @pid
 
     while (line = @server.gets)
       refute line.include?("Terminating timed out worker")
-      break if line.include?("Worker 10")
+      break if line.include?("Worker 15")
     end
   end
 


### PR DESCRIPTION
### Description

Closes https://github.com/puma/puma/issues/2786.

Ensures that worker 0 is pinged on every forked worker's post-boot ping to prevent it from timing out.

~An integration test for this would be something like https://github.com/puma/puma/issues/2786#issuecomment-1704766900 but might not be practical considering the time it takes. I'll add some unit tests when I get a chance unless anyone has a better idea.~

I've added a regression test with a lowered worker timeout to simulate a high worker count + high worker timeout real world scenario.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
