### PR TITLE
fix define_method calls, use Symbol parameter instead of String

### DIFF
--- a/lib/puma/state_file.rb
+++ b/lib/puma/state_file.rb
@@ -56,11 +56,11 @@ module Puma
     end
 
     ALLOWED_FIELDS.each do |f|
-      define_method f do
+      define_method f.to_sym do
         @options[f]
       end
 
-      define_method "#{f}=" do |v|
+      define_method :"#{f}=" do |v|
         @options[f] = v
       end
     end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1334,12 +1334,12 @@ class TestPumaServer < Minitest::Test
   # overriding content-length.
   {"cr" => "\r", "lf" => "\n", "crlf" => "\r\n"}.each do |suffix, line_ending|
     # The cr-only case for the following test was CVE-2020-5247
-    define_method("test_prevent_response_splitting_headers_#{suffix}") do
+    define_method(:"test_prevent_response_splitting_headers_#{suffix}") do
       app = ->(_) { [200, {'X-header' => "untrusted input#{line_ending}Cookie: hack"}, ["Hello"]] }
       assert_does_not_allow_http_injection(app)
     end
 
-    define_method("test_prevent_response_splitting_headers_early_hint_#{suffix}") do
+    define_method(:"test_prevent_response_splitting_headers_early_hint_#{suffix}") do
       app = ->(env) do
         env['rack.early_hints'].call("X-header" => "untrusted input#{line_ending}Cookie: hack")
         [200, {}, ["Hello"]]
@@ -1347,7 +1347,7 @@ class TestPumaServer < Minitest::Test
       assert_does_not_allow_http_injection(app, early_hints: true)
     end
 
-    define_method("test_prevent_content_length_injection_#{suffix}") do
+    define_method(:"test_prevent_content_length_injection_#{suffix}") do
       app = ->(_) { [200, {'content-length' => "untrusted input#{line_ending}Cookie: hack"}, ["Hello"]] }
       assert_does_not_allow_http_injection(app)
     end


### PR DESCRIPTION
### Description

Recent RuboCop fails with a similar error in four places:
```
lib/puma/state_file.rb:63:21: C: [Correctable] Performance/StringIdentifierArgument: Use :"#{f}=" instead of "#{f}=".
      define_method "#{f}=" do |v|
                    ^^^^^^^
```

We've used a string parameter for `define_method`, but Ruby's docs show it as a symbol.  Also, an interpolated symbol could be used, but it's not commonly used, and these aren't 'hot' paths.

Fixed all occurrences.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
