### PR TITLE
Single mode skip wait_for_less_busy_worker

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -360,7 +360,7 @@ module Puma
                 break if handle_check
               else
                 pool.wait_until_not_full
-                pool.wait_for_less_busy_worker(options[:wait_for_less_busy_worker])
+                pool.wait_for_less_busy_worker(options[:wait_for_less_busy_worker]) if @clustered
 
                 io = begin
                   sock.accept_nonblock

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -309,3 +309,34 @@ module TestTempFile
   end
 end
 Minitest::Test.include TestTempFile
+
+# This module is modified based on https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/testing/method_call_assertions.rb
+module MethodCallAssertions
+  def assert_called_on_instance_of(klass, method_name, message = nil, times: 1, returns: nil)
+    times_called = 0
+    klass.send(:define_method, :"stubbed_#{method_name}") do |*|
+      times_called += 1
+
+      returns
+    end
+
+    klass.send(:alias_method, :"original_#{method_name}", method_name)
+    klass.send(:alias_method, method_name, :"stubbed_#{method_name}")
+
+    yield
+
+    error = "Expected #{method_name} to be called #{times} times, but was called #{times_called} times"
+    error = "#{message}.\n#{error}" if message
+
+    assert_equal times, times_called, error
+  ensure
+    klass.send(:alias_method, method_name, :"original_#{method_name}")
+    klass.send(:undef_method, :"original_#{method_name}")
+    klass.send(:undef_method, :"stubbed_#{method_name}")
+  end
+
+  def assert_not_called_on_instance_of(klass, method_name, message = nil, &block)
+    assert_called_on_instance_of(klass, method_name, message, times: 0, &block)
+  end
+end
+Minitest::Test.include MethodCallAssertions

--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -64,7 +64,7 @@ class TestBusyWorker < Minitest::Test
   # Multiple concurrent requests are not processed
   # sequentially as a small delay is introduced
   def test_multiple_requests_waiting_on_less_busy_worker
-    with_server(wait_for_less_busy_worker: 1.0) do |_|
+    with_server(wait_for_less_busy_worker: 1.0, workers: 2) do |_|
       sleep(0.1)
 
       [200, {}, [""]]
@@ -84,7 +84,7 @@ class TestBusyWorker < Minitest::Test
   # Multiple concurrent requests are processed
   # in parallel as a delay is disabled
   def test_multiple_requests_processing_in_parallel
-    with_server(wait_for_less_busy_worker: 0.0) do |_|
+    with_server(wait_for_less_busy_worker: 0.0, workers: 2) do |_|
       sleep(0.1)
 
       [200, {}, [""]]
@@ -99,5 +99,25 @@ class TestBusyWorker < Minitest::Test
     assert_equal n, @requests_count, "number of requests needs to match"
     assert_equal 0, @requests_running, "none of requests needs to be running"
     assert_equal n, @requests_max_running, "maximum number of concurrent requests needs to match"
+  end
+
+  def test_not_wait_for_less_busy_worker
+    with_server do
+      [200, {}, [""]]
+    end
+
+    assert_not_called_on_instance_of(Puma::ThreadPool, :wait_for_less_busy_worker) do
+      send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+    end
+  end
+
+  def test_wait_for_less_busy_worker
+    with_server(workers: 2) do
+      [200, {}, [""]]
+    end
+
+    assert_called_on_instance_of(Puma::ThreadPool, :wait_for_less_busy_worker) do
+      send_http_and_read "GET / HTTP/1.0\r\n\r\n"
+    end
   end
 end


### PR DESCRIPTION
### Description
Great job on the #2079 PR!
#2079 PR added the `wait_for_less_busy_worker` method, which improves request allocation to avoid being assigned to busy workers. However, for a single model, there are no multiple workers, so there is no need to call the `wait_for_less_busy_worker` method.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.

_PS: English is not my native language; please excuse typing errors._