### PR TITLE
Add comment about `NoDelay=true` in systemd docs

### DIFF
--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -101,7 +101,8 @@ ListenStream=0.0.0.0:9293
 # Socket options matching Puma defaults
 ReusePort=true
 Backlog=1024
-# Socket option NoDelay will set TCP_NODELAY if puma is run with parameter low_latency. This is off by default.
+# Enable this if you're using Puma with the "low_latency" option, read more in Puma DSL docs and systemd docs:
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.socket.html#NoDelay=
 # NoDelay=true
 
 [Install]

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -99,9 +99,10 @@ ListenStream=0.0.0.0:9293
 # ListenStream=/run/puma.sock
 
 # Socket options matching Puma defaults
-NoDelay=true
 ReusePort=true
 Backlog=1024
+# Socket option NoDelay will set TCP_NODELAY if puma is run with parameter low_latency. This is off by default.
+# NoDelay=true
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION


### Description
Since NoDelay apparently is no longer the default, the example in the systemd docs should also reflect this. This follows up https://github.com/puma/puma/pull/2631.

If the line should be removed instead of commented out (or if the added comment is unclear or unhelpful), please let me know!

(This is my first PR here, and I hope I've ticked the right boxes. Sorry if I overlooked anything!)

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
