### PR TITLE
MiniSSL.java - set serialVersionUID, fix RaiseException deprecation

### DIFF
--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -501,7 +501,7 @@ public class MiniSSL extends RubyObject { // MiniSSL::Engine
   }
 
   private static RaiseException newError(Ruby runtime, RubyClass errorClass, String message, Throwable cause) {
-    RaiseException ex = new RaiseException(runtime, errorClass, message, true);
+    RaiseException ex = RaiseException.from(runtime, errorClass, message);
     ex.initCause(cause);
     return ex;
   }

--- a/ext/puma_http11/org/jruby/puma/MiniSSL.java
+++ b/ext/puma_http11/org/jruby/puma/MiniSSL.java
@@ -47,6 +47,7 @@ import static javax.net.ssl.SSLEngineResult.Status;
 import static javax.net.ssl.SSLEngineResult.HandshakeStatus;
 
 public class MiniSSL extends RubyObject { // MiniSSL::Engine
+  private static final long serialVersionUID = -6903439483039141234L;
   private static ObjectAllocator ALLOCATOR = new ObjectAllocator() {
     public IRubyObject allocate(Ruby runtime, RubyClass klass) {
       return new MiniSSL(runtime, klass);


### PR DESCRIPTION
### Description

While working on the test framework, there have been consistent intermittent failures with JRuby, but never with the job that did not use SSL.  The failures were much more consistent in CI, but much less common locally.  But, I've got a lot of RAM.

The failures showed that all tests passed, but the test process freezes, and the CI step times out.

For quite a while, the following has been logged in the JRuby compile step.  There are also case fall-thru warnings, but the case statements have integer switches, so multiple matches cannot happen:

```
ext/puma_http11/org/jruby/puma/MiniSSL.java:503: warning: [deprecation] RaiseException(Ruby,RubyClass,String,boolean) in RaiseException has been deprecated
    RaiseException ex = new RaiseException(runtime, errorClass, message, true);
                        ^
ext/puma_http11/org/jruby/puma/MiniSSL.java:49: warning: [serial] serializable class MiniSSL has no definition of serialVersionUID
public class MiniSSL extends RubyObject { // MiniSSL::Engine
```

Not being a java type, I googled and also looked at `nio4r`.  In `nio4r`, `serialVersionUID` is set to what appears to be random long values.  So, I added a similar statement to our java code, and the tests are completing.  Or, no more frozen test processes.

@kares - sorry for the ping.  Does this look okay to you?  Is the `RaiseException` warning easy to fix?  TIA...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
