### PR TITLE
 Allow alternative schemes in Binder

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -36,3 +36,7 @@ object that is useful for additional configuration.
 
 Public methods in [`Puma::Plugin`](../lib/puma/plugin.rb) are treated as a
 public API for plugins.
+
+## Binder hooks
+
+There's `Puma::Binder#before_parse` method that allows to add proc to run before the body of `Puma::Binder#parse`. Example of usage can be found in [that repository](https://github.com/anchordotdev/puma-acme/blob/v0.1.3/lib/puma/acme/plugin.rb#L97-L118) (`before_parse_hook` could be renamed `before_parse`, making monkey patching of [binder.rb](https://github.com/anchordotdev/puma-acme/blob/v0.1.3/lib/puma/acme/binder.rb) is unnecessary).

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -141,7 +141,14 @@ module Puma
       end
     end
 
+    def before_parse(&block)
+      @before_parse ||= []
+      @before_parse << block if block
+      @before_parse
+    end
+
     def parse(binds, log_writer = nil, log_msg = 'Listening')
+      before_parse.each(&:call)
       log_writer ||= @log_writer
       binds.each do |str|
         uri = URI.parse str

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -89,7 +89,7 @@ class TestBinderParallel < TestBinderBase
 
     @binder.parse ["tcp://localhost:0"]
 
-    mock.verify
+    assert_mock mock
     assert_equal @binder.instance_variable_get(:@before_parse), [proc]
   end
 

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -79,6 +79,20 @@ class TestBinderParallel < TestBinderBase
     assert_equal expected, result
   end
 
+  def test_runs_before_parse_hooks
+    mock = Minitest::Mock.new
+    proc = -> { mock.call }
+
+    @binder.before_parse &proc
+
+    mock.expect(:call, nil)
+
+    @binder.parse ["tcp://localhost:0"]
+
+    mock.verify
+    assert_equal @binder.instance_variable_get(:@before_parse), [proc]
+  end
+
   def test_localhost_addresses_dont_alter_listeners_for_tcp_addresses
     @binder.parse ["tcp://localhost:0"], @log_writer
 


### PR DESCRIPTION
### Description
Allows for adding `before_parse` hooks to the `Binder#parse` method.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] * All new and existing tests passed, including Rubocop. 

* tests went thorugh on my fork: https://github.com/tomurb/puma/actions

Closes #3302