### PR TITLE
[ci skip] | Docs | Clarify `worker_timeout` minimum value

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -894,7 +894,8 @@ module Puma
     # not a request timeout, it is to protect against a hung or dead process.
     # Setting this value will not protect against slow requests.
     #
-    # The minimum value is 6 seconds, the default value is 60 seconds.
+    # The minimum value needs to be greater than the worker reporting interval,
+    # the default value is 60 seconds.
     #
     # @note Cluster mode only.
     # @example

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -894,8 +894,8 @@ module Puma
     # not a request timeout, it is to protect against a hung or dead process.
     # Setting this value will not protect against slow requests.
     #
-    # The minimum value needs to be greater than the worker reporting interval,
-    # the default value is 60 seconds.
+    # This value must be greater than worker_check_interval.
+    # The default value is 60 seconds.
     #
     # @note Cluster mode only.
     # @example


### PR DESCRIPTION
### Description

When writing a test for https://github.com/puma/puma/pull/3225 I set the `worker_timeout` to be `2s` to avoid a test timeout. To do that, I needed to reduce the `worker_check_interval` to `1s` to comply with [this validation](https://github.com/puma/puma/blob/04b8b09ad20ace1a3a5cfe06375dc24818697d19/lib/puma/dsl.rb#L908-L910).

However, the docs imply that the minimum `worker_timeout` **can only be** `6s`, since it is greater than the default `worker_check_interval` of `5s`.

I've updated the docs to clarify that the minimum simply needs to comply with this validation, and removed any mention of a specific value as it can be infered from either the default `worker_check_interval` in the docs or the user configured value.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
