### PR TITLE
[CI] - Ruby head changed 'odd' backtick in error messages to apostrophe / single quote

### DIFF
--- a/test/test_error_logger.rb
+++ b/test/test_error_logger.rb
@@ -80,7 +80,7 @@ class TestErrorLogger < Minitest::Test
       end
 
       assert_match %r!non-blank!, err
-      assert_match %r!:in `dummy_error'!, err
+      assert_match %r!:in [`'](TestErrorLogger#)?dummy_error'!, err
     end
   end
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -473,7 +473,7 @@ class TestPumaServer < Minitest::Test
     data = send_http_and_sysread "GET / HTTP/1.0\r\n\r\n"
 
     assert_start_with data, 'HTTP/1.0 500 Internal Server Error'
-    assert_includes data, "Puma caught this error: undefined method `to_i' for"
+    assert_match(/Puma caught this error: undefined method [`']to_i' for/, data)
     assert_includes data, "Array"
     refute_includes data, 'lowlevel_error'
     sleep 0.1 unless ::Puma::IS_MRI

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -69,7 +69,7 @@ class WebServerTest < Minitest::Test
     data = socket.read
     assert_start_with data, "HTTP/1.1 400 Bad Request\r\nContent-Length: "
     # match is for last backtrace line, may be brittle
-    assert_match(/\.rb:\d+:in `[^']+'\z/, data)
+    assert_match(/\.rb:\d+:in [`'][^']+'\z/, data)
     socket.close
   end
 


### PR DESCRIPTION
### Description

CI only changes to account for Ruby head error logging changes.  Current head builds are failing.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
