### PR TITLE
[CI] Fix macOS TruffleRuby

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -140,6 +140,7 @@ jobs:
     needs: [rubocop, skip_duplicate_runs]
     env:
       CI: true
+      PUMA_TEST_DEBUG: true
       TESTOPTS: -v
       PUMA_NO_RUBOCOP: true
 

--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -11,7 +11,10 @@ end
 unless ENV["PUMA_DISABLE_SSL"]
   # don't use pkg_config('openssl') if '--with-openssl-dir' is used
   has_openssl_dir = dir_config('openssl').any?
-  found_pkg_config = !has_openssl_dir && pkg_config('openssl')
+  # macOS TruffleRuby problem
+  found_pkg_config = RUBY_ENGINE == 'truffleruby' &&
+      RUBY_PLATFORM.include?('darwin') && ENV['GITHUB_ACTIONS'] == 'true' ?
+    false : !has_openssl_dir && pkg_config('openssl')
 
   found_ssl = if !$mingw && found_pkg_config
     puts 'using OpenSSL pkgconfig (openssl.pc)'


### PR DESCRIPTION
### Description

macOS TruffleRuby has been failing with backtraces showing a OpenSSL build/runtime problem.  Or, Puma is compiling with one version, but running with another.

This fixes the issue by adding a conditional to not use pkg_config only when running on Actions with macOS TruffleRuby.  Example from a log:
```
Error reached top of thread-pool: External LLVMFunction SSL_get1_peer_certificate cannot be found. (Polyglot::ForeignException)
TestCLI#test_control_for_ssl = [MinitestRetry] retry 'test_control_for_ssl' count: 1,  msg: EOFError: EOFError
    /Users/runner/work/puma/puma/test/helpers/test_puma/puma_socket.rb:271:in `block (2 levels) in <module:PumaSocket>'
```

There are still intermittent failures with macOS TruffleRuby, 

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
