### PR TITLE
integration.rb - less blocking in wait_for_server_to_* methods

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -167,13 +167,9 @@ jobs:
         if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
         uses: actions/checkout@v4
 
-      - name: set JAVA_HOME
-        if: |
-          startsWith(matrix.os, 'macos') &&
-          (needs.skip_duplicate_runs.outputs.should_skip != 'true')
-        shell: bash
-        run:  |
-          echo JAVA_HOME=$JAVA_HOME_11_X64 >> $GITHUB_ENV
+      - name: set JAVA_HOME to JDK 17
+        if: (needs.skip_duplicate_runs.outputs.should_skip != 'true')
+        run: echo JAVA_HOME=$JAVA_HOME_17_X64 >> $GITHUB_ENV
 
       - name: load ruby, ragel
         if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}

--- a/test/config/event_on_booted_exit.rb
+++ b/test/config/event_on_booted_exit.rb
@@ -1,5 +1,12 @@
 on_booted do
   pid = Process.pid
-  Process.kill :TERM, pid
-  Process.wait pid
+  begin
+    Process.kill :TERM, pid
+  rescue Errno::ESRCH
+  end
+
+  begin
+    Process.wait2 pid
+  rescue Errno::ECHILD
+  end
 end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -183,7 +183,7 @@ class TestIntegration < Minitest::Test
         @server_log << line
         puts "    #{line}" if log
       end
-    rescue Exception => e
+    rescue StandardError => e
       error_retries += 1
       raise(e, "Waiting for server to log #{match_obj.inspect}") if error_retries == LOG_ERROR_QTY
       sleep LOG_ERROR_SLEEP

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -1,6 +1,8 @@
 require_relative "helper"
 require_relative "helpers/integration"
 
+require "puma/configuration"
+
 require "time"
 
 class TestIntegrationCluster < TestIntegration

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -299,8 +299,9 @@ class TestIntegrationCluster < TestIntegration
       no_wait: true
 
     load_path = []
-    while (line = @server.gets) =~ /^LOAD_PATH/
-      load_path << line.gsub(/^LOAD_PATH: /, '')
+    load_path << wait_for_server_to_match(/\ALOAD_PATH: (.+)/, 1)
+    while (line = @server.gets).start_with? 'LOAD_PATH: '
+      load_path << line.sub(/\ALOAD_PATH: /, '')
     end
     assert_match(%r{gems/minitest-[\d.]+/lib$}, load_path.last)
   end
@@ -310,8 +311,9 @@ class TestIntegrationCluster < TestIntegration
       no_wait: true
 
     load_path = []
-    while (line = @server.gets) =~ /^LOAD_PATH/
-      load_path << line.gsub(/^LOAD_PATH: /, '')
+    load_path << wait_for_server_to_match(/\ALOAD_PATH: (.+)/, 1)
+    while (line = @server.gets).start_with? 'LOAD_PATH: '
+      load_path << line.sub(/\ALOAD_PATH: /, '')
     end
 
     load_path.each do |path|

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -118,6 +118,8 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_term_exit_code
+    skip_unless_signal_exist? :TERM
+
     cli_server "-w #{workers} test/rackup/hello.ru"
     _, status = stop_server
 
@@ -125,6 +127,8 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_term_suppress
+    skip_unless_signal_exist? :TERM
+
     cli_server "-w #{workers} -C test/config/suppress_exception.rb test/rackup/hello.ru"
 
     _, status = stop_server
@@ -133,16 +137,15 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_on_booted
-    cli_server "-w #{workers} -C test/config/event_on_booted.rb -C test/config/event_on_booted_exit.rb test/rackup/hello.ru", no_wait: true
+    skip_unless_signal_exist? :TERM
+    cli_server "-w #{workers} -C test/config/event_on_booted.rb -C test/config/event_on_booted_exit.rb test/rackup/hello.ru",
+      no_wait: true
 
-    output = []
-
-    output << $_ while @server.gets
-
-    assert output.any? { |msg| msg == "on_booted called\n" } != nil
+    assert wait_for_server_to_include('on_booted called')
   end
 
   def test_term_worker_clean_exit
+    skip_unless_signal_exist? :TERM
     cli_server "-w #{workers} test/rackup/hello.ru"
 
     # Get the PIDs of the child workers.
@@ -292,7 +295,8 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_load_path_includes_extra_deps
-    cli_server "-w #{workers} -C test/config/prune_bundler_with_deps.rb test/rackup/hello.ru"
+    cli_server "-w #{workers} -C test/config/prune_bundler_with_deps.rb test/rackup/hello.ru",
+      no_wait: true
 
     load_path = []
     while (line = @server.gets) =~ /^LOAD_PATH/
@@ -302,7 +306,8 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_load_path_does_not_include_nio4r
-    cli_server "-w #{workers} -C test/config/prune_bundler_with_deps.rb test/rackup/hello.ru"
+    cli_server "-w #{workers} -C test/config/prune_bundler_with_deps.rb test/rackup/hello.ru",
+      no_wait: true
 
     load_path = []
     while (line = @server.gets) =~ /^LOAD_PATH/

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -50,13 +50,12 @@ class TestIntegrationSingle < TestIntegration
   end
 
   def test_on_booted
-    cli_server "-C test/config/event_on_booted.rb -C test/config/event_on_booted_exit.rb test/rackup/hello.ru", no_wait: true
+    skip_unless_signal_exist? :TERM
 
-    output = []
+    cli_server "-C test/config/event_on_booted.rb -C test/config/event_on_booted_exit.rb test/rackup/hello.ru",
+      no_wait: true
 
-    output << $_ while @server.gets
-
-    assert output.any? { |msg| msg == "on_booted called\n" } != nil
+    assert wait_for_server_to_include('on_booted called')
   end
 
   def test_term_suppress

--- a/test/test_plugin_systemd_jruby.rb
+++ b/test/test_plugin_systemd_jruby.rb
@@ -3,6 +3,8 @@
 require_relative "helper"
 require_relative "helpers/integration"
 
+require 'puma/plugin'
+
 class TestPluginSystemdJruby < TestIntegration
 
   THREAD_LOG = TRUFFLE ? "{ 0/16 threads, 16 available, 0 backlog }" :

--- a/test/test_plugin_systemd_jruby.rb
+++ b/test/test_plugin_systemd_jruby.rb
@@ -3,7 +3,7 @@
 require_relative "helper"
 require_relative "helpers/integration"
 
-require 'puma/plugin'
+require "puma/plugin"
 
 class TestPluginSystemdJruby < TestIntegration
 


### PR DESCRIPTION
### Description

In the `TestIntegration` class, two methods, `wait_for_server_to_include` and `wait_for_server_to_match` may block.  Decrease blocking, and accumulate the server log into a string.

Other commits are CI related, several decreasing blocking.  I can make separate if people would prefer that...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
