### PR TITLE
Use test_runner for tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -132,7 +132,7 @@ jobs:
       - name: test
         if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
         timeout-minutes: 6
-        run: bundle exec rake test:all
+        run: test/runner --verbose
 
   test_non_mri:
     name: >-
@@ -206,7 +206,7 @@ jobs:
         if: | # only run if previous steps have succeeded
           success() &&
           (needs.skip_duplicate_runs.outputs.should_skip != 'true')
-        run: bundle exec rake test:all
+        run: test/runner --verbose
 
       - name: >-
           Test outcome: ${{ steps.test.outcome }}

--- a/test/runner
+++ b/test/runner
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+
+=begin
+A simplified test runner; it runs all tests by default.
+It assumes that "bundle exec rake compile" has been run.
+
+It can also be passed a glob or test file names.  If multiple test file names
+are used, separate them by the File::PATH_SEPARATOR character with no spaces.
+The file extension is optional.
+
+If arguments are used that take values (eg seed), use the 'no space' version,
+like -s33388 or --seed=33388
+
+Finally, to keep the code simple, if you pass an invalid argument for file
+filtering it will either error or run minitest with no tests loaded
+
+Examples, run from the top Puma repo folder:
+test/runner
+test/runner -v
+test/runner -v test_puma_server
+test/runner --verbose test_puma_server*
+test/runner --verbose test_integration_cluster:test_integration_single
+test/runner --verbose test*ssl*
+=end
+
+require 'bundler/setup'
+
+if ARGV.empty? || ARGV.last.start_with?('-')
+  if RUBY_VERSION >= '2.5'
+    Dir['test_*.rb', base: __dir__].each { |tf| require_relative tf }
+  else
+    Dir["#{__dir__}/test_*.rb"].each { |tf| require tf }
+  end
+else
+  file_arg = ARGV.pop.sub(/\.rb\z/, '')
+  if file_arg.include? File::PATH_SEPARATOR
+    file_args = file_arg.split(File::PATH_SEPARATOR).map { |fn| fn.sub(/\.rb\z/, '') }
+    file_args.each { |tf| require_relative "#{tf}.rb" }
+  elsif file_arg.include? '*'
+    if RUBY_VERSION >= '2.5'
+      Dir["#{file_arg}.rb", base: __dir__].each { |tf| require_relative tf }
+    else
+      Dir["#{__dir__}/#{file_arg}.rb"].each { |tf| require tf }
+    end
+  else
+    require_relative "#{file_arg}.rb"
+  end
+end
+
+require 'minitest'

--- a/test/runner.cmd
+++ b/test/runner.cmd
@@ -1,0 +1,2 @@
+@ECHO OFF
+@ruby.exe -x "%~dpn0" %*


### PR DESCRIPTION
### Description

Currently `rake` is used to run tests.  `rake` creates a main process, and runs tasks in sub-processes.  This allows chaining tasks, as we do, allowing `compile` to run before `test`.

CI systems' resources are limited, and probably much smaller than most dev's local PC's.

The PR creates two files for test runners (`test_runner.cmd` is used only on Windows) and uses them in the Actions CI test.yaml script.

Note that `test_runner` runs the full test suite.  So, for local testing, using other code should still be used, unless one is very familiar with minitest, etc.  More functionality can be added in the future.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
