### PR TITLE
[CI] test_pumactl.rb - use port 0 on server, misc

### DIFF
--- a/test/config/app.rb
+++ b/test/config/app.rb
@@ -1,4 +1,4 @@
-port ENV['PORT'] if ENV['PORT']
+port ENV.fetch('PORT', 0)
 
 app do |env|
   [200, {}, ["embedded app"]]

--- a/test/helpers/test_puma/puma_socket.rb
+++ b/test/helpers/test_puma/puma_socket.rb
@@ -74,6 +74,12 @@ module TestPuma
 
     SET_TCP_NODELAY = Socket.const_defined?(:IPPROTO_TCP) && ::Socket.const_defined?(:TCP_NODELAY)
 
+    def before_setup
+      @ios_to_close ||= []
+      @bind_port = nil
+      @bind_path = nil
+    end
+
     # Closes all io's in `@ios_to_close`, also deletes them if they are files
     def after_teardown
       return if skipped?


### PR DESCRIPTION
### Description

Remove Minitest `capture_subprocess_io`, use a pipe since it is accounted for in Puma code...

Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
