### PR TITLE
[ci skip] Note symlink mechanism in restart documentation for hot restart

### DIFF
--- a/docs/restart.md
+++ b/docs/restart.md
@@ -27,6 +27,7 @@ Any of the following will cause a Puma server to perform a hot restart:
 
 ### Additional notes
 
+* The newly started Puma process changes its current working directory to the directory specified by the `directory` option. If `directory` is set to symlink, this is automatically re-evaluated, so this mechanism can be used to upgrade the application.
 * Only one version of the application is running at a time.
 * `on_restart` is invoked just before the server shuts down. This can be used to clean up resources (like long-lived database connections) gracefully. Since Ruby 2.0, it is not typically necessary to explicitly close file descriptors on restart. This is because any file descriptor opened by Ruby will have the `FD_CLOEXEC` flag set, meaning that file descriptors are closed on `exec`. `on_restart` is useful, though, if your application needs to perform any more graceful protocol-specific shutdown procedures before closing connections.
 


### PR DESCRIPTION
### Description
Hi! I recently tried to set up puma with hot restart, deployed with capistrano to a symlinked directory, and ran into the problem that after deploy changes to the app were not picked up. I have only glanced over the phased restart section before and didn't realize that the "cd to `directory` on startup" mechanism is also relevant for hot restarts. Here's a minor doc change to clarify that.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] ~~I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.~~
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] ~~If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.~~
- [x] I have updated the documentation accordingly.
- [ ] ~~All new and existing tests passed, including Rubocop.~~
