### PR TITLE
ragel.yml - remove Windows due to incorrect line directives

### DIFF
--- a/.github/workflows/ragel.yml
+++ b/.github/workflows/ragel.yml
@@ -29,7 +29,9 @@ jobs:
         include:
           - { os: ubuntu-20.04 , ruby: head }
           - { os: macos-11     , ruby: head }
-          - { os: windows-2022 , ruby: ucrt }
+          # Dec-2023 - incorrect line directives with Windows
+          # occurs with both MSYS2 and MSFT/vpkg versions of ragel
+          # - { os: windows-2022 , ruby: ucrt } 
 
     steps:
       # windows git will convert \n to \r\n


### PR DESCRIPTION
### Description

See comments.  This only affects when errors are thrown, as the line directives pass information about error locations.

See Actions job log at https://github.com/puma/puma/actions/runs/7290009317/job/19866006642#step:5:49

Sample of diff:
```diff
diff --git a/ext/puma_http11/http11_parser.c b/ext/puma_http11/http11_parser.c
index 388a098..fa298f2 100644
--- a/ext/puma_http11/http11_parser.c
+++ b/ext/puma_http11/http11_parser.c
@@ -38,7 +38,7 @@ static void snake_upcase_char(char *c)
 
 /** Data **/
 
-#line 42 "ext/puma_http11/http11_parser.c"
+#line 37 "ext/puma_http11/http11_parser.c"
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
