### PR TITLE
DSL#warn_if_in_single_mode - fixup when workers set via CLI

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1190,8 +1190,8 @@ module Puma
 
     def warn_if_in_single_mode(hook_name)
       return if @options[:silence_fork_callback_warning]
-
-      if (@options[:workers] || 0) == 0
+      # user_options (CLI) have precedence over config file
+      if (@config.options.user_options[:workers] || @options[:workers] || 0) == 0
         log_string =
           "Warning: You specified code to run in a `#{hook_name}` block, " \
           "but Puma is not configured to run in cluster mode (worker count > 0 ), " \

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -506,6 +506,18 @@ class TestIntegrationCluster < TestIntegration
     File.unlink file1 if File.file? file1
   end
 
+  def test_worker_hook_warning_cli
+    cli_server "-w2 test/rackup/hello.ru", config: <<~CONFIG
+      on_worker_boot(:test) do |index, data|
+        data[:test] = index
+      end
+    CONFIG
+
+    get_worker_pids
+    line = @server_log[/.+on_worker_boot.+/]
+    refute line, "Warning below should not be shown!\n#{line}"
+  end
+
   def test_puma_debug_loaded_exts
     cli_server "-w #{workers} test/rackup/hello.ru", puma_debug: true
 


### PR DESCRIPTION
### Description

About seven months ago, code was added that logged warnings if worker hooks were added in a config file, but workers were not used (workers = 0).  The code only checks for workers being set in the config file.  So, if one uses `-w2` as a cli argument, the warnings are incorrectly shown.

Running the additional test in master fails, with the following:
```
  1) Failure:
TestIntegrationCluster#test_worker_hook_warning_cli [/mnt/c/Greg/GitHub/puma/test/test_integration_cluster.rb:518]:
Warning below should not be shown!
Warning: You specified code to run in a `on_worker_boot` block, but Puma is not configured to run in cluster mode (worker count > 0 ), so your `on_worker_boot` block did not run
```

Found while working with the new test framework server files...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
