### PR TITLE
[CI] - Fix Ruby head failures

### DIFF
--- a/test/test_log_writer.rb
+++ b/test/test_log_writer.rb
@@ -170,10 +170,8 @@ class TestLogWriter < Minitest::Test
     assert_includes error, "peer: 127.0.0.1"
     assert_includes error, "cert: test_cert"
 
-    log_writer.stderr.string = ''
-
     log_writer.ssl_error OpenSSL::SSL::SSLError, ssl_mock.call(nil, nil)
-    error = log_writer.stderr.string
+    error = log_writer.stderr.string.lines[1]
     assert_includes error, "SSL error"
     assert_includes error, "peer: <unknown>"
     assert_includes error, "cert: :"

--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -15,9 +15,9 @@ class TestWorkerGemIndependence < TestIntegration
 
   def test_changing_nio4r_version_during_phased_restart
     change_gem_version_during_phased_restart old_app_dir: 'worker_gem_independence_test/old_nio4r',
-                                             old_version: '2.3.0',
+                                             old_version: '2.6.0',
                                              new_app_dir: 'worker_gem_independence_test/new_nio4r',
-                                             new_version: '2.3.1'
+                                             new_version: '2.6.1'
   end
 
   def test_changing_json_version_during_phased_restart

--- a/test/worker_gem_independence_test/new_nio4r/Gemfile
+++ b/test/worker_gem_independence_test/new_nio4r/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem 'puma', path: '../../..'
-gem 'nio4r', '= 2.3.1'
+gem 'nio4r', '= 2.6.1'

--- a/test/worker_gem_independence_test/old_nio4r/Gemfile
+++ b/test/worker_gem_independence_test/old_nio4r/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem 'puma', path: '../../..'
-gem 'nio4r', '= 2.3.0'
+gem 'nio4r', '= 2.6.0'


### PR DESCRIPTION
### Description

Ruby head has been failing in CI, and also noticed more failures locally with Ubuntu & Windows.

Two issues:

1. Failures in:
https://github.com/puma/puma/blob/87fd289503c16bf794c7a1a5c6e622bca2b4a071/test/test_worker_gem_independence.rb#L16-L21

   With recent changes in Ruby head, nio4r previous to 2.6.0 won't compile, fixed in https://github.com/socketry/nio4r/commit/3c1f9b83250df696f1c7d055a9a4d7bd7fee126e.  Solution was updating the nio4r versions.

2. Failures in:
https://github.com/puma/puma/blob/87fd289503c16bf794c7a1a5c6e622bca2b4a071/test/test_log_writer.rb#L151-L181

   Fixed by only using LogWriter to to write to itself...

Closes #3342

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
