### PR TITLE
Deterministic `require`s in `test/runner`

### DIFF
--- a/test/runner
+++ b/test/runner
@@ -27,9 +27,9 @@ require 'bundler/setup'
 
 if ARGV.empty? || ARGV.last.start_with?('-')
   if RUBY_VERSION >= '2.5'
-    Dir['test_*.rb', base: __dir__].each { |tf| require_relative tf }
+    Dir['test_*.rb', base: __dir__].sort.each { |tf| require_relative tf }
   else
-    Dir["#{__dir__}/test_*.rb"].each { |tf| require tf }
+    Dir["#{__dir__}/test_*.rb"].sort.each { |tf| require tf }
   end
 else
   file_arg = ARGV.pop.sub(/\.rb\z/, '')
@@ -38,9 +38,9 @@ else
     file_args.each { |tf| require_relative "#{tf}.rb" }
   elsif file_arg.include? '*'
     if RUBY_VERSION >= '2.5'
-      Dir["#{file_arg}.rb", base: __dir__].each { |tf| require_relative tf }
+      Dir["#{file_arg}.rb", base: __dir__].sort.each { |tf| require_relative tf }
     else
-      Dir["#{__dir__}/#{file_arg}.rb"].each { |tf| require tf }
+      Dir["#{__dir__}/#{file_arg}.rb"].sort.each { |tf| require tf }
     end
   else
     require_relative "#{file_arg}.rb"


### PR DESCRIPTION
We had (rack2) tests fail on 2.4 like this:

    /home/runner/work/puma/puma/lib/rack/handler/puma.rb:140:in `<top (required)>': undefined method `register' for Rack::Handler:Module (NoMethodError)
            from /home/runner/work/puma/puma/test/test_rack_handler.rb:6:in `require'
            from /home/runner/work/puma/puma/test/test_rack_handler.rb:6:in `<module:TestRackUp>'
            from /home/runner/work/puma/puma/test/test_rack_handler.rb:5:in `<top (required)>'
            from test/runner:32:in `require'
            from test/runner:32:in `block in <main>'
            from test/runner:32:in `each'
            from test/runner:32:in `<main>'

https://github.com/puma/puma/actions/runs/7672076948/job/20911807383#step:10:13