### PR TITLE
Test Framework Update (Draft, review only)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -211,4 +211,4 @@ jobs:
       - name: >-
           Test outcome: ${{ steps.test.outcome }}
         # every step must define a `uses` or `run` key
-        run: echo NOOP
+        run: ps -eo pid,time,command | grep java | grep -v grep || true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -153,15 +153,15 @@ jobs:
       matrix:
         include:
           # tto - test timeout
-          - { tto: 8 , os: ubuntu-22.04 , ruby: jruby }
-          - { tto: 8 , os: ubuntu-22.04 , ruby: jruby, no-ssl: ' no SSL' }
-          - { tto: 8 , os: ubuntu-22.04 , ruby: jruby-head, allow-failure: true }
-          - { tto: 8 , os: ubuntu-20.04 , ruby: truffleruby, allow-failure: true } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
-          - { tto: 8 , os: ubuntu-20.04 , ruby: truffleruby-head, allow-failure: true }
-          - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby, allow-failure: true } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
-          - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby-head, allow-failure: true }
-          - { tto: 8 , os: macos-12     , ruby: jruby }
-          - { tto: 8 , os: macos-12     , ruby: truffleruby, allow-failure: true }
+          - { tto: 9 , os: ubuntu-22.04 , ruby: jruby }
+          - { tto: 9 , os: ubuntu-22.04 , ruby: jruby, no-ssl: ' no SSL' }
+          - { tto: 9 , os: ubuntu-22.04 , ruby: jruby-head      , allow-failure: true }
+          - { tto: 8 , os: ubuntu-20.04 , ruby: truffleruby      }
+          - { tto: 8 , os: ubuntu-20.04 , ruby: truffleruby-head }
+          - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby      }
+          - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby-head }
+          - { tto: 9 , os: macos-12     , ruby: jruby           , allow-failure: true }
+          - { tto: 8 , os: macos-12     , ruby: truffleruby     , allow-failure: true }
 
     steps:
       - name: repo checkout

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -132,7 +132,7 @@ jobs:
       - name: test
         if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
         timeout-minutes: 6
-        run: bundle exec rake test:all
+        run: ./test_runner  --verbose
 
   test_non_mri:
     name: >-
@@ -206,7 +206,7 @@ jobs:
         if: | # only run if previous steps have succeeded
           success() &&
           (needs.skip_duplicate_runs.outputs.should_skip != 'true')
-        run: bundle exec rake test:all
+        run: ./test_runner  --verbose
 
       - name: >-
           Test outcome: ${{ steps.test.outcome }}

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,6 +11,8 @@ if RUBY_VERSION == '2.4.1'
   end
 end
 
+STDOUT.syswrite "\n#{Process.pid}      Test Process\n"
+
 require "securerandom"
 
 require_relative "minitest/verbose"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -20,6 +20,7 @@ require "minitest/proveit"
 require "minitest/stub_const"
 require "net/http"
 require_relative "helpers/apps"
+require_relative "helpers/tmp_path"
 
 Thread.abort_on_exception = true
 
@@ -211,7 +212,7 @@ end
 Minitest::Test.include TestSkips
 
 class Minitest::Test
-
+  include ::TmpPath
   PROJECT_ROOT = File.dirname(__dir__)
 
   def self.run(reporter, options = {}) # :nodoc:

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -184,6 +184,7 @@ module TestSkips
         when :unix        then "Skipped if UNIXSocket exists"    if Puma::HAS_UNIX_SOCKET
         when :aunix       then "Skipped if abstract UNIXSocket"  if Puma.abstract_unix_socket?
         when :rack3       then "Skipped if Rack 3.x"             if Rack.release >= '3'
+        when :yjit        then "Skipped if using yjit"           if ENV['RUBYOPT']&.include?('--yjit')
         else false
       end
       skip skip_msg, bt if skip_msg

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,9 +11,12 @@ if RUBY_VERSION == '2.4.1'
   end
 end
 
-STDOUT.syswrite "\n#{Process.pid}      Test Process\n"
+require "puma"
+require "puma/detect"
 
-require "securerandom"
+unless ::Puma::HAS_NATIVE_IO_WAIT
+  require "io/wait"
+end
 
 require_relative "minitest/verbose"
 require "minitest/autorun"
@@ -25,16 +28,13 @@ require_relative "helpers/apps"
 require_relative "helpers/tmp_path"
 require_relative "helpers/test_puma"
 
+require "securerandom"
+
 Thread.abort_on_exception = true
 
 $debugging_hold = false   # needed for TestCLI#test_control_clustered
 
-require "puma"
-require "puma/detect"
-
-unless ::Puma::HAS_NATIVE_IO_WAIT
-  require "io/wait"
-end
+STDOUT.syswrite "\n#{Process.pid}      Test Process\n"
 
 # used in various ssl test files, see test_puma_server_ssl.rb and
 # test_puma_localhost_authority.rb

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -3,12 +3,10 @@
 require "puma/control_cli"
 require "json"
 require "open3"
-require_relative 'tmp_path'
 
 # Only single mode tests go here. Cluster and pumactl tests
 # have their own files, use those instead
 class TestIntegration < Minitest::Test
-  include TmpPath
   HOST  = "127.0.0.1"
   TOKEN = "xxyyzz"
   RESP_READ_LEN = 65_536

--- a/test/helpers/ssl.rb
+++ b/test/helpers/ssl.rb
@@ -2,8 +2,7 @@ module SSLHelper
   def ssl_query
     @ssl_query ||= if Puma.jruby?
       @keystore = File.expand_path "../../examples/puma/keystore.jks", __dir__
-      @ssl_cipher_list = "TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-      "keystore=#{@keystore}&keystore-pass=jruby_puma&ssl_cipher_list=#{@ssl_cipher_list}"
+      "keystore=#{@keystore}&keystore-pass=jruby_puma"
     else
       @cert = File.expand_path "../../examples/puma/cert_puma.pem", __dir__
       @key  = File.expand_path "../../examples/puma/puma_keypair.pem", __dir__

--- a/test/helpers/test_puma.rb
+++ b/test/helpers/test_puma.rb
@@ -3,10 +3,16 @@
 require 'socket'
 require 'tmpdir'
 
+# This module is included in `TesPuma::ServerBase` and contains methods used
+# across the test framework.  It also includes a few class methods related to
+# debug logging.
+
 module TestPuma
 
   DEBUGGING_INFO = Queue.new
   DEBUGGING_PIDS = {}
+
+  IS_GITHUB_ACTIONS = ENV['GITHUB_ACTIONS'] == 'true'
 
   AFTER_RUN_OK = [false]
 
@@ -47,8 +53,22 @@ module TestPuma
 
   TOKEN = "xxyyzz"
 
+  def before_setup
+    @files_to_unlink = nil
+  end
+
+  def after_teardown
+    @files_to_unlink&.each do |path|
+      begin
+        File&.unlink path
+      rescue Errno::ENOENT
+      end
+    end
+  end
+
   # Returns an available port by using `TCPServer.open(host, 0)`
   def unique_port(host = HOST)
+    host = host.gsub RE_HOST_TO_IP, ''
     TCPServer.open(host, 0) { |server| server.connect_address.ip_port }
   end
 
@@ -118,7 +138,7 @@ module TestPuma
       path = File.join(dir, path)
       unless File.exist? path
         File.write(path, contents, perm: 0600, mode: 'wb') if contents
-        (@tmp_paths ||= []) << path
+        (@files_to_unlink ||= []) << path
         return io ? File.open(path) : path
       end
       n ||= 0
@@ -127,5 +147,112 @@ module TestPuma
         raise "cannot generate temporary name using `#{basename}' under `#{dir}'"
       end
     end
+  end
+
+  def with_env(env = {})
+    original_env = {}
+    env.each do |k, v|
+      original_env[k] = ENV[k]
+      ENV[k] = v
+    end
+    yield
+  ensure
+    original_env.each do |k, v|
+      v.nil? ? ENV.delete(k) : ENV[k] = v
+    end
+  end
+
+  def kill_and_wait(pid, signal: nil, timeout: 10)
+    signal ||= :TERM
+    signal = :KILL if Puma::IS_WINDOWS
+    begin
+      Process.kill signal, pid
+    rescue Errno::ESRCH
+    end
+    wait2_timeout pid, timeout: timeout
+  end
+
+  def wait2_timeout(pid, timeout: 10)
+    ary = nil
+    err_msg = "Timeout waiting Process.wait2 in after_teardown"
+
+    th =  Thread.new do
+      begin
+        ary = Process.wait2 pid
+      rescue Errno::ECHILD
+      end
+    end.join timeout
+
+    raise(Timeout::Error, err_msg) unless th
+    ary
+  end
+
+  module_function :kill_and_wait, :wait2_timeout
+
+  def self.handle_defunct
+    defunct = {}
+    txt = +''
+    loop do
+      begin
+        pid, status = Process.wait2(-1, Process::WNOHANG)
+        break unless pid
+        defunct[pid] = status unless ::Puma::IS_WINDOWS && status == 0
+      rescue Errno::ECHILD
+        break
+      end
+    end
+
+    if defunct.empty?
+      txt << format("\n\n%5d      Test Process\n", Process.pid)
+    else
+      dash = "\u2500"
+      txt << (IS_GITHUB_ACTIONS ? "\n\n##[group]Child Processes:\n" :
+        "\n\n#{dash * 40} Child Processes:\n")
+
+      txt << "#{Process.pid}      Test Process\n"
+
+      # list all children, kill test processes
+      defunct.each do |pid, status|
+        if (test_name = DEBUGGING_PIDS[pid])
+          txt << format("%5d #{status&.exitstatus.to_s.rjust 3}  #{test_name}\n", pid)
+          kill_and_wait pid
+        else
+          txt << format("%5d #{status&.exitstatus.to_s.rjust 3}  Unknown\n", pid)
+        end
+      end
+
+      # kill unknown processes
+      defunct.each do |pid, _|
+        unless DEBUGGING_PIDS.key? pid
+          kill_and_wait pid
+        end
+      end
+
+      txt << (IS_GITHUB_ACTIONS ? "::[endgroup]\n\n" : "#{dash * 57}\n\n")
+    end
+    TestPuma::AFTER_RUN_OK[0] = true
+    txt
+  end
+
+  def self.debugging_info
+    info = ''
+    if AFTER_RUN_OK[0] && ENV['PUMA_TEST_DEBUG'] && !DEBUGGING_INFO.empty?
+      ary = Array.new(DEBUGGING_INFO.size) { DEBUGGING_INFO.pop }
+      ary.sort!
+      out = ary.join.strip
+      unless out.empty?
+        dash = "\u2500"
+        wid = IS_GITHUB_ACTIONS ? 88 : 90
+        txt = " Debugging Info #{dash * 2}".rjust wid, dash
+        if IS_GITHUB_ACTIONS
+          info = "\n\n##[group]#{txt}\n#{out}\n#{dash * wid}\n\n::[endgroup]\n\n"
+        else
+          info = "\n\n#{txt}\n#{out}\n#{dash * wid}\n\n"
+        end
+      end
+    end
+    info
+  ensure
+    DEBUGGING_INFO.close
   end
 end

--- a/test/helpers/test_puma.rb
+++ b/test/helpers/test_puma.rb
@@ -1,13 +1,19 @@
 # frozen_string_literal: true
 
 require 'socket'
+require 'tmpdir'
 
 module TestPuma
 
-  RESP_SPLIT = "\r\n\r\n"
-  LINE_SPLIT = "\r\n"
+  DEBUGGING_INFO = Queue.new
+  DEBUGGING_PIDS = {}
+
+  AFTER_RUN_OK = [false]
 
   RE_HOST_TO_IP = /\A\[|\]\z/o
+
+  RESP_SPLIT = "\r\n\r\n"
+  LINE_SPLIT = "\r\n"
 
   HOST4 = begin
     t = Socket.ip_address_list.select(&:ipv4_loopback?).map(&:ip_address)
@@ -42,23 +48,84 @@ module TestPuma
   TOKEN = "xxyyzz"
 
   # Returns an available port by using `TCPServer.open(host, 0)`
-  def new_port(host = HOST)
+  def unique_port(host = HOST)
     TCPServer.open(host, 0) { |server| server.connect_address.ip_port }
   end
 
-  def bind_uri_str
-    if @bind_port
-      "tcp://#{HOST}:#{@bind_port}"
-    elsif @bind_path
-      "unix://#{HOST}:#{@bind_path}"
+  alias_method :new_port, :unique_port
+
+  # With some macOS configurations, the following error may be raised when
+  # creating a UNIXSocket:
+  #
+  # too long unix socket path (106 bytes given but 104 bytes max) (ArgumentError)
+  #
+  PUMA_CI_TMPDIR =
+    begin
+      if ::Puma::IS_OSX
+        # adds subdirectory 'tmp/ci' in repository folder
+        dir_temp = File.absolute_path("#{__dir__}/../../tmp")
+        Dir.mkdir(dir_temp) unless Dir.exist? dir_temp
+        dir_temp += '/ci'
+        Dir.mkdir(dir_temp) unless Dir.exist? dir_temp
+        dir_temp
+      elsif ENV['GITHUB_ACTIONS'] && (rt_dir = ENV['RUNNER_TEMP'])
+        # GitHub runners temp may be on a HD, rt_dir is always an SSD
+        rt_dir
+      else
+        Dir.tmpdir()
+      end
+    end
+
+  UNUSABLE_CHARS = "^,-.0-9A-Z_a-z~"
+  private_constant :UNUSABLE_CHARS
+
+  # Dedicated random number generator
+  RANDOM = Object.new
+  class << RANDOM
+    # Maximum random number
+    MAX = 36**6 # < 0x100000000
+
+    # Returns new random string upto 6 bytes
+    def next
+      rand(0x100000000).to_s(36)
     end
   end
+  RANDOM.freeze
+  private_constant :RANDOM
 
-  def control_uri_str
-    if @control_port
-      "tcp://#{HOST}:#{@control_port}"
-    elsif @control_path
-      "unix://#{HOST}:#{@control_path}"
+  # Generates a unique file path.  Optionally, writes to the file
+  def unique_path(basename = '', dir: PUMA_CI_TMPDIR, contents: nil, io: nil)
+    max_try = 10
+    n = nil
+    if basename.is_a? String
+      prefix, suffix = '', basename
+    else
+      prefix, suffix = basename
+    end
+    prefix = (String.try_convert(prefix) or
+              raise ArgumentError, "unexpected prefix: #{prefix.inspect}")
+    prefix = prefix.delete(UNUSABLE_CHARS)
+    suffix &&= (String.try_convert(suffix) or
+                raise ArgumentError, "unexpected suffix: #{suffix.inspect}")
+    suffix &&= suffix.delete(UNUSABLE_CHARS)
+
+    loop do
+      # 366235959999.to_s(36) => 4o8vfnb3, eight characters
+      # dddhhmmss ms
+      t = Time.now.strftime('%j%H%M%S%L').to_i.to_s(36).rjust 8, '0'
+      path = "#{prefix}#{t}-#{RANDOM.next}"\
+             "#{n ? %[-#{n}] : ''}#{suffix || ''}"
+      path = File.join(dir, path)
+      unless File.exist? path
+        File.write(path, contents, perm: 0600, mode: 'wb') if contents
+        (@tmp_paths ||= []) << path
+        return io ? File.open(path) : path
+      end
+      n ||= 0
+      n += 1
+      if n > max_try
+        raise "cannot generate temporary name using `#{basename}' under `#{dir}'"
+      end
     end
   end
 end

--- a/test/helpers/test_puma/puma_socket.rb
+++ b/test/helpers/test_puma/puma_socket.rb
@@ -7,7 +7,7 @@ require_relative 'response'
 module TestPuma
 
   # @!macro [new] req
-  #   @param req [String, GET_11] request path
+  #   @param req [String] request path
 
   # @!macro [new] skt
   #   @param host: [String] tcp/ssl host
@@ -138,9 +138,9 @@ module TestPuma
 
     # Sends a request and returns the response header lines as an array of strings.
     # Includes the status line.
-    # @!macro req
-    # @!macro skt
-    # @!macro resp
+    # @macro req
+    # @macro skt
+    # @macro resp
     # @return [Array<String>] array of header lines in the response
     def send_http_read_resp_headers(req = GET_11, host: nil, port: nil, path: nil, ctx: nil,
         session: nil, len: nil, timeout: nil)
@@ -150,9 +150,9 @@ module TestPuma
     end
 
     # Sends a request and returns the HTTP response body.
-    # @!macro req
-    # @!macro skt
-    # @!macro resp
+    # @macro req
+    # @macro skt
+    # @macro resp
     # @return [Response] the body portion of the HTTP response
     def send_http_read_resp_body(req = GET_11, host: nil, port: nil, path: nil, ctx: nil,
         session: nil, len: nil, timeout: nil)
@@ -162,8 +162,8 @@ module TestPuma
 
     # Sends a request and returns whatever can be read.  Use when multiple
     # responses are sent by the server
-    # @!macro req
-    # @!macro skt
+    # @macro req
+    # @macro skt
     # @return [String] socket read string
     def send_http_read_all(req = GET_11, host: nil, port: nil, path: nil, ctx: nil,
         session: nil, len: nil, timeout: nil)
@@ -194,9 +194,9 @@ module TestPuma
     end
 
     # Sends a request and returns the HTTP response.  Assumes one response is sent
-    # @!macro req
-    # @!macro skt
-    # @!macro resp
+    # @macro req
+    # @macro skt
+    # @macro resp
     # @return [Response] the HTTP response
     def send_http_read_response(req = GET_11, host: nil, port: nil, path: nil, ctx: nil,
         session: nil, len: nil, timeout: nil)
@@ -206,8 +206,8 @@ module TestPuma
 
     # Sends a request and returns the socket
     # @param req [String, nil] The request stirng.
-    # @!macro req
-    # @!macro skt
+    # @macro req
+    # @macro skt
     # @return [OpenSSL::SSL::SSLSocket, TCPSocket, UNIXSocket] the created socket
     def send_http(req = GET_11, host: nil, port: nil, path: nil, ctx: nil, session: nil)
       skt = new_socket host: host, port: port, path: path, ctx: ctx, session: session
@@ -225,21 +225,21 @@ module TestPuma
     # Determines whether the socket has been closed by the server.  Only works when
     # `Socket::TCP_INFO is defined`, linux/Ubuntu
     # @param socket [OpenSSL::SSL::SSLSocket, TCPSocket, UNIXSocket]
-    # @return [Boolean] true if closed by server, false is indeterminate, as
-    #   it may not be writable
+    # @return [Boolean,nil] true if closed by server, false is indeterminate, nil
+    #   if the socket can't be queried.
     #
     def skt_closed_by_server(socket)
       skt = socket.to_io
-      return false unless skt.kind_of?(TCPSocket)
+      return nil unless skt.kind_of?(TCPSocket)
 
       begin
         tcp_info = skt.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_INFO)
       rescue IOError, SystemCallError
-        false
+        nil
       else
         state = tcp_info.unpack('C')[0]
         # TIME_WAIT: 6, CLOSE: 7, CLOSE_WAIT: 8, LAST_ACK: 9, CLOSING: 11
-        (state >= 6 && state <= 9) || state == 11
+        state.between?(6, 9) || state == 11
       end
     end
 
@@ -342,7 +342,7 @@ module TestPuma
     end
 
     # Creates a new client socket.  TCP, SSL, and UNIX are supported
-    # @!macro req
+    # @macro skt
     # @return [OpenSSL::SSL::SSLSocket, TCPSocket, UNIXSocket] the created socket
     #
     def new_socket(host: nil, port: nil, path: nil, ctx: nil, session: nil, bind_type: @bind_type)

--- a/test/helpers/test_puma/response.rb
+++ b/test/helpers/test_puma/response.rb
@@ -20,9 +20,13 @@ module TestPuma
     end
 
     # Returns response headers as a hash. All keys and values are strings.
+    # @note Keys are converted to lower case, similar to net/http.
     # @return [Hash]
     def headers_hash
-      @headers_hash ||= headers.map { |hdr| hdr.split ': ', 2 }.to_h
+      @headers_hash ||= headers.map { |hdr|
+        k,v = hdr.split ': ', 2
+        [k.downcase, v]
+      }.to_h
     end
 
     def status

--- a/test/helpers/test_puma/server_base.rb
+++ b/test/helpers/test_puma/server_base.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require "puma/control_cli"
+require "puma/dsl"
+require "json"
+
+require_relative "../test_puma"
+require_relative "puma_socket"
+
+module TestPuma
+
+  # Base class for `TestPuma::ServerSpawn` and `TestPuma::ServerInProcess`.
+  # It contains methods that:
+  # * setup socket parameters (both listeners and control)
+  # * return strings for use in CLI arguments and/or config files
+  # * assist in setting SSL connection parameters
+  #
+  # The variables set here are used by `TestPuma:PumaSocket` for client request
+  # setup.
+
+  class ServerBase < Minitest::Test
+    include TestPuma
+    include TestPuma::PumaSocket
+
+    HELLO_RU = "test/rackup/hello.ru"
+
+    #————————————————————————————————————————————————————————————— SSL constants
+    CERT_PATH = File.expand_path "../../../examples/puma/", __dir__
+    CLIENT_CERTS_PATH = "#{CERT_PATH}/client-certs"
+
+    DFLT_SSL_QUERY = if Puma::IS_JRUBY
+      { keystore: "#{CERT_PATH}/keystore.jks",
+        keystore_pass: "jruby_puma"
+      }
+    else
+      { key:  "#{CERT_PATH}/puma_keypair.pem",
+        cert: "#{CERT_PATH}/cert_puma.pem"
+      }
+    end
+
+    if Puma::HAS_SSL
+      MINI_VERIFY_PEER = ::Puma::MiniSSL::VERIFY_PEER
+      MINI_FORCE_PEER  = ::Puma::MiniSSL::VERIFY_PEER | ::Puma::MiniSSL::VERIFY_FAIL_IF_NO_PEER_CERT
+      MINI_VERIFY_NONE = ::Puma::MiniSSL::VERIFY_NONE
+      HAS_TLS_1_3 = OpenSSL::SSL.const_defined? :TLS1_3_VERSION
+    end
+
+    def before_setup
+      super
+      @config_path = nil
+      @server = nil
+      @state_path = nil
+      @workers = nil
+      @spawn_ext_pids = []
+    end
+
+    def after_teardown
+      @spawn_ext_pids.each { |pid| kill_and_wait pid }
+      super
+    end
+
+    def set_bind_type(type, host: nil)
+      @bind_host = host if host
+      case type
+      when :aunix, :unix
+        skip_unless type
+        @bind_type = type
+      when :ssl
+        skip_unless :ssl
+        @bind_type = :ssl
+      when :tcp
+        @bind_type = :tcp
+      else
+        raise ArgumentError, "Invalid bind type #{type.inspect}, must be one of :aunix, :ssl, :tcp, :unix"
+      end
+    end
+
+    def set_control_type(type, host: nil)
+      @control_host = host if host
+      case type
+      when :aunix, :unix
+        skip_unless type
+        @control_type = type
+      when :ssl
+        skip_unless :ssl
+        @control_type = :ssl
+      when :tcp
+        @control_type = :tcp
+      else
+        raise ArgumentError, "Invalid control type #{type.inspect}, must be one of :aunix, :ssl, :tcp, :unix"
+      end
+    end
+
+    def bind_host
+      @bind_host ||= HOST
+    end
+
+    def bind_path
+      @bind_path ||= @bind_type == :aunix ?
+        "@#{File.basename unique_path(['bind_', '.sock'])}" :
+        unique_path(['bind_', '.sock'])
+    end
+
+    def bind_port
+      @bind_port ||= unique_port bind_host
+    end
+
+    def control_host
+      @control_host ||= HOST
+    end
+
+    def control_path
+      @control_path ||= @control_type == :aunix ?
+        "@#{File.basename unique_path(['ctrl_', '.sock'])}" :
+        unique_path(['ctrl_', '.sock'])
+    end
+
+    def control_port
+      @control_port ||= unique_port control_host
+    end
+
+    def set_bind_ssl(**opts)
+      host = opts.delete(:host) || bind_host
+      port = opts.delete(:port) || bind_port
+      @bind_ssl = Puma::DSL.ssl_bind_str host, port, opts
+    end
+
+    def bind_ssl(**opts)
+      @bind_ssl ||= set_bind_ssl(**DFLT_SSL_QUERY.merge(opts))
+    end
+
+    def set_control_ssl(hash)
+      @control_ssl = Puma::DSL.ssl_bind_str control_host, control_port, hash
+    end
+
+    def control_ssl
+      @control_ssl ||= set_control_ssl DFLT_SSL_QUERY
+    end
+
+    def bind_uri_str
+      case @bind_type
+      when :ssl
+        bind_ssl
+      when :tcp
+        "tcp://#{bind_host}:#{bind_port}"
+      when :aunix, :unix
+        "unix://#{bind_path}"
+      end
+    end
+
+    def control_uri_str
+      case @control_type
+      when :ssl
+        control_ssl
+      when :tcp
+        "tcp://#{control_host}:#{control_port}"
+      when :unix
+        "unix://#{control_path}"
+      end
+    end
+
+    # Returns arguments used in a command line string to create or use a
+    # Puma control server
+    def set_pumactl_args
+      # Used in both `Puma::CLI` and `Puma::ControlCLI`
+      "--control-url #{control_uri_str} --control-token #{TOKEN}"
+    end
+
+    # returns the line used in a Puma configuration file to create a control server
+    def control_config_str
+      case @control_type
+      when :tcp
+        "activate_control_app 'tcp://#{control_host}:#{control_port}', auth_token: '#{TOKEN}'"
+      when :unix
+        "activate_control_app 'unix://#{control_path}', auth_token: '#{TOKEN}'"
+      end
+    end
+
+    def config_path(contents = nil)
+      if contents
+        @config_path ||= unique_path %w[config_ .rb], contents: contents
+      else
+        @config_path
+      end
+    end
+
+    def state_path
+      @state_path ||= unique_path '.state'
+    end
+
+    def set_workers(count)
+      @workers = count
+    end
+
+    def workers
+      @workers ||= 0
+    end
+  end
+
+  def spawn_ext_cmd(env = {}, cmd)
+    opts = {}
+
+    out_r, out_w = IO.pipe
+    opts[:out] = out_w
+
+    err_r, err_w = IO.pipe
+    opts[:err] = err_w
+
+    out_r.binmode
+    err_r.binmode
+
+    pid = spawn(env, cmd, opts)
+    @spawn_ext_pids << pid
+    [out_w, err_w].each(&:close)
+    @ios_to_close << out_r << err_r
+    [out_r, err_r, pid]
+  end
+
+  def curl_and_get_response(url, method: :get, args: nil)
+    cmd = "curl -s -v --show-error #{args} -X #{method.to_s.upcase} -k #{url}"
+
+    out_r, err_r, _ = spawn_ext_cmd cmd
+
+    out_r.wait_readable 3
+
+    err = err_r.read
+    out = out_r.read
+
+    http_status = err[/< (HTTP\/1.1 \d+ [A-Z ]+)/, 1] # < HTTP/1.1 200 OK
+
+    assert_equal "HTTP/1.1 200 OK", http_status, "Incorrect HTTP status\n#{err}\n"
+
+    out
+  end
+end

--- a/test/helpers/test_puma/server_in_process.rb
+++ b/test/helpers/test_puma/server_in_process.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require_relative "server_base"
+
+require "puma/minissl" if ::Puma::HAS_SSL
+require "puma/events"
+
+module TestPuma
+
+  # Creates in-process `Puma::Server`'s.  These can be created either by using
+  # `#cli_run` (using `Puma::CLI.new.run`)  or `#server_run` (using `Puma::Server.new.run`).
+  #
+  class ServerInProcess < ServerBase
+    include TestPuma
+    include TestPuma::PumaSocket
+
+    APP_URL_SCHEME = ->(env) { [200, {}, [env['rack.url_scheme']]] }
+
+    # Don't set anything if already set cia ctx proc
+    DFLT_SSL_CTX = begin
+      if ::Puma::HAS_SSL
+        -> (ctx) {
+          cert_path = File.expand_path "../../../examples/puma", __dir__
+          if Puma::IS_JRUBY
+            ctx.keystore      ||= "#{cert_path}/keystore.jks"
+            ctx.keystore_pass ||= 'jruby_puma'
+          elsif !(ctx.cert || ctx.cert_pem || ctx.key || ctx.key_pem)
+            ctx.key  = "#{cert_path}/puma_keypair.pem"
+            ctx.cert = "#{cert_path}/cert_puma.pem"
+          end
+          ctx.verify_mode ||= Puma::MiniSSL::VERIFY_NONE
+        }
+      else
+        nil
+      end
+    end
+
+    def before_setup
+      @cli           = nil
+      @cli_thread    = nil
+      @events        = nil
+      @log_writer    = nil
+      @ready         = nil
+      @server_ctx    = nil
+      @server_thread = nil
+      @wait          = nil
+      super
+    end
+
+    def after_teardown
+      @server&.stop true
+      Thread.kill(@server_thread) if @server_thread&.alive?
+      @server_ctx    = nil
+      @server_thread = nil
+
+      if @cli && @cli_thread
+        @cli.launcher&.stop
+        @cli_thread.join 5
+        retries = 0
+        loop do
+          log = @log_writer.stdout.string
+          break if log.include? 'Goodbye!'
+          sleep 0.01
+          Thread.pass
+          retries += 1
+          break if retries > 10
+        end
+        Thread.kill(@cli_thread) if @cli_thread.alive?
+        @cli_thread = nil
+      end
+      super
+    end
+
+    # Creates a `Puma::Server` instance, runs it, and returns the thread or server instance.
+    def server_run(app: APP_URL_SCHEME, ctx: DFLT_SSL_CTX, background: true, **options)
+      options ||= {}
+      server_new(options, app: app, ctx: ctx)
+      server_new_run background: background
+    end
+
+    # Creates a `Puma::Server` instance. See `#server_run`
+    def server_new(options = {}, app: APP_URL_SCHEME, ctx: DFLT_SSL_CTX)
+      @log_writer = options[:log_writer] ||= Puma::LogWriter.strings
+      options[:min_threads] ||= 1
+      @events ||= Puma::Events.new
+
+      @server = Puma::Server.new app, @events, options
+
+      case @bind_type
+      when :ssl
+        if ctx.is_a? Puma::MiniSSL::Context
+          @server_ctx = ctx
+        elsif ctx == false
+          # used for LocalhostAuthority testing
+          @server_ctx = nil
+        else
+          @server_ctx = Puma::MiniSSL::Context.new
+          ctx&.call @server_ctx
+          DFLT_SSL_CTX.call @server_ctx # set defaults
+        end
+        @server.add_ssl_listener bind_host, 0, @server_ctx
+        @bind_port = @server.connected_ports[0]
+      when :tcp
+        @server.add_tcp_listener bind_host, 0
+        @bind_port = @server.connected_ports[0]
+      when :unix, :aunix
+        @server.add_unix_listener bind_path
+      end
+      @server
+    end
+
+    # Starts an existing `Puma::Server` instance.  Only used if an existing server
+    # has been created with `#server_new`.
+    #
+    def server_new_run(background: true)
+      min_threads = @server.instance_variable_get :@min_threads
+      if background
+        @server_thread = @server.run
+      else
+        @server.run false
+      end
+      until @server.running >= min_threads
+        Thread.pass
+        sleep 0.005
+      end
+      @server_thread
+    end
+
+    # Creates a server and runs it via a `Puma::CLI` instance.
+    def cli_run(opts = [])
+      cli_new opts
+      @cli_thread = Thread.new { @cli.run }
+
+      begin
+        @wait.sysread 1
+      rescue Errno::EAGAIN
+        sleep 0.001
+        retry
+      end
+    end
+
+    # Creates a server via a `Puma::CLI` instance.
+    def cli_new(opts = [])
+      @wait, @ready = IO.pipe
+      options = ['-b', bind_uri_str]
+      options += set_pumactl_args.split(' ') if @control_type
+      options += opts
+
+      @log_writer = Puma::LogWriter.strings
+
+      @events ||= Puma::Events.new
+      @events.on_booted { @ready << "!" }
+
+      @cli = Puma::CLI.new options, @log_writer, @events
+    end
+  end
+end

--- a/test/helpers/test_puma/server_spawn.rb
+++ b/test/helpers/test_puma/server_spawn.rb
@@ -1,0 +1,435 @@
+# frozen_string_literal: true
+
+require "puma/control_cli"
+require "json"
+require_relative "server_base"
+
+module TestPuma
+
+  # Creates a server by spawning a sub-process and running `bin/puma`.  These
+  # should be used for testing of startup, restarts, and shutdown.  They are also
+  # isolated from the test environment.  Becuase they spawn a sub-process, they
+  # are much slower than in-process servers created with `TestPuma::ServerInProcess`.
+  #
+  class ServerSpawn < ServerBase
+
+    # used in wait_for_server_to_* methods
+    LOG_TIMEOUT   = Puma::IS_JRUBY ? 20 : 10
+    LOG_WAIT_READ = Puma::IS_JRUBY ? 5 : 2
+    LOG_ERROR_SLEEP = 0.2
+    LOG_ERROR_QTY   = 5
+
+    BASE = Puma::IS_WINDOWS ? Gem.ruby : ""
+
+    DFLT_RUBYOPT = ENV['RUBYOPT']
+
+    def before_setup
+      super
+      @server_err = nil
+      @server_log = +''
+      @pid = nil
+      @spawn_pid = nil
+      @cli_pumactl_spawn_pids = []
+    end
+
+    def after_teardown
+      if @server
+        if @control_port && Puma::IS_WINDOWS
+          begin
+            cli_pumactl 'stop'
+          rescue SystemExit
+            TestPuma::DEBUGGING_INFO << "ControlCLI system exit #{full_name}\n"
+          end
+        elsif @pid && !Puma::IS_WINDOWS
+          stop_server signal: :INT
+        end
+      end
+
+      if @spawn_pid && @spawn_pid != @pid
+        stop_server @spawn_pid, signal: :INT
+      end
+
+      unless @cli_pumactl_spawn_pids.empty?
+        @cli_pumactl_spawn_pids.each { |pid| kill_and_wait pid, signal: :INT }
+      end
+
+      if @bind_path
+        refute File.exist?(@bind_path), "Bind path must be removed after stop"
+        File.unlink(@bind_path) rescue nil
+      end
+      super
+    end
+
+    def server_spawn(argv = nil, # rubocop:disable Metrics/ParameterLists
+        config: nil,       # string to use for config file
+        no_bind: nil,      # if true, binds are defined config file
+        log: nil,          # output server log to console (for debugging)
+        no_wait: false,    # don't wait for server to boot
+        puma_debug: nil,   # set env['PUMA_DEBUG'] = 'true'
+        env: {})           # pass env setting to spawned Puma process
+
+      if config
+        if no_bind
+          config_contents = @bind_type == :ssl ? config :
+            "bind '#{bind_uri_str}'\n#{config}"
+          if @control_type
+            config_contents = "#{control_config_str}\n#{config_contents}"
+          end
+          config_args = "-C #{config_path config_contents}"
+        else
+          config_args = "-C #{config_path config}"
+        end
+      else
+        config_args = nil
+      end
+
+      puma_path = File.expand_path '../../../bin/puma', __dir__
+
+      cmd =
+        if no_bind
+          "#{BASE} #{puma_path} #{config_args} #{argv}"
+        elsif @control_type
+          "#{BASE} #{puma_path} #{config_args} #{set_pumactl_args} -b '#{bind_uri_str}' #{argv}"
+        else
+          "#{BASE} #{puma_path} #{config_args} -b '#{bind_uri_str}' #{argv}"
+        end
+
+      env['PUMA_DEBUG'] = 'true' if puma_debug
+      env['RUBYOPT'] = DFLT_RUBYOPT unless ENV['RUBYOPT']
+
+      STDOUT.syswrite "\n——— #{full_name}\n    #{cmd}\n" if log
+
+      @server, @server_err, @spawn_pid = spawn_cmd env, cmd.strip
+
+      wait_for_server_to_include('Ctrl-C', log: log) unless no_wait
+      @pid = @server_log[/(?:Master|      ) PID: (\d+)$/, 1]&.to_i || @spawn_pid
+      TestPuma::DEBUGGING_PIDS[@pid] = full_name
+      TestPuma::DEBUGGING_PIDS[@spawn_pid] = "spawn #{full_name}" if @spawn_pid != @pid
+      @server
+    end
+
+    # rescue statements are just in case method is called with a server
+    # that is already stopped/killed, especially since Process.wait2 is
+    # blocking
+    def stop_server(pid = @pid, signal: :TERM,  timeout: 10)
+      ary = kill_and_wait pid, signal: signal
+
+      if pid == @pid && @spawn_pid != @pid && ary.nil?
+        ary = wait2_timeout @spawn_pid,  timeout: timeout
+      end
+
+      if pid == @pid
+        @server = nil
+        @spawn_pid = nil if @spawn_pid == @pid
+        @pid = nil
+      end
+      ary
+    end
+
+    def silent_and_checked_system_command(*args)
+      assert(system(*args, out: File::NULL, err: File::NULL))
+    end
+
+    def restart_server_and_listen(argv, log: false)
+      server_spawn argv
+      socket = send_http
+      initial_reply = socket.read_body
+      restart_server socket, log: log
+      # Ruby 2.6 and later all read the below socket,
+      # Ruby 2.5 intermittently throws Errno::ECONNRESET or EOFError
+      socket.read_body unless RUBY_VERSION < '2.6'
+
+      # above socket may be answered by original server
+      # below socket answered by restarted server
+      [initial_reply, send_http_read_resp_body]
+    end
+
+    # reuses an existing connection to make sure that works
+    def restart_server(socket, log: false)
+      Process.kill :USR2, @pid
+      socket << GET_11
+      wait_for_server_to_include 'Ctrl-C', log: log
+    end
+
+    # Returns true if and when server log includes str.  Will timeout otherwise.
+    def wait_for_server_to_include(str, timeout: LOG_TIMEOUT, log: false)
+      time_timeout = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      line = ''
+
+      puts "\n——— #{full_name} waiting for '#{str}'" if log
+      line = server_gets(str, time_timeout, log: log) until line&.include?(str)
+      true
+    end
+
+    # Returns line if and when server log matches re, unless idx is specified,
+    # then returns regex match.  Will timeout otherwise.
+    def wait_for_server_to_match(re, idx = nil, timeout: LOG_TIMEOUT, log: false)
+      time_timeout = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      line = ''
+
+      puts "\n——— #{full_name} waiting for '#{re.inspect}'" if log
+      line = server_gets(re, time_timeout, log: log) until line&.match?(re)
+      idx ? line[re, idx] : line
+    end
+
+    def server_gets(match_obj, time_timeout, log: false)
+      error_retries = 0
+      line = ''
+
+      sleep 0.05 unless @server.is_a?(IO) or Process.clock_gettime(Process::CLOCK_MONOTONIC) > time_timeout
+
+      unless @server.is_a? IO
+        raise RuntimeError,  "@server is not an IO"
+      end
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) > time_timeout
+        raise Timeout::Error, "Timeout waiting for server to log #{match_obj.inspect}"
+      end
+
+      begin
+        if @server.wait_readable(LOG_WAIT_READ) and line = @server&.gets
+          @server_log << line
+          puts "    #{line}" if log
+        end
+      rescue StandardError => e
+        error_retries += 1
+        raise(e, "Waiting for server to log #{match_obj.inspect}") if error_retries == LOG_ERROR_QTY
+        sleep LOG_ERROR_SLEEP
+        retry
+      end
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) > time_timeout
+        raise Timeout::Error, "Timeout waiting for server to log #{match_obj.inspect}"
+      end
+      line
+    end
+
+    # gets worker pids from @server output
+    def get_worker_pids(phase = 0, size = workers, log: false)
+      pids = []
+      re = /PID: (\d+)\) booted in [.0-9]+s, phase: #{phase}/
+      while pids.size < size
+        if pid = wait_for_server_to_match(re, 1, log: log)
+          pids << pid
+        end
+      end
+      pids.map(&:to_i)
+    end
+
+    # used to define correct 'refused' errors
+    def thread_run_refused
+      DARWIN ? [EOFError, IOError, SystemCallError] : [IOError, SystemCallError]
+    end
+
+    def cli_pumactl(argv, no_bind: nil)
+      arg =
+        if no_bind
+          argv.split(/ +/)
+        elsif @state_path && !argv.include?(@state_path)
+          %W[-S #{@state_path} #{argv}]
+        else
+          %W[-C #{control_uri_str} -T #{TOKEN} #{argv}]
+        end
+
+      r, w = IO.pipe
+      @ios_to_close << r
+      Puma::ControlCLI.new(arg, w, w).run
+      w.close
+      r
+    end
+
+    def cli_pumactl_spawn(argv, no_bind: nil)
+      arg =
+        if no_bind
+          argv
+        elsif @state_path && !argv.include?(@state_path)
+          %W[-S #{@state_path} #{argv}]
+        else
+          %W[-C #{control_uri_str} -T #{TOKEN} #{argv}]
+        end
+
+      pumactl_path = File.expand_path '../../../bin/pumactl', __dir__
+
+      cmd = "#{BASE} #{pumactl_path} #{arg}"
+
+      io, _, pid = spawn_cmd cmd
+      @cli_pumactl_spawn_pids << pid
+      TestPuma::DEBUGGING_PIDS[pid] = "pumactl #{full_name}"
+      @ios_to_close << io
+      io
+    end
+
+    def get_stats
+      read_pipe = cli_pumactl "stats"
+      JSON.parse(read_pipe.readlines.last)
+    end
+
+    def spawn_cmd(env = {}, cmd)
+      opts = {}
+
+      out_r, out_w = IO.pipe
+      opts[:out] = out_w
+
+      err_r, err_w = IO.pipe
+      opts[:err] = err_w
+
+      pid = spawn(env, cmd, opts)
+      [out_w, err_w].each(&:close)
+      @ios_to_close << out_r << err_r
+      [out_r, err_r, pid]
+    end
+
+    def hot_restart_does_not_drop_connections(num_threads: 1, total_requests: 500)
+      skipped = true
+      skip_if :jruby, suffix: <<~MSG
+        - file descriptors are not preserved on exec on JRuby; connection reset errors are expected during restarts
+      MSG
+      skip_if :truffleruby, suffix: ' - Undiagnosed failures on TruffleRuby'
+      skipped = false
+
+      args = "-w#{workers} -t 5:5 -q test/rackup/hello_with_delay.ru"
+      set_control_type :tcp if Puma::IS_WINDOWS
+      server_spawn args
+
+      skipped = false
+      replies = Hash.new 0
+      refused = thread_run_refused
+      message = 'A' * 16_256  # 2^14 - 128
+      request = "POST / HTTP/1.1\r\nContent-Length: #{message.bytesize}\r\n\r\n#{message}"
+
+      mutex = Mutex.new
+      restart_count = 0
+      client_threads = []
+
+      num_requests = (total_requests/num_threads).to_i
+
+      request_loop = ->() do
+        num_requests.times do |req_num|
+          begin
+            begin
+              socket = send_http request
+            rescue => e
+              replies[:write_error] += 1
+              raise e
+            end
+            body = socket.read_body
+            if body == "Hello World"
+              mutex.synchronize {
+                replies[:success] += 1
+                replies[:restart] += 1 if restart_count > 0
+              }
+            else
+              mutex.synchronize { replies[:unexpected_response] += 1 }
+            end
+          rescue Errno::ECONNRESET, Errno::EBADF, Errno::ENOTCONN, Errno::ENOTSOCK
+            # connection was accepted but then closed
+            # client would see an empty response
+            # Errno::EBADF Windows may not be able to make a connection
+            mutex.synchronize { replies[:reset] += 1 }
+          rescue *refused, IOError
+            # IOError intermittently thrown by Ubuntu, add to allow retry
+            mutex.synchronize { replies[:refused] += 1 }
+          rescue ::Timeout::Error
+            mutex.synchronize { replies[:read_timeout] += 1 }
+          ensure
+            if socket.is_a?(IO) && !socket.closed?
+              begin
+                socket.close
+              rescue Errno::EBADF
+              end
+            end
+          end
+        end
+      end
+
+      run = true
+
+      restart_thread = Thread.new do
+        sleep 0.05  # let some connections in before 1st restart
+        while run do
+          begin
+            if Puma::IS_WINDOWS
+              cli_pumactl 'restart'
+            else
+              Process.kill :USR2, @pid
+            end
+            wait_for_server_to_include 'Ctrl-C'
+            restart_count += 1
+            sleep(Puma::IS_WINDOWS ? 1.0 : 0.2)
+          rescue Errno::EBADF, Timeout::Error
+            break
+          end
+        end
+      end
+
+      if num_threads > 1
+        num_threads.times do |thread|
+          client_threads << Thread.new do
+            begin
+              request_loop.call
+            rescue StandardError
+            end
+          end
+        end
+        client_threads.each do |th|
+          begin
+            th&.join
+          rescue StandardError
+          end
+        end
+      else
+        request_loop.call
+      end
+
+      run = false
+      restart_thread.join
+      if Puma::IS_WINDOWS
+        cli_pumactl 'stop'
+        Process.wait @spawn_pid
+      else
+        stop_server
+      end
+      @server = nil
+
+      msg = ("   %4d write error\n"           % replies.fetch(:write_error,0)).dup
+      msg << "   %4d unexpected_response\n"   % replies.fetch(:unexpected_response,0)
+      msg << "   %4d refused\n"               % replies.fetch(:refused,0)
+      msg << "   %4d read timeout\n"          % replies.fetch(:read_timeout,0)
+      msg << "   %4d reset\n"                 % replies.fetch(:reset,0)
+      msg << "   %4d success\n"               % replies.fetch(:success,0)
+      msg << "   %4d success after restart\n" % replies.fetch(:restart,0)
+      msg << "   %4d restart count\n"         % restart_count
+
+      refused = replies[:refused]
+      reset   = replies[:reset]
+
+      # assert_operator - 1st parameter is logged as expected
+
+      if Puma::IS_WINDOWS
+        # 5 is default thread count in Puma?
+        max_reset = num_threads * restart_count
+        assert_operator max_reset,     :>=, reset  ,  "#{msg}Expected no more than #{max_reset} reset connections"
+        assert_operator        50,     :>=, refused,  "#{msg}Expected no more than 40 refused connections"
+      else
+        max_refused = [0.001 * num_threads * num_requests, 1].max.round.to_i
+        assert_operator restart_count, :>=, reset  ,  "#{msg}Expected no more that #{restart_count} reset connections"
+        assert_operator max_refused  , :>=, refused,  "#{msg}Expected no more than #{max_refused} refused connections"
+      end
+      assert_equal 0, replies[:unexpected_response], "#{msg}Unexpected response"
+      assert_equal 0, replies[:read_timeout]       , "#{msg}Expected no read timeouts"
+
+      expected = 0.7 * (num_threads * num_requests - reset - refused)
+
+      assert_operator expected, :<=, replies[:restart], "#{msg}Expected more than #{expected} connections after restart"
+    ensure
+      unless skipped
+        if passed?
+          msg = "    #{restart_count} restarts, #{reset} resets, #{refused} refused," \
+            "#{replies[:write_error]} write error, #{replies[:restart]}/#{replies[:success]} success restart/total"
+          TestPuma::DEBUGGING_INFO << "#{full_name}\n#{msg}\n"
+        else
+          client_threads.each { |thr| thr.kill if thr.is_a? Thread }
+          TestPuma::DEBUGGING_INFO << "#{full_name}\n#{msg}\n"
+        end
+      end
+    end
+  end
+end

--- a/test/test_bundle_pruner.rb
+++ b/test/test_bundle_pruner.rb
@@ -1,6 +1,6 @@
-require_relative 'helper'
+# frozen_string_literal: true
 
-require 'puma/events'
+require_relative 'helper'
 
 class TestBundlePruner < Minitest::Test
 

--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -1,34 +1,14 @@
-require_relative "helper"
+# frozen_string_literal: true
 
-class TestBusyWorker < Minitest::Test
+require_relative "helper"
+require_relative "helpers/test_puma/server_in_process"
+
+class TestBusyWorker < TestPuma::ServerInProcess
   def setup
     skip_unless :mri # This feature only makes sense on MRI
-    @ios = []
-    @server = nil
   end
 
-  def teardown
-    return if skipped?
-    @server&.stop true
-    @ios.each {|i| i.close unless i.closed?}
-  end
-
-  def new_connection
-    TCPSocket.new('127.0.0.1', @port).tap {|s| @ios << s}
-  rescue IOError
-    Puma::Util.purge_interrupt_queue
-    retry
-  end
-
-  def send_http(req)
-    new_connection << req
-  end
-
-  def send_http_and_read(req)
-    send_http(req).read
-  end
-
-  def with_server(**options, &app)
+  def with_server(qty, **options)
     @requests_count = 0 # number of requests processed
     @requests_running = 0 # current number of requests running
     @requests_max_running = 0 # max number of requests running in parallel
@@ -44,7 +24,8 @@ class TestBusyWorker < Minitest::Test
       end
 
       begin
-        yield(env)
+        sleep 0.1
+        [200, {}, [""]]
       ensure
         @mutex.synchronize do
           @requests_running -= 1
@@ -52,52 +33,34 @@ class TestBusyWorker < Minitest::Test
       end
     end
 
-    options[:min_threads] ||= 0
-    options[:max_threads] ||= 10
+    # we want more than one thread 'alive' when the requests are sent
+    options[:min_threads] ||= 4
+    options[:max_threads] ||= 4
     options[:log_writer]  ||= Puma::LogWriter.strings
 
-    @server = Puma::Server.new request_handler, nil, **options
-    @port = (@server.add_tcp_listener '127.0.0.1', 0).addr[1]
-    @server.run
+    server_run app: request_handler, **options
+
+    Array.new(qty) { send_http GET_10 }.each(&:read_response)
+
+    assert_equal qty, @requests_count, "number of requests needs to match"
+    assert_equal 0, @requests_running, "none of requests needs to be running"
   end
 
   # Multiple concurrent requests are not processed
   # sequentially as a small delay is introduced
   def test_multiple_requests_waiting_on_less_busy_worker
-    with_server(wait_for_less_busy_worker: 1.0) do |_|
-      sleep(0.1)
+    n = 4
+    with_server n, wait_for_less_busy_worker: 1.0
 
-      [200, {}, [""]]
-    end
-
-    n = 2
-
-    Array.new(n) do
-      Thread.new { send_http_and_read "GET / HTTP/1.0\r\n\r\n" }
-    end.each(&:join)
-
-    assert_equal n, @requests_count, "number of requests needs to match"
-    assert_equal 0, @requests_running, "none of requests needs to be running"
     assert_equal 1, @requests_max_running, "maximum number of concurrent requests needs to be 1"
   end
 
   # Multiple concurrent requests are processed
   # in parallel as a delay is disabled
   def test_multiple_requests_processing_in_parallel
-    with_server(wait_for_less_busy_worker: 0.0) do |_|
-      sleep(0.1)
-
-      [200, {}, [""]]
-    end
-
     n = 4
+    with_server n, wait_for_less_busy_worker: 0.0
 
-    Array.new(n) do
-      Thread.new { send_http_and_read "GET / HTTP/1.0\r\n\r\n" }
-    end.each(&:join)
-
-    assert_equal n, @requests_count, "number of requests needs to match"
-    assert_equal 0, @requests_running, "none of requests needs to be running"
     assert_equal n, @requests_max_running, "maximum number of concurrent requests needs to match"
   end
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -1,237 +1,103 @@
+# frozen_string_literal: true
+
 require_relative "helper"
-require_relative "helpers/ssl" if ::Puma::HAS_SSL
-require_relative "helpers/tmp_path"
-require_relative "helpers/test_puma/puma_socket"
+require_relative "helpers/test_puma/server_in_process"
 
 require "puma/cli"
 require "json"
 require "psych"
 
-class TestCLI < Minitest::Test
-  include SSLHelper if ::Puma::HAS_SSL
-  include TmpPath
-  include TestPuma::PumaSocket
+class TestCLI < TestPuma::ServerInProcess
 
   def setup
     @environment = 'production'
 
-    @tmp_path = tmp_path('puma-test')
-    @tmp_path2 = "#{@tmp_path}2"
-
-    File.unlink @tmp_path  if File.exist? @tmp_path
-    File.unlink @tmp_path2 if File.exist? @tmp_path2
-
-    @wait, @ready = IO.pipe
-
-    @log_writer = Puma::LogWriter.strings
-
-    @events = Puma::Events.new
-    @events.on_booted { @ready << "!" }
-
     @puma_version_pattern = "\\d+.\\d+.\\d+(\\.[a-z\\d]+)?"
   end
 
-  def wait_booted
-    @wait.sysread 1
-  rescue Errno::EAGAIN
-    sleep 0.001
-    retry
-  end
+  def control_protocol
+    cli_run [HELLO_RU]
 
-  def teardown
-    File.unlink @tmp_path if File.exist? @tmp_path
-    File.unlink @tmp_path2 if File.exist? @tmp_path2
-
-    @wait.close
-    @ready.close
-  end
-
-  def test_control_for_tcp
-    control_port = UniquePort.call
-    url = "tcp://127.0.0.1:#{control_port}/"
-
-    cli = Puma::CLI.new ["-b", "tcp://127.0.0.1:0",
-                         "--control-url", url,
-                         "--control-token", "",
-                         "test/rackup/hello.ru"], @log_writer, @events
-
-    t = Thread.new { cli.run }
-
-    wait_booted
-
-    body = send_http_read_resp_body "GET /stats HTTP/1.0\r\n\r\n", port: control_port
+    body = send_http_control_read_resp_body 'stats'
 
     assert_equal Puma.stats_hash, JSON.parse(Puma.stats, symbolize_names: true)
 
     dmt = Puma::Configuration::DEFAULTS[:max_threads]
     expected_stats = /\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
     assert_match(expected_stats, body)
-  ensure
-    cli.launcher.stop
-    t.join
+  end
+
+  def test_control_for_tcp
+    set_control_type :tcp
+    control_protocol
   end
 
   def test_control_for_ssl
-    skip_unless :ssl
-
-    require "net/http"
-    control_port = UniquePort.call
-    control_host = "127.0.0.1"
-    control_url = "ssl://#{control_host}:#{control_port}?#{ssl_query}"
-    token = "token"
-
-    cli = Puma::CLI.new ["-b", "tcp://127.0.0.1:0",
-                         "--control-url", control_url,
-                         "--control-token", token,
-                         "test/rackup/hello.ru"], @log_writer, @events
-
-    t = Thread.new { cli.run }
-
-    wait_booted
-
-    body = send_http_read_resp_body "GET /stats?token=#{token} HTTP/1.0\r\n\r\n",
-      port: control_port, ctx: new_ctx
-
-    dmt = Puma::Configuration::DEFAULTS[:max_threads]
-    expected_stats = /{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt}/
-    assert_match(expected_stats, body)
-  ensure
-    # always called, even if skipped
-    cli&.launcher&.stop
-    t&.join
+    set_control_type :ssl
+    control_protocol
   end
 
   def test_control_clustered
     skip_unless :fork
-    skip_unless :unix
-    url = "unix://#{@tmp_path}"
+    set_control_type :unix
 
-    cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
-                         "-t", "2:2",
-                         "-w", "2",
-                         "--control-url", url,
-                         "--control-token", "",
-                         "test/rackup/hello.ru"], @log_writer, @events
+    cli_run ["-t", "2:2", "-w", "2", HELLO_RU]
 
-    # without this, Minitest.after_run will trigger on this test ?
-    $debugging_hold = true
-
-    t = Thread.new { cli.run }
-
-    wait_booted
-
-    body = send_http_read_resp_body "GET /stats HTTP/1.0\r\n\r\n", path: @tmp_path
+    body = send_http_control_read_resp_body 'stats'
 
     status = JSON.parse(body)
 
     assert_equal 2, status["workers"]
 
-    body = send_http_read_resp_body "GET /stats HTTP/1.0\r\n\r\n", path: @tmp_path
+    body = send_http_control_read_resp_body 'stats'
 
     expected_stats = /\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","workers":2,"phase":0,"booted_workers":2,"old_workers":0,"worker_status":\[\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":0,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\},\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":1,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\}\],"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
     assert_match(expected_stats, body)
-  ensure
-    if UNIX_SKT_EXIST && HAS_FORK
-      cli.launcher.stop
-      t.join
-
-      done = nil
-      until done
-        @log_writer.stdout.rewind
-        log = @log_writer.stdout.readlines.join ''
-        done = log[/ - Goodbye!/]
-      end
-
-      $debugging_hold = false
-    end
   end
 
   def test_control
-    skip_unless :unix
-    url = "unix://#{@tmp_path}"
+    set_control_type :unix
 
-    cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
-                         "--control-url", url,
-                         "--control-token", "",
-                         "test/rackup/hello.ru"], @log_writer, @events
+    cli_run [HELLO_RU]
 
-    t = Thread.new { cli.run }
-
-    wait_booted
-
-    body = send_http_read_resp_body "GET /stats HTTP/1.0\r\n\r\n", path: @tmp_path
+    body = send_http_control_read_resp_body 'stats'
 
     dmt = Puma::Configuration::DEFAULTS[:max_threads]
     expected_stats = /{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
     assert_match(expected_stats, body)
-  ensure
-    if UNIX_SKT_EXIST
-      cli.launcher.stop
-      t.join
-    end
   end
 
   def test_control_stop
-    skip_unless :unix
-    url = "unix://#{@tmp_path}"
+    set_control_type :unix
 
-    cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
-                         "--control-url", url,
-                         "--control-token", "",
-                         "test/rackup/hello.ru"], @log_writer, @events
+    cli_run [HELLO_RU]
 
-    t = Thread.new { cli.run }
-
-    wait_booted
-
-    body = send_http_read_resp_body "GET /stop HTTP/1.0\r\n\r\n", path: @tmp_path
+    body = send_http_control_read_resp_body 'stop'
 
     assert_equal '{ "status": "ok" }', body
-  ensure
-    t.join if UNIX_SKT_EXIST
   end
 
   def test_control_requests_count
-    @bind_port = UniquePort.call
-    control_port = UniquePort.call
-    url = "tcp://127.0.0.1:#{control_port}/"
+    set_control_type :tcp
 
-    cli = Puma::CLI.new ["-b", "tcp://127.0.0.1:#{@bind_port}",
-                         "--control-url", url,
-                         "--control-token", "",
-                         "test/rackup/hello.ru"], @log_writer, @events
+    cli_run [HELLO_RU]
 
-    t = Thread.new { cli.run }
-
-    wait_booted
-
-    body = send_http_read_resp_body "GET /stats HTTP/1.0\r\n\r\n", port: control_port
+    body = send_http_control_read_resp_body 'stats'
 
     assert_equal 0, JSON.parse(body)['requests_count']
 
     # send real requests to server
     3.times { send_http_read_resp_body GET_10 }
 
-    body = send_http_read_resp_body "GET /stats HTTP/1.0\r\n\r\n", port: control_port
+    body = send_http_control_read_resp_body 'stats'
 
     assert_equal 3, JSON.parse(body)['requests_count']
-  ensure
-    cli.launcher.stop
-    t.join
   end
 
   def test_control_thread_backtraces
-    skip_unless :unix
-    url = "unix://#{@tmp_path}"
+    set_control_type :unix
 
-    cli = Puma::CLI.new ["-b", "unix://#{@tmp_path2}",
-                         "--control-url", url,
-                         "--control-token", "",
-                         "test/rackup/hello.ru"], @log_writer, @events
-
-    t = Thread.new { cli.run }
-
-    wait_booted
+    cli_run [HELLO_RU]
 
     if TRUFFLE
       Thread.pass
@@ -239,25 +105,21 @@ class TestCLI < Minitest::Test
     end
 
     # All thread backtraces may be very large, just get a chunk
-    socket = send_http "GET /thread-backtraces HTTP/1.0\r\n\r\n", path: @tmp_path
+    socket = send_http_control "thread-backtraces"
     socket.wait_readable 3
     body = socket.sysread 32_768
     assert_match %r{Thread: TID-}, body
-  ensure
-    cli.launcher.stop if cli
-    t.join if UNIX_SKT_EXIST
   end
 
-
   def test_tmp_control
+    skip_unless :unix
     skip_if :jruby, suffix: " - Unknown issue"
 
-    cli = Puma::CLI.new ["--state", @tmp_path, "--control-url", "auto"]
-    cli.launcher.write_state
+    cli_run ["--state", state_path, "--control-url", "auto", HELLO_RU]
 
-    opts = cli.launcher.instance_variable_get(:@options)
+    opts = @cli.launcher.instance_variable_get(:@options)
 
-    data = Psych.load_file @tmp_path
+    data = Psych.load_file state_path
 
     Puma::StateFile::ALLOWED_FIELDS.each do |key|
       val =
@@ -278,59 +140,82 @@ class TestCLI < Minitest::Test
 
   def test_state_file_callback_filtering
     skip_unless :fork
-    cli = Puma::CLI.new [ "--config", "test/config/state_file_testing_config.rb",
-                          "--state", @tmp_path ]
-    cli.launcher.write_state
 
-    data = Psych.load_file @tmp_path
+    config_path <<~'CONFIG'
+      pidfile 't3-pid'
+      workers 3
+      on_worker_boot do |index|
+        File.open("t3-worker-#{index}-pid", "w") { |f| f.puts Process.pid }
+      end
+
+      before_fork { 1 }
+      on_worker_shutdown { 1 }
+      on_worker_boot { 1 }
+      on_worker_fork { 1 }
+      on_restart { 1 }
+      after_worker_boot { 1 }
+      lowlevel_error_handler { 1 }
+    CONFIG
+
+    cli_new ["--config", config_path, "--state", state_path]
+
+    @cli.launcher.write_state
+
+    data = Psych.load_file state_path
 
     assert_equal (Puma::StateFile::ALLOWED_FIELDS & data.keys).sort, data.keys.sort
   end
 
   def test_log_formatter_default_single
-    cli = Puma::CLI.new [ ]
+    cli = Puma::CLI.new []
     assert_instance_of Puma::LogWriter::DefaultFormatter, cli.launcher.log_writer.formatter
   end
 
   def test_log_formatter_default_clustered
     skip_unless :fork
 
-    cli = Puma::CLI.new [ "-w 2" ]
+    cli = Puma::CLI.new ["-w 2"]
     assert_instance_of Puma::LogWriter::PidFormatter, cli.launcher.log_writer.formatter
   end
 
+  def log_formatter(ary)
+    config_path <<~'CONFIG'
+      log_formatter do |str|
+        "[#{Process.pid}] [#{Socket.gethostname}] #{Time.now}: #{str}"
+      end
+    CONFIG
+    cli_new (["--config", config_path] + ary)
+    assert_instance_of Proc, @cli.launcher.log_writer.formatter
+    assert_match(/^\[.*\] \[.*\] .*: test$/, @cli.launcher.log_writer.format('test'))
+  end
+
   def test_log_formatter_custom_single
-    cli = Puma::CLI.new [ "--config", "test/config/custom_log_formatter.rb" ]
-    assert_instance_of Proc, cli.launcher.log_writer.formatter
-    assert_match(/^\[.*\] \[.*\] .*: test$/, cli.launcher.log_writer.format('test'))
+    log_formatter []
   end
 
   def test_log_formatter_custom_clustered
     skip_unless :fork
-
-    cli = Puma::CLI.new [ "--config", "test/config/custom_log_formatter.rb", "-w 2" ]
-    assert_instance_of Proc, cli.launcher.log_writer.formatter
-    assert_match(/^\[.*\] \[.*\] .*: test$/, cli.launcher.log_writer.format('test'))
+    log_formatter ["-w 2"]
   end
 
   def test_state
-    url = "tcp://127.0.0.1:#{UniquePort.call}"
-    cli = Puma::CLI.new ["--state", @tmp_path, "--control-url", url]
-    cli.launcher.write_state
+    set_control_type :tcp
+    cli_new ["--state", state_path]
+    @cli.launcher.write_state
 
-    data = Psych.load_file @tmp_path
+    data = Psych.load_file state_path
 
     assert_equal Process.pid, data["pid"]
-    assert_equal url, data["control_url"]
+    assert_equal control_uri_str, data["control_url"]
   end
 
   def test_load_path
-    Puma::CLI.new ["--include", 'foo/bar']
+    cli_new ["--include", 'foo/bar']
 
     assert_equal 'foo/bar', $LOAD_PATH[0]
     $LOAD_PATH.shift
 
-    Puma::CLI.new ["--include", 'foo/bar:baz/qux']
+    cli_new ["--include", 'foo/bar:baz/qux']
 
     assert_equal 'foo/bar', $LOAD_PATH[0]
     $LOAD_PATH.shift
@@ -339,8 +224,8 @@ class TestCLI < Minitest::Test
   end
 
   def test_extra_runtime_dependencies
-    cli = Puma::CLI.new ['--extra-runtime-dependencies', 'a,b']
-    extra_dependencies = cli.instance_variable_get(:@conf)
+    cli_new ['--extra-runtime-dependencies', 'a,b']
+    extra_dependencies = @cli.instance_variable_get(:@conf)
                             .instance_variable_get(:@options)[:extra_runtime_dependencies]
 
     assert_equal %w[a b], extra_dependencies
@@ -351,41 +236,44 @@ class TestCLI < Minitest::Test
     ENV['RAILS_ENV'] = @environment
     ENV['APP_ENV'] = 'test'
 
-    cli = Puma::CLI.new []
-    cli.send(:setup_options)
+    cli_new []
+    @cli.send :setup_options
 
-    assert_equal 'test', cli.instance_variable_get(:@conf).environment
+    assert_equal 'test', @cli.instance_variable_get(:@conf).environment
   ensure
     ENV.delete 'APP_ENV'
+    ENV.delete 'RACK_ENV'
     ENV.delete 'RAILS_ENV'
   end
 
   def test_environment_rack_env
     ENV['RACK_ENV'] = @environment
 
-    cli = Puma::CLI.new []
-    cli.send(:setup_options)
+    cli_new []
+    @cli.send :setup_options
 
-    assert_equal @environment, cli.instance_variable_get(:@conf).environment
+    assert_equal @environment, @cli.instance_variable_get(:@conf).environment
+  ensure
+    ENV.delete 'RACK_ENV'
   end
 
   def test_environment_rails_env
     ENV.delete 'RACK_ENV'
     ENV['RAILS_ENV'] = @environment
 
-    cli = Puma::CLI.new []
-    cli.send(:setup_options)
+    cli_new []
+    @cli.send :setup_options
 
-    assert_equal @environment, cli.instance_variable_get(:@conf).environment
+    assert_equal @environment, @cli.instance_variable_get(:@conf).environment
   ensure
     ENV.delete 'RAILS_ENV'
   end
 
   def test_silent
-    cli = Puma::CLI.new ['--silent']
-    cli.send(:setup_options)
+    cli_new ['--silent']
+    @cli.send(:setup_options)
 
-    log_writer = cli.instance_variable_get(:@log_writer)
+    log_writer = @cli.instance_variable_get(:@log_writer)
 
     assert_equal log_writer.class, Puma::LogWriter.null.class
     assert_equal log_writer.stdout.class, Puma::NullIO

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 require_relative "helper"
-require_relative "helpers/config_file"
+require_relative "helpers/test_puma"
 
 require "puma/configuration"
-require 'puma/log_writer'
-require 'rack'
+require "rack"
 
-class TestConfigFile < TestConfigFileBase
+class TestConfigFile < Minitest::Test
   parallelize_me!
 
   def test_default_max_threads
@@ -604,7 +603,7 @@ class TestConfigFile < TestConfigFileBase
 end
 
 # contains tests that cannot run parallel
-class TestConfigFileSingle < TestConfigFileBase
+class TestConfigFileSingle < Minitest::Test
   def test_custom_logger_from_DSL
     conf = Puma::Configuration.new { |c| c.load 'test/config/custom_logger.rb' }
 
@@ -616,7 +615,9 @@ class TestConfigFileSingle < TestConfigFileBase
 end
 
 # Thread unsafe modification of ENV
-class TestEnvModifificationConfig < TestConfigFileBase
+class TestEnvModifificationConfig < Minitest::Test
+  include TestPuma
+
   def test_double_bind_port
     port = (rand(10_000) + 30_000).to_s
     with_env("PORT" => port) do
@@ -631,7 +632,9 @@ class TestEnvModifificationConfig < TestConfigFileBase
   end
 end
 
-class TestConfigEnvVariables < TestConfigFileBase
+class TestConfigEnvVariables < Minitest::Test
+  include TestPuma
+
   def test_config_loads_correct_min_threads
     assert_equal 0, Puma::Configuration.new.options.default_options[:min_threads]
 
@@ -683,7 +686,9 @@ class TestConfigEnvVariables < TestConfigFileBase
   end
 end
 
-class TestConfigFileWithFakeEnv < TestConfigFileBase
+class TestConfigFileWithFakeEnv < Minitest::Test
+  include TestPuma
+
   def setup
     FileUtils.mkpath("config/puma")
     File.write("config/puma/fake-env.rb", "")

--- a/test/test_error_logger.rb
+++ b/test/test_error_logger.rb
@@ -1,5 +1,8 @@
-require 'puma/error_logger'
+# frozen_string_literal: true
+
 require_relative "helper"
+
+require "puma/error_logger"
 
 class TestErrorLogger < Minitest::Test
   Req = Struct.new(:env, :body)

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -1,5 +1,8 @@
-require 'puma/events'
+# frozen_string_literal: true
+
 require_relative "helper"
+
+require "puma/events"
 
 class TestEvents < Minitest::Test
   def test_register_callback_with_block

--- a/test/test_example_cert_expiration.rb
+++ b/test/test_example_cert_expiration.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
+
 require 'openssl'
 
 #

--- a/test/test_http10.rb
+++ b/test/test_http10.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 
 require "puma/puma_http11"

--- a/test/test_http11.rb
+++ b/test/test_http11.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright (c) 2011 Evan Phoenix
 # Copyright (c) 2005 Zed A. Shaw
 

--- a/test/test_integration_ssl.rb
+++ b/test/test_integration_ssl.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
-require_relative "helpers/integration"
+require_relative "helpers/test_puma/server_spawn"
 
 if ::Puma::HAS_SSL # don't load any files if no ssl support
-  require "net/http"
   require "openssl"
   require_relative "helpers/test_puma/puma_socket"
 end
@@ -11,335 +12,45 @@ end
 # integration tests isolate the server from the test environment, so there
 # should be a few SSL tests.
 #
-# For instance, since other tests make use of 'client' SSLSockets created by
-# net/http, OpenSSL is loaded in the CI process.  By shelling out with IO.popen,
-# the server process isn't affected by whatever is loaded in the CI process.
+# For instance, since other tests make use of 'client' SSLSocketss, so OpenSSL
+# is loaded in the CI process.  By shelling out with spawn, the server process
+# isn't affected by whatever is loaded in the CI process.
 
-class TestIntegrationSSL < TestIntegration
-  parallelize_me! if ::Puma.mri?
+class TestIntegrationSSL < TestPuma::ServerSpawn
+  parallelize_me! if ::Puma::IS_MRI
 
-  LOCALHOST = ENV.fetch 'PUMA_CI_DFLT_HOST', 'localhost'
-
-  include TestPuma::PumaSocket
-
-  def teardown
-    @server.close if @server && !@server.closed?
-    @server = nil
-    super
+  def setup
+    set_bind_type :ssl
+    set_control_type :tcp
   end
 
-  def bind_port
-    @bind_port ||= UniquePort.call
+  def test_ssl_run_cli
+    # windows won't parse the CLI ssl bind properly
+    skip_if :windows
+    server_spawn "-q -t1:5 test/rackup/url_scheme.ru"
+
+    assert_equal "https", send_http_read_resp_body
   end
 
-  def control_tcp_port
-    @control_tcp_port ||= UniquePort.call
-  end
+  def test_ssl_run_config
+    server_spawn "-q -t1:5 test/rackup/url_scheme.ru", no_bind: true,
+      config: "bind '#{bind_uri_str}'"
 
-  def with_server(config)
-    config_file = Tempfile.new %w(config .rb)
-    config_file.write config
-    config_file.close
-    config_file.path
-
-    # start server
-    cmd = "#{BASE} bin/puma -C #{config_file.path}"
-    @server = IO.popen cmd, 'r'
-    wait_for_server_to_boot
-    @pid = @server.pid
-
-    http = Net::HTTP.new HOST, bind_port
-    http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-
-    yield http
-
-    # stop server
-    sock = TCPSocket.new HOST, control_tcp_port
-    @ios_to_close << sock
-    sock.syswrite "GET /stop?token=#{TOKEN} HTTP/1.1\r\n\r\n"
-    sock.read
-    assert_match 'Goodbye!', @server.read
-  end
-
-  def test_ssl_run
-    config = <<~RUBY
-      if ::Puma.jruby?
-        keystore =  '#{File.expand_path '../examples/puma/keystore.jks', __dir__}'
-        keystore_pass = 'jruby_puma'
-
-        ssl_bind '#{HOST}', '#{bind_port}', {
-          keystore: keystore,
-          keystore_pass:  keystore_pass,
-          verify_mode: 'none'
-        }
-      else
-        key  = '#{File.expand_path '../examples/puma/puma_keypair.pem', __dir__}'
-        cert = '#{File.expand_path '../examples/puma/cert_puma.pem', __dir__}'
-
-        ssl_bind '#{HOST}', '#{bind_port}', {
-          cert: cert,
-          key:  key,
-          verify_mode: 'none'
-        }
-      end
-
-      activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
-
-      app do |env|
-        [200, {}, [env['rack.url_scheme']]]
-      end
-    RUBY
-
-    with_server(config) do |http|
-      body = nil
-      http.start do
-        req = Net::HTTP::Get.new '/', {}
-        http.request(req) { |resp| body = resp.body }
-      end
-      assert_equal 'https', body
-    end
-  end
-
-  # should use TLSv1.3 with OpenSSL 1.1 or later
-  def test_verify_client_cert_roundtrip(tls1_2 = nil)
-    cert_path = File.expand_path '../examples/puma/client-certs', __dir__
-    bind_port
-
-    config = <<~CONFIG
-      if ::Puma::IS_JRUBY
-        ssl_bind '#{LOCALHOST}', '#{@bind_port}', {
-          keystore: '#{cert_path}/keystore.jks',
-          keystore_pass: 'jruby_puma',
-          verify_mode: 'force_peer'
-        }
-      else
-        ssl_bind '#{LOCALHOST}', '#{@bind_port}', {
-          cert: '#{cert_path}/server.crt',
-          key:  '#{cert_path}/server.key',
-          ca:   '#{cert_path}/ca.crt',
-          verify_mode: 'force_peer'
-        }
-      end
-      threads 1, 5
-
-      app do |env|
-        [200, {}, [env['puma.peercert'].to_s]]
-      end
-    CONFIG
-
-    cli_server "-t1:5 #{set_pumactl_args}", config: config, no_bind: true
-
-    client_cert = File.read "#{cert_path}/client.crt"
-
-    body = send_http_read_resp_body host: LOCALHOST, port: @bind_port, ctx: new_ctx { |c|
-        ca   = "#{cert_path}/ca.crt"
-        key  = "#{cert_path}/client.key"
-        c.ca_file = ca
-        c.cert = ::OpenSSL::X509::Certificate.new client_cert
-        c.key  = ::OpenSSL::PKey::RSA.new File.read(key)
-        c.verify_mode = ::OpenSSL::SSL::VERIFY_PEER
-        if tls1_2
-          if c.respond_to? :max_version=
-            c.max_version = :TLS1_2
-          else
-            c.ssl_version = :TLSv1_2
-          end
-        end
-      }
-
-    assert_equal client_cert, body
-  ensure
-    cli_pumactl 'stop'
-  end
-
-  def test_verify_client_cert_roundtrip_tls1_2
-    test_verify_client_cert_roundtrip true
-  end
-
-  def test_ssl_run_with_curl_client
-    skip_if :windows; require 'stringio'
-
-    app = lambda { |_| [200, { 'Content-Type' => 'text/plain' }, ["HELLO", ' ', "THERE"]] }
-    opts = {max_threads: 1}
-    server = Puma::Server.new app, nil, opts
-    if Puma.jruby?
-      ssl_params = {
-          'keystore'      => File.expand_path('../examples/puma/client-certs/keystore.jks', __dir__),
-          'keystore-pass' => 'jruby_puma', # keystore includes server.p12 as well as ca.crt
-      }
-    else
-      ssl_params = {
-          'cert' => File.expand_path('../examples/puma/client-certs/server.crt', __dir__),
-          'key'  => File.expand_path('../examples/puma/client-certs/server.key', __dir__),
-          'ca'   => File.expand_path('../examples/puma/client-certs/ca.crt', __dir__),
-      }
-    end
-    ssl_params['verify_mode'] = 'force_peer' # 'peer'
-    out_err = StringIO.new
-    ssl_context = Puma::MiniSSL::ContextBuilder.new(ssl_params, Puma::LogWriter.new(out_err, out_err)).context
-    server.add_ssl_listener(LOCALHOST, bind_port, ssl_context)
-
-    server.run(true)
-    begin
-      ca = File.expand_path('../examples/puma/client-certs/ca.crt', __dir__)
-      cert = File.expand_path('../examples/puma/client-certs/client.crt', __dir__)
-      key = File.expand_path('../examples/puma/client-certs/client.key', __dir__)
-      # NOTE: JRuby used to end up in a hang with TLS peer verification enabled
-      # it's easier to reproduce using an external client such as CURL (using net/http client the bug isn't triggered)
-      # also the "hang", being buffering related, seems to showcase better with TLS 1.2 than 1.3
-      body = curl_and_get_response "https://#{LOCALHOST}:#{bind_port}",
-                                   args: "--cacert #{ca} --cert #{cert} --key #{key} --tlsv1.2 --tls-max 1.2"
-
-      warn out_err.string unless out_err.string.empty?
-      assert_equal 'HELLO THERE', body
-    ensure
-      server.stop(true)
-    end
-    assert_equal '', out_err.string
-  end
-
-  def test_ssl_run_with_pem
-    skip_if :jruby
-
-    config = <<~RUBY
-      key_path  = '#{File.expand_path '../examples/puma/puma_keypair.pem', __dir__}'
-      cert_path = '#{File.expand_path '../examples/puma/cert_puma.pem', __dir__}'
-
-      ssl_bind '#{HOST}', '#{bind_port}', {
-        cert_pem: File.read(cert_path),
-        key_pem:  File.read(key_path),
-        verify_mode: 'none'
-      }
-
-      activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
-
-      app do |env|
-        [200, {}, [env['rack.url_scheme']]]
-      end
-    RUBY
-
-    with_server(config) do |http|
-      body = nil
-      http.start do
-        req = Net::HTTP::Get.new '/', {}
-        http.request(req) { |resp| body = resp.body }
-      end
-      assert_equal 'https', body
-    end
+    assert_equal "https", send_http_read_resp_body
   end
 
   def test_ssl_run_with_localhost_authority
     skip_if :jruby
 
-    config = <<~RUBY
+    server_spawn no_bind: true, config: <<~CONFIG
       require 'localhost'
-      ssl_bind '#{HOST}', '#{bind_port}'
-
-      activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
+      ssl_bind '#{LOCALHOST}', '#{bind_port}'
 
       app do |env|
         [200, {}, [env['rack.url_scheme']]]
       end
-    RUBY
+    CONFIG
 
-    with_server(config) do |http|
-      body = nil
-      http.start do
-        req = Net::HTTP::Get.new '/', {}
-        http.request(req) { |resp| body = resp.body }
-      end
-      assert_equal 'https', body
-    end
+    assert_equal "https", send_http_read_resp_body
   end
-
-  def test_ssl_run_with_encrypted_key
-    skip_if :jruby
-
-    config = <<~RUBY
-      key_path  = '#{File.expand_path '../examples/puma/encrypted_puma_keypair.pem', __dir__}'
-      cert_path = '#{File.expand_path '../examples/puma/cert_puma.pem', __dir__}'
-      key_command = ::Puma::IS_WINDOWS ? 'echo hello world' :
-        '#{File.expand_path '../examples/puma/key_password_command.sh', __dir__}'
-
-      ssl_bind '#{HOST}', '#{bind_port}', {
-        cert: cert_path,
-        key: key_path,
-        verify_mode: 'none',
-        key_password_command: key_command
-      }
-
-      activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
-
-      app do |env|
-        [200, {}, [env['rack.url_scheme']]]
-      end
-    RUBY
-
-    with_server(config) do |http|
-      body = nil
-      http.start do
-        req = Net::HTTP::Get.new '/', {}
-        http.request(req) { |resp| body = resp.body }
-      end
-      assert_equal 'https', body
-    end
-  end
-
-  def test_ssl_run_with_encrypted_pem
-    skip_if :jruby
-
-    config = <<~RUBY
-      key_path  = '#{File.expand_path '../examples/puma/encrypted_puma_keypair.pem', __dir__}'
-      cert_path = '#{File.expand_path '../examples/puma/cert_puma.pem', __dir__}'
-      key_command = ::Puma::IS_WINDOWS ? 'echo hello world' :
-        '#{File.expand_path '../examples/puma/key_password_command.sh', __dir__}'
-
-      ssl_bind '#{HOST}', '#{bind_port}', {
-        cert_pem: File.read(cert_path),
-        key_pem: File.read(key_path),
-        verify_mode: 'none',
-        key_password_command: key_command
-      }
-
-      activate_control_app 'tcp://#{HOST}:#{control_tcp_port}', { auth_token: '#{TOKEN}' }
-
-      app do |env|
-        [200, {}, [env['rack.url_scheme']]]
-      end
-    RUBY
-
-    with_server(config) do |http|
-      body = nil
-      http.start do
-        req = Net::HTTP::Get.new '/', {}
-        http.request(req) { |resp| body = resp.body }
-      end
-      assert_equal 'https', body
-    end
-  end
-
-  private
-
-  def curl_and_get_response(url, method: :get, args: nil); require 'open3'
-    cmd = "curl -s -v --show-error #{args} -X #{method.to_s.upcase} -k #{url}"
-    begin
-      out, err, status = Open3.capture3(cmd)
-    rescue Errno::ENOENT
-      fail "curl not available, make sure curl binary is installed and available on $PATH"
-    end
-
-    if status.success?
-      http_status = err.match(/< HTTP\/1.1 (.*?)/)[1] || '0' # < HTTP/1.1 200 OK\r\n
-      if http_status.strip[0].to_i > 2
-        warn out
-        fail "#{cmd.inspect} unexpected response: #{http_status}\n\n#{err}"
-      end
-      return out
-    else
-      warn out
-      fail "#{cmd.inspect} process failed: #{status}\n\n#{err}"
-    end
-  end
-
 end if ::Puma::HAS_SSL

--- a/test/test_iobuffer.rb
+++ b/test/test_iobuffer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 
 require "puma/io_buffer"

--- a/test/test_json_serialization.rb
+++ b/test/test_json_serialization.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 require_relative "helper"
+
 require "json"
 require "puma/json_serialization"
 

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 require_relative "helper"
-require_relative "helpers/tmp_path"
+require_relative "helpers/test_puma"
 
 require "puma/configuration"
-require 'puma/log_writer'
+require "puma/log_writer"
 
 class TestLauncher < Minitest::Test
-  include TmpPath
+  include TestPuma
 
   def test_prints_thread_traces
     launcher.thread_status do |name, _backtrace|
@@ -14,7 +16,7 @@ class TestLauncher < Minitest::Test
   end
 
   def test_pid_file
-    pid_path = tmp_path('.pid')
+    pid_path = unique_path('.pid')
 
     conf = Puma::Configuration.new do |c|
       c.pidfile pid_path
@@ -28,7 +30,7 @@ class TestLauncher < Minitest::Test
   end
 
   def test_state_permission_0640
-    state_path = tmp_path('.state')
+    state_path = unique_path('.state')
     state_permission = 0640
 
     conf = Puma::Configuration.new do |c|
@@ -44,7 +46,7 @@ class TestLauncher < Minitest::Test
   end
 
   def test_state_permission_nil
-    state_path = tmp_path('.state')
+    state_path = unique_path('.state')
 
     conf = Puma::Configuration.new do |c|
       c.state_path state_path
@@ -59,7 +61,7 @@ class TestLauncher < Minitest::Test
   end
 
   def test_no_state_permission
-    state_path = tmp_path('.state')
+    state_path = unique_path('.state')
 
     conf = Puma::Configuration.new do |c|
       c.state_path state_path
@@ -128,7 +130,7 @@ class TestLauncher < Minitest::Test
   def test_fire_on_stopped
     conf = Puma::Configuration.new do |c|
       c.app -> {[200, {}, ['']]}
-      c.port UniquePort.call
+      c.port unique_port
     end
 
     launcher = launcher(conf)

--- a/test/test_minissl.rb
+++ b/test/test_minissl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 
 require "puma/minissl" if ::Puma::HAS_SSL

--- a/test/test_out_of_band_server.rb
+++ b/test/test_out_of_band_server.rb
@@ -1,11 +1,12 @@
-require_relative "helper"
+# frozen_string_literal: true
 
-class TestOutOfBandServer < Minitest::Test
-  parallelize_me!
+require_relative "helper"
+require_relative "helpers/test_puma/server_in_process"
+
+class TestOutOfBandServer < TestPuma::ServerInProcess
+  parallelize_me! if ::Puma::IS_MRI
 
   def setup
-    @ios = []
-    @server = nil
     @oob_finished = ConditionVariable.new
     @app_finished = ConditionVariable.new
   end
@@ -13,31 +14,6 @@ class TestOutOfBandServer < Minitest::Test
   def teardown
     @oob_finished.broadcast
     @app_finished.broadcast
-    @server&.stop true
-
-    @ios.each do |io|
-      begin
-        io.close if io.is_a?(IO) && !io.closed?
-      rescue
-      ensure
-        io = nil
-      end
-    end
-  end
-
-  def new_connection
-    TCPSocket.new('127.0.0.1', @port).tap {|s| @ios << s}
-  rescue IOError
-    Puma::Util.purge_interrupt_queue
-    retry
-  end
-
-  def send_http(req)
-    new_connection << req
-  end
-
-  def send_http_and_read(req)
-    send_http(req).read
   end
 
   def oob_server(**options)
@@ -66,14 +42,10 @@ class TestOutOfBandServer < Minitest::Test
       [200, {}, [""]]
     end
 
-    options[:min_threads] ||= 1
     options[:max_threads] ||= 1
-    options[:log_writer]  ||= Puma::LogWriter.strings
+    options[:out_of_band] = [oob]
 
-    @server = Puma::Server.new app, nil, out_of_band: [oob], **options
-    @port = (@server.add_tcp_listener '127.0.0.1', 0).addr[1]
-    @server.run
-    sleep 0.15 if Puma.jruby?
+    server_run app: app, **options
   end
 
   # Sequential requests should trigger out_of_band after every request.
@@ -82,7 +54,7 @@ class TestOutOfBandServer < Minitest::Test
     oob_server
     n.times do
       @mutex.synchronize do
-        send_http "GET / HTTP/1.0\r\n\r\n"
+        send_http GET_10
         @oob_finished.wait(@mutex, 1)
       end
     end
@@ -95,7 +67,7 @@ class TestOutOfBandServer < Minitest::Test
   def test_stream
     oob_server app_wait: true, max_threads: 2
     n = 100
-    Array.new(n) {send_http("GET / HTTP/1.0\r\n\r\n")}
+    Array.new(n) { send_http GET_10 }
     Thread.pass until @request_count == n
     @mutex.synchronize do
       @app_finished.signal
@@ -110,15 +82,15 @@ class TestOutOfBandServer < Minitest::Test
     oob_server oob_wait: true, max_threads: 2
 
     # Establish connection for Req2 before OOB
-    req2 = new_connection
+    req2 = new_socket
     sleep 0.01
 
     @mutex.synchronize do
-      send_http "GET / HTTP/1.0\r\n\r\n"
+      send_http GET_10
       @oob_finished.wait(@mutex) # enter OOB
 
       # Send Req2
-      req2 << "GET / HTTP/1.0\r\n\r\n"
+      req2 << GET_10
       # If Req2 is processed now it raises 'OOB Conflict' in the response.
       sleep 0.01
 
@@ -134,7 +106,7 @@ class TestOutOfBandServer < Minitest::Test
   # Partial requests should not trigger OOB.
   def test_partial_request
     oob_server
-    new_connection.close
+    new_socket.close
     sleep 0.01
     assert_equal 0, @oob_count
   end
@@ -144,8 +116,8 @@ class TestOutOfBandServer < Minitest::Test
   def test_partial_concurrent
     oob_server max_threads: 2
     @mutex.synchronize do
-      send_http("GET / HTTP/1.0\r\n\r\n")
-      100.times {new_connection.close}
+      send_http GET_10
+      100.times { new_socket.close }
       @oob_finished.wait(@mutex, 1)
     end
     assert_equal 1, @oob_count
@@ -155,13 +127,13 @@ class TestOutOfBandServer < Minitest::Test
   def test_blocks_new_connection
     oob_server oob_wait: true, max_threads: 2
     @mutex.synchronize do
-      send_http("GET / HTTP/1.0\r\n\r\n")
+      send_http GET_10
       @oob_finished.wait(@mutex)
     end
     accepted = false
     io = @server.binder.ios.last
-    io.stub(:accept_nonblock, -> {accepted = true; new_connection}) do
-      new_connection.close
+    io.stub(:accept_nonblock, -> {accepted = true; new_socket}) do
+      new_socket.close
       sleep 0.01
     end
     refute accepted, 'New connection accepted during out of band'

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -1,103 +1,90 @@
+# frozen_string_literal: true
+
 require_relative "helper"
+require_relative "helpers/test_puma/server_in_process"
 
-class TestPersistent < Minitest::Test
+class TestPersistent < TestPuma::ServerInProcess
+  parallelize_me!
 
-  HOST = "127.0.0.1"
+  VALID_REQUEST     = "GET / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
+  CLOSE_REQUEST     = "GET / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n"
+  HTTP10_REQUEST    = "GET / HTTP/1.0\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
+  HTTP10_KA_REQUEST = "GET / HTTP/1.0\r\nHost: test.com\r\nContent-Type: text/plain\r\nConnection: Keep-Alive\r\n\r\n"
+
+  VALID_POST    = "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello"
+  VALID_NO_BODY  = "GET / HTTP/1.1\r\nHost: test.com\r\nX-Status: 204\r\nContent-Type: text/plain\r\n\r\n"
+
+  HTTP11_200_OK = "HTTP/1.1 200 OK"
 
   def setup
-    @valid_request  = "GET / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
-    @close_request  = "GET / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n"
-    @http10_request = "GET / HTTP/1.0\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
-    @keep_request   = "GET / HTTP/1.0\r\nHost: test.com\r\nContent-Type: text/plain\r\nConnection: Keep-Alive\r\n\r\n"
-
-    @valid_post    = "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello"
-    @valid_no_body  = "GET / HTTP/1.1\r\nHost: test.com\r\nX-Status: 204\r\nContent-Type: text/plain\r\n\r\n"
-
     @headers = { "X-Header" => "Works" }
     @body = ["Hello"]
+    @size = @body[0].size.to_s
+
     @inputs = []
 
-    @simple = lambda do |env|
+    @simple = ->(env) do
       @inputs << env['rack.input']
       status = Integer(env['HTTP_X_STATUS'] || 200)
       [status, @headers, @body]
     end
 
-    opts = {max_threads: 1}
-    @server = Puma::Server.new @simple, nil, opts
-    @port = (@server.add_tcp_listener HOST, 0).addr[1]
-    @server.run
-    sleep 0.15 if Puma.jruby?
-    @client = TCPSocket.new HOST, @port
+    server_run app: @simple
   end
 
-  def teardown
-    @client.close
-    @server.stop(true)
-  end
+  def assert_response(response, status = HTTP11_200_OK)
+    standard_response = @standard_response = <<~RESP.gsub("\n", "\r\n").strip
+      #{status}
+      X-Header: Works
+      Content-Length: #{@size}
 
-  def lines(count, s=@client)
-    str = +''
-    Timeout.timeout(5) do
-      count.times { str << (s.gets || "") }
-    end
-    str
+      Hello
+    RESP
+    assert_equal standard_response, response
+
+    assert_equal status, response.status
+    assert_equal ["X-Header: Works", "Content-Length: #{@size}"], response.headers
+    assert_equal "Hello", response.body
   end
 
   def test_one_with_content_length
-    @client << @valid_request
-    sz = @body[0].size.to_s
-
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    assert_response send_http_read_response(VALID_REQUEST)
   end
 
   def test_two_back_to_back
-    @client << @valid_request
-    sz = @body[0].size.to_s
+    socket = send_http VALID_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    assert_response socket.read_response
 
-    @client << @valid_request
-    sz = @body[0].size.to_s
-
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    assert_response socket.send_request(VALID_REQUEST).read_response
   end
 
   def test_post_then_get
-    @client << @valid_post
-    sz = @body[0].size.to_s
+    socket = send_http VALID_POST
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    assert_response socket.read_response
 
-    @client << @valid_request
-    sz = @body[0].size.to_s
-
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    assert_response socket.send_request(VALID_REQUEST).read_response
   end
 
   def test_no_body_then_get
-    @client << @valid_no_body
-    assert_equal "HTTP/1.1 204 No Content\r\nX-Header: Works\r\n\r\n", lines(3)
+    socket = send_http VALID_NO_BODY
+    assert_equal "HTTP/1.1 204 No Content\r\nX-Header: Works\r\n\r\n",
+      socket.read_response
 
-    @client << @valid_request
-    sz = @body[0].size.to_s
-
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    assert_response socket.send_request(VALID_REQUEST).read_response
   end
 
   def test_chunked
     @body << "Chunked"
     @body = @body.to_enum
 
-    @client << @valid_request
+    response = send_http_read_response VALID_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n7\r\nChunked\r\n0\r\n\r\n", lines(10)
+    assert_equal HTTP11_200_OK, response.status
+    assert_equal ["X-Header: Works", "Transfer-Encoding: chunked"], response.headers
+    assert_equal "5\r\nHello\r\n7\r\nChunked\r\n0\r\n\r\n", response.body
+    assert_equal "HelloChunked", response.decode_body
   end
 
   def test_chunked_with_empty_part
@@ -105,19 +92,25 @@ class TestPersistent < Minitest::Test
     @body << "Chunked"
     @body = @body.to_enum
 
-    @client << @valid_request
+    response = send_http_read_response VALID_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n7\r\nChunked\r\n0\r\n\r\n", lines(10)
+    assert_equal HTTP11_200_OK, response.status
+    assert_equal ["X-Header: Works", "Transfer-Encoding: chunked"], response.headers
+    assert_equal "5\r\nHello\r\n7\r\nChunked\r\n0\r\n\r\n", response.body
+    assert_equal "HelloChunked", response.decode_body
   end
 
   def test_no_chunked_in_http10
     @body << "Chunked"
     @body = @body.to_enum
 
-    @client << @http10_request
+    socket = send_http HTTP10_REQUEST
+    sleep 0.01 if Puma::IS_JRUBY # may just receive 'Hello'
+    response = socket.read_response
 
-    assert_equal "HTTP/1.0 200 OK\r\nX-Header: Works\r\n\r\n", lines(3)
-    assert_equal "HelloChunked", @client.read
+    assert_equal "HTTP/1.0 200 OK", response.status
+    assert_equal ["X-Header: Works"], response.headers
+    assert_equal "HelloChunked", response.body
   end
 
   def test_hex
@@ -125,48 +118,47 @@ class TestPersistent < Minitest::Test
     @body << str
     @body = @body.to_enum
 
-    @client << @valid_request
+    response = send_http_read_response VALID_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n#{str.size.to_s(16)}\r\n#{str}\r\n0\r\n\r\n", lines(10)
-
+    assert_equal HTTP11_200_OK, response.status
+    assert_equal ["X-Header: Works", "Transfer-Encoding: chunked"], response.headers
+    assert_equal "5\r\nHello\r\n#{str.size.to_s(16)}\r\n#{str}\r\n0\r\n\r\n", response.body
+    assert_equal "HelloThis is longer and will be in hex", response.decode_body
   end
 
   def test_client11_close
-    @client << @close_request
-    sz = @body[0].size.to_s
+    response = send_http_read_response CLOSE_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nConnection: close\r\nContent-Length: #{sz}\r\n\r\n", lines(5)
-    assert_equal "Hello", @client.read(5)
+    assert_equal HTTP11_200_OK, response.status
+    assert_equal ["X-Header: Works", "Connection: close", "Content-Length: #{@size}"],
+      response.headers
+    assert_equal "Hello", response.body
   end
 
   def test_client10_close
-    @client << @http10_request
-    sz = @body[0].size.to_s
+    response = send_http_read_response HTTP10_REQUEST
 
-    assert_equal "HTTP/1.0 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    assert_response(response, "HTTP/1.0 200 OK")
   end
 
   def test_one_with_keep_alive_header
-    @client << @keep_request
-    sz = @body[0].size.to_s
+    response = send_http_read_response HTTP10_KA_REQUEST
 
-    assert_equal "HTTP/1.0 200 OK\r\nX-Header: Works\r\nConnection: Keep-Alive\r\nContent-Length: #{sz}\r\n\r\n", lines(5)
-    assert_equal "Hello", @client.read(5)
+    assert_equal "HTTP/1.0 200 OK", response.status
+    assert_equal ["X-Header: Works", "Connection: Keep-Alive", "Content-Length: #{@size}"],
+      response.headers
+    assert_equal "Hello", response.body
   end
 
   def test_persistent_timeout
     @server.instance_variable_set(:@persistent_timeout, 1)
-    @client << @valid_request
-    sz = @body[0].size.to_s
+    socket = send_http VALID_REQUEST
+    assert_response(socket.read_response)
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
-
-    sleep 2
+    sleep 1.5
 
     assert_raises EOFError do
-      @client.read_nonblock(1)
+      socket.read_nonblock 1
     end
   end
 
@@ -174,11 +166,11 @@ class TestPersistent < Minitest::Test
     @body = ["hello", " world"]
     @headers['Content-Length'] = "11"
 
-    @client << @valid_request
+    response = send_http_read_response VALID_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: 11\r\n\r\n",
-                 lines(4)
-    assert_equal "hello world", @client.read(11)
+    assert_equal HTTP11_200_OK, response.status
+    assert_equal ["X-Header: Works", "Content-Length: 11"], response.headers
+    assert_equal "hello world", response.body
   end
 
   def test_allow_app_to_chunk_itself
@@ -186,63 +178,56 @@ class TestPersistent < Minitest::Test
 
     @body = ["5\r\nhello\r\n0\r\n\r\n"]
 
-    @client << @valid_request
+    response = send_http_read_response VALID_REQUEST
 
-    assert_equal "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n", lines(7)
+    assert_equal HTTP11_200_OK, response.status
+    assert_equal ["Transfer-Encoding: chunked"], response.headers
+    assert_equal "5\r\nhello\r\n0\r\n\r\n", response.body
+    assert_equal "hello", response.decode_body
   end
-
 
   def test_two_requests_in_one_chunk
     @server.instance_variable_set(:@persistent_timeout, 3)
 
-    req = @valid_request.to_s
+    req = VALID_REQUEST.to_s
     req += "GET /second HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
 
-    @client << req
+    data = send_http_read_all req
 
-    sz = @body[0].size.to_s
+    first_resp, remaining = data.split "\r\n\r\n", 2
+    first_resp << "\r\n\r\n" << remaining[0, 5]
+    second_resp = remaining[5..-1]
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
-
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    assert_response TestPuma::Response.new(first_resp)
+    assert_response TestPuma::Response.new(second_resp)
   end
 
   def test_second_request_not_in_first_req_body
     @server.instance_variable_set(:@persistent_timeout, 3)
 
-    req = @valid_request.to_s
+    req = VALID_REQUEST.to_s
     req += "GET /second HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
 
-    @client << req
+    data = send_http_read_all req
 
-    sz = @body[0].size.to_s
+    first_resp, remaining = data.split "\r\n\r\n", 2
+    first_resp << "\r\n\r\n" << remaining[0, 5]
+    second_resp = remaining[5..-1]
 
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
-
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4)
-    assert_equal "Hello", @client.read(5)
+    assert_response TestPuma::Response.new(first_resp)
+    assert_response TestPuma::Response.new(second_resp)
 
     assert_kind_of Puma::NullIO, @inputs[0]
     assert_kind_of Puma::NullIO, @inputs[1]
   end
 
   def test_keepalive_doesnt_starve_clients
-    sz = @body[0].size.to_s
+    socket1 = send_http VALID_REQUEST
+    socket2 = send_http VALID_REQUEST
 
-    @client << @valid_request
+    assert socket2.wait_readable(1), "2nd request starved"
 
-    c2 = TCPSocket.new HOST, @port
-    c2 << @valid_request
-
-    assert c2.wait_readable(1), "2nd request starved"
-
-    assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nContent-Length: #{sz}\r\n\r\n", lines(4, c2)
-    assert_equal "Hello", c2.read(5)
-  ensure
-    c2.close
+    assert_response socket1.read_response
+    assert_response socket2.read_response
   end
-
 end

--- a/test/test_plugin.rb
+++ b/test/test_plugin.rb
@@ -1,27 +1,29 @@
-require_relative "helper"
-require_relative "helpers/integration"
+# frozen_string_literal: true
 
-class TestPlugin < TestIntegration
+require_relative "helper"
+require_relative "helpers/test_puma/server_spawn"
+
+class TestPlugin < TestPuma::ServerSpawn
   def test_plugin
     skip "Skipped on Windows Ruby < 2.5.0, Ruby bug" if windows? && RUBY_VERSION < '2.5.0'
-    @control_tcp_port = UniquePort.call
+    set_control_type :tcp
 
     Dir.mkdir("tmp") unless Dir.exist?("tmp")
 
-    cli_server "--control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN} test/rackup/hello.ru",
+    server_spawn "test/rackup/hello.ru",
       config: "plugin 'tmp_restart'"
 
-    File.open('tmp/restart.txt', mode: 'wb') { |f| f.puts "Restart #{Time.now}" }
+    File.write 'tmp/restart.txt', "Restart #{Time.now}", mode: 'wb'
 
     assert wait_for_server_to_include('Restarting...')
 
-    assert wait_for_server_to_boot
+    assert wait_for_server_to_include('Ctrl-C')
 
     cli_pumactl "stop"
 
     assert wait_for_server_to_include('Goodbye')
 
-    @server.close
-    @server = nil
+  ensure
+    @server = nil if ::Puma::IS_WINDOWS # see ServerSpawn#after_teardown
   end
 end

--- a/test/test_plugin_systemd_jruby.rb
+++ b/test/test_plugin_systemd_jruby.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 require_relative "helper"
-require_relative "helpers/integration"
+require_relative "helpers/test_puma/server_spawn"
 
 require "puma/plugin"
 
-class TestPluginSystemdJruby < TestIntegration
+class TestPluginSystemdJruby < TestPuma::ServerSpawn
 
   THREAD_LOG = TRUFFLE ? "{ 0/16 threads, 16 available, 0 backlog }" :
     "{ 0/5 threads, 5 available, 0 backlog }"
@@ -16,8 +16,6 @@ class TestPluginSystemdJruby < TestIntegration
     skip_unless_signal_exist? :TERM
     skip_unless :jruby
 
-    super
-
     ENV["NOTIFY_SOCKET"] = "/tmp/doesntmatter"
   end
 
@@ -26,7 +24,7 @@ class TestPluginSystemdJruby < TestIntegration
   end
 
   def test_systemd_plugin_not_loaded
-    cli_server "test/rackup/hello.ru"
+    server_spawn "test/rackup/hello.ru"
 
     assert_nil Puma::Plugins.instance_variable_get(:@plugins)["systemd"]
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1,151 +1,103 @@
+# frozen_string_literal: true
+
 require_relative "helper"
-require "puma/events"
-require "puma/server"
-require "net/http"
-require "nio"
-require "ipaddr"
+require_relative "helpers/test_puma/server_in_process"
 
 class WithoutBacktraceError < StandardError
   def backtrace; nil; end
   def message; "no backtrace error"; end
 end
 
-class TestPumaServer < Minitest::Test
+class TestPumaServer < TestPuma::ServerInProcess
   parallelize_me!
 
   STATUS_CODES = ::Puma::HTTP_STATUS_CODES
 
-  def setup
-    @host = "127.0.0.1"
+  def test_http10_req_to_http10_resp
+    server_run app: ->(env) { [200, {}, [env["SERVER_PROTOCOL"]]] }
 
-    @ios = []
-
-    @app = ->(env) { [200, {}, [env['rack.url_scheme']]] }
-
-    @log_writer = Puma::LogWriter.strings
-    @events = Puma::Events.new
-    @server = Puma::Server.new @app, @events, {log_writer: @log_writer}
+    response = send_http_read_response GET_10
+    assert_equal "HTTP/1.0 200 OK", response.status
+    assert_equal "HTTP/1.0"       , response.body
   end
 
-  def teardown
-    @server.stop(true)
-    # Errno::EBADF raised on macOS
-    @ios.each do |io|
-      begin
-        io.close if io.respond_to?(:close) && !io.closed?
-        File.unlink io.path if io.is_a? File
-      rescue Errno::EBADF
-      ensure
-        io = nil
-      end
-    end
+  def test_http10_req_to_http10_resp_ssl
+    set_bind_type :ssl
+    server_run app: ->(env) { [200, {}, [env["SERVER_PROTOCOL"]]] }
+
+    response = send_http_read_response GET_10
+    assert_equal "HTTP/1.0 200 OK", response.status
+    assert_equal "HTTP/1.0"       , response.body
   end
 
-  def server_run(**options, &block)
-    options[:log_writer]  ||= @log_writer
-    options[:min_threads] ||= 1
-    @server = Puma::Server.new block || @app, @events, options
-    @port = (@server.add_tcp_listener @host, 0).addr[1]
-    @server.run
+  def test_http10_req_to_http10_resp_unix
+    set_bind_type :unix
+    server_run app: ->(env) { [200, {}, [env["SERVER_PROTOCOL"]]] }
+
+    response = send_http_read_response GET_10
+    assert_equal "HTTP/1.0 200 OK", response.status
+    assert_equal "HTTP/1.0"       , response.body
   end
 
-  def header(socket)
-    header = []
-    while true
-      socket.wait_readable 5
-      line = socket.gets
-      break if line == "\r\n"
-      header << line.strip
-    end
 
-    header
-  end
+  def test_http11_req_to_http11_resp
+    server_run app: ->(env) { [200, {}, [env["SERVER_PROTOCOL"]]] }
 
-  # only for shorter bodies!
-  def send_http_and_sysread(req)
-    socket = send_http(req)
-    socket.wait_readable 5
-    socket.sysread 2_048
-  end
-
-  def send_http_and_read(req)
-    socket = send_http req
-    socket.wait_readable 5
-    socket.read
-  end
-
-  def send_http(req)
-    new_connection << req
-  end
-
-  def send_proxy_v1_http(req, remote_ip, multisend = false)
-    addr = IPAddr.new(remote_ip)
-    family = addr.ipv4? ? "TCP4" : "TCP6"
-    target = addr.ipv4? ? "127.0.0.1" : "::1"
-    conn = new_connection
-    if multisend
-      conn << "PROXY #{family} #{remote_ip} #{target} 10000 80\r\n"
-      sleep 0.15
-      conn << req
-    else
-      conn << ("PROXY #{family} #{remote_ip} #{target} 10000 80\r\n" + req)
-    end
-  end
-
-  def new_connection
-    TCPSocket.new(@host, @port).tap {|socket| @ios << socket}
+    response = send_http_read_response GET_11
+    assert_equal "HTTP/1.1 200 OK", response.status
+    assert_equal "HTTP/1.1"       , response.body
   end
 
   def test_normalize_host_header_missing
-    server_run do |env|
+    server_run app: ->(env) do
       [200, {}, [env["SERVER_NAME"], "\n", env["SERVER_PORT"]]]
     end
 
-    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
-    assert_equal "localhost\n80", data.split("\r\n").last
+    body = send_http_read_resp_body GET_10
+    assert_equal "localhost\n80", body
   end
 
   def test_normalize_host_header_hostname
-    server_run do |env|
+    server_run app: ->(env) do
       [200, {}, [env["SERVER_NAME"], "\n", env["SERVER_PORT"]]]
     end
 
-    data = send_http_and_read "GET / HTTP/1.0\r\nHost: example.com:456\r\n\r\n"
-    assert_equal "example.com\n456", data.split("\r\n").last
+    body = send_http_read_resp_body "GET / HTTP/1.0\r\nHost: example.com:456\r\n\r\n"
+    assert_equal "example.com\n456", body
 
-    data = send_http_and_read "GET / HTTP/1.0\r\nHost: example.com\r\n\r\n"
-    assert_equal "example.com\n80", data.split("\r\n").last
+    body = send_http_read_resp_body "GET / HTTP/1.0\r\nHost: example.com\r\n\r\n"
+    assert_equal "example.com\n80", body
   end
 
   def test_normalize_host_header_ipv4
-    server_run do |env|
+    server_run app: ->(env) do
       [200, {}, [env["SERVER_NAME"], "\n", env["SERVER_PORT"]]]
     end
 
-    data = send_http_and_read "GET / HTTP/1.0\r\nHost: 123.123.123.123:456\r\n\r\n"
-    assert_equal "123.123.123.123\n456", data.split("\r\n").last
+    body = send_http_read_resp_body "GET / HTTP/1.0\r\nHost: 123.123.123.123:456\r\n\r\n"
+    assert_equal "123.123.123.123\n456", body
 
-    data = send_http_and_read "GET / HTTP/1.0\r\nHost: 123.123.123.123\r\n\r\n"
-    assert_equal "123.123.123.123\n80", data.split("\r\n").last
+    body = send_http_read_resp_body "GET / HTTP/1.0\r\nHost: 123.123.123.123\r\n\r\n"
+    assert_equal "123.123.123.123\n80", body
   end
 
   def test_normalize_host_header_ipv6
-    server_run do |env|
+    server_run app: ->(env) do
       [200, {}, [env["SERVER_NAME"], "\n", env["SERVER_PORT"]]]
     end
 
-    data = send_http_and_read "GET / HTTP/1.0\r\nHost: [::ffff:127.0.0.1]:9292\r\n\r\n"
-    assert_equal "[::ffff:127.0.0.1]\n9292", data.split("\r\n").last
+    body = send_http_read_resp_body "GET / HTTP/1.0\r\nHost: [::ffff:127.0.0.1]:9292\r\n\r\n"
+    assert_equal "[::ffff:127.0.0.1]\n9292", body
 
-    data = send_http_and_read "GET / HTTP/1.0\r\nHost: [::1]:9292\r\n\r\n"
-    assert_equal "[::1]\n9292", data.split("\r\n").last
+    body = send_http_read_resp_body "GET / HTTP/1.0\r\nHost: [::1]:9292\r\n\r\n"
+    assert_equal "[::1]\n9292", body
 
-    data = send_http_and_read "GET / HTTP/1.0\r\nHost: [::1]\r\n\r\n"
-    assert_equal "[::1]\n80", data.split("\r\n").last
+    body = send_http_read_resp_body "GET / HTTP/1.0\r\nHost: [::1]\r\n\r\n"
+    assert_equal "[::1]\n80", body
   end
 
   def test_streaming_body
-    server_run do |env|
+    server_run app: ->(env) do
       body = lambda do |stream|
         stream.write("Hello World")
         stream.close
@@ -154,26 +106,23 @@ class TestPumaServer < Minitest::Test
       [200, {}, body]
     end
 
-    data = send_http_and_read "GET / HTTP/1.0\r\nConnection: close\r\n\r\n"
+    body = send_http_read_resp_body "GET / HTTP/1.0\r\nConnection: close\r\n\r\n"
 
-    assert_equal "Hello World", data.split("\r\n\r\n", 2).last
+    assert_equal "Hello World", body
   end
 
   def test_file_body
     random_bytes = SecureRandom.random_bytes(4096 * 32)
 
-    tf = tempfile_create("test_file_body", random_bytes)
+    tf = unique_path %w[body_ .io], contents: random_bytes, io: true
 
-    server_run { |env| [200, {}, tf] }
+    server_run app: ->(env) { [200, {}, tf] }
 
-    data = +''
-    socket = send_http("GET / HTTP/1.1\r\nHost: [::ffff:127.0.0.1]:#{@port}\r\n\r\n")
-    data << socket.sysread(65_536) while socket.wait_readable(0.1)
+    req = "GET / HTTP/1.1\r\nHost: [::ffff:127.0.0.1]:#{bind_port}\r\n\r\n"
+    body = send_http_read_resp_body req
 
-    ary = data.split("\r\n\r\n", 2)
-
-    assert_equal random_bytes.bytesize, ary.last.bytesize
-    assert_equal random_bytes, ary.last
+    assert_equal random_bytes.bytesize, body.bytesize
+    assert_equal random_bytes, body
   ensure
     tf.close
   end
@@ -181,30 +130,26 @@ class TestPumaServer < Minitest::Test
   def test_file_to_path
     random_bytes = SecureRandom.random_bytes(4096 * 32)
 
-    tf = tempfile_create("test_file_to_path", random_bytes)
-    path = tf.path
+    path = unique_path %w[body_ .io], contents: random_bytes
 
     obj = Object.new
     obj.singleton_class.send(:define_method, :to_path) { path }
     obj.singleton_class.send(:define_method, :each) { path } # dummy, method needs to exist
 
-    server_run { |env| [200, {}, obj] }
+    server_run app: ->(env) { [200, {}, obj] }
 
-    data = +''
-    socket = send_http("GET / HTTP/1.1\r\nHost: [::ffff:127.0.0.1]:#{@port}\r\n\r\n")
-    data << socket.sysread(65_536) while socket.wait_readable(0.1)
-    ary = data.split("\r\n\r\n", 2)
+    req = "GET / HTTP/1.1\r\nHost: [::ffff:127.0.0.1]:#{bind_port}\r\n\r\n"
 
-    assert_equal random_bytes.bytesize, ary.last.bytesize
-    assert_equal random_bytes, ary.last
-  ensure
-    tf.close
+    body = send_http_read_resp_body req
+
+    assert_equal random_bytes.bytesize, body.bytesize
+    assert_equal random_bytes, body
   end
 
   def test_proper_stringio_body
     data = nil
 
-    server_run do |env|
+    server_run app: ->(env) do
       data = env['rack.input'].read
       [200, {}, ["ok"]]
     end
@@ -223,14 +168,14 @@ class TestPumaServer < Minitest::Test
 
   def test_puma_socket
     body = "HTTP/1.1 750 Upgraded to Awesome\r\nDone: Yep!\r\n"
-    server_run do |env|
+    server_run app: ->(env) do
       io = env['puma.socket']
       io.write body
       io.close
       [-1, {}, []]
     end
 
-    data = send_http_and_read "PUT / HTTP/1.0\r\n\r\nHello"
+    data = send_http_read_response "PUT / HTTP/1.0\r\n\r\nHello"
 
     assert_equal body, data
   end
@@ -238,11 +183,11 @@ class TestPumaServer < Minitest::Test
   def test_very_large_return
     giant = "x" * 2056610
 
-    server_run do
+    server_run app: ->(env) do
       [200, {}, [giant]]
     end
 
-    socket = send_http "GET / HTTP/1.0\r\n\r\n"
+    socket = send_http GET_10
 
     while true
       line = socket.gets
@@ -259,7 +204,7 @@ class TestPumaServer < Minitest::Test
     env['HOST'] = "example.com"
     env['HTTP_X_FORWARDED_PROTO'] = "https,http"
 
-    assert_equal "443", @server.default_server_port(env)
+    assert_equal "443", server_new.default_server_port(env)
   end
 
   def test_respect_x_forwarded_ssl_on
@@ -267,7 +212,7 @@ class TestPumaServer < Minitest::Test
     env['HOST'] = 'example.com'
     env['HTTP_X_FORWARDED_SSL'] = 'on'
 
-    assert_equal "443", @server.default_server_port(env)
+    assert_equal "443", server_new.default_server_port(env)
   end
 
   def test_respect_x_forwarded_scheme
@@ -275,63 +220,52 @@ class TestPumaServer < Minitest::Test
     env['HOST'] = 'example.com'
     env['HTTP_X_FORWARDED_SCHEME'] = 'https'
 
-    assert_equal '443', @server.default_server_port(env)
+    assert_equal '443', server_new.default_server_port(env)
   end
 
   def test_default_server_port
-    server_run do |env|
-      [200, {}, [env['SERVER_PORT']]]
-    end
+    server_run app: ->(env) { [200, {}, [env['SERVER_PORT']]] }
 
-    req = Net::HTTP::Get.new '/'
-    req['HOST'] = 'example.com'
+    req = "GET / HTTP/1.0\r\nHost: example.com\r\n\r\n"
 
-    res = Net::HTTP.start @host, @port do |http|
-      http.request(req)
-    end
+    body = send_http_read_resp_body req
 
-    assert_equal "80", res.body
+    assert_equal "80", body
   end
 
   def test_default_server_port_respects_x_forwarded_proto
-    server_run do |env|
-      [200, {}, [env['SERVER_PORT']]]
-    end
+    server_run app: ->(env) { [200, {}, [env['SERVER_PORT']]] }
 
-    req = Net::HTTP::Get.new("/")
-    req['HOST'] = "example.com"
-    req['X-FORWARDED-PROTO'] = "https,http"
+    req = "GET / HTTP/1.0\r\nHost: example.com\r\nx-forwarded-proto: https,http\r\n\r\n"
 
-    res = Net::HTTP.start @host, @port do |http|
-      http.request(req)
-    end
+    body = send_http_read_resp_body req
 
-    assert_equal "443", res.body
+    assert_equal "443", body
   end
 
   def test_HEAD_has_no_body
-    server_run { [200, {"Foo" => "Bar"}, ["hello"]] }
+    server_run app: ->(env) { [200, {"Foo" => "Bar"}, ["hello"]] }
 
-    data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response "HEAD / HTTP/1.0\r\n\r\n"
 
     assert_equal "HTTP/1.0 200 OK\r\nFoo: Bar\r\nContent-Length: 5\r\n\r\n", data
   end
 
   def test_GET_with_empty_body_has_sane_chunking
-    server_run { [200, {}, [""]] }
+    server_run app: ->(env) { [200, {}, [""]] }
 
-    data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response "HEAD / HTTP/1.0\r\n\r\n"
 
     assert_equal "HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n", data
   end
 
   def test_early_hints_works
-    server_run(early_hints: true) do |env|
+    server_run early_hints: true, app: ->(env) do
      env['rack.early_hints'].call("Link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload")
      [200, { "X-Hello" => "World" }, ["Hello world!"]]
     end
 
-    data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response "HEAD / HTTP/1.0\r\n\r\n"
 
     expected_data = <<~EOF.gsub("\n", "\r\n") + "\r\n"
       HTTP/1.1 103 Early Hints
@@ -348,8 +282,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_early_hints_are_ignored_if_connection_lost
-
-    server_run(early_hints: true) do |env|
+    server_run early_hints: true, app: ->(env) do
       env['rack.early_hints'].call("Link" => "</script.js>; rel=preload")
       [200, { "X-Hello" => "World" }, ["Hello world!"]]
     end
@@ -369,12 +302,12 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_early_hints_is_off_by_default
-    server_run do |env|
+    server_run app: ->(env) do
      assert_nil env['rack.early_hints']
      [200, { "X-Hello" => "World" }, ["Hello world!"]]
     end
 
-    data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response "HEAD / HTTP/1.0\r\n\r\n"
 
     expected_data = <<~EOF.gsub("\n", "\r\n") + "\r\n"
       HTTP/1.0 200 OK
@@ -387,41 +320,43 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_request_payload_too_large
-    server_run(http_content_length_limit: 10)
+    server_run http_content_length_limit: 10
 
-    socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 19\r\n\r\n"
-    socket << "hello world foo bar"
+    req = "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\n" \
+      "Content-Length: 19\r\n\r\nhello world foo bar"
 
-    data = socket.gets
+    response = send_http_read_response req
 
     # Content Too Large
-    assert_equal "HTTP/1.1 413 #{STATUS_CODES[413]}\r\n", data
+    assert_equal "HTTP/1.1 413 #{STATUS_CODES[413]}", response.status
   end
 
   def test_http_11_keep_alive_with_large_payload
-    server_run(http_content_length_limit: 10) { [204, {}, []] }
+    server_run http_content_length_limit: 10,
+      app: ->(env) { [204, {}, []] }
 
     socket = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nContent-Length: 17\r\n\r\n"
     socket << "hello world foo bar"
-    h = header socket
+    response = socket.read_response
 
     # Content Too Large
-    assert_equal ["HTTP/1.1 413 #{STATUS_CODES[413]}", "Content-Length: 17"], h
-
+    assert_equal "HTTP/1.1 413 #{STATUS_CODES[413]}", response.status
+    assert_equal ["Content-Length: 17"], response.headers
   end
 
   def test_GET_with_no_body_has_sane_chunking
-    server_run { [200, {}, []] }
+    server_run app: ->(env) { [200, {}, []] }
 
-    data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response "HEAD / HTTP/1.0\r\n\r\n"
 
     assert_equal "HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n", data
   end
 
   def test_doesnt_print_backtrace_in_production
-    server_run(environment: :production) { raise "don't leak me bro" }
+    server_run environment: :production,
+      app: ->(env) { raise "don't leak me bro" }
 
-    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response GET_10
 
     refute_match(/don't leak me bro/, data)
     assert_match(/HTTP\/1.0 500 Internal Server Error/, data)
@@ -430,7 +365,7 @@ class TestPumaServer < Minitest::Test
   def test_eof_on_connection_close_is_not_logged_as_an_error
     server_run
 
-    new_connection.close # Make a connection and close without writing
+    new_socket.close # Make a connection and close without writing
 
     @server.stop(true)
     stderr = @log_writer.stderr.string
@@ -439,12 +374,13 @@ class TestPumaServer < Minitest::Test
 
   def test_force_shutdown_custom_error_message
     handler = lambda {|err, env, status| [500, {"Content-Type" => "application/json"}, ["{}\n"]]}
-    server_run(lowlevel_error_handler: handler, force_shutdown_after: 2) do
+    server_run lowlevel_error_handler: handler, force_shutdown_after: 2,
+    app: ->(env) do
       @server.stop
       sleep 5
     end
 
-    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response GET_10
 
     assert_match(/HTTP\/1.0 500 Internal Server Error/, data)
     assert_match(/Content-Type: application\/json/, data)
@@ -466,11 +402,10 @@ class TestPumaServer < Minitest::Test
   def test_lowlevel_error_body_close
     app_body = ArrayClose.new(['lowlevel_error'])
 
-    server_run(log_writer: @log_writer, :force_shutdown_after => 2) do
-      [[0,1], {}, app_body]
-    end
+    server_run log_writer: @log_writer, :force_shutdown_after => 2,
+      app: ->(env) { [[0,1], {}, app_body] }
 
-    data = send_http_and_sysread "GET / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response GET_10
 
     assert_includes data, 'HTTP/1.0 500 Internal Server Error'
     assert_includes data, "Puma caught this error: undefined method `to_i' for"
@@ -481,11 +416,10 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_lowlevel_error_message
-    server_run(log_writer: @log_writer, :force_shutdown_after => 2) do
-      raise NoMethodError, "Oh no an error"
-    end
+    server_run log_writer: @log_writer, force_shutdown_after: 2,
+    app: ->(env) { raise NoMethodError, "Oh no an error" }
 
-    data = send_http_and_sysread "GET / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response GET_10
 
     # Internal Server Error
     assert_includes data, "HTTP/1.0 500 #{STATUS_CODES[500]}"
@@ -493,11 +427,10 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_lowlevel_error_message_without_backtrace
-    server_run(log_writer: @log_writer, :force_shutdown_after => 2) do
-      raise WithoutBacktraceError.new
-    end
+    server_run log_writer: @log_writer, force_shutdown_after: 2,
+    app: ->(env) { raise WithoutBacktraceError.new }
 
-    data = send_http_and_sysread "GET / HTTP/1.1\r\n\r\n"
+    data = send_http_read_response
     # Internal Server Error
     assert_includes data, "HTTP/1.1 500 #{STATUS_CODES[500]}"
     assert_includes data, 'Puma caught this error: no backtrace error (WithoutBacktraceError)'
@@ -505,12 +438,12 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_force_shutdown_error_default
-    server_run(force_shutdown_after: 2) do
+    server_run force_shutdown_after: 2, app: ->(env) do
       @server.stop
       sleep 5
     end
 
-    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response GET_10
 
     assert_match(/HTTP\/1.0 503 Service Unavailable/, data)
     assert_match(/Puma caught this error.+Puma::ThreadPool::ForceShutdown/, data)
@@ -518,9 +451,9 @@ class TestPumaServer < Minitest::Test
 
   def test_prints_custom_error
     re = lambda { |err| [302, {'Content-Type' => 'text', 'Location' => 'foo.html'}, ['302 found']] }
-    server_run(lowlevel_error_handler: re) { raise "don't leak me bro" }
+    server_run lowlevel_error_handler: re, app: ->(env) { raise "don't leak me bro" }
 
-    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response GET_10
 
     assert_match(/HTTP\/1.0 302 Found/, data)
   end
@@ -531,9 +464,9 @@ class TestPumaServer < Minitest::Test
       [302, {'Content-Type' => 'text', 'Location' => 'foo.html'}, ['302 found']]
     }
 
-    server_run(lowlevel_error_handler: re) { raise "don't leak me bro" }
+    server_run lowlevel_error_handler: re, app: ->(env) { raise "don't leak me bro" }
 
-    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response GET_10
 
     assert_match(/HTTP\/1.0 302 Found/, data)
   end
@@ -544,47 +477,48 @@ class TestPumaServer < Minitest::Test
       [302, {'Content-Type' => 'text', 'Location' => 'foo.html'}, ['302 found']]
     }
 
-    server_run(lowlevel_error_handler: re) { raise "don't leak me bro" }
+    server_run lowlevel_error_handler: re, app: ->(env) { raise "don't leak me bro" }
 
-    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response GET_10
 
     assert_match(/HTTP\/1.0 302 Found/, data)
   end
 
   def test_custom_http_codes_10
-    server_run { [449, {}, [""]] }
+    server_run app: ->(env) { [449, {}, [""]] }
 
-    data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response GET_10
 
     assert_equal "HTTP/1.0 449 CUSTOM\r\nContent-Length: 0\r\n\r\n", data
   end
 
   def test_custom_http_codes_11
-    server_run { [449, {}, [""]] }
+    server_run app: ->(env) { [449, {}, [""]] }
 
-    data = send_http_and_read "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
+    data = send_http_read_response "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
 
     assert_equal "HTTP/1.1 449 CUSTOM\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
   end
 
   def test_HEAD_returns_content_headers
-    server_run { [200, {"Content-Type" => "application/pdf",
-                                     "Content-Length" => "4242"}, []] }
+    server_run app: ->(env) do [200, {"Content-Type" => "application/pdf",
+      "Content-Length" => "4242"}, []]
+    end
 
-    data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response "HEAD / HTTP/1.0\r\n\r\n"
 
     assert_equal "HTTP/1.0 200 OK\r\nContent-Type: application/pdf\r\nContent-Length: 4242\r\n\r\n", data
   end
 
   def test_status_hook_fires_when_server_changes_states
-
     states = []
 
+    @events = Puma::Events.new
     @events.register(:state) { |s| states << s }
 
-    server_run { [200, {}, [""]] }
+    server_run app: ->(_) { [200, {}, [""]] }
 
-    _ = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
+    send_http_read_response GET_10
 
     assert_equal [:booting, :running], states
 
@@ -594,27 +528,21 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_timeout_in_data_phase(**options)
-    server_run(first_data_timeout: 1, **options)
+    server_run first_data_timeout: 1, **options
 
     socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\n"
 
     socket << "Hello" unless socket.wait_readable(1.15)
 
-    data = socket.gets
-
     # Request Timeout
-    assert_equal "HTTP/1.1 408 #{STATUS_CODES[408]}\r\n", data
+    assert_equal "HTTP/1.1 408 #{STATUS_CODES[408]}", socket.read_response.status
   end
 
   def test_timeout_data_no_queue
-    test_timeout_in_data_phase(queue_requests: false)
+    test_timeout_in_data_phase queue_requests: false
   end
 
-  # https://github.com/puma/puma/issues/2574
-  def test_no_timeout_after_data_received
-    @server.instance_variable_set(:@first_data_timeout, 1)
-    server_run
-
+  def no_timeout_after_data_received
     socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 11\r\n\r\n"
     sleep 0.5
 
@@ -624,44 +552,48 @@ class TestPumaServer < Minitest::Test
     sleep 0.5
     socket << "!"
 
-    data = socket.gets
+    assert_equal "HTTP/1.1 200 OK", socket.read_response.status
+  end
 
-    assert_equal "HTTP/1.1 200 OK\r\n", data
+  # https://github.com/puma/puma/issues/2574
+  def test_no_timeout_after_data_received
+    server_run first_data_timeout: 1
+    no_timeout_after_data_received
   end
 
   def test_no_timeout_after_data_received_no_queue
-    @server = Puma::Server.new @app, @events, {log_writer: @log_writer, queue_requests: false}
-    test_no_timeout_after_data_received
+    server_run first_data_timeout: 1, queue_requests: false
+    no_timeout_after_data_received
   end
 
   def test_idle_timeout_before_first_request
-    server_run(idle_timeout: 1)
+    server_run idle_timeout: 1
 
     sleep 1.15
 
     assert @server.shutting_down?
 
     assert_raises Errno::ECONNREFUSED do
-      send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
+      send_http "POST / HTTP/1.1\r\nHost: test.com\r\n" \
+        "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
     end
   end
 
   def test_idle_timeout_before_first_request_data
-    server_run(idle_timeout: 1)
+    server_run idle_timeout: 1
 
-    socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
+    socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\n" \
+      "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
 
     sleep 1.15
 
     socket << "hello world!"
 
-    data = socket.gets
-
-    assert_equal "HTTP/1.1 200 OK\r\n", data
+    assert_equal "HTTP/1.1 200 OK", socket.read_response.status
   end
 
   def test_idle_timeout_between_first_request_data
-    server_run(idle_timeout: 1)
+    server_run idle_timeout: 1
 
     socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
 
@@ -671,21 +603,17 @@ class TestPumaServer < Minitest::Test
 
     socket << " world!"
 
-    data = socket.gets
-
-    assert_equal "HTTP/1.1 200 OK\r\n", data
+    assert_equal "HTTP/1.1 200 OK", socket.read_response.status
   end
 
   def test_idle_timeout_after_first_request
-    server_run(idle_timeout: 1)
+    server_run idle_timeout: 1
 
     socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
 
     socket << "hello world!"
 
-    data = socket.gets
-
-    assert_equal "HTTP/1.1 200 OK\r\n", data
+    assert_equal "HTTP/1.1 200 OK", socket.read_response.status
 
     sleep 1.15
 
@@ -693,24 +621,25 @@ class TestPumaServer < Minitest::Test
 
     assert socket.wait_readable(1), 'Unexpected timeout'
     assert_raises Errno::ECONNREFUSED do
-      send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
+      send_http "POST / HTTP/1.1\r\nHost: test.com\r\n" \
+        "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
     end
   end
 
   def test_idle_timeout_between_request_data
-    server_run(idle_timeout: 1)
+    server_run idle_timeout: 1
 
-    socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
+    socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\n" \
+      "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
 
     socket << "hello world!"
 
-    data = socket.gets
-
-    assert_equal "HTTP/1.1 200 OK\r\n", data
+    assert_equal "HTTP/1.1 200 OK", socket.read_response.status
 
     sleep 0.5
 
-    socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
+    socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\n" \
+      "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
 
     socket << "hello"
 
@@ -718,9 +647,7 @@ class TestPumaServer < Minitest::Test
 
     socket << " world!"
 
-    data = socket.gets
-
-    assert_equal "HTTP/1.1 200 OK\r\n", data
+    assert_equal "HTTP/1.1 200 OK", socket.read_response.status
 
     sleep 1.15
 
@@ -728,30 +655,29 @@ class TestPumaServer < Minitest::Test
 
     assert socket.wait_readable(1), 'Unexpected timeout'
     assert_raises Errno::ECONNREFUSED do
-      send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
+      send_http "POST / HTTP/1.1\r\nHost: test.com\r\n" \
+        "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
     end
   end
 
   def test_idle_timeout_between_requests
-    server_run(idle_timeout: 1)
+    server_run idle_timeout: 1
 
-    socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
+    socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\n" \
+      "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
 
     socket << "hello world!"
 
-    data = socket.gets
-
-    assert_equal "HTTP/1.1 200 OK\r\n", data
+    assert_equal "HTTP/1.1 200 OK", socket.read_response.status
 
     sleep 0.5
 
-    socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
+    socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\n" \
+      "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
 
     socket << "hello world!"
 
-    data = socket.gets
-
-    assert_equal "HTTP/1.1 200 OK\r\n", data
+    assert_equal "HTTP/1.1 200 OK", socket.read_response.status
 
     sleep 1.15
 
@@ -759,98 +685,96 @@ class TestPumaServer < Minitest::Test
 
     assert socket.wait_readable(1), 'Unexpected timeout'
     assert_raises Errno::ECONNREFUSED do
-      send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
+      send_http "POST / HTTP/1.1\r\nHost: test.com\r\n" \
+        "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
     end
   end
 
   def test_http_11_keep_alive_with_body
-    server_run { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
+    server_run app: ->(env) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\n\r\n"
+    req  = "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\n\r\n"
+    response = send_http_read_response req
 
-    h = header socket
-
-    body = socket.gets
-
-    assert_equal ["HTTP/1.1 200 OK", "Content-Type: plain/text", "Content-Length: 6"], h
-    assert_equal "hello\n", body
-
-    socket.close
+    assert_equal ["Content-Type: plain/text", "Content-Length: 6"], response.headers
+    assert_equal "hello\n", response.body
   end
 
   def test_http_11_close_with_body
-    server_run { [200, {"Content-Type" => "plain/text"}, ["hello"]] }
+    server_run app: ->(env) { [200, {"Content-Type" => "plain/text"}, ["hello"]] }
 
-    data = send_http_and_read "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
+    data = send_http_read_response "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
 
     assert_equal "HTTP/1.1 200 OK\r\nContent-Type: plain/text\r\nConnection: close\r\nContent-Length: 5\r\n\r\nhello", data
   end
 
   def test_http_11_keep_alive_without_body
-    server_run { [204, {}, []] }
+    server_run app: ->(env) { [204, {}, []] }
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\n\r\n"
+    req = "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\n\r\n"
 
-    h = header socket
+    status = send_http_read_response(req).status
 
     # No Content
-    assert_equal ["HTTP/1.1 204 #{STATUS_CODES[204]}"], h
+    assert_equal "HTTP/1.1 204 #{STATUS_CODES[204]}", status
   end
 
   def test_http_11_close_without_body
-    server_run { [204, {}, []] }
+    server_run app: ->(env) { [204, {}, []] }
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
+    req = "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
 
-    h = header socket
+    response = send_http_read_response req
 
     # No Content
-    assert_equal ["HTTP/1.1 204 #{STATUS_CODES[204]}", "Connection: close"], h
+    assert_equal "HTTP/1.1 204 #{STATUS_CODES[204]}", response.status
+    assert_equal ["Connection: close"], response.headers
   end
 
   def test_http_10_keep_alive_with_body
-    server_run { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
+    server_run app: ->(env) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 
-    socket = send_http "GET / HTTP/1.0\r\nConnection: Keep-Alive\r\n\r\n"
+    req = "GET / HTTP/1.0\r\nConnection: Keep-Alive\r\n\r\n"
 
-    h = header socket
+    response = send_http_read_response req
 
-    body = socket.gets
-
-    assert_equal ["HTTP/1.0 200 OK", "Content-Type: plain/text", "Connection: Keep-Alive", "Content-Length: 6"], h
-    assert_equal "hello\n", body
+    assert_equal ["Content-Type: plain/text", "Connection: Keep-Alive", "Content-Length: 6"],
+      response.headers
+    assert_equal "hello\n", response.body
   end
 
   def test_http_10_close_with_body
-    server_run { [200, {"Content-Type" => "plain/text"}, ["hello"]] }
+    server_run app: ->(env) { [200, {"Content-Type" => "plain/text"}, ["hello"]] }
 
-    data = send_http_and_read "GET / HTTP/1.0\r\nConnection: close\r\n\r\n"
+    response = send_http_read_response "GET / HTTP/1.0\r\nConnection: close\r\n\r\n"
 
-    assert_equal "HTTP/1.0 200 OK\r\nContent-Type: plain/text\r\nContent-Length: 5\r\n\r\nhello", data
+    assert_equal ["Content-Type: plain/text", "Content-Length: 5"], response.headers
+    assert_equal "hello", response.body
   end
 
   def test_http_10_keep_alive_without_body
-    server_run { [204, {}, []] }
+    server_run app: ->(env) { [204, {}, []] }
 
-    socket = send_http "GET / HTTP/1.0\r\nConnection: Keep-Alive\r\n\r\n"
+    req = "GET / HTTP/1.0\r\nConnection: Keep-Alive\r\n\r\n"
 
-    h = header socket
+    response = send_http_read_response req
 
-    assert_equal ["HTTP/1.0 204 No Content", "Connection: Keep-Alive"], h
+    assert_equal "HTTP/1.0 204 No Content", response.status
+    assert_equal ["Connection: Keep-Alive"], response.headers
   end
 
   def test_http_10_close_without_body
-    server_run { [204, {}, []] }
+    server_run app: ->(env) { [204, {}, []] }
 
-    data = send_http_and_read "GET / HTTP/1.0\r\nConnection: close\r\n\r\n"
+    status = send_http_read_response("GET / HTTP/1.0\r\nConnection: close\r\n\r\n").status
 
-    assert_equal "HTTP/1.0 204 No Content\r\n\r\n", data
+    assert_equal "HTTP/1.0 204 No Content", status
   end
 
   def test_Expect_100
-    server_run { [200, {}, [""]] }
+    server_run app: ->(env) { [200, {}, [""]] }
 
-    data = send_http_and_read "GET / HTTP/1.1\r\nConnection: close\r\nExpect: 100-continue\r\n\r\n"
+    data = send_http_read_response "GET / HTTP/1.1\r\nConnection: close\r\nExpect: 100-continue\r\n\r\n"
 
     assert_equal "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
   end
@@ -859,16 +783,16 @@ class TestPumaServer < Minitest::Test
     body = nil
     content_length = nil
     transfer_encoding = nil
-    server_run { |env|
+    server_run app: ->(env) do
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       transfer_encoding = env['HTTP_TRANSFER_ENCODING']
       [200, {}, [""]]
-    }
+    end
 
-    data = send_http_and_read "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: gzip,chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
+    response = send_http_read_response "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: gzip,chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
-    assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
+    assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", response
     assert_equal "hello", body
     assert_equal "5", content_length
     assert_nil transfer_encoding
@@ -877,11 +801,11 @@ class TestPumaServer < Minitest::Test
   def test_large_chunked_request
     body = nil
     content_length = nil
-    server_run { |env|
+    server_run app: ->(env) do
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
-    }
+    end
 
     header = "GET / HTTP/1.1\r\nConnection: close\r\nContent-Length: 200\r\nTransfer-Encoding: chunked\r\n\r\n"
 
@@ -896,7 +820,7 @@ class TestPumaServer < Minitest::Test
       request_body = '.' * size
       request = "#{header}#{size.to_s(16)}\r\n#{request_body}\r\n0\r\n\r\n"
 
-      data = send_http_and_read request
+      data = send_http_read_response request
 
       assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
       assert_equal size, Integer(content_length)
@@ -907,18 +831,18 @@ class TestPumaServer < Minitest::Test
   def test_chunked_request_pause_before_value
     body = nil
     content_length = nil
-    server_run { |env|
+    server_run app: ->(env) do
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
-    }
+    end
 
     socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r\n"
     sleep 1
 
     socket << "h\r\n4\r\nello\r\n0\r\n\r\n"
 
-    data = socket.read
+    data = socket.read_response
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
@@ -928,18 +852,18 @@ class TestPumaServer < Minitest::Test
   def test_chunked_request_pause_between_chunks
     body = nil
     content_length = nil
-    server_run { |env|
+    server_run app: ->(env) do
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
-    }
+    end
 
     socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n"
     sleep 1
 
     socket << "4\r\nello\r\n0\r\n\r\n"
 
-    data = socket.read
+    data = socket.read_response
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
@@ -949,18 +873,18 @@ class TestPumaServer < Minitest::Test
   def test_chunked_request_pause_mid_count
     body = nil
     content_length = nil
-    server_run { |env|
+    server_run app: ->(env) do
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
-    }
+    end
 
     socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r"
     sleep 1
 
     socket << "\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
-    data = socket.read
+    data = socket.read_response
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
@@ -970,18 +894,18 @@ class TestPumaServer < Minitest::Test
   def test_chunked_request_pause_before_count_newline
     body = nil
     content_length = nil
-    server_run { |env|
+    server_run app: ->(env) do
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
-    }
+    end
 
     socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1"
     sleep 1
 
     socket << "\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
-    data = socket.read
+    data = socket.read_response
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
@@ -991,18 +915,18 @@ class TestPumaServer < Minitest::Test
   def test_chunked_request_pause_mid_value
     body = nil
     content_length = nil
-    server_run { |env|
+    server_run app: ->(env) do
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
-    }
+    end
 
     socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\ne"
     sleep 1
 
     socket << "llo\r\n0\r\n\r\n"
 
-    data = socket.read
+    data = socket.read_response
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
@@ -1012,11 +936,11 @@ class TestPumaServer < Minitest::Test
   def test_chunked_request_pause_between_cr_lf_after_size_of_second_chunk
     body = nil
     content_length = nil
-    server_run { |env|
+    server_run app: ->(env) do
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
-    }
+    end
 
     part1 = 'a' * 4200
 
@@ -1032,7 +956,7 @@ class TestPumaServer < Minitest::Test
 
     socket << chunked_body[-9..-1]
 
-    data = socket.read
+    data = socket.read_response
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal (part1 + 'b'), body
@@ -1042,11 +966,11 @@ class TestPumaServer < Minitest::Test
   def test_chunked_request_pause_between_closing_cr_lf
     body = nil
     content_length = nil
-    server_run { |env|
+    server_run app: ->(env) do
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
-    }
+    end
 
     socket = send_http "PUT /path HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r"
 
@@ -1054,7 +978,7 @@ class TestPumaServer < Minitest::Test
 
     socket << "\n0\r\n\r\n"
 
-    data = socket.read
+    data = socket.read_response
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal 'hello', body
@@ -1064,11 +988,11 @@ class TestPumaServer < Minitest::Test
   def test_chunked_request_pause_before_closing_cr_lf
     body = nil
     content_length = nil
-    server_run { |env|
+    server_run app: ->(env) do
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
-    }
+    end
 
     socket = send_http "PUT /path HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello"
 
@@ -1076,7 +1000,7 @@ class TestPumaServer < Minitest::Test
 
     socket << "\r\n0\r\n\r\n"
 
-    data = socket.read
+    data = socket.read_response
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal 'hello', body
@@ -1086,13 +1010,13 @@ class TestPumaServer < Minitest::Test
   def test_chunked_request_header_case
     body = nil
     content_length = nil
-    server_run { |env|
+    server_run app: ->(env) do
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
-    }
+    end
 
-    data = send_http_and_read "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: Chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
+    data = send_http_read_response "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: Chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
     assert_equal "hello", body
@@ -1102,31 +1026,30 @@ class TestPumaServer < Minitest::Test
   def test_chunked_keep_alive
     body = nil
     content_length = nil
-    server_run { |env|
+    server_run app: ->(env) do
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
-    }
+    end
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
+    req = "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n" \
+      "\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
-    h = header socket
+    response = send_http_read_response(req)
 
-    assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], h
+    assert_equal ["Content-Length: 0"], response.headers
     assert_equal "hello", body
     assert_equal "5", content_length
-
-    socket.close
   end
 
   def test_chunked_keep_alive_two_back_to_back
     body = nil
     content_length = nil
-    server_run { |env|
+    server_run app: ->(env) do
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
       [200, {}, [""]]
-    }
+    end
 
     socket = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n"
 
@@ -1139,8 +1062,9 @@ class TestPumaServer < Minitest::Test
       last_crlf_written = true
     end
 
-    h = header(socket)
-    assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], h
+    response = socket.read_response
+
+    assert_equal ["Content-Length: 0"], response.headers
     assert_equal "hello", body
     assert_equal "5", content_length
     sleep 0.05 if TRUFFLE
@@ -1151,30 +1075,32 @@ class TestPumaServer < Minitest::Test
     socket << "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ngood\r\n3\r\nbye\r\n0\r\n\r\n"
     sleep 0.1
 
-    h = header(socket)
+    response = socket.read_response
 
-    assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], h
+    assert_equal ["Content-Length: 0"], response.headers
     assert_equal "goodbye", body
     assert_equal "7", content_length
-
-    socket.close
   end
 
   def test_chunked_keep_alive_two_back_to_back_with_set_remote_address
     body = nil
     content_length = nil
     remote_addr =nil
-    server_run(remote_address: :header, remote_address_header: 'HTTP_X_FORWARDED_FOR') { |env|
-      body = env['rack.input'].read
-      content_length = env['CONTENT_LENGTH']
-      remote_addr = env['REMOTE_ADDR']
-      [200, {}, [""]]
-    }
+    server_run remote_address: :header, remote_address_header: 'HTTP_X_FORWARDED_FOR',
+      app: ->(env) do
+        body = env['rack.input'].read
+        content_length = env['CONTENT_LENGTH']
+        remote_addr = env['REMOTE_ADDR']
+        [200, {}, [""]]
+      end
 
-    socket = send_http "GET / HTTP/1.1\r\nX-Forwarded-For: 127.0.0.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
+    req = "GET / HTTP/1.1\r\nX-Forwarded-For: 127.0.0.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
-    h = header socket
-    assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], h
+    socket = send_http req
+
+    response = socket.read_response
+
+    assert_equal ["Content-Length: 0"], response.headers
     assert_equal "hello", body
     assert_equal "5", content_length
     assert_equal "127.0.0.1", remote_addr
@@ -1182,21 +1108,20 @@ class TestPumaServer < Minitest::Test
     socket << "GET / HTTP/1.1\r\nX-Forwarded-For: 127.0.0.2\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ngood\r\n3\r\nbye\r\n0\r\n\r\n"
     sleep 0.1
 
-    h = header(socket)
-
-    assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], h
+    response = socket.read_response
+    assert_equal ["Content-Length: 0"], response.headers
     assert_equal "goodbye", body
     assert_equal "7", content_length
     assert_equal "127.0.0.2", remote_addr
-
-    socket.close
   end
 
   def test_chunked_encoding
     enc = Encoding::UTF_16LE
-    str = "──иї_テスト──\n".encode enc
+    str = "──иї_テスト──\n".encode(enc, Encoding::UTF_8)
 
-    server_run {
+    suffix = "\nHello World\n".encode(enc, Encoding::UTF_8)
+
+    server_run app: ->(env) do
       hdrs = {}
       hdrs['Content-Type'] = "text; charset=#{enc.to_s.downcase}"
 
@@ -1204,39 +1129,41 @@ class TestPumaServer < Minitest::Test
         100.times do |entry|
           yielder << str
         end
-        yielder << "\nHello World\n".encode(enc)
+        yielder << suffix
       end
 
       [200, hdrs, body]
-    }
-
-    body = Net::HTTP.start @host, @port do |http|
-      http.request(Net::HTTP::Get.new '/').body.force_encoding(enc)
     end
-    assert_includes body, str
+
+    # PumaSocket doesn't process Content-Type charset
+    body = send_http_read_response.decode_body
+    body = body.force_encoding enc
+
+    assert_operator body, :start_with?, str
+    assert_operator body, :end_with?  , suffix
     assert_equal enc, body.encoding
   end
 
   def test_empty_header_values
-    server_run { [200, {"X-Empty-Header" => ""}, []] }
+    server_run app: ->(env) { [200, {"X-Empty-Header" => ""}, []] }
 
-    data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response "HEAD / HTTP/1.0\r\n\r\n"
 
     assert_equal "HTTP/1.0 200 OK\r\nX-Empty-Header: \r\nContent-Length: 0\r\n\r\n", data
   end
 
   def test_request_body_wait
     request_body_wait = nil
-    server_run { |env|
+    server_run app: ->(env) do
       request_body_wait = env['puma.request_body_wait']
       [204, {}, []]
-    }
+    end
 
     socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nh"
     sleep 1
     socket << "ello"
 
-    socket.gets
+    socket.read_response
 
     assert request_body_wait.is_a?(Float)
     # Could be 1000 but the tests get flaky. We don't care if it's extremely precise so much as that
@@ -1246,16 +1173,16 @@ class TestPumaServer < Minitest::Test
 
   def test_request_body_wait_chunked
     request_body_wait = nil
-    server_run { |env|
+    server_run app: ->(env) do
       request_body_wait = env['puma.request_body_wait']
       [204, {}, []]
-    }
+    end
 
     socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n"
     sleep 3
     socket << "4\r\nello\r\n0\r\n\r\n"
 
-    socket.gets
+    socket.read_response
 
     # Could be 1000 but the tests get flaky. We don't care if it's extremely precise so much as that
     # it is set to a reasonable number.
@@ -1263,11 +1190,12 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_open_connection_wait(**options)
-    server_run(**options) { [200, {}, ["Hello"]] }
+    server_run(**options, app: ->(env) { [200, {}, ["Hello"]] })
+
     s = send_http nil
     sleep 0.1
-    s << "GET / HTTP/1.0\r\n\r\n"
-    assert_equal 'Hello', s.readlines.last
+    s << GET_10
+    assert_equal 'Hello', s.read_body
   end
 
   def test_open_connection_wait_no_queue
@@ -1276,45 +1204,57 @@ class TestPumaServer < Minitest::Test
 
   # Rack may pass a newline in a header expecting us to split it.
   def test_newline_splits
-    server_run { [200, {'X-header' => "first line\nsecond line"}, ["Hello"]] }
+    server_run app: ->(env) { [200, {'X-header' => "first line\nsecond line"}, ["Hello"]] }
 
-    data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response "HEAD / HTTP/1.0\r\n\r\n"
 
     assert_match "X-header: first line\r\nX-header: second line\r\n", data
   end
 
   def test_newline_splits_in_early_hint
-    server_run(early_hints: true) do |env|
+    server_run early_hints: true, app: ->(env) do
       env['rack.early_hints'].call({'X-header' => "first line\nsecond line"})
       [200, {}, ["Hello world!"]]
     end
 
-    data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response "HEAD / HTTP/1.0\r\n\r\n"
 
     assert_match "X-header: first line\r\nX-header: second line\r\n", data
   end
 
-  def test_proxy_protocol
-    server_run(remote_address: :proxy_protocol, remote_address_proxy_protocol: :v1) do |env|
-      [200, {}, [env["REMOTE_ADDR"]]]
+  def send_proxy_v1_http(req, remote_ip, multisend = false)
+    addr = IPAddr.new(remote_ip)
+    family = addr.ipv4? ? "TCP4" : "TCP6"
+    target = addr.ipv4? ? "127.0.0.1" : "::1"
+    socket = new_socket
+    if multisend
+      socket << "PROXY #{family} #{remote_ip} #{target} 10000 80\r\n"
+      socket << req
+    else
+      socket << ("PROXY #{family} #{remote_ip} #{target} 10000 80\r\n" + req)
     end
+  end
 
-    remote_addr = send_proxy_v1_http("GET / HTTP/1.0\r\n\r\n", "1.2.3.4").read.split("\r\n").last
+  def test_proxy_protocol
+    server_run remote_address: :proxy_protocol, remote_address_proxy_protocol: :v1,
+      app: ->(env) { [200, {}, [env["REMOTE_ADDR"]]] }
+
+    remote_addr = send_proxy_v1_http(GET_10, "1.2.3.4").read.split("\r\n").last
     assert_equal '1.2.3.4', remote_addr
 
-    remote_addr = send_proxy_v1_http("GET / HTTP/1.0\r\n\r\n", "fd00::1").read.split("\r\n").last
+    remote_addr = send_proxy_v1_http(GET_10, "fd00::1").read.split("\r\n").last
     assert_equal 'fd00::1', remote_addr
 
-    remote_addr = send_proxy_v1_http("GET / HTTP/1.0\r\n\r\n", "fd00::1", true).read.split("\r\n").last
+    remote_addr = send_proxy_v1_http(GET_10, "fd00::1", true).read.split("\r\n").last
     assert_equal 'fd00::1', remote_addr
   end
 
   # To comply with the Rack spec, we have to split header field values
   # containing newlines into multiple headers.
   def assert_does_not_allow_http_injection(app, opts = {})
-    server_run(early_hints: opts[:early_hints], &app)
+    server_run early_hints: opts[:early_hints], app: ->(env) { app }
 
-    data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
+    data = send_http_read_response "HEAD / HTTP/1.0\r\n\r\n"
 
     refute_match(/[\r\n]Cookie: hack[\r\n]/, data)
   end
@@ -1353,18 +1293,19 @@ class TestPumaServer < Minitest::Test
     end
   end
 
-  # Perform a server shutdown while requests are pending (one in app-server response, one still sending client request).
+  # Perform a server shutdown while requests are pending,
+  # one in app-server response, one still sending client request.
   def shutdown_requests(s1_complete: true, s1_response: nil, post: false, s2_response: nil, **options)
     mutex = Mutex.new
     app_finished = ConditionVariable.new
-    server_run(**options) { |env|
+    server_run(**options, app: ->(env) {
       path = env['REQUEST_PATH']
       mutex.synchronize do
         app_finished.signal
         app_finished.wait(mutex) if path == '/s1'
       end
       [204, {}, []]
-    }
+    })
 
     pool = @server.instance_variable_get(:@thread_pool)
 
@@ -1431,55 +1372,59 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_http11_connection_header_queue
-    server_run { [200, {}, [""]] }
+    server_run app: ->(env) { [200, {}, [""]] }
 
-    socket = send_http "GET / HTTP/1.1\r\n\r\n"
-    assert_equal ["HTTP/1.1 200 OK", "Content-Length: 0"], header(socket)
+    socket = send_http GET_11
+
+    response = socket.read_response
+
+    assert_equal ["Content-Length: 0"], response.headers
 
     socket << "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
-    assert_equal ["HTTP/1.1 200 OK", "Connection: close", "Content-Length: 0"], header(socket)
+    response = socket.read_response
 
-    socket.close
+    assert_equal ["Connection: close", "Content-Length: 0"], response.headers
   end
 
   def test_http10_connection_header_queue
-    server_run { [200, {}, [""]] }
+    server_run app: ->(env) { [200, {}, [""]] }
 
     socket = send_http "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n"
-    assert_equal ["HTTP/1.0 200 OK", "Connection: Keep-Alive", "Content-Length: 0"], header(socket)
+    response = socket.read_response
 
-    socket << "GET / HTTP/1.0\r\n\r\n"
-    assert_equal ["HTTP/1.0 200 OK", "Content-Length: 0"], header(socket)
-    socket.close
+    assert_equal ["Connection: Keep-Alive", "Content-Length: 0"], response.headers
+
+    socket << GET_10
+    response = socket.read_response
+
+    assert_equal ["Content-Length: 0"], response.headers
   end
 
   def test_http11_connection_header_no_queue
-    server_run(queue_requests: false) { [200, {}, [""]] }
-    socket = send_http "GET / HTTP/1.1\r\n\r\n"
-    assert_equal ["HTTP/1.1 200 OK", "Connection: close", "Content-Length: 0"], header(socket)
-    socket.close
+    server_run queue_requests: false, app: ->(env) { [200, {}, [""]] }
+    response = send_http_read_response GET_11
+    assert_equal ["Connection: close", "Content-Length: 0"], response.headers
   end
 
   def test_http10_connection_header_no_queue
-    server_run(queue_requests: false) { [200, {}, [""]] }
-    socket = send_http "GET / HTTP/1.0\r\n\r\n"
-    assert_equal ["HTTP/1.0 200 OK", "Content-Length: 0"], header(socket)
-    socket.close
+    server_run queue_requests: false, app: ->(env) { [200, {}, [""]] }
+    response = send_http_read_response GET_10
+    assert_equal ["Content-Length: 0"], response.headers
+
   end
 
   def stub_accept_nonblock(error)
-    @port = (@server.add_tcp_listener @host, 0).addr[1]
-    io = @server.binder.ios.last
-
+    io = server_new.binder.ios.last
     accept_old = io.method(:accept_nonblock)
-    io.singleton_class.send :define_method, :accept_nonblock do
+    io.define_singleton_method :accept_nonblock do
       accept_old.call.close
       raise error
     end
 
-    @server.run
-    new_connection
-    sleep 0.01
+    server_new_run
+
+    send_http
+    sleep Puma::IS_WINDOWS ? 0.1 : 0.01
   end
 
   # System-resource errors such as EMFILE should not be silently swallowed by accept loop.
@@ -1505,36 +1450,27 @@ class TestPumaServer < Minitest::Test
       [500, {"Content-Type" => "application/json"}, ["{}\n"]]
     }
 
-    server_run(lowlevel_error_handler: handler) { [200, {}, ['Hello World']] }
+    server_run lowlevel_error_handler: handler,
+      app: ->(env) { [200, {}, ['Hello World']] }
 
     # valid req & read, close
-    socket = TCPSocket.new @host, @port
-    socket.syswrite "GET / HTTP/1.0\r\n\r\n"
+    socket = send_http GET_10
     sleep 0.05  # macOS TruffleRuby may not get the body without
-    resp = socket.sysread 256
-    socket.close
-    assert_match 'Hello World', resp
-    sleep 0.5
+    assert_match 'Hello World', socket.read_body
     assert_empty @log_writer.stdout.string
 
     # valid req, close
-    socket = TCPSocket.new @host, @port
-    socket.syswrite "GET / HTTP/1.0\r\n\r\n"
-    socket.close
-    sleep 0.5
+    send_http(GET_10).close
     assert_empty @log_writer.stdout.string
 
     # invalid req, close
-    socket = TCPSocket.new @host, @port
-    socket.syswrite "GET / HTTP"
-    socket.close
-    sleep 0.5
+    send_http("GET / HTTP").close
     assert_empty @log_writer.stdout.string
   end
 
   def test_idle_connections_closed_immediately_on_shutdown
     server_run
-    socket = new_connection
+    socket = new_socket
     sleep 0.5 # give enough time for new connection to enter reactor
     @server.stop false
 
@@ -1545,16 +1481,18 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_run_stop_thread_safety
+    server_new
     100.times do
-      thread = @server.run
+      thread = server_new_run
       @server.stop
       assert thread.join(1)
     end
   end
 
   def test_command_ignored_before_run
+    server_new
     @server.stop # ignored
-    @server.run
+    server_run
     @server.halt
     done = Queue.new
     @server.events.register(:state) do |state|
@@ -1564,32 +1502,32 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_custom_io_selector
-    backend = NIO::Selector.backends.first
+    require "nio" unless Object.const_defined? :NIO # if this test runs first...
+    backend = ::NIO::Selector.backends.first
 
-    @server = Puma::Server.new @app, @events, {log_writer: @log_writer, :io_selector_backend => backend}
-    @server.run
+    server_run io_selector_backend: backend
 
     selector = @server.instance_variable_get(:@reactor).instance_variable_get(:@selector)
 
     assert_equal selector.backend, backend
   end
 
-  def test_drain_on_shutdown(drain=true)
+  def test_drain_on_shutdown(drain = true)
     num_connections = 10
 
     wait = Queue.new
-    server_run(drain_on_shutdown: drain, max_threads: 1) do
+    server_run drain_on_shutdown: drain, max_threads: 1, app: ->(env) do
       wait.pop
       [200, {}, ["DONE"]]
     end
-    connections = Array.new(num_connections) {send_http "GET / HTTP/1.0\r\n\r\n"}
+    connections = Array.new(num_connections) { send_http GET_10 }
     @server.stop
     wait.close
     bad = 0
     connections.each do |s|
       begin
         if s.wait_readable(1) and drain # JRuby may hang on read with drain is false
-          assert_match 'DONE', s.read
+          assert_operator s.read, :end_with?, "DONE"
         else
           bad += 1
         end
@@ -1609,33 +1547,15 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_remote_address_header
-    server_run(remote_address: :header, remote_address_header: 'HTTP_X_REMOTE_IP') do |env|
-      [200, {}, [env['REMOTE_ADDR']]]
-    end
-    remote_addr = send_http_and_read("GET / HTTP/1.1\r\nX-Remote-IP: 1.2.3.4\r\n\r\n").split("\r\n").last
+    server_run remote_address: :header, remote_address_header: 'HTTP_X_REMOTE_IP',
+      app: ->(env) { [200, {}, [env['REMOTE_ADDR']]] }
+
+    remote_addr = send_http_read_response("GET / HTTP/1.1\r\nX-Remote-IP: 1.2.3.4\r\n\r\n").split("\r\n").last
     assert_equal '1.2.3.4', remote_addr
 
     # TODO: it would be great to test a connection from a non-localhost IP, but we can't really do that. For
     # now, at least test that it doesn't return garbage.
-    remote_addr = send_http_and_sysread("GET / HTTP/1.1\r\n\r\n").split("\r\n").last
-    assert_equal @host, remote_addr
-  end
-
-  def get_chunk_times
-    body = +''
-    times = []
-    Net::HTTP.start @host, @port do |http|
-      req = Net::HTTP::Get.new '/'
-      http.request req do |resp|
-        resp.read_body do |chunk|
-          next if chunk.empty?
-          body << chunk
-          times << Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        end
-
-      end
-    end
-    [body, times]
+    assert_equal HOST, send_http_read_resp_body
   end
 
   # see https://github.com/sinatra/sinatra/blob/master/examples/stream.ru
@@ -1643,7 +1563,7 @@ class TestPumaServer < Minitest::Test
     str = "Hello Puma World"
     body_len = str.bytesize * 3
 
-    server_run do |env|
+    server_run app: ->(env) do
       hdrs = {}
       hdrs['Content-Type'] = "text; charset=utf-8"
 
@@ -1657,7 +1577,10 @@ class TestPumaServer < Minitest::Test
       [200, hdrs, body]
     end
 
-    resp_body, times = get_chunk_times
+    response = send_http_read_response
+    resp_body = response.decode_body
+    times = response.times
+
     assert_equal body_len, resp_body.bytesize
     assert_equal str * 3, resp_body
     assert times[1] - times[0] > 0.4
@@ -1672,7 +1595,7 @@ class TestPumaServer < Minitest::Test
     loops = 10
     body_len = str.bytesize * loops
 
-    server_run do |env|
+    server_run app: ->(env) do
       hdrs = {}
       hdrs['Content-Type'] = "text; charset=utf-8"
 
@@ -1684,32 +1607,36 @@ class TestPumaServer < Minitest::Test
       end
       [200, hdrs, body]
     end
-    resp_body, times = get_chunk_times
+
+    response = send_http_read_response
+    resp_body = response.decode_body
+    times = response.times
+
     assert_equal body_len, resp_body.bytesize
     assert_equal str * loops, resp_body
     assert_operator times.last - times.first, :>, 1.0
   end
 
   def test_empty_body_array_content_length_0
-    server_run { |env| [404, {'Content-Length' => '0'}, []] }
+    server_run app: ->(env) { [404, {'Content-Length' => '0'}, []] }
 
-    resp = send_http_and_sysread "GET / HTTP/1.1\r\n\r\n"
+    resp = send_http_read_response
     # Not Found
     assert_equal "HTTP/1.1 404 #{STATUS_CODES[404]}\r\nContent-Length: 0\r\n\r\n", resp
   end
 
   def test_empty_body_array_no_content_length
-    server_run { |env| [404, {}, []] }
+    server_run app: ->(env) { [404, {}, []] }
 
-    resp = send_http_and_sysread "GET / HTTP/1.1\r\n\r\n"
+    resp = send_http_read_response
     # Not Found
     assert_equal "HTTP/1.1 404 #{STATUS_CODES[404]}\r\nContent-Length: 0\r\n\r\n", resp
   end
 
   def test_empty_body_enum
-    server_run { |env| [404, {}, [].to_enum] }
+    server_run app: ->(env) { [404, {}, [].to_enum] }
 
-    resp = send_http_and_sysread "GET / HTTP/1.1\r\n\r\n"
+    resp = send_http_read_response
     # Not Found
     assert_equal "HTTP/1.1 404 #{STATUS_CODES[404]}\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n", resp
   end
@@ -1723,23 +1650,16 @@ class TestPumaServer < Minitest::Test
 
     file_bytesize = file_contents.bytesize + 3 # 3 = BOM byte size
 
-    fio = Tempfile.create 'win_bom_utf8_'
+    temp_file_path = unique_path '.win_bom_utf8', contents: "\xEF\xBB\xBF#{file_contents}"
 
-    temp_file_path = fio.path
-    fio.close
-
-    File.open temp_file_path, "wb:UTF-8" do |f|
-      f.write "\xEF\xBB\xBF#{file_contents}"
-    end
-
-    server_run do |env|
+    server_run app: ->(env) do
       req_body = env['rack.input'].read
       [200, {}, [req_body]]
     end
 
-    cmd = "curl -H 'transfer-encoding: chunked' --form data=@#{temp_file_path} http://127.0.0.1:#{@port}/"
+    cmd = "curl -H 'transfer-encoding: chunked' --form data=@#{temp_file_path} http://#{HOST}:#{bind_port}/"
 
-    out_r, _, _ = spawn_cmd cmd
+    out_r, _, _ = spawn_ext_cmd cmd
 
     out_r.wait_readable 3
 
@@ -1758,19 +1678,16 @@ class TestPumaServer < Minitest::Test
 
     file_bytesize = file_contents.bytesize
 
-    fio = tempfile_create 'win_utf8_', file_contents
+    temp_file_path = unique_path '.win_utf8', contents: file_contents
 
-    temp_file_path = fio.path
-    fio.close
-
-    server_run do |env|
+    server_run app: ->(env) do
       req_body = env['rack.input'].read
       [200, {}, [req_body]]
     end
 
-    cmd = "curl -H 'transfer-encoding: chunked' --form data=@#{temp_file_path} http://127.0.0.1:#{@port}/"
+    cmd = "curl -H 'transfer-encoding: chunked' --form data=@#{temp_file_path} http://127.0.0.1:#{bind_port}/"
 
-    out_r, _, _ = spawn_cmd cmd
+    out_r, _, _ = spawn_ext_cmd cmd
 
     out_r.wait_readable 3
 
@@ -1781,57 +1698,44 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_supported_http_methods_match
-    server_run(supported_http_methods: ['PROPFIND', 'PROPPATCH']) do |env|
-      body = [env['REQUEST_METHOD']]
-      [200, {}, body]
-    end
-    resp = send_http_and_read "PROPFIND / HTTP/1.0\r\n\r\n"
-    assert_match 'PROPFIND', resp
+    server_run supported_http_methods: ['PROPFIND', 'PROPPATCH'],
+      app: ->(env) do
+        body = [env['REQUEST_METHOD']]
+        [200, {}, body]
+      end
+
+    resp = send_http_read_response "PROPFIND / HTTP/1.0\r\n\r\n"
+    assert_includes resp, 'PROPFIND'
   end
 
   def test_supported_http_methods_no_match
-    server_run(supported_http_methods: ['PROPFIND', 'PROPPATCH']) do |env|
-      body = [env['REQUEST_METHOD']]
-      [200, {}, body]
-    end
-    resp = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
-    assert_match 'Not Implemented', resp
+    server_run supported_http_methods: ['PROPFIND', 'PROPPATCH'],
+      app: ->(env) do
+        body = [env['REQUEST_METHOD']]
+        [200, {}, body]
+      end
+    resp = send_http_read_response GET_10
+    assert_includes resp, 'Not Implemented'
   end
 
   def test_supported_http_methods_accept_all
-    server_run(supported_http_methods: :any) do |env|
-      body = [env['REQUEST_METHOD']]
-      [200, {}, body]
-    end
-    resp = send_http_and_read "YOUR_SPECIAL_METHOD / HTTP/1.0\r\n\r\n"
-    assert_match 'YOUR_SPECIAL_METHOD', resp
+    server_run supported_http_methods: :any,
+      app: ->(env) do
+        body = [env['REQUEST_METHOD']]
+        [200, {}, body]
+      end
+    resp = send_http_read_response "YOUR_SPECIAL_METHOD / HTTP/1.0\r\n\r\n"
+    assert_includes resp, 'YOUR_SPECIAL_METHOD'
   end
 
   def test_supported_http_methods_empty
-    server_run(supported_http_methods: []) do |env|
-      body = [env['REQUEST_METHOD']]
-      [200, {}, body]
-    end
-    resp = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+    server_run supported_http_methods: [],
+      app: ->(env) do
+        body = [env['REQUEST_METHOD']]
+        [200, {}, body]
+      end
+    resp = send_http_read_response GET_10
     assert_match(/\AHTTP\/1\.0 501 Not Implemented/, resp)
-  end
-
-
-  def spawn_cmd(env = {}, cmd)
-    opts = {}
-
-    out_r, out_w = IO.pipe
-    opts[:out] = out_w
-
-    err_r, err_w = IO.pipe
-    opts[:err] = err_w
-
-    out_r.binmode
-    err_r.binmode
-
-    pid = spawn(env, cmd, opts)
-    [out_w, err_w].each(&:close)
-    [out_r, err_r, pid]
   end
 
   def test_lowlevel_error_handler_response
@@ -1840,19 +1744,16 @@ class TestPumaServer < Minitest::Test
         [500, {}, ["something wrong happened"]]
       end
     }
-    broken_app = ->(_env) { [200, nil, []] }
 
-    server_run(**options, &broken_app)
+    server_run(**options, app: ->(env) { [200, nil, []] })
 
-    data = send_http_and_read "GET / HTTP/1.1\r\n\r\n"
+    data = send_http_read_response
 
     assert_match(/something wrong happened/, data)
   end
 
   def test_cl_empty_string
-    server_run do |env|
-      [200, {}, [""]]
-    end
+    server_run app: ->(env) { [200, {}, [""]] }
 
     empty_cl_request = <<~REQ.gsub("\n", "\r\n")
       GET / HTTP/1.1
@@ -1864,14 +1765,14 @@ class TestPumaServer < Minitest::Test
 
     REQ
 
-    data = send_http_and_read empty_cl_request
+    data = send_http_read_response empty_cl_request
+
     assert_operator data, :start_with?, 'HTTP/1.1 400 Bad Request'
+    assert_includes data, 'Invalid Content-Length'
   end
 
   def test_crlf_trailer_smuggle
-    server_run do |env|
-      [200, {}, [""]]
-    end
+    server_run app: ->(env) { [200, {}, [""]] }
 
     smuggled_payload = <<~REQ.gsub("\n", "\r\n")
       GET / HTTP/1.1
@@ -1887,18 +1788,21 @@ class TestPumaServer < Minitest::Test
 
     REQ
 
-    data = send_http_and_read smuggled_payload
-    assert_equal 2, data.scan("HTTP/1.1 200 OK").size
+    data = send_http_read_all smuggled_payload
+
+    resp = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n" * 2
+
+    assert_equal resp, data
   end
 
   # test to check if content-length is ignored when 'transfer-encoding: chunked'
   # is used.  See also test_large_chunked_request
   def test_cl_and_te_smuggle
     body = nil
-    server_run { |env|
+    server_run app: ->(env) do
       body = env['rack.input'].read
       [200, {}, [""]]
-    }
+    end
 
     req = <<~REQ.gsub("\n", "\r\n")
       POST /search HTTP/1.1
@@ -1918,10 +1822,10 @@ class TestPumaServer < Minitest::Test
 
     REQ
 
-    data = send_http_and_read req
+    data = send_http_read_response req
 
     assert_includes body, "GET /404 HTTP/1.1\r\n"
     assert_includes body, "Content-Length: 144\r\n"
-    assert_equal 1, data.scan("HTTP/1.1 200 OK").size
+    assert_equal "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n", data
   end
 end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -569,7 +569,7 @@ class TestPumaServer < TestPuma::ServerInProcess
   def test_idle_timeout_before_first_request
     server_run idle_timeout: 1
 
-    sleep 1.15
+    sleep 1.5
 
     assert @server.shutting_down?
 
@@ -585,7 +585,7 @@ class TestPumaServer < TestPuma::ServerInProcess
     socket = send_http "POST / HTTP/1.1\r\nHost: test.com\r\n" \
       "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
 
-    sleep 1.15
+    sleep 1.5
 
     socket << "hello world!"
 

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -1,12 +1,10 @@
-# Nothing in this file runs if Puma isn't compiled with ssl support
-#
-# helper is required first since it loads Puma, which needs to be
-# loaded so HAS_SSL is defined
+# frozen_string_literal: true
+
 require_relative "helper"
+require_relative "helpers/test_puma/server_in_process"
 
 if ::Puma::HAS_SSL
   require "puma/minissl"
-  require_relative "helpers/test_puma/puma_socket"
 
   if ENV['PUMA_TEST_DEBUG']
     require "openssl" unless Object.const_defined? :OpenSSL
@@ -24,63 +22,23 @@ if ::Puma::HAS_SSL
   end
 end
 
-class TestPumaServerSSL < Minitest::Test
+class TestPumaServerSSL < TestPuma::ServerInProcess
   parallelize_me!
 
-  include TestPuma
-  include TestPuma::PumaSocket
-
-  PROTOCOL_USE_MIN_MAX =
-    OpenSSL::SSL::SSLContext.private_instance_methods(false).include?(:set_minmax_proto_version)
-
-  OPENSSL_3 = OpenSSL::OPENSSL_LIBRARY_VERSION.match?(/OpenSSL 3\.\d\.\d/)
-
   def setup
-    @server = nil
-  end
-
-  def teardown
-    @server&.stop true
-  end
-
-  # yields ctx to block, use for ctx setup & configuration
-  def start_server
-    app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
-
-    ctx = Puma::MiniSSL::Context.new
-
-    if Puma.jruby?
-      ctx.keystore =  File.expand_path "../examples/puma/keystore.jks", __dir__
-      ctx.keystore_pass = 'jruby_puma'
-    else
-      ctx.key  =  File.expand_path "../examples/puma/puma_keypair.pem", __dir__
-      ctx.cert = File.expand_path "../examples/puma/cert_puma.pem", __dir__
-    end
-
-    ctx.verify_mode = Puma::MiniSSL::VERIFY_NONE
-
-    yield ctx if block_given?
-
-    @log_writer = SSLLogWriterHelper.new STDOUT, STDERR
-    @server = Puma::Server.new app, nil, {log_writer: @log_writer}
-    @port = (@server.add_ssl_listener HOST, 0, ctx).addr[1]
-    @bind_port = @port
-    @server.run
+    set_bind_type :ssl
   end
 
   def test_url_scheme_for_https
-    start_server
-    assert_equal "https", send_http_read_resp_body(ctx: new_ctx)
+    server_run
+    assert_equal "https", send_http_read_resp_body
   end
 
   def test_request_wont_block_thread
-    start_server
-    # Open a connection and give enough data to trigger a read, then wait
-    ctx = OpenSSL::SSL::SSLContext.new
-    ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    @bind_port = @server.connected_ports[0]
+    server_run
 
-    socket = send_http "HEAD",  ctx: new_ctx
+    # Open a connection and give enough data to trigger a read, then wait
+    socket = send_http 'HEAD'
     sleep 0.1
 
     # Capture the amount of threads being used after connecting and being idle
@@ -95,82 +53,85 @@ class TestPumaServerSSL < Minitest::Test
   end
 
   def test_very_large_return
-    start_server
+    server_run
     giant = "x" * 2056610
 
-    @server.app = proc { [200, {}, [giant]] }
+    server_run app: ->(_) { [200, {}, [giant]] }
 
-    body = send_http_read_resp_body(ctx: new_ctx)
+    body = send_http_read_resp_body
 
     assert_equal giant.bytesize, body.bytesize
   end
 
   def test_form_submit
-    start_server
-    @server.app = proc { |env| [200, {}, [env['rack.url_scheme'], "\n", env['rack.input'].read]] }
+    server_run app: ->(env) do
+      [200, {}, [env['rack.url_scheme'], "\n", env['rack.input'].read]]
+    end
 
     req = "POST / HTTP/1.1\r\nContent-Type: text/plain\r\nContent-Length: 7\r\n\r\na=1&b=2"
 
-    body = send_http_read_resp_body req, ctx: new_ctx
+    body = send_http_read_resp_body req
 
     assert_equal "https\na=1&b=2", body
   end
 
-  def test_ssl_v3_rejection
-    skip("SSLv3 protocol is unavailable") if Puma::MiniSSL::OPENSSL_NO_SSL3
-    start_server
+  def rejection(server, min_max, ssl_version)
+    if server
+      server_run ctx: server
+    else
+      server_run
+    end
+
+    msg = nil
 
     assert_raises(OpenSSL::SSL::SSLError) do
-      send_http_read_resp_body ctx: new_ctx { |c| c.ssl_version = :SSLv3 }
+      begin
+        send_http_read_response ctx: new_ctx { |ctx|
+          if PROTOCOL_USE_MIN_MAX && min_max
+            ctx.max_version = min_max
+          else
+            ctx.ssl_version = ssl_version
+          end
+        }
+      rescue => e
+        msg = e.message
+        raise e
+      end
     end
-    unless Puma.jruby?
-      msg = /wrong version number|no protocols available|version too low|unknown SSL method/
-      assert_match(msg, @log_writer.error.message) if @log_writer.error
+
+    unless Puma::IS_JRUBY
+      expected = /SSL_connect SYSCALL returned=5|wrong version number|(unknown|unsupported) protocol|no protocols available|version too low|unknown SSL method/
+      assert_match expected, msg
     end
+
+    # make sure a good request succeeds
+    assert_equal "https", send_http_read_resp_body(GET_10)
+  end
+
+  def test_ssl_v3_rejection
+    skip("SSLv3 protocol is unavailable") if Puma::MiniSSL::OPENSSL_NO_SSL3
+
+    rejection nil, nil, :SSLv3
   end
 
   def test_tls_v1_rejection
-    start_server { |ctx| ctx.no_tlsv1 = true }
-
-    assert_raises(OpenSSL::SSL::SSLError) do
-      send_http_read_resp_body ctx: new_ctx { |c|
-        if PROTOCOL_USE_MIN_MAX
-          c.max_version = :TLS1
-        else
-          c.ssl_version = :TLSv1
-        end
-      }
-    end
-    unless Puma.jruby?
-      msg = /wrong version number|(unknown|unsupported) protocol|no protocols available|version too low|unknown SSL method/
-      assert_match(msg, @log_writer.error.message) if @log_writer.error
-    end
+    rejection ->(ctx) { ctx.no_tlsv1 = true }, :TLS1, :TLSv1
   end
 
   def test_tls_v1_1_rejection
-    start_server { |ctx| ctx.no_tlsv1_1 = true }
-
-    assert_raises(OpenSSL::SSL::SSLError) do
-      send_http_read_response ctx: new_ctx { |c|
-        if PROTOCOL_USE_MIN_MAX
-          c.max_version = :TLS1_1
-        else
-          c.ssl_version = :TLSv1_1
-        end
-      }
-    end
-    unless Puma.jruby?
-      msg = /wrong version number|(unknown|unsupported) protocol|no protocols available|version too low|unknown SSL method/
-      assert_match(msg, @log_writer.error.message) if @log_writer.error
-    end
+    rejection ->(ctx) { ctx.no_tlsv1_1 = true }, :TLS1_1, :TLSv1_1
   end
 
   def test_tls_v1_3
-    skip("TLSv1.3 protocol can not be set") unless OpenSSL::SSL::SSLContext.instance_methods(false).include?(:min_version=)
+    skip("TLSv1.3 protocol is not available") unless OpenSSL::SSL.const_defined? :TLS1_3_VERSION
 
-    start_server
+    if Puma::IS_JRUBY
+      server_run ctx: ->(ctx) { ctx.protocols = %w[TLSv1 TLSv1.1 TLSv1.2 TLSv1.3] }
+    else
+      server_run
+    end
 
-    body = send_http_read_resp_body ctx: new_ctx { |c|
+    socket = send_http ctx: new_ctx { |c|
       if PROTOCOL_USE_MIN_MAX
         c.min_version = :TLS1_3
       else
@@ -178,6 +139,9 @@ class TestPumaServerSSL < Minitest::Test
       end
     }
 
+    body = socket.read_body
+
+    assert_equal "TLSv1.3", socket.ssl_version
     assert_equal "https", body
   end
 
@@ -185,16 +149,17 @@ class TestPumaServerSSL < Minitest::Test
     body_http  = nil
     body_https = nil
 
-    start_server
+    server_run
 
     tcp = Thread.new do
       assert_raises(Errno::ECONNREFUSED, EOFError, Timeout::Error) do
-        body_http = send_http_read_resp_body timeout: 4
+        socket = new_socket(bind_type: :tcp) << GET_11
+        socket.read_body timeout: 4
       end
     end
 
     ssl = Thread.new do
-      body_https = send_http_read_resp_body ctx: new_ctx
+      body_https = send_http_read_resp_body
     end
 
     tcp.join
@@ -207,25 +172,163 @@ class TestPumaServerSSL < Minitest::Test
     thread_pool = @server.instance_variable_get(:@thread_pool)
     busy_threads = thread_pool.spawned - thread_pool.waiting
 
-    assert busy_threads.zero?, "Our connection wasn't dropped"
+    assert busy_threads.zero?, "Our http connection wasn't dropped"
   end
 
-  unless Puma.jruby?
+  def verify_client_cert_roundtrip(tls1_2 = nil)
+    app = ->(env) { [200, {}, [env['puma.peercert'].to_s]] }
+
+    ctx = Puma::MiniSSL::Context.new
+    if ::Puma::IS_JRUBY
+      ctx.keystore = "#{CLIENT_CERTS_PATH}/keystore.jks"
+      ctx.keystore_pass = "jruby_puma"
+    else
+      ctx.cert = "#{CLIENT_CERTS_PATH}/server.crt"
+      ctx.key  = "#{CLIENT_CERTS_PATH}/server.key"
+      ctx.ca   = "#{CLIENT_CERTS_PATH}/ca.crt"
+    end
+    ctx.verify_mode = MINI_FORCE_PEER
+
+    server_run app: app, ctx: ctx
+
+    client_cert = File.read "#{CLIENT_CERTS_PATH}/client.crt"
+
+    socket = send_http ctx: new_ctx { |c|
+      ca   = "#{CLIENT_CERTS_PATH}/ca.crt"
+      key  = "#{CLIENT_CERTS_PATH}/client.key"
+      c.ca_file = ca
+      c.cert = ::OpenSSL::X509::Certificate.new client_cert
+      c.key  = ::OpenSSL::PKey::RSA.new File.read(key)
+      c.verify_mode = ::OpenSSL::SSL::VERIFY_PEER
+      if tls1_2
+        if c.respond_to? :max_version=
+          c.max_version = :TLS1_2
+        else
+          c.ssl_version = :TLSv1_2
+        end
+      end
+    }
+
+    assert_equal client_cert, socket.read_body
+    socket
+  end
+
+  def test_verify_client_cert_roundtrip_tls1_2
+    socket = verify_client_cert_roundtrip(true)
+    assert_equal "TLSv1.2", socket.ssl_version
+  end
+
+  # should use TLSv1.3 with OpenSSL 1.1 or later
+  def test_verify_client_cert_roundtrip_tls1_3
+    skip("TLSv1.3 protocol is not available") unless HAS_TLS_1_3
+    socket = verify_client_cert_roundtrip
+    assert_equal "TLSv1.3", socket.ssl_version
+  end
+
+  def test_verify_client_cert_roundtrip_with_curl_client
+    skip_if :windows
+
+    app = ->(env) { [200, {}, [env['puma.peercert'].to_s]] }
+
+    ctx = Puma::MiniSSL::Context.new
+    if ::Puma::IS_JRUBY
+      ctx.keystore = "#{CLIENT_CERTS_PATH}/keystore.jks"
+      ctx.keystore_pass = "jruby_puma"
+    else
+      ctx.cert = "#{CLIENT_CERTS_PATH}/server.crt"
+      ctx.key  = "#{CLIENT_CERTS_PATH}/server.key"
+      ctx.ca   = "#{CLIENT_CERTS_PATH}/ca.crt"
+    end
+    ctx.verify_mode = MINI_FORCE_PEER
+
+    server_run app: app, ctx: ctx
+
+    ca   = "#{CLIENT_CERTS_PATH}/ca.crt"
+    cert = "#{CLIENT_CERTS_PATH}/client.crt"
+    key  = "#{CLIENT_CERTS_PATH}/client.key"
+    # NOTE: JRuby used to end up in a hang with TLS peer verification enabled
+    # it's easier to reproduce using an external client such as CURL (using net/http client the bug isn't triggered)
+    # also the "hang", being buffering related, seems to showcase better with TLS 1.2 than 1.3
+    body = curl_and_get_response "https://#{LOCALHOST}:#{bind_port}",
+      args: "--cacert #{ca} --cert #{cert} --key #{key} --tlsv1.2 --tls-max 1.2"
+
+    client_cert = File.read "#{CLIENT_CERTS_PATH}/client.crt"
+
+    assert_equal client_cert, body
+  end
+
+  unless Puma::IS_JRUBY
+
+    def test_verify_client_cert_roundtrip_pems
+      app = ->(env) { [200, {}, [env['puma.peercert'].to_s]] }
+
+      ctx = Puma::MiniSSL::Context.new
+      ctx.cert_pem = File.read "#{CLIENT_CERTS_PATH}/server.crt"
+      ctx.key_pem  = File.read "#{CLIENT_CERTS_PATH}/server.key"
+      ctx.ca   = "#{CLIENT_CERTS_PATH}/ca.crt"
+      ctx.verify_mode = MINI_FORCE_PEER
+
+      server_run app: app, ctx: ctx
+
+      client_cert = File.read "#{CLIENT_CERTS_PATH}/client.crt"
+
+      socket = send_http ctx: new_ctx { |c|
+        ca   = "#{CLIENT_CERTS_PATH}/ca.crt"
+        key  = "#{CLIENT_CERTS_PATH}/client.key"
+        c.ca_file = ca
+        c.cert = ::OpenSSL::X509::Certificate.new client_cert
+        c.key  = ::OpenSSL::PKey::RSA.new File.read(key)
+        c.verify_mode = ::OpenSSL::SSL::VERIFY_PEER
+      }
+
+      assert_equal client_cert, socket.read_body
+    end
+
+    def test_with_encrypted_key
+      key_command = ::Puma::IS_WINDOWS ? "echo hello world" :
+        "#{CERT_PATH}/key_password_command.sh"
+
+      ctx = Puma::MiniSSL::Context.new
+      ctx.cert = "#{CERT_PATH}/cert_puma.pem"
+      ctx.key  = "#{CERT_PATH}/encrypted_puma_keypair.pem"
+      ctx.verify_mode = MINI_VERIFY_NONE
+      ctx.key_password_command = key_command
+
+      server_run ctx: ctx
+
+      assert_equal "https", send_http_read_resp_body
+    end
+
+    def test_with_encrypted_pem
+      key_command = ::Puma::IS_WINDOWS ? "echo hello world" :
+        "#{CERT_PATH}/key_password_command.sh"
+
+      ctx = Puma::MiniSSL::Context.new
+      ctx.cert_pem = File.read "#{CERT_PATH}/cert_puma.pem"
+      ctx.key_pem  = File.read "#{CERT_PATH}/encrypted_puma_keypair.pem"
+      ctx.verify_mode = MINI_VERIFY_NONE
+      ctx.key_password_command = key_command
+
+      server_run ctx: ctx
+
+      assert_equal "https", send_http_read_resp_body
+    end
+
     def test_invalid_cert
       assert_raises(Puma::MiniSSL::SSLError) do
-        start_server { |ctx| ctx.cert = __FILE__ }
+        server_run ctx: ->(ctx) { ctx.cert = __FILE__ }
       end
     end
 
     def test_invalid_key
       assert_raises(Puma::MiniSSL::SSLError) do
-        start_server { |ctx| ctx.key = __FILE__ }
+        server_run ctx: ->(ctx) { ctx.key = __FILE__ }
       end
     end
 
     def test_invalid_cert_pem
       assert_raises(Puma::MiniSSL::SSLError) do
-        start_server { |ctx|
+        server_run ctx: ->(ctx) {
           ctx.instance_variable_set(:@cert, nil)
           ctx.cert_pem = 'Not a valid pem'
         }
@@ -234,7 +337,7 @@ class TestPumaServerSSL < Minitest::Test
 
     def test_invalid_key_pem
       assert_raises(Puma::MiniSSL::SSLError) do
-        start_server { |ctx|
+        server_run ctx: ->(ctx) {
           ctx.instance_variable_set(:@key, nil)
           ctx.key_pem = 'Not a valid pem'
         }
@@ -243,7 +346,7 @@ class TestPumaServerSSL < Minitest::Test
 
     def test_invalid_ca
       assert_raises(Puma::MiniSSL::SSLError) do
-        start_server { |ctx|
+        server_run ctx: ->(ctx) {
           ctx.ca = __FILE__
         }
       end
@@ -252,17 +355,18 @@ class TestPumaServerSSL < Minitest::Test
 end if ::Puma::HAS_SSL
 
 # client-side TLS authentication tests
-class TestPumaServerSSLClient < Minitest::Test
-  parallelize_me! unless ::Puma.jruby?
-
-  include TestPuma
-  include TestPuma::PumaSocket
+class TestPumaServerSSLClient < TestPuma::ServerInProcess
+  parallelize_me!
 
   CERT_PATH = File.expand_path "../examples/puma/client-certs", __dir__
 
-  # Context can be shared, may help with JRuby
-  CTX = Puma::MiniSSL::Context.new.tap { |ctx|
-    if Puma.jruby?
+  def setup
+    set_bind_type :ssl
+  end
+
+  def new_server_context
+    ctx = Puma::MiniSSL::Context.new
+    if Puma::IS_JRUBY
       ctx.keystore =  "#{CERT_PATH}/keystore.jks"
       ctx.keystore_pass = 'jruby_puma'
     else
@@ -270,20 +374,16 @@ class TestPumaServerSSLClient < Minitest::Test
       ctx.cert = "#{CERT_PATH}/server.crt"
       ctx.ca   = "#{CERT_PATH}/ca.crt"
     end
-    ctx.verify_mode = Puma::MiniSSL::VERIFY_PEER | Puma::MiniSSL::VERIFY_FAIL_IF_NO_PEER_CERT
-  }
+    ctx.verify_mode = MINI_FORCE_PEER
+    ctx
+  end
 
-  def assert_ssl_client_error_match(error, subject: nil, context: CTX, &blk)
-    port = 0
+  def assert_ssl_client_error_match(error, subject: nil, context: new_server_context, &blk)
+    log_writer = SSLLogWriterHelper.new StringIO.new, StringIO.new
 
-    app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
+    server_run log_writer: log_writer, ctx: context
 
-    log_writer = SSLLogWriterHelper.new STDOUT, STDERR
-    server = Puma::Server.new app, nil, {log_writer: log_writer}
-    server.add_ssl_listener LOCALHOST, port, context
-    host_addrs = server.binder.ios.map { |io| io.to_io.addr[2] }
-    @bind_port = server.connected_ports[0]
-    server.run
+    host_addrs = @server.binder.ios.map { |io| io.to_io.addr[2] }
 
     ctx = OpenSSL::SSL::SSLContext.new
     yield ctx
@@ -311,19 +411,19 @@ class TestPumaServerSSLClient < Minitest::Test
     end
     assert_equal subject, log_writer.cert.subject.to_s if subject
   ensure
-    server&.stop true
+    @server&.stop true
   end
 
   def test_verify_fail_if_no_client_cert
-    error = Puma.jruby? ? /Empty client certificate chain/ : 'peer did not return a certificate'
+    error = Puma::IS_JRUBY ? /Empty client certificate chain/ : 'peer did not return a certificate'
     assert_ssl_client_error_match(error) do |client_ctx|
       # nothing
     end
   end
 
   def test_verify_fail_if_client_unknown_ca
-    error = Puma.jruby? ? /No trusted certificate found/ : /self[- ]signed certificate in certificate chain/
-    cert_subject = Puma.jruby? ? '/DC=net/DC=puma/CN=localhost' : '/DC=net/DC=puma/CN=CAU'
+    error = Puma::IS_JRUBY ? /No trusted certificate found/ : /self[- ]signed certificate in certificate chain/
+    cert_subject = Puma::IS_JRUBY ? '/DC=net/DC=puma/CN=localhost' : '/DC=net/DC=puma/CN=CAU'
     assert_ssl_client_error_match(error, subject: cert_subject) do |client_ctx|
       key = "#{CERT_PATH}/client_unknown.key"
       crt = "#{CERT_PATH}/client_unknown.crt"
@@ -331,10 +431,11 @@ class TestPumaServerSSLClient < Minitest::Test
       client_ctx.cert = OpenSSL::X509::Certificate.new File.read(crt)
       client_ctx.ca_file = "#{CERT_PATH}/unknown_ca.crt"
     end
+
   end
 
   def test_verify_fail_if_client_expired_cert
-    error = Puma.jruby? ? /NotAfter:/ : 'certificate has expired'
+    error = Puma::IS_JRUBY ? /NotAfter:/ : 'certificate has expired'
     assert_ssl_client_error_match(error, subject: '/DC=net/DC=puma/CN=localhost') do |client_ctx|
       key = "#{CERT_PATH}/client_expired.key"
       crt = "#{CERT_PATH}/client_expired.crt"
@@ -363,7 +464,7 @@ class TestPumaServerSSLClient < Minitest::Test
     ctx.truststore =  "#{CERT_PATH}/ca_store.p12"
     ctx.truststore_type = 'pkcs12'
     ctx.truststore_pass = 'jruby_puma'
-    ctx.verify_mode = Puma::MiniSSL::VERIFY_PEER
+    ctx.verify_mode = MINI_VERIFY_PEER
 
     assert_ssl_client_error_match(false, context: ctx) do |client_ctx|
       key = "#{CERT_PATH}/client.key"
@@ -373,7 +474,7 @@ class TestPumaServerSSLClient < Minitest::Test
       client_ctx.ca_file = "#{CERT_PATH}/ca.crt"
       client_ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
     end
-  end if Puma.jruby?
+  end if Puma::IS_JRUBY
 
   def test_verify_client_cert_without_truststore
     ctx = Puma::MiniSSL::Context.new
@@ -383,7 +484,7 @@ class TestPumaServerSSLClient < Minitest::Test
     ctx.truststore = "#{CERT_PATH}/unknown_ca_store.p12"
     ctx.truststore_type = 'pkcs12'
     ctx.truststore_pass = 'jruby_puma'
-    ctx.verify_mode = Puma::MiniSSL::VERIFY_PEER
+    ctx.verify_mode = MINI_VERIFY_PEER
 
     assert_ssl_client_error_match(true, context: ctx) do |client_ctx|
       key = "#{CERT_PATH}/client.key"
@@ -393,7 +494,7 @@ class TestPumaServerSSLClient < Minitest::Test
       client_ctx.ca_file = "#{CERT_PATH}/ca.crt"
       client_ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
     end
-  end if Puma.jruby?
+  end if Puma::IS_JRUBY
 
   def test_allows_using_default_truststore
     ctx = Puma::MiniSSL::Context.new
@@ -402,7 +503,7 @@ class TestPumaServerSSLClient < Minitest::Test
     ctx.keystore_pass = 'jruby_puma'
     ctx.truststore = :default
     # NOTE: a little hard to test - we're at least asserting that setting :default does not raise errors
-    ctx.verify_mode = Puma::MiniSSL::VERIFY_NONE
+    ctx.verify_mode = MINI_VERIFY_NONE
 
     assert_ssl_client_error_match(false, context: ctx) do |client_ctx|
       key = "#{CERT_PATH}/client.key"
@@ -412,10 +513,10 @@ class TestPumaServerSSLClient < Minitest::Test
       client_ctx.ca_file = "#{CERT_PATH}/ca.crt"
       client_ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
     end
-  end if Puma.jruby?
+  end if Puma::IS_JRUBY
 
   def test_allows_to_specify_cipher_suites_and_protocols
-    ctx = CTX.dup
+    ctx = new_server_context
     ctx.cipher_suites = [ 'TLS_RSA_WITH_AES_128_GCM_SHA256' ]
     ctx.protocols = 'TLSv1.2'
 
@@ -430,10 +531,10 @@ class TestPumaServerSSLClient < Minitest::Test
       client_ctx.ssl_version = :TLSv1_2
       client_ctx.ciphers = [ 'TLS_RSA_WITH_AES_128_GCM_SHA256' ]
     end
-  end if Puma.jruby?
+  end if Puma::IS_JRUBY
 
   def test_fails_when_no_cipher_suites_in_common
-    ctx = CTX.dup
+    ctx = new_server_context
     ctx.cipher_suites = [ 'TLS_RSA_WITH_AES_128_GCM_SHA256' ]
     ctx.protocols = 'TLSv1.2'
 
@@ -448,7 +549,7 @@ class TestPumaServerSSLClient < Minitest::Test
       client_ctx.ssl_version = :TLSv1_2
       client_ctx.ciphers = [ 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384' ]
     end
-  end if Puma.jruby?
+  end if Puma::IS_JRUBY
 
   def test_verify_client_cert_with_truststore_without_pass
     ctx = Puma::MiniSSL::Context.new
@@ -457,7 +558,7 @@ class TestPumaServerSSLClient < Minitest::Test
     ctx.keystore_pass = 'jruby_puma'
     ctx.truststore =  "#{CERT_PATH}/ca_store.jks" # cert entry can be read without password
     ctx.truststore_type = 'jks'
-    ctx.verify_mode = Puma::MiniSSL::VERIFY_PEER
+    ctx.verify_mode = MINI_VERIFY_PEER
 
     assert_ssl_client_error_match(false, context: ctx) do |client_ctx|
       key = "#{CERT_PATH}/client.key"
@@ -467,27 +568,23 @@ class TestPumaServerSSLClient < Minitest::Test
       client_ctx.ca_file = "#{CERT_PATH}/ca.crt"
       client_ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
     end
-  end if Puma.jruby?
+  end if Puma::IS_JRUBY
 
 end if ::Puma::HAS_SSL
 
-class TestPumaServerSSLWithCertPemAndKeyPem < Minitest::Test
-  include TestPuma
-  include TestPuma::PumaSocket
-
+class TestPumaServerSSLWithCertPemAndKeyPem < TestPuma::ServerInProcess
   CERT_PATH = File.expand_path "../examples/puma/client-certs", __dir__
 
-  def test_server_ssl_with_cert_pem_and_key_pem
-    ctx = Puma::MiniSSL::Context.new
-    ctx.cert_pem = File.read "#{CERT_PATH}/server.crt"
-    ctx.key_pem  = File.read "#{CERT_PATH}/server.key"
+  def setup
+    set_bind_type :ssl
+  end
 
-    app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
-    log_writer = SSLLogWriterHelper.new STDOUT, STDERR
-    server = Puma::Server.new app, nil, {log_writer: log_writer}
-    server.add_ssl_listener LOCALHOST, 0, ctx
-    @bind_port = server.connected_ports[0]
-    server.run
+  def test_server_ssl_with_cert_pem_and_key_pem
+    server_run app: ->(_) { [200, {}, [env['rack.url_scheme']]] },
+      ctx: ->(ctx) {
+        ctx.cert_pem = File.read "#{CERT_PATH}/server.crt"
+        ctx.key_pem  = File.read "#{CERT_PATH}/server.key"
+      }
 
     client_error = nil
     begin
@@ -502,7 +599,7 @@ class TestPumaServerSSLWithCertPemAndKeyPem < Minitest::Test
 
     assert_nil client_error
   ensure
-    server&.stop true
+    @server&.stop true
   end
 end if ::Puma::HAS_SSL && !Puma::IS_JRUBY
 
@@ -513,59 +610,58 @@ end if ::Puma::HAS_SSL && !Puma::IS_JRUBY
 #
 #   bundle exec ruby ../examples/puma/chain_cert/generate_chain_test.rb
 #
-class TestPumaSSLCertChain < Minitest::Test
-  include TestPuma
-  include TestPuma::PumaSocket
-
+class TestPumaSSLCertChain < TestPuma::ServerInProcess
   CHAIN_DIR = File.expand_path '../examples/puma/chain_cert', __dir__
 
   # OpenSSL::X509::Name#to_utf8 only available in Ruby 2.5 and later
   USE_TO_UTFT8 = OpenSSL::X509::Name.instance_methods(false).include? :to_utf8
 
+  def setup
+    set_bind_type :ssl
+  end
+
   def cert_chain(&blk)
-    app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
+    server_run ctx: blk
 
-    @log_writer = SSLLogWriterHelper.new STDOUT, STDERR
-    @server = Puma::Server.new app, nil, {log_writer: @log_writer}
+    socket = send_http host: LOCALHOST
 
-    mini_ctx = Puma::MiniSSL::Context.new
-    mini_ctx.key  = "#{CHAIN_DIR}/cert.key"
-    yield mini_ctx
-
-    @bind_port = (@server.add_ssl_listener HOST, 0, mini_ctx).addr[1]
-    @server.run
-
-    socket = new_socket ctx: new_ctx
+    assert_equal 'https', socket.read_body
 
     subj_chain = socket.peer_cert_chain.map(&:subject)
     subj_map = USE_TO_UTFT8 ?
       subj_chain.map { |subj| subj.to_utf8[/CN=(.+ - )?([^,]+)/,2] } :
       subj_chain.map { |subj| subj.to_s(OpenSSL::X509::Name::RFC2253)[/CN=(.+ - )?([^,]+)/,2] }
 
-    @server&.stop true
-
     assert_equal ['test.puma.localhost', 'intermediate.puma.localhost', 'ca.puma.localhost'], subj_map
   end
 
   def test_single_cert_file_with_ca
     cert_chain { |mini_ctx|
+      mini_ctx.key  = "#{CHAIN_DIR}/cert.key"
       mini_ctx.cert = "#{CHAIN_DIR}/cert.crt"
       mini_ctx.ca   = "#{CHAIN_DIR}/ca_chain.pem"
     }
   end
 
   def test_chain_cert_file_without_ca
-    cert_chain { |mini_ctx| mini_ctx.cert = "#{CHAIN_DIR}/cert_chain.pem" }
+    cert_chain { |mini_ctx|
+      mini_ctx.key  = "#{CHAIN_DIR}/cert.key"
+      mini_ctx.cert = "#{CHAIN_DIR}/cert_chain.pem"
+    }
   end
 
   def test_single_cert_string_with_ca
     cert_chain { |mini_ctx|
+      mini_ctx.key  = "#{CHAIN_DIR}/cert.key"
       mini_ctx.cert_pem = File.read "#{CHAIN_DIR}/cert.crt"
       mini_ctx.ca   = "#{CHAIN_DIR}/ca_chain.pem"
     }
   end
 
   def test_chain_cert_string_without_ca
-    cert_chain { |mini_ctx| mini_ctx.cert_pem = File.read "#{CHAIN_DIR}/cert_chain.pem" }
+    cert_chain { |mini_ctx|
+      mini_ctx.key  = "#{CHAIN_DIR}/cert.key"
+      mini_ctx.cert_pem = File.read "#{CHAIN_DIR}/cert_chain.pem"
+    }
   end
 end if ::Puma::HAS_SSL && !::Puma::IS_JRUBY

--- a/test/test_state_file.rb
+++ b/test/test_state_file.rb
@@ -1,19 +1,20 @@
-require_relative "helper"
-require_relative "helpers/tmp_path"
+# frozen_string_literal: true
 
-require 'puma/state_file'
+require_relative "helper"
+require_relative "helpers/test_puma"
+
+require "puma/state_file"
 
 class TestStateFile < Minitest::Test
-  include TmpPath
+  include TestPuma
 
   def test_load_empty_value_as_nil
-    state_path = tmp_path('.state')
-    File.write state_path, <<-STATE
----
-pid: 123456
-control_url:
-control_auth_token:
-running_from: "/path/to/app"
+    state_path = unique_path '.state', contents: <<~STATE
+      ---
+      pid: 123456
+      control_url:
+      control_auth_token:
+      running_from: "/path/to/app"
     STATE
 
     sf = Puma::StateFile.new
@@ -22,6 +23,5 @@ running_from: "/path/to/app"
     assert_equal '/path/to/app', sf.running_from
     assert_nil sf.control_url
     assert_nil sf.control_auth_token
-
   end
 end

--- a/test/test_url_map.rb
+++ b/test/test_url_map.rb
@@ -1,24 +1,16 @@
+# frozen_string_literal: true
+
 require_relative "helper"
-require_relative "helpers/integration"
+require_relative "helpers/test_puma/server_spawn"
 
-class TestURLMap < TestIntegration
-
-  def teardown
-    return if skipped?
-    super
-  end
+class TestURLMap < TestPuma::ServerSpawn
 
   # make sure the mapping defined in url_map_test/config.ru works
   def test_basic_url_mapping
-    skip_if :jruby
     env = { "BUNDLE_GEMFILE" => "#{__dir__}/url_map_test/Gemfile" }
     Dir.chdir("#{__dir__}/url_map_test") do
-      cli_server set_pumactl_args, env: env
+      server_spawn env: env
     end
-    connection = connect("/ok")
-    # Puma 6.2.2 and below will time out here with Ruby v3.3
-    # see https://github.com/puma/puma/pull/3165
-    body = read_body(connection, 1)
-    assert_equal("OK", body)
+    assert_equal "OK", send_http_read_resp_body("GET /ok HTTP/1.1\r\n\r\n")
   end
 end

--- a/test_runner
+++ b/test_runner
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+# simplified test runner, runs all tests, todo: add more options
+
+require 'bundler/setup'
+
+if RUBY_VERSION >= '2.5'
+  Dir['test/test_*.rb', base: __dir__].each { |tf| require_relative tf }
+else
+  Dir["#{__dir__}/test/test_*.rb"].each { |tf| require tf }
+end
+
+require 'minitest'

--- a/test_runner.cmd
+++ b/test_runner.cmd
@@ -1,0 +1,2 @@
+@ECHO OFF
+@ruby.exe -x "%~dpn0" %*


### PR DESCRIPTION
### Description

This is the branch I've been working on the test framework in.  The first and last commits are framework related, most of the middle commits are revisions to single test files.

Looking for review re the API, method names, organization, etc.  Pick your favorite test files, find the commits, and review the diffs...

A few points:
* Seems a lot more stable than the current tests.  There are issues with JRuby (macOS in particular), as often jobs complete with all tests passing, but the test process is frozen. Of course, it's intermittent...  More work to determine the cause.
* I tried to remove as many blocking operations in test code as possible.  When running tests parallel, blocking operations will cause a lot of failures/retries.
* Tests should be portable, assuming the base class (ServerSpawn or ServerInProcess) remains the same.
* I think in many cases the 'test intent' is much easier to see, as there isn't the code clutter to setup things not pertinent to the test intent.
* I've got a shell script that runs all the test files one at a time.  Wrote it for the JRuby issue, but I also found some issues with running tests by themselves.  So, some code changes due to that, along with standardizing the `require` code.
* The current test system has 'helper code' that passes blocks.  The blocks vary with the helper code.  It gets tricky and cluttered trying to pass multiple blocks to a method, so the test framework uses lambdas for almost everything.
* The current test system often loaded rackup or config files.  I found that to be a PITA, as one needed to open other files to look at what the test was doing.  The framework allows config strings to be used, it handles writing a temp file for use by Puma.

 I have started doc'ing the code, see the doc at https://msp-greg.github.io/puma_test/.  All the test modules/classes are children of the TestPuma module at the bottom of the class list.

Once people have reviewed this, I'd start with a PR of the test framework files, then submit a PR for each test file update?  Or, we could commit several without squashing the commits when merging...

Finally, the current test system divides test files by the server type used (in-process or spawned/IO.popen).  This PR follows with the same idea.  I think they could be combined, so one test file could contain both server types.  Thoughts?

Thanks in advance.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
