### PR TITLE
[CI] test_rack_handler.rb - fix test ensure when skipped

### DIFF
--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -309,6 +309,7 @@ module TestRackUp
     end
 
     def test_bin
+      pid = nil
       # JRuby & TruffleRuby take a long time using IO.popen
       skip_unless :mri
       io = IO.popen "rackup -p 0"
@@ -319,10 +320,12 @@ module TestRackUp
       assert_includes log, 'Puma version'
       assert_includes log, 'Use Ctrl-C to stop'
     ensure
-      if Puma::IS_WINDOWS
-        `taskkill /F /PID #{pid}`
-      else
-        `kill #{pid}`
+      if pid
+        if Puma::IS_WINDOWS
+          `taskkill /F /PID #{pid}`
+        else
+          `kill -s KILL #{pid}`
+        end
       end
     end
   end


### PR DESCRIPTION
### Description

Currently, logs warning when skipped, as `kill` has no pid

### Your checklist for this pull request
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
