### PR TITLE
[#3253] Adds --plugin option to the CLI

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -157,6 +157,10 @@ module Puma
             user_config.pidfile arg
           end
 
+          o.on "--plugin PLUGIN", "Load the given PLUGIN. Can be used multiple times to load multiple plugins." do |arg|
+            user_config.plugin arg
+          end
+
           o.on "--preload", "Preload the app. Cluster mode only" do
             user_config.preload_app!
           end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -391,4 +391,14 @@ class TestCLI < Minitest::Test
     assert_equal log_writer.stdout.class, Puma::NullIO
     assert_equal log_writer.stderr, $stderr
   end
+
+  def test_plugins
+    assert_empty Puma::Plugins.instance_variable_get(:@plugins)
+
+    cli = Puma::CLI.new ['--plugin', 'tmp_restart', '--plugin', 'systemd']
+    cli.send(:setup_options)
+
+    assert Puma::Plugins.find("tmp_restart")
+    assert Puma::Plugins.find("systemd")
+  end
 end


### PR DESCRIPTION
### Description
Closes https://github.com/puma/puma/issues/3253

This PR adds a `--plugin PLUGIN` option which loads the mentioned Puma plugin.

USAGE:
```sh
bundle exec puma --plugin tmp_restart
```


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
