### PR TITLE
Improve Puma::NullIO consistency with real IO

### DIFF
--- a/lib/puma/null_io.rb
+++ b/lib/puma/null_io.rb
@@ -18,8 +18,22 @@ module Puma
 
     # Mimics IO#read with no data.
     #
-    def read(count = nil, _buffer = nil)
-      count && count > 0 ? nil : ""
+    def read(length = nil, buffer = nil)
+      if length.to_i < 0
+        raise ArgumentError, "(negative length #{length} given)"
+      end
+
+      buffer = if buffer.nil?
+        "".b
+      else
+        String.try_convert(buffer) or raise TypeError, "no implicit conversion of #{buffer.class} into String"
+      end
+      buffer.clear
+      if length.to_i > 0
+        nil
+      else
+        buffer
+      end
     end
 
     def rewind


### PR DESCRIPTION
This isn't a big deal, but every small difference has a chance to let a bug slip as it's likely not every scenario is tested with both NullIO and a real IO.
