### PR TITLE
Lazily require `Puma::Rack::Builder`

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'rack/builder'
 require_relative 'plugin'
 require_relative 'const'
 require_relative 'dsl'
@@ -354,11 +353,10 @@ module Puma
       begin
         require 'rack'
         require 'rack/builder'
+        ::Rack::Builder
       rescue LoadError
-        # ok, use builtin version
-        return Puma::Rack::Builder
-      else
-        return ::Rack::Builder
+        require_relative 'rack/builder'
+        Puma::Rack::Builder
       end
     end
 


### PR DESCRIPTION
### Description

A minor thing I noticed when looking into something unrelated. We seem to always be requiring the builtin rack builder even when it isn't used. This PR ensures that `Puma::Rack::Builder` is only required when `Rack::Builder` cannot be loaded.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
