### PR TITLE
ragel.yml - use 'bundle exec rake' instead of 'rake'

### DIFF
--- a/.github/workflows/ragel.yml
+++ b/.github/workflows/ragel.yml
@@ -62,7 +62,7 @@ jobs:
           ragel --version
           Remove-Item -Path ext/puma_http11/http11_parser.c
           Remove-Item -Path ext/puma_http11/org/jruby/puma/Http11Parser.java
-          rake ragel
+          bundle exec rake ragel
           if ($IsWindows) {
             dos2unix ext/puma_http11/http11_parser.c
             dos2unix ext/puma_http11/org/jruby/puma/Http11Parser.java


### PR DESCRIPTION
### Description

Rake 13.1.0 has been released, and the ragel CI is failing in my fork.

`BUNDLE_PATH` is set by setup/ruby using `bundle config --local path <path>`, so the gems installed by it are not accessible unless `bundle exec` is used.  Hence, one should always use `bundle exec` or `require 'bundler/setup'`.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.