### PR TITLE
mini_ssl.c - fix TruffleRuby compile error

### DIFF
--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -546,7 +546,7 @@ NORETURN(void raise_error(SSL* ssl, int result));
 
 void raise_error(SSL* ssl, int result) {
   char buf[512];
-  char msg[512];
+  char msg[768];
   const char* err_str;
   int err = errno;
   int mask = 4095;


### PR DESCRIPTION
### Description

Fixes:
```
compiling ../../../../ext/puma_http11/mini_ssl.c
../../../../ext/puma_http11/mini_ssl.c: In function ‘raise_error’:
../../../../ext/puma_http11/mini_ssl.c:569:50: error: ‘%s’ directive output may be truncated writing up to 511 bytes into a region of size 497 [-Werror=format-truncation=]
  569 |       snprintf(msg, sizeof(msg), "OpenSSL error: %s - %d", buf, err & mask);
      |                                                  ^~        ~~~
../../../../ext/puma_http11/mini_ssl.c:569:34: note: directive argument in the range [0, 4095]
  569 |       snprintf(msg, sizeof(msg), "OpenSSL error: %s - %d", buf, err & mask);
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:867,
                 from /home/runner/.rubies/truffleruby-head/lib/cext/include/ruby/defines.h:16,
                 from /home/runner/.rubies/truffleruby-head/lib/cext/include/truffleruby/truffleruby-pre.h:[38](https://github.com/MSP-Greg/puma/actions/runs/7160290330/job/19494508272#step:7:39),
                 from /home/runner/.rubies/truffleruby-head/lib/cext/include/ruby/internal/config.h:164,
                 from /home/runner/.rubies/truffleruby-head/lib/cext/include/ruby/ruby.h:15,
                 from /home/runner/.rubies/truffleruby-head/lib/cext/include/ruby.h:38,
                 from ../../../../ext/puma_http11/mini_ssl.c:3:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 20 and 534 bytes into a destination of size [51](https://github.com/MSP-Greg/puma/actions/runs/7160290330/job/19494508272#step:7:52)2
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:[56](https://github.com/MSP-Greg/puma/actions/runs/7160290330/job/19494508272#step:7:57)6: mini_ssl.o] Error 1
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
