### PR TITLE
Fix response repeated status line when request is invalid or errors are raised

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -570,7 +570,6 @@ module Puma
     def response_to_error(client, requests, err, status_code)
       status, headers, res_body = lowlevel_error(err, client.env, status_code)
       prepare_response(status, headers, res_body, requests, client)
-      client.write_error(status_code)
     end
     private :response_to_error
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,6 +13,9 @@ end
 
 require "securerandom"
 
+# needs to be loaded before minitest for Ruby 2.7 and earlier
+require_relative "helpers/test_puma/assertions"
+
 require_relative "minitest/verbose"
 require "minitest/autorun"
 require "minitest/pride"

--- a/test/helpers/test_puma/assertions.rb
+++ b/test/helpers/test_puma/assertions.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module TestPuma
+  module Assertions
+    def assert_start_with(obj, str, msg = nil)
+      msg = message(msg) {
+        "Expected\n#{obj}\nto start with #{str}"
+      }
+      assert_respond_to obj, :start_with?
+      assert obj.start_with?(str), msg
+    end
+
+    def assert_end_with(obj, str, msg = nil)
+      msg = message(msg) {
+        "Expected\n#{obj}\nto end with #{str}"
+      }
+      assert_respond_to obj, :end_with?
+      assert obj.end_with?(str), msg
+    end
+
+    # if obj is longer than 80 characters, show as string, not inspected
+    def assert_match(matcher, obj, msg = nil)
+      msg = if obj.length < 80
+        message(msg) { "Expected #{mu_pp matcher} to match #{mu_pp obj}" }
+      else
+        message(msg) { "Expected #{mu_pp matcher} to match:\n#{obj}\n" }
+      end
+      assert_respond_to matcher, :"=~"
+      matcher = Regexp.new Regexp.escape matcher if String === matcher
+      assert matcher =~ obj, msg
+    end
+  end
+end
+
+module Minitest
+  module Assertions
+    prepend TestPuma::Assertions
+  end
+end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -424,7 +424,7 @@ class TestPumaServer < Minitest::Test
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
     refute_match(/don't leak me bro/, data)
-    assert_match(/HTTP\/1.0 500 Internal Server Error/, data)
+    assert_start_with data, 'HTTP/1.0 500 Internal Server Error'
   end
 
   def test_eof_on_connection_close_is_not_logged_as_an_error
@@ -446,7 +446,7 @@ class TestPumaServer < Minitest::Test
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.0 500 Internal Server Error/, data)
+    assert_start_with(data, 'HTTP/1.0 500 Internal Server Error')
     assert_match(/Content-Type: application\/json/, data)
     assert_match(/{}\n$/, data)
   end
@@ -472,7 +472,7 @@ class TestPumaServer < Minitest::Test
 
     data = send_http_and_sysread "GET / HTTP/1.0\r\n\r\n"
 
-    assert_includes data, 'HTTP/1.0 500 Internal Server Error'
+    assert_start_with data, 'HTTP/1.0 500 Internal Server Error'
     assert_includes data, "Puma caught this error: undefined method `to_i' for"
     assert_includes data, "Array"
     refute_includes data, 'lowlevel_error'
@@ -512,7 +512,7 @@ class TestPumaServer < Minitest::Test
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.0 503 Service Unavailable/, data)
+    assert_start_with(data, 'HTTP/1.0 503 Service Unavailable')
     assert_match(/Puma caught this error.+Puma::ThreadPool::ForceShutdown/, data)
   end
 
@@ -522,7 +522,7 @@ class TestPumaServer < Minitest::Test
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.0 302 Found/, data)
+    assert_start_with(data, 'HTTP/1.0 302 Found')
   end
 
   def test_leh_gets_env_as_well
@@ -535,7 +535,7 @@ class TestPumaServer < Minitest::Test
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.0 302 Found/, data)
+    assert_start_with(data, 'HTTP/1.0 302 Found')
   end
 
   def test_leh_has_status
@@ -548,7 +548,7 @@ class TestPumaServer < Minitest::Test
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.0 302 Found/, data)
+    assert_start_with(data, 'HTTP/1.0 302 Found')
   end
 
   def test_custom_http_codes_10

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -915,7 +915,7 @@ class TestPumaServer < Minitest::Test
 
     data = socket.read
 
-    assert_match "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
+    assert_equal "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", data
   end
 
   def test_chunked_request_pause_before_value

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -66,7 +66,10 @@ class WebServerTest < Minitest::Test
 
   def test_bad_path
     socket = do_test("GET : HTTP/1.1\r\n\r\n", 3)
-    assert_match "HTTP/1.1 400 Bad Request\r\n\r\n", socket.read
+    data = socket.read
+    assert_start_with data, "HTTP/1.1 400 Bad Request\r\nContent-Length: "
+    # match is for last backtrace line, may be brittle
+    assert_match(/\.rb:\d+:in `[^']+'\z/, data)
     socket.close
   end
 


### PR DESCRIPTION
### Description

The third commit fixes the error.  If one runs the test suite with the first two commits, the following failures occur:
```
TestPumaServer#test_large_chunked_request_header [/mnt/c/Greg/GitHub/puma/test/test_puma_server.rb:917] 

WebServerTest#test_bad_path [/mnt/c/Greg/GitHub/puma/test/test_web_server.rb:72]
```

Also, the 2nd error above generates a log of the below, which is a pita to read:
```
  1) Failure:
WebServerTest#test_bad_path [/mnt/c/Greg/GitHub/puma/test/test_web_server.rb:72]:
Expected /\.rb:\d+:in `[^']+'\z/ to match # encoding: ASCII-8BIT
#    valid: true
"HTTP/1.1 400 Bad Request\r\nContent-Length: 491\r\n\r\nPuma caught this error: Puma::HttpParserError (Puma::HttpParserError)\n/mnt/c/Greg/GitHub/puma/lib/puma/request.rb:426:in `rescue in normalize_env'\n/mnt/c/Greg/GitHub/puma/lib/puma/request.rb:423:in `normalize_env'\n/mnt/c/Greg/GitHub/puma/lib/puma/request.rb:63:in `handle_request'\n/mnt/c/Greg/GitHub/puma/lib/puma/server.rb:465:in `process_client'\n/mnt/c/Greg/GitHub/puma/lib/puma/server.rb:246:in `block in run'\n/mnt/c/Greg/GitHub/puma/lib/puma/thread_pool.rb:155:in `block in spawn_thread'HTTP/1.1 400 Bad Request\r\n\r\n".
```

The addition of `test_puma/assertions.rb` changes it.  If the object of an `assert_match` is longer than 80 characters, the string is output as is, not inspected, as below, which clearly shows the repeated status line:
```
  1) Failure:
WebServerTest#test_bad_path [/mnt/c/Greg/GitHub/puma/test/test_web_server.rb:72]:
Expected /\.rb:\d+:in `[^']+'\z/ to match:
HTTP/1.1 400 Bad Request
Content-Length: 491

Puma caught this error: Puma::HttpParserError (Puma::HttpParserError)
/mnt/c/Greg/GitHub/puma/lib/puma/request.rb:426:in `rescue in normalize_env'
/mnt/c/Greg/GitHub/puma/lib/puma/request.rb:423:in `normalize_env'
/mnt/c/Greg/GitHub/puma/lib/puma/request.rb:63:in `handle_request'
/mnt/c/Greg/GitHub/puma/lib/puma/server.rb:465:in `process_client'
/mnt/c/Greg/GitHub/puma/lib/puma/server.rb:246:in `block in run'
/mnt/c/Greg/GitHub/puma/lib/puma/thread_pool.rb:155:in `block in spawn_thread'HTTP/1.1 400 Bad Request
```

I hope others also find that much easier to read...

Closes #3307

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
