### PR TITLE
[CI] test.yaml 'NON-MRI: ubuntu-22.04 jruby no SSL' test timeout

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -153,7 +153,7 @@ jobs:
         include:
           # tto - test timeout
           - { tto: 8 , os: ubuntu-22.04 , ruby: jruby }
-          - { tto: 7 , os: ubuntu-22.04 , ruby: jruby, no-ssl: ' no SSL' }
+          - { tto: 8 , os: ubuntu-22.04 , ruby: jruby, no-ssl: ' no SSL' }
           - { tto: 8 , os: ubuntu-22.04 , ruby: jruby-head, allow-failure: true }
           - { tto: 8 , os: ubuntu-20.04 , ruby: truffleruby, allow-failure: true } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
           - { tto: 8 , os: ubuntu-20.04 , ruby: truffleruby-head, allow-failure: true }


### PR DESCRIPTION
### Description

Currently, all NON-MRI jobs have a test timout of 8 minutes, except 'ubuntu-22.04 jruby no SSL', which is 7.

Increase to 8, so false failures don't happen.

### Your checklist for this pull request
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
