### PR TITLE
[Fix #3044] Set conditional config defaults after CLI options are parsed and config files are loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ For an in-depth discussion of the tradeoffs of thread and process count settings
 
 In cluster mode, Puma can "preload" your application. This loads all the application code *prior* to forking. Preloading reduces total memory usage of your application via an operating system feature called [copy-on-write](https://en.wikipedia.org/wiki/Copy-on-write).
 
-If the `WEB_CONCURRENCY` environment variable is set to a value > 1 (and `--prune-bundler` has not been specified), preloading will be enabled by default. Otherwise, you can use the `--preload` flag from the command line:
+If the number of workers is greater than 1 (and `--prune-bundler` has not been specified), preloading will be enabled by default. Otherwise, you can use the `--preload` flag from the command line:
 
 ```
 $ puma -w 3 --preload

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -39,10 +39,8 @@ module Puma
       @control_url = nil
       @control_options = {}
 
-      setup_options env
-
       begin
-        @parser.parse! @argv
+        setup_options env
 
         if file = @argv.shift
           @conf.configure do |user_config, file_config|
@@ -240,7 +238,7 @@ module Puma
             $stdout.puts o
             exit 0
           end
-        end
+        end.parse! @argv
       end
     end
   end

--- a/test/config/worker_respawn.rb
+++ b/test/config/worker_respawn.rb
@@ -1,0 +1,4 @@
+worker_shutdown_timeout 2
+# Workers may be respawned with either :TERM or phased restart (:USR1),
+# preloading is not compatible with the latter.
+preload_app! false

--- a/test/config/worker_shutdown_timeout_2.rb
+++ b/test/config/worker_shutdown_timeout_2.rb
@@ -1,1 +1,0 @@
-worker_shutdown_timeout 2

--- a/test/config/workers_0.rb
+++ b/test/config/workers_0.rb
@@ -1,0 +1,1 @@
+workers 0

--- a/test/config/workers_2.rb
+++ b/test/config/workers_2.rb
@@ -1,0 +1,1 @@
+workers 2

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -349,7 +349,6 @@ class TestCLI < PumaTest
     ENV['APP_ENV'] = 'test'
 
     cli = Puma::CLI.new []
-    cli.send(:setup_options)
 
     conf = cli.instance_variable_get(:@conf)
     conf.clamp
@@ -364,7 +363,6 @@ class TestCLI < PumaTest
     ENV['RACK_ENV'] = @environment
 
     cli = Puma::CLI.new []
-    cli.send(:setup_options)
 
     conf = cli.instance_variable_get(:@conf)
     conf.clamp
@@ -377,7 +375,6 @@ class TestCLI < PumaTest
     ENV['RAILS_ENV'] = @environment
 
     cli = Puma::CLI.new []
-    cli.send(:setup_options)
 
     conf = cli.instance_variable_get(:@conf)
     conf.clamp
@@ -389,7 +386,6 @@ class TestCLI < PumaTest
 
   def test_silent
     cli = Puma::CLI.new ['--silent']
-    cli.send(:setup_options)
 
     log_writer = cli.instance_variable_get(:@log_writer)
 
@@ -402,9 +398,26 @@ class TestCLI < PumaTest
     assert_empty Puma::Plugins.instance_variable_get(:@plugins)
 
     cli = Puma::CLI.new ['--plugin', 'tmp_restart', '--plugin', 'systemd']
-    cli.send(:setup_options)
 
     assert Puma::Plugins.find("tmp_restart")
     assert Puma::Plugins.find("systemd")
+  end
+
+  def test_config_does_not_preload_app_with_workers
+    skip_unless :fork
+
+    cli = Puma::CLI.new ['-w 0']
+    config = Puma.cli_config
+
+    assert_equal false, config.options[:preload_app]
+  end
+
+  def test_config_preloads_app_with_workers
+    skip_unless :fork
+
+    cli = Puma::CLI.new ['-w 2']
+    config = Puma.cli_config
+
+    assert_equal true, config.options[:preload_app]
   end
 end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -651,6 +651,45 @@ class TestConfigFile < PumaTest
     assert_kind_of Array, conf.config_files
   end
 
+  def test_config_does_not_preload_app_if_not_using_workers
+    conf = Puma::Configuration.new({ workers: 0 })
+    conf.clamp
+
+    assert_equal false, conf.options.default_options[:preload_app]
+  end
+
+  def test_config_preloads_app_if_using_workers
+    conf = Puma::Configuration.new({ workers: 2 })
+    conf.clamp
+    preload = Puma.forkable?
+
+    assert_equal preload, conf.options.default_options[:preload_app]
+  end
+
+  def test_config_does_not_preload_app_if_using_workers_and_prune_bundler
+    conf = Puma::Configuration.new({ workers: 2 }) do |c|
+      c.prune_bundler
+    end
+    conf.clamp
+
+    assert_equal false, conf.options.default_options[:preload_app]
+  end
+
+  def test_config_file_does_not_preload_app_if_not_using_workers
+    conf = Puma::Configuration.new { |c| c.load 'test/config/workers_0.rb' }
+    conf.clamp
+
+    assert_equal false, conf.options.default_options[:preload_app]
+  end
+
+  def test_config_file_preloads_app_if_using_workers
+    conf = Puma::Configuration.new { |c| c.load 'test/config/workers_2.rb' }
+    conf.clamp
+    preload = Puma.forkable?
+
+    assert_equal preload, conf.options.default_options[:preload_app]
+  end
+
   private
 
   def assert_run_hooks(hook_name, options = {})

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -34,22 +34,22 @@ class TestIntegrationCluster < TestIntegration
 
   def test_phased_restart_does_not_drop_connections_threads
     restart_does_not_drop_connections num_threads: 10, total_requests: 3_000,
-      signal: :USR1
+      signal: :USR1, config: "preload_app! false"
   end
 
   def test_phased_restart_does_not_drop_connections
     restart_does_not_drop_connections num_threads: 1, total_requests: 1_000,
-      signal: :USR1
+      signal: :USR1, config: "preload_app! false"
   end
 
   def test_phased_restart_does_not_drop_connections_threads_fork_worker
     restart_does_not_drop_connections num_threads: 10, total_requests: 3_000,
-      signal: :USR1, config: 'fork_worker'
+      signal: :USR1, config: "fork_worker; preload_app! false"
   end
 
   def test_phased_restart_does_not_drop_connections_unix
     restart_does_not_drop_connections num_threads: 1, total_requests: 1_000,
-      signal: :USR1, unix: true
+      signal: :USR1, unix: true, config: "preload_app! false"
   end
 
   def test_pre_existing_unix
@@ -74,7 +74,7 @@ class TestIntegrationCluster < TestIntegration
 
     File.open(@bind_path, mode: 'wb') { |f| f.puts 'pre existing' }
 
-    cli_server "-w #{workers} -q test/rackup/sleep_step.ru", unix: :unix
+    cli_server "-w #{workers} -q test/rackup/sleep_step.ru", unix: :unix, config: "preload_app! false"
     connection = connect(nil, unix: true)
     restart_server connection
 
@@ -387,6 +387,7 @@ class TestIntegrationCluster < TestIntegration
       # to simulate worker 0 timeout, total boot time for all workers
       # needs to exceed single worker timeout
       workers #{worker_count}
+      preload_app! false
     CONFIG
 
     get_worker_pids 0, worker_count
@@ -687,7 +688,7 @@ class TestIntegrationCluster < TestIntegration
     end
   end
 
-  def worker_respawn(phase = 1, size = workers, config = 'test/config/worker_shutdown_timeout_2.rb')
+  def worker_respawn(phase = 1, size = workers, config = 'test/config/worker_respawn.rb')
     threads = []
 
     cli_server "-w #{workers} -t 1:1 -C #{config} test/rackup/sleep_pid.ru"

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -58,7 +58,12 @@ class TestIntegrationPumactl < TestIntegration
 
   def test_phased_restart_cluster
     skip_unless :fork
-    cli_server "-q -w #{workers} test/rackup/sleep.ru #{set_pumactl_args unix: true} -S #{@state_path}", unix: true
+    cli_server "test/rackup/sleep.ru #{set_pumactl_args unix: true}", unix: true, config: <<~RUBY
+      quiet
+      workers #{workers}
+      preload_app! false
+      state_path "#{@state_path}"
+    RUBY
 
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -80,7 +80,10 @@ class TestPluginSystemd < TestIntegration
 
   def assert_restarts_with_systemd(signal, workers: 2)
     skip_unless(:fork) unless workers.zero?
-    cli_server "-w#{workers} test/rackup/hello.ru", env: @env
+    cli_server "test/rackup/hello.ru", env: @env, config: <<~CONFIG
+      workers #{workers}
+      #{"preload_app! false" if signal == :USR1}
+    CONFIG
     get_worker_pids(0, workers) if workers == 2
     assert_message 'READY=1'
 


### PR DESCRIPTION
### Description

Closes https://github.com/puma/puma/issues/3044

`CLI` options are parsed during `CLI` initialisation, but after `Configuration` initialisation. This PR changes this so that the parsing takes place during `Configuration` initialisation. This ensures that `CLI` options are also used when some config defaults are conditionally set during initialisation.

~**Note:** Even with the changes in this PR `preload_app` isn't enabled by default if using `#workers` in a config file. I'm happy to address that here too if prefered. Else we have an inconsistency with the cli and config file.~

Addressed in [these changes](https://github.com/puma/puma/compare/3ac0f65f5e98adde1d42e1361ea491a2ae29e103..d4f9f5d489ce37d7be690f89a085ef7639a1a11f). We now ensure that conditional defaults are also set when config files are loaded.

### Warning

The side effect of these changes which fixes the linked issue is that `preload_app` is now consistently enabled by default regardless of configuration method if [these conditions are met](https://github.com/joshuay03/puma/blob/b081b02a17459a1d86fa18eb5ede2a25c1587737/lib/puma/configuration.rb#L384-L387).

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
