### PR TITLE
[CI] test_puma_server.rb - use PumaSocket

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -301,7 +301,7 @@ module TestTempFile
     fio.write data
     fio.flush
     fio.rewind
-    @ios << fio
+    @ios_to_close << fio
     fio
   end
 end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -54,6 +54,24 @@ class TestPumaServer < Minitest::Test
     end
   end
 
+  def test_http10_req_to_http10_resp
+    server_run do |env|
+      [200, {}, [env["SERVER_PROTOCOL"]]]
+    end
+    response = send_http_read_response GET_10
+    assert_equal "HTTP/1.0 200 OK", response.status
+    assert_equal "HTTP/1.0"       , response.body
+  end
+
+  def test_http11_req_to_http11_resp
+    server_run do |env|
+      [200, {}, [env["SERVER_PROTOCOL"]]]
+    end
+    response = send_http_read_response GET_11
+    assert_equal "HTTP/1.1 200 OK", response.status
+    assert_equal "HTTP/1.1"       , response.body
+  end
+
   def test_normalize_host_header_missing
     server_run do |env|
       [200, {}, [env["SERVER_NAME"], "\n", env["SERVER_PORT"]]]

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -38,6 +38,7 @@ class TestPumaServer < Minitest::Test
     @server = Puma::Server.new block || @app, @events, options
     @bind_port = (@server.add_tcp_listener @host, 0).addr[1]
     @server.run
+    Thread.pass until @server.running >= options[:min_threads]
   end
 
   def send_proxy_v1_http(req, remote_ip, multisend = false)
@@ -47,7 +48,6 @@ class TestPumaServer < Minitest::Test
     socket = new_socket
     if multisend
       socket << "PROXY #{family} #{remote_ip} #{target} 10000 80\r\n"
-      sleep 0.15
       socket << req
     else
       socket << ("PROXY #{family} #{remote_ip} #{target} 10000 80\r\n" + req)

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -21,8 +21,6 @@ class TestPumaServer < Minitest::Test
   def setup
     @host = "127.0.0.1"
 
-    @ios = []
-
     @app = ->(env) { [200, {}, [env['rack.url_scheme']]] }
 
     @log_writer = Puma::LogWriter.strings
@@ -31,17 +29,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def teardown
-    @server.stop(true)
-    # Errno::EBADF raised on macOS
-    @ios.each do |io|
-      begin
-        io.close if io.respond_to?(:close) && !io.closed?
-        File.unlink io.path if io.is_a? File
-      rescue Errno::EBADF
-      ensure
-        io = nil
-      end
-    end
+    @server&.stop(true)
   end
 
   def server_run(**options, &block)


### PR DESCRIPTION
### Description

As described.  Previously, there were a lot of tests that used a method `header`, which has been removed.  The method returned the status line and all the header lines as an array.  The new method used, `Response#headers`, only returns the headers.

Two tests were added that test the status line return, just in case.  Even with the two extra methods, the file has decreased by about 50 lines.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
