### PR TITLE
[Fix #3282] `idle-timeout` not waiting on all workers in cluster mode

### DIFF
--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -146,8 +146,6 @@ module Puma
         # Invoke any worker shutdown hooks so they can prevent the worker
         # exiting until any background operations are completed
         @config.run_hooks(:before_worker_shutdown, index, @log_writer, @hook_data)
-
-        Process.kill "SIGTERM", master if server.idle_timeout_reached
       ensure
         @worker_write << "t#{Process.pid}\n" rescue nil
         @worker_write.close

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -37,7 +37,6 @@ module Puma
     attr_reader :events
     attr_reader :min_threads, :max_threads  # for #stats
     attr_reader :requests_count             # @version 5.0.0
-    attr_reader :idle_timeout_reached
 
     # @todo the following may be deprecated in the future
     attr_reader :auto_trim_time, :early_hints, :first_data_timeout,
@@ -82,6 +81,8 @@ module Puma
         UserFileDefaultOptions.new(options, Configuration::DEFAULTS)
       end
 
+      @clustered                 = (@options.fetch :workers, 0) > 0
+      @worker_write              = @options[:worker_write]
       @log_writer                = @options.fetch :log_writer, LogWriter.stdio
       @early_hints               = @options[:early_hints]
       @first_data_timeout        = @options[:first_data_timeout]
@@ -333,10 +334,22 @@ module Puma
             unless ios
               unless shutting_down?
                 @idle_timeout_reached = true
-                @status = :stop
+
+                if @clustered
+                  @worker_write << "i#{Process.pid}\n" rescue nil
+                  next
+                else
+                  @log_writer.log "- Idle timeout reached"
+                  @status = :stop
+                end
               end
 
               break
+            end
+
+            if @idle_timeout_reached && @clustered
+              @idle_timeout_reached = false
+              @worker_write << "i#{Process.pid}\n" rescue nil
             end
 
             ios.first.each do |sock|

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -226,7 +226,10 @@ class TestIntegrationCluster < TestIntegration
 
     get_worker_pids # wait for workers to boot
 
-    connect
+    10.times {
+      fast_connect
+      sleep 0.5
+    }
 
     sleep 1.15
 


### PR DESCRIPTION
### Description

Closes https://github.com/puma/puma/issues/3282

Ensures that the master process (and therefore the entire cluster) is only gracefully shut down when all workers have reached the idle timeout when in cluster mode, as opposed to any worker (current implementation).

<details>
<summary>Also adds a log to indicate that the idle time out has been reached in both modes</summary>

```
Puma starting in single mode...
* Puma version: 6.4.0 (ruby 3.2.2-p53) ("The Eagle of Durango")
*  Min threads: 0
*  Max threads: 5
*  Environment: development
*          PID: 70263
* Listening on http://0.0.0.0:9292
Use Ctrl-C to stop
- Idle timeout reached # 👈🏽
- Gracefully stopping, waiting for requests to finish
=== puma shutdown: 2023-11-29 16:15:05 +1000 ===
- Goodbye!
```

```
[70332] Puma starting in cluster mode...
[70332] * Puma version: 6.4.0 (ruby 3.2.2-p53) ("The Eagle of Durango")
[70332] *  Min threads: 0
[70332] *  Max threads: 5
[70332] *  Environment: development
[70332] *   Master PID: 70332
[70332] *      Workers: 2
[70332] *     Restarts: (✔) hot (✔) phased
[70332] * Listening on http://0.0.0.0:9292
[70332] Use Ctrl-C to stop
[70332] - Worker 0 (PID: 70346) booted in 0.0s, phase: 0
[70332] - Worker 1 (PID: 70347) booted in 0.0s, phase: 0
[70332] - All workers reached idle timeout # 👈🏽
[70332] - Gracefully shutting down workers...
[70332] === puma shutdown: 2023-11-29 16:15:35 +1000 ===
[70332] - Goodbye!
```

</details>

FWIW I've manually tested this against the Rails monolith I work on and it's looking good!

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
