### PR TITLE
Return 405, not 501, when an unsupported HTTP method is used

### DIFF
--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -101,7 +101,11 @@ module Puma
           end
         else
           @log_writer.log "Unsupported HTTP method used: #{env[REQUEST_METHOD]}"
-          status, headers, app_body = [501, {}, ["#{env[REQUEST_METHOD]} method is not supported"]]
+          status, headers, app_body = [
+            405,
+            {"Allow" => @supported_http_methods.keys.join(", ")},
+            ["#{env[REQUEST_METHOD]} method is not supported"]
+          ]
         end
 
         # app_body needs to always be closed, hold value in case lowlevel_error

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1795,7 +1795,8 @@ class TestPumaServer < Minitest::Test
       [200, {}, body]
     end
     resp = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
-    assert_match 'Not Implemented', resp
+    assert_match 'Allow: PROPFIND, PROPPATCH', resp
+    assert_match '405 Method Not Allowed', resp
   end
 
   def test_supported_http_methods_accept_all
@@ -1813,7 +1814,7 @@ class TestPumaServer < Minitest::Test
       [200, {}, body]
     end
     resp = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
-    assert_match(/\AHTTP\/1\.0 501 Not Implemented/, resp)
+    assert_match(/\AHTTP\/1\.0 405 Method Not Allowed/, resp)
   end
 
 

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -95,7 +95,7 @@ class WebServerTest < Minitest::Test
   def test_nonexistent_http_method
     socket = do_test("FOOBARBAZ www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
     response = socket.read
-    assert_match "Not Implemented", response
+    assert_match "Method Not Allowed", response
     socket.close
   end
 


### PR DESCRIPTION
### Description

Currently, when the `supported_http_methods` DSL config option is not set to `:any`, the behaviour upon encountering an unexpected HTTP method is to return an `501 Not Implemented` response.

Whilst this is technically correct, it can be somewhat problematic; in situations where 5xx error responses are used as a heuristic to determine whether or not an application is healthy, a single person sending a flood of requests with invalid HTTP methods can result in an application being considered 'unhealthy' because Puma returns a 501.

It seems the somewhat more semantically correct response code to use in this scenario is `405 Method Not Allowed` – this is how Rails deals with HTTP methods it can't handle, for example. The HTTP spec requires that an `Allow` header is returned alongside it with details of which methods _are_ acceptable.

To that end, this modifies the behaviour of Puma to return a 405 when supplied an unsupported HTTP method, rather than a 501, and return an `Allow` header with the valid methods.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [X] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed, including Rubocop.
