### PR TITLE
Dockerfile for minimal repros: use Ruby 3.2, expect bundler installed [ci skip]

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,6 +1,6 @@
 # Use this Dockerfile to create minimal reproductions of issues
 
-FROM ruby:3.1
+FROM ruby:3.2
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
@@ -8,7 +8,7 @@ RUN bundle config --global frozen 1
 WORKDIR /usr/src/app
 
 COPY . .
-RUN gem install bundler
+
 RUN bundle install
 RUN bundle exec rake compile
 


### PR DESCRIPTION
### Description

This PR updates the "minimal repro" Dockerfile to use latest supported Ruby version, AND it assumes that Bundler exists in the container, since Ruby 3.x ships with it, and it is used on line 6.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
