### PR TITLE
[Fix #3228] `idle-timeout` not working in cluster mode

### DIFF
--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -146,6 +146,8 @@ module Puma
         # Invoke any worker shutdown hooks so they can prevent the worker
         # exiting until any background operations are completed
         @config.run_hooks(:before_worker_shutdown, index, @log_writer, @hook_data)
+
+        Process.kill "SIGTERM", master if server.idle_timeout_reached
       ensure
         @worker_write << "t#{Process.pid}\n" rescue nil
         @worker_write.close

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -70,7 +70,7 @@ module Puma
 
       app = Puma::App::Status.new @launcher, token
 
-      # A Reactor is not created aand nio4r is not loaded when 'queue_requests: false'
+      # A Reactor is not created and nio4r is not loaded when 'queue_requests: false'
       # Use `nil` for events, no hooks in control server
       control = Puma::Server.new app, nil,
         { min_threads: 0, max_threads: 1, queue_requests: false, log_writer: @log_writer }

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -221,6 +221,20 @@ class TestIntegrationCluster < TestIntegration
     RUBY
   end
 
+  def test_idle_timeout
+    cli_server "-w #{workers} test/rackup/hello.ru", config: "idle_timeout 1"
+
+    get_worker_pids # wait for workers to boot
+
+    connect
+
+    sleep 1.15
+
+    assert_raises Errno::ECONNREFUSED, "Connection refused" do
+      connect
+    end
+  end
+
   def test_worker_index_is_with_in_options_limit
     skip_unless_signal_exist? :TERM
 

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -254,6 +254,18 @@ class TestIntegrationSingle < TestIntegration
     cli_pumactl 'stop'
   end
 
+  def test_idle_timeout
+    cli_server "test/rackup/hello.ru", config: "idle_timeout 1"
+
+    connect
+
+    sleep 1.15
+
+    assert_raises Errno::ECONNREFUSED, "Connection refused" do
+      connect
+    end
+  end
+
   def test_pre_existing_unix_after_idle_timeout
     skip_unless :unix
 


### PR DESCRIPTION
### Description

Closes https://github.com/puma/puma/issues/3228.

Ensures that a worker kills the master process if its server shut down due the the idle timeout elapsing. The master will gracefully shut down the rest of the workers and then itself.

~I wonder if we should backport this to https://github.com/puma/puma/tree/v6.4.0 🤔~

Stupid question 🤦🏽‍♂️

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
