### PR TITLE
[C] test framework update

### DIFF
--- a/test/helpers/test_puma.rb
+++ b/test/helpers/test_puma.rb
@@ -4,6 +4,9 @@ require 'socket'
 
 module TestPuma
 
+  RESP_SPLIT = "\r\n\r\n"
+  LINE_SPLIT = "\r\n"
+
   RE_HOST_TO_IP = /\A\[|\]\z/o
 
   HOST4 = begin
@@ -38,4 +41,25 @@ module TestPuma
   DARWIN = RUBY_PLATFORM.include? 'darwin'
 
   TOKEN = "xxyyzz"
+
+  # Returns an available port by using `TCPServer.open(host, 0)`
+  def new_port(host = HOST)
+    TCPServer.open(host, 0) { |server| server.connect_address.ip_port }
+  end
+
+  def bind_uri_str
+    if @bind_port
+      "tcp://#{HOST}:#{@bind_port}"
+    elsif @bind_path
+      "unix://#{HOST}:#{@bind_path}"
+    end
+  end
+
+  def control_uri_str
+    if @control_port
+      "tcp://#{HOST}:#{@control_port}"
+    elsif @control_path
+      "unix://#{HOST}:#{@control_path}"
+    end
+  end
 end

--- a/test/helpers/test_puma/response.rb
+++ b/test/helpers/test_puma/response.rb
@@ -1,0 +1,56 @@
+module TestPuma
+
+  # A subclass of String, allows processing the response returned by
+  # `PumaSocket#send_http_read_response` and the `read_response` method added
+  # to native socket instances (created with `PumaSocket#new_socket` and
+  # `PumaSocket#send_http`.
+  #
+  class Response < String
+
+    attr_accessor :times
+
+    # Returns response headers as an array of lines
+    # @return [Array<String>]
+    def headers
+      @headers ||= begin
+        ary = self.split(RESP_SPLIT, 2).first.split LINE_SPLIT
+        @status = ary.shift
+        ary
+      end
+    end
+
+    # Returns response headers as a hash. All keys and values are strings.
+    # @return [Hash]
+    def headers_hash
+      @headers_hash ||= headers.map { |hdr| hdr.split ': ', 2 }.to_h
+    end
+
+    def status
+      headers
+      @status
+    end
+
+    def body
+      self.split(RESP_SPLIT, 2).last
+    end
+
+    # Decodes a chunked body
+    # @return [String] the decoded body
+    def decode_body
+      decoded = String.new  # rubocop: disable Performance/UnfreezeString
+
+      body = self.split(RESP_SPLIT, 2).last
+      body = body.byteslice 0, body.bytesize - 5 # remove terminating bytes
+
+      loop do
+        size, body = body.split LINE_SPLIT, 2
+        size = size.to_i 16
+
+        decoded << body.byteslice(0, size)
+        body = body.byteslice (size+2)..-1       # remove segment ending "\r\n"
+        break if body.empty? || body.nil?
+      end
+      decoded
+    end
+  end
+end


### PR DESCRIPTION
### Description

Adds file [`test/helpers/test_puma/response.rb`](https://github.com/puma/puma/commit/707696a0410cbfc117b16f31b59c9b9e9f6421df) which is now returned as the Response object.

It is a `String` subclass, and has methods `status`, `headers`, `headers_hash`, `body`, and `decode_body`.

It also an attribute `times`, which is an array of times, each being the interval from the start time of each response chunk received.  It used in a few tests that 'stream' the response body.

Class instances are returned by methods in `PumaSocket`.  It would never be used by itself.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
