### PR TITLE
[CI] non MRI fixes - test_thread_pool.rb, test_plugin_systemd_jruby.rb

### DIFF
--- a/test/test_plugin_systemd_jruby.rb
+++ b/test/test_plugin_systemd_jruby.rb
@@ -26,9 +26,14 @@ class TestPluginSystemdJruby < TestIntegration
   end
 
   def test_systemd_plugin_not_loaded
-    cli_server "test/rackup/hello.ru"
+    cli_server "test/rackup/hello.ru",
+      env: {'NOTIFY_SOCKET' => '/tmp/doesntmatter' }, config: <<~CONFIG
+      app do |_|
+        [200, {}, [Puma::Plugins.instance_variable_get(:@plugins)['systemd'].to_s]]
+      end
+    CONFIG
 
-    assert_nil Puma::Plugins.instance_variable_get(:@plugins)["systemd"]
+    assert_empty read_body(connect)
 
     stop_server
   end


### PR DESCRIPTION
### Description

Fixes common failures in JRuby & TruffleRuby.

1. [[CI] Fix test_thread_pool.rb (TestThreadPool#test_trim_thread_exit_hook)](https://github.com/puma/puma/commit/fac1c9af928ff3d7bbf6ce938925e715dd3eac74) - give non-MRI jobs some time to process.

2. [[CI] FIx test_plugin_systemd_jruby.rb](https://github.com/puma/puma/commit/5d30be8d31b33fb35eece4c390142db1c91c86b9) - test was checking a value in the main test process, but JRuby is running in a sub-process.


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
