### PR TITLE
Fixup macOS detection

### DIFF
--- a/lib/puma/detect.rb
+++ b/lib/puma/detect.rb
@@ -12,15 +12,14 @@ module Puma
 
   IS_JRUBY = Object.const_defined? :JRUBY_VERSION
 
-  IS_OSX = RUBY_PLATFORM.include? 'darwin'
+  IS_OSX = RUBY_DESCRIPTION.include? 'darwin'
 
-  IS_WINDOWS = !!(RUBY_PLATFORM =~ /mswin|ming|cygwin/) ||
-    IS_JRUBY && RUBY_DESCRIPTION.include?('mswin')
+  IS_WINDOWS = RUBY_DESCRIPTION.match?(/mswin|ming|cygwin/)
 
   IS_LINUX = !(IS_OSX || IS_WINDOWS)
 
   # @version 5.2.0
-  IS_MRI = (RUBY_ENGINE == 'ruby' || RUBY_ENGINE.nil?)
+  IS_MRI = RUBY_ENGINE == 'ruby'
 
   def self.jruby?
     IS_JRUBY

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -9,7 +9,6 @@ require_relative 'tmp_path'
 # have their own files, use those instead
 class TestIntegration < Minitest::Test
   include TmpPath
-  DARWIN = RUBY_PLATFORM.include? 'darwin'
   HOST  = "127.0.0.1"
   TOKEN = "xxyyzz"
   RESP_READ_LEN = 65_536

--- a/test/helpers/tmp_path.rb
+++ b/test/helpers/tmp_path.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TmpPath
   def clean_tmp_paths
     while path = tmp_paths.pop
@@ -14,7 +16,8 @@ module TmpPath
   #
   PUMA_TMPDIR =
     begin
-      if RUBY_PLATFORM.include? 'darwin'
+      if RUBY_DESCRIPTION.include? 'darwin'
+        # adds subdirectory 'tmp' in repository folder
         dir_temp = File.absolute_path("#{__dir__}/../../tmp")
         Dir.mkdir dir_temp unless Dir.exist? dir_temp
         './tmp'


### PR DESCRIPTION
### Description

Previously. `RUBY_PLATFORM.include? 'darwin'` was used for macOS detection.  When using JRuby on macOS, the value of `RUBY_PLATFORM` is `java`.  Fix in both lib code and test code.  I could not find `Puma::IS_OSX` or `Puma.osx?` anywhere in the lib files...

Also since all supported Ruby versions have `String#match?` available, replace `=~` with it.

See the most recent workflow at https://github.com/MSP-Greg/github-actions-ruby-info/actions/workflows/ruby.yml for info on various Ruby versions/builds.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
