### PR TITLE
lib/client.rb - use Tempfile.create instead of Tempfile.new for request bodies

### DIFF
--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -53,7 +53,6 @@ module Puma
       socket  = client.io   # io may be a MiniSSL::Socket
       app_body = nil
 
-
       return false if closed_socket?(socket)
 
       if client.http_content_length_limit_exceeded
@@ -135,7 +134,7 @@ module Puma
       io_buffer.reset
       uncork_socket client.io
       app_body.close if app_body.respond_to? :close
-      client.tempfile&.unlink
+      client&.tempfile_close
       after_reply = env[RACK_AFTER_REPLY] || []
       begin
         after_reply.each { |o| o.call }


### PR DESCRIPTION
### Description

Currently, `Tempfile.new` is used in `Client` when a request contains content (a body) that is either very large or indeterminate (chunked).  `Tempfile.new` creates a finalizer that removes the `Tempfile`, so its removal is dependent on GC.

Recently, Windows head builds started logging the following in CI, a log is [here](https://github.com/puma/puma/actions/runs/7301425484/job/19898046945#step:11:433).  Note that Ruby head (3.3) has had many changes re GC, and one might call it more agressive...
```
D:/a/puma/puma/lib/puma/thread_pool.rb:113: warning: Exception in finalizer #<Tempfile::Remover:0x000001939f62dc50 @pid=2472, @path="D:/a/_temp/puma20231222-2472-94nq5x">
D:/ruby-mswin/lib/ruby/3.3.0+0/tempfile.rb:319:in `unlink': Permission denied @ apply2files - D:/a/_temp/puma20231222-2472-94nq5x (Errno::EACCES)
```

I doubt many people are using Puma on Windows, but Windows CI may show things that indicate issues.  On Windows, one cannot delete a file if it is open, unlike '*nix' platforms.

Also, in general, I think we'd prefer that Puma does its own cleanup, and not depend on GC to do so, at least with system resources like IO (files, pipes, sockets, etc).

So, use `Tempfile.create` and remove the file when Puma is finished with it.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
