### PR TITLE
configuration.rb - move dsl require back to top

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -3,7 +3,7 @@
 require_relative 'rack/builder'
 require_relative 'plugin'
 require_relative 'const'
-# note that dsl is loaded at end of file, requires ConfigDefault constants
+require_relative 'dsl'
 
 module Puma
   # A class used for storing "leveled" configuration options.
@@ -387,5 +387,3 @@ module Puma
     end
   end
 end
-
-require_relative 'dsl'


### PR DESCRIPTION
### Description

See issue https://github.com/puma/puma/issues/2922, which led to PR https://github.com/puma/puma/pull/2928, which made the EOF require unnecessary.

Closes #3287

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
