### PR TITLE
Use Rails `7.1` with Ruby head in `turbo-rails` CI

### DIFF
--- a/.github/workflows/turbo-rails.yml
+++ b/.github/workflows/turbo-rails.yml
@@ -29,7 +29,10 @@ jobs:
           - { os: ubuntu-20.04 , ruby: '3.1', rails: '7.0' }
           - { os: ubuntu-20.04 , ruby: '3.2', rails: '7.0' }
           - { os: ubuntu-22.04 , ruby: '3.3', rails: '7.0' }
-          - { os: ubuntu-22.04 , ruby: head , rails: '7.0' }
+          - { os: ubuntu-20.04 , ruby: '3.1', rails: '7.1' }
+          - { os: ubuntu-20.04 , ruby: '3.2', rails: '7.1' }
+          - { os: ubuntu-22.04 , ruby: '3.3', rails: '7.1' }
+          - { os: ubuntu-22.04 , ruby: head , rails: '7.1' }
     env:
       CI: true
       RAILS_VERSION: "${{ matrix.rails }}"


### PR DESCRIPTION
### Description

Context:
- https://github.com/ruby/ruby/commit/d16f992e1bfacb638b8a9b8b5a7ef8149ee1d50d
- https://github.com/ruby/ruby/commit/1500946ce4ed7d89ed33059e3629e526b1dc207a

Experiment to see if this fixes [a failing CI worflow](https://github.com/puma/puma/actions/runs/7529388305/job/20493515442#step:6:22) since [`mutex_m` was added to the relevant Rails gemfiles](https://github.com/rails/rails/pull/48907) and [included in the `7.1` release](https://github.com/rails/rails/releases/tag/v7.1.0). It has also [since been dropeed](https://github.com/rails/rails/commit/bcdeea5da7657375df21a856135ae7a66a8c3812) on Rails edge.

~Even if this passes, the root cause is that it's missing from the gemfiles in https://github.com/ruby-concurrency/concurrent-ruby. I'm hoping to resolve that in https://github.com/ruby-concurrency/concurrent-ruby/pull/1034.~

~However, we still need to point to a version of Rails that either requires `mutex_m` itelf or uses a version of `concurrent-ruby` that does, so this change is needed regardless of that patch.~

I've also pointed the other rubies to `7.1` for consistency, please let me know if I should revert that.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
