### PR TITLE
[CI] test_puma_server_ssl.rb - add Errno::ECONNABORTED to invalid cert errors

### DIFF
--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -288,11 +288,18 @@ class TestPumaServerSSLClient < Minitest::Test
     ctx = OpenSSL::SSL::SSLContext.new
     yield ctx
 
+    expected_errors = [
+      EOFError,
+      IOError,
+      OpenSSL::SSL::SSLError,
+      Errno::ECONNABORTED,
+      Errno::ECONNRESET
+    ]
+
     client_error = false
     begin
       send_http_read_resp_body host: LOCALHOST, ctx: ctx
-    rescue OpenSSL::SSL::SSLError, EOFError, Errno::ECONNRESET, IOError => e
-      # Errno::ECONNRESET TruffleRuby, IOError macOS JRuby
+    rescue *expected_errors => e
       client_error = e
     end
 


### PR DESCRIPTION
### Description

Add Errno::ECONNABORTED to assert_ssl_client_error_match as allowed error for client cert missing/incorrect

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
