### PR TITLE
Fix TestPuma::HOST4

### DIFF
--- a/test/helpers/test_puma.rb
+++ b/test/helpers/test_puma.rb
@@ -11,7 +11,7 @@ module TestPuma
 
   HOST4 = begin
     t = Socket.ip_address_list.select(&:ipv4_loopback?).map(&:ip_address)
-      .uniq.sort(&:length)
+      .uniq.sort_by(&:length)
     # puts "IPv4 Loopback #{t}"
     str = t.include?('127.0.0.1') ? +'127.0.0.1' : +"#{t.first}"
     str.define_singleton_method(:ip) { self }
@@ -20,9 +20,8 @@ module TestPuma
 
   HOST6 = begin
     t = Socket.ip_address_list.select(&:ipv6_loopback?).map(&:ip_address)
-      .uniq.sort(&:length)
+      .uniq.sort_by(&:length)
     # puts "IPv6 Loopback #{t}"
-    t.include?('::1') ? +'[::1]' : "[#{t.first}]"
     str = t.include?('::1') ? +'[::1]' : +"[#{t.first}]"
     str.define_singleton_method(:ip) { self.gsub RE_HOST_TO_IP, '' }
     str.freeze


### PR DESCRIPTION
`Array#sort` takes a block that accept 2 parameters.

The intent here was to use `sort_by`.

```
test/helpers/test_puma.rb:14:in `length': wrong number of arguments (given 1, expected 0) (ArgumentError)

      .uniq.sort(&:length)
                 ^^^^^^^^
	from puma/test/helpers/test_puma.rb:14:in `sort'
	from puma/test/helpers/test_puma.rb:14:in `<module:TestPuma>'
	from puma/test/helpers/test_puma.rb:5:in `<top (required)>'
	from puma/test/helpers/test_puma/puma_socket.rb:4:in `require_relative'
	from puma/test/helpers/test_puma/puma_socket.rb:4:in `<top (required)>'
	from puma/test/test_cli.rb:4:in `require_relative'
	from puma/test/test_cli.rb:4:in `<top (required)>'
	from /rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `require'
	from /rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `select'
	from /rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `<main>'
```