### PR TITLE
Improve auto trim free thread condition

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -255,7 +255,7 @@ module Puma
 
 
       @thread_pool.auto_reap! if options[:reaping_time]
-      @thread_pool.auto_trim! if options[:auto_trim_time]
+      @thread_pool.auto_trim! if options[:auto_trim_time] && @max_threads != @min_threads
 
       @check, @notify = Puma::Util.pipe unless @notify
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -341,34 +341,3 @@ module TestTempFile
   end
 end
 Minitest::Test.include TestTempFile
-
-# This module is modified based on https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/testing/method_call_assertions.rb
-module MethodCallAssertions
-  def assert_called_on_instance_of(klass, method_name, message = nil, times: 1, returns: nil)
-    times_called = 0
-    klass.send(:define_method, :"stubbed_#{method_name}") do |*|
-      times_called += 1
-
-      returns
-    end
-
-    klass.send(:alias_method, :"original_#{method_name}", method_name)
-    klass.send(:alias_method, method_name, :"stubbed_#{method_name}")
-
-    yield
-
-    error = "Expected #{method_name} to be called #{times} times, but was called #{times_called} times"
-    error = "#{message}.\n#{error}" if message
-
-    assert_equal times, times_called, error
-  ensure
-    klass.send(:alias_method, method_name, :"original_#{method_name}")
-    klass.send(:undef_method, :"original_#{method_name}")
-    klass.send(:undef_method, :"stubbed_#{method_name}")
-  end
-
-  def assert_not_called_on_instance_of(klass, method_name, message = nil, &block)
-    assert_called_on_instance_of(klass, method_name, message, times: 0, &block)
-  end
-end
-Minitest::Test.include MethodCallAssertions

--- a/test/helpers/test_puma/assertions.rb
+++ b/test/helpers/test_puma/assertions.rb
@@ -29,6 +29,36 @@ module TestPuma
       matcher = Regexp.new Regexp.escape matcher if String === matcher
       assert matcher =~ obj, msg
     end
+
+    # These methods is modified based on https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/testing/method_call_assertions.rb
+    ### BEGIN
+    def assert_called_on_instance_of(klass, method_name, message = nil, times: 1, returns: nil)
+      times_called = 0
+      klass.send(:define_method, :"stubbed_#{method_name}") do |*|
+        times_called += 1
+
+        returns
+      end
+
+      klass.send(:alias_method, :"original_#{method_name}", method_name)
+      klass.send(:alias_method, method_name, :"stubbed_#{method_name}")
+
+      yield
+
+      error = "Expected #{method_name} to be called #{times} times, but was called #{times_called} times"
+      error = "#{message}.\n#{error}" if message
+
+      assert_equal times, times_called, error
+    ensure
+      klass.send(:alias_method, method_name, :"original_#{method_name}")
+      klass.send(:undef_method, :"original_#{method_name}")
+      klass.send(:undef_method, :"stubbed_#{method_name}")
+    end
+
+    def assert_not_called_on_instance_of(klass, method_name, message = nil, &block)
+      assert_called_on_instance_of(klass, method_name, message, times: 0, &block)
+    end
+    ### END
   end
 end
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -2043,4 +2043,14 @@ class TestPumaServer < Minitest::Test
     assert_includes body, "Content-Length: 144\r\n"
     assert_equal 1, response.scan("HTTP/1.1 200 OK").size
   end
+
+  def test_auto_trim_free_thread
+    assert_not_called_on_instance_of(Puma::ThreadPool, :auto_trim!) do # max_threads == min_threads
+      server_run(max_threads: 1, min_threads: 1)
+    end
+
+    assert_called_on_instance_of(Puma::ThreadPool, :auto_trim!) do # max_threads != min_threads
+      server_run(max_threads: 2, min_threads: 1)
+    end
+  end
 end


### PR DESCRIPTION
### Description
When `max_threads` and `min_threads` are the same, it is no need to call `auto_trim!`, which can reduce one thread.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.

_PS: English is not my native language; please excuse typing errors._

***

Added @joshuay03 as a collaborator here, because @joshuay03 created a similar #3384 to fix this problem.
Co-authored-by: Joshua Young <djry1999@gmail.com>


