### PR TITLE
Avoid checking if all workers reached timeout unless idle timeout is configured

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -348,8 +348,6 @@ module Puma
     def run
       @status = :run
 
-      @idle_workers = {}
-
       output_header "cluster"
 
       # This is aligned with the output from Runner, see Runner#output_header
@@ -440,7 +438,7 @@ module Puma
 
         while @status == :run
           begin
-            if all_workers_idle_timed_out?
+            if @options[:idle_timeout] && all_workers_idle_timed_out?
               log "- All workers reached idle timeout"
               break
             end
@@ -500,10 +498,10 @@ module Puma
                     booted = true
                   end
                 when Puma::Const::PipeRequest::IDLE
-                  if @idle_workers[pid]
-                    @idle_workers.delete pid
+                  if idle_workers[pid]
+                    idle_workers.delete pid
                   else
-                    @idle_workers[pid] = true
+                    idle_workers[pid] = true
                   end
                 end
               else
@@ -608,7 +606,11 @@ module Puma
     end
 
     def idle_timed_out_worker_pids
-      @idle_workers.keys
+      idle_workers.keys
+    end
+
+    def idle_workers
+      @idle_workers ||= {}
     end
   end
 end


### PR DESCRIPTION
### Description

An oversight on my part in #3283. `Puma::Cluster#run` constantly checks if all workers have reached their idle timeout even when the feature isn't being used. This change ensures that this check only runs when `idle_timeout` is configured.

Also includes a micro-optimisation which ensures the idle workers state hash isn't unnecessarily initialised until actually required (either a worker indicates timeout reached via pipe or `Puma::Cluster#run` checks if `all_workers_idle_timed_out?`).

All of these changes are covered by existing tests.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
