### PR TITLE
Add `ssl_ciphersuites` option for TLSv1.3 ciphers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Puma is a **simple, fast, multi-threaded, and highly parallel HTTP 1.1 server fo
 
 ## Built For Speed &amp; Parallelism
 
-Puma is a server for [Rack](https://github.com/rack/rack)-powered HTTP applications written in Ruby.  It is: 
+Puma is a server for [Rack](https://github.com/rack/rack)-powered HTTP applications written in Ruby.  It is:
 * **Multi-threaded**. Each request is served in a separate thread. This helps you serve more requests per second with less memory use.
 * **Multi-process**. "Pre-forks" in cluster mode, using less memory per-process thanks to copy-on-write memory.
 * **Standalone**. With SSL support, zero-downtime rolling restarts and a built-in request bufferer, you can deploy Puma without any reverse proxy.
@@ -249,7 +249,7 @@ $ puma -b ssl://localhost:9292 -b tcp://localhost:9393 -C config/use_local_host.
 
 #### Controlling SSL Cipher Suites
 
-To use or avoid specific SSL cipher suites, use `ssl_cipher_filter` or `ssl_cipher_list` options.
+To use or avoid specific SSL ciphers for TLSv1.2 and below, use `ssl_cipher_filter` or `ssl_cipher_list` options.
 
 ##### Ruby:
 
@@ -261,6 +261,14 @@ $ puma -b 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert&ssl_cipher_fil
 
 ```
 $ puma -b 'ssl://127.0.0.1:9292?keystore=path_to_keystore&keystore-pass=keystore_password&ssl_cipher_list=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA'
+```
+
+To configure the available TLSv1.3 ciphersuites, use `ssl_ciphersuites` option (not available for JRuby).
+
+##### Ruby:
+
+```
+$ puma -b 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert&ssl_ciphersuites=TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256'
 ```
 
 See https://www.openssl.org/docs/man1.1.1/man1/ciphers.html for cipher filter format and full list of cipher suites.

--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -33,22 +33,27 @@ unless ENV["PUMA_DISABLE_SSL"]
   if found_ssl
     have_header "openssl/bio.h"
 
+    ssl_h = "openssl/ssl.h".freeze
+
     # below is  yes for 1.0.2 & later
-    have_func "DTLS_method"                            , "openssl/ssl.h"
-    have_func "SSL_CTX_set_session_cache_mode(NULL, 0)", "openssl/ssl.h"
+    have_func "DTLS_method"                            , ssl_h
+    have_func "SSL_CTX_set_session_cache_mode(NULL, 0)", ssl_h
 
     # below are yes for 1.1.0 & later
-    have_func "TLS_server_method"                      , "openssl/ssl.h"
-    have_func "SSL_CTX_set_min_proto_version(NULL, 0)" , "openssl/ssl.h"
+    have_func "TLS_server_method"                      , ssl_h
+    have_func "SSL_CTX_set_min_proto_version(NULL, 0)" , ssl_h
+
+    # below are yes for 1.1.1 & later
+    have_func "SSL_CTX_set_ciphersuites(NULL, \"\")"   , ssl_h
 
     have_func "X509_STORE_up_ref"
-    have_func "SSL_CTX_set_ecdh_auto(NULL, 0)"         , "openssl/ssl.h"
+    have_func "SSL_CTX_set_ecdh_auto(NULL, 0)"         , ssl_h
 
     # below exists in 1.1.0 and later, but isn't documented until 3.0.0
-    have_func "SSL_CTX_set_dh_auto(NULL, 0)"           , "openssl/ssl.h"
+    have_func "SSL_CTX_set_dh_auto(NULL, 0)"           , ssl_h
 
     # below is yes for 3.0.0 & later
-    have_func "SSL_get1_peer_certificate"              , "openssl/ssl.h"
+    have_func "SSL_get1_peer_certificate"              , ssl_h
 
     # Random.bytes available in Ruby 2.5 and later, Random::DEFAULT deprecated in 3.0
     if Random.respond_to?(:bytes)

--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -446,11 +446,13 @@ sslctx_initialize(VALUE self, VALUE mini_ssl_ctx) {
     SSL_CTX_set_cipher_list(ctx, "HIGH:!aNULL@STRENGTH");
   }
 
+#if HAVE_SSL_CTX_SET_CIPHERSUITES
   // Only override OpenSSL default ciphersuites if config option is supplied.
   if (!NIL_P(ssl_ciphersuites)) {
     StringValue(ssl_ciphersuites);
     SSL_CTX_set_ciphersuites(ctx, RSTRING_PTR(ssl_ciphersuites));
   }
+#endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10002000L
   // Remove this case if OpenSSL 1.0.1 (now EOL) support is no longer needed.

--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -229,7 +229,7 @@ VALUE
 sslctx_initialize(VALUE self, VALUE mini_ssl_ctx) {
   SSL_CTX* ctx;
   int ssl_options;
-  VALUE key, cert, ca, verify_mode, ssl_cipher_filter, no_tlsv1, no_tlsv1_1,
+  VALUE key, cert, ca, verify_mode, ssl_cipher_filter, ssl_ciphersuites, no_tlsv1, no_tlsv1_1,
     verification_flags, session_id_bytes, cert_pem, key_pem, key_password_command, key_password;
   BIO *bio;
   X509 *x509 = NULL;
@@ -268,6 +268,8 @@ sslctx_initialize(VALUE self, VALUE mini_ssl_ctx) {
   verify_mode = rb_funcall(mini_ssl_ctx, rb_intern_const("verify_mode"), 0);
 
   ssl_cipher_filter = rb_funcall(mini_ssl_ctx, rb_intern_const("ssl_cipher_filter"), 0);
+
+  ssl_ciphersuites = rb_funcall(mini_ssl_ctx, rb_intern_const("ssl_ciphersuites"), 0);
 
   no_tlsv1 = rb_funcall(mini_ssl_ctx, rb_intern_const("no_tlsv1"), 0);
 
@@ -442,6 +444,12 @@ sslctx_initialize(VALUE self, VALUE mini_ssl_ctx) {
   }
   else {
     SSL_CTX_set_cipher_list(ctx, "HIGH:!aNULL@STRENGTH");
+  }
+
+  // Only override OpenSSL default ciphersuites if config option is supplied.
+  if (!NIL_P(ssl_ciphersuites)) {
+    StringValue(ssl_ciphersuites);
+    SSL_CTX_set_ciphersuites(ctx, RSTRING_PTR(ssl_ciphersuites));
   }
 
 #if OPENSSL_VERSION_NUMBER < 0x10002000L

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -85,6 +85,7 @@ module Puma
           "&verify_mode=#{verify}#{tls_str}#{ca_additions}#{backlog_str}"
       else
         ssl_cipher_filter = opts[:ssl_cipher_filter] ? "&ssl_cipher_filter=#{opts[:ssl_cipher_filter]}" : nil
+        ssl_ciphersuites = opts[:ssl_ciphersuites] ? "&ssl_ciphersuites=#{opts[:ssl_ciphersuites]}" : nil
         v_flags = (ary = opts[:verification_flags]) ? "&verification_flags=#{Array(ary).join ','}" : nil
 
         cert_flags = (cert = opts[:cert]) ? "cert=#{Puma::Util.escape(cert)}" : nil
@@ -115,7 +116,7 @@ module Puma
             nil
           end
 
-        "ssl://#{host}:#{port}?#{cert_flags}#{key_flags}#{password_flags}#{ssl_cipher_filter}" \
+        "ssl://#{host}:#{port}?#{cert_flags}#{key_flags}#{password_flags}#{ssl_cipher_filter}#{ssl_ciphersuites}" \
           "#{reuse_flag}&verify_mode=#{verify}#{tls_str}#{ca_additions}#{v_flags}#{backlog_str}#{low_latency_str}"
       end
     end
@@ -530,6 +531,7 @@ module Puma
     #     cert: path_to_cert,
     #     key: path_to_key,
     #     ssl_cipher_filter: cipher_filter, # optional
+    #     ssl_ciphersuites: ciphersuites,   # optional
     #     verify_mode: verify_mode,         # default 'none'
     #     verification_flags: flags,        # optional, not supported by JRuby
     #     reuse: true                       # optional

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -289,6 +289,7 @@ module Puma
         attr_reader :cert_pem
         attr_reader :key_pem
         attr_accessor :ssl_cipher_filter
+        attr_accessor :ssl_ciphersuites
         attr_accessor :verification_flags
 
         attr_reader :reuse, :reuse_cache_size, :reuse_timeout

--- a/lib/puma/minissl/context_builder.rb
+++ b/lib/puma/minissl/context_builder.rb
@@ -57,7 +57,7 @@ module Puma
 
           ctx.ca = params['ca'] if params['ca']
           ctx.ssl_cipher_filter = params['ssl_cipher_filter'] if params['ssl_cipher_filter']
-          ctx.ssl_ciphersuites = params['ssl_ciphersuites'] if params['ssl_ciphersuites']
+          ctx.ssl_ciphersuites = params['ssl_ciphersuites'] if params['ssl_ciphersuites'] && HAS_TLS1_3
 
           ctx.reuse = params['reuse'] if params['reuse']
         end

--- a/lib/puma/minissl/context_builder.rb
+++ b/lib/puma/minissl/context_builder.rb
@@ -57,6 +57,7 @@ module Puma
 
           ctx.ca = params['ca'] if params['ca']
           ctx.ssl_cipher_filter = params['ssl_cipher_filter'] if params['ssl_cipher_filter']
+          ctx.ssl_ciphersuites = params['ssl_ciphersuites'] if params['ssl_ciphersuites']
 
           ctx.reuse = params['reuse'] if params['reuse']
         end

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -543,6 +543,7 @@ class TestBinderMRI < TestBinderBase
 
   def test_binder_parses_ssl_ciphersuites
     skip_unless :ssl
+    skip('Requires TLSv1.3') unless Puma::MiniSSL::HAS_TLS1_3
 
     ssl_ciphersuites = "TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256"
 

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -541,6 +541,16 @@ class TestBinderMRI < TestBinderBase
     assert_equal ssl_cipher_filter, ssl_context_for_binder.ssl_cipher_filter
   end
 
+  def test_binder_parses_ssl_ciphersuites
+    skip_unless :ssl
+
+    ssl_ciphersuites = "TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256"
+
+    @binder.parse ["ssl://0.0.0.0?#{ssl_query}&ssl_ciphersuites=#{ssl_ciphersuites}"], @log_writer
+
+    assert_equal ssl_ciphersuites, ssl_context_for_binder.ssl_ciphersuites
+  end
+
   def test_binder_parses_ssl_verification_flags_one
     skip_unless :ssl
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -297,6 +297,25 @@ class TestConfigFile < TestConfigFileBase
     assert ssl_binding.include?("&ssl_cipher_filter=#{cipher_filter}")
   end
 
+  def test_ssl_bind_with_ciphersuites
+    skip_if :jruby
+    skip_unless :ssl
+
+    ciphersuites = "TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256"
+    conf = Puma::Configuration.new do |c|
+      c.ssl_bind "0.0.0.0", "9292", {
+        cert: "cert",
+        key: "key",
+        ssl_ciphersuites: ciphersuites,
+      }
+    end
+
+    conf.load
+
+    ssl_binding = conf.options[:binds].first
+    assert ssl_binding.include?("&ssl_ciphersuites=#{ciphersuites}")
+  end
+
   def test_ssl_bind_with_verification_flags
     skip_if :jruby
     skip_unless :ssl

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -300,6 +300,7 @@ class TestConfigFile < TestConfigFileBase
   def test_ssl_bind_with_ciphersuites
     skip_if :jruby
     skip_unless :ssl
+    skip('Requires TLSv1.3') unless Puma::MiniSSL::HAS_TLS1_3
 
     ciphersuites = "TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256"
     conf = Puma::Configuration.new do |c|


### PR DESCRIPTION
### Description
Closes https://github.com/puma/puma/issues/3343

As described in the linked issue, it's desirable to be able to restrict the ciphersuites used for TLSv1.3 connections for security reasons, but Puma doesn't yet support that. https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_cipher_list.html explains that OpenSSL has a different setting for TLSv1.3 ciphers than for TLSv1.2 and below. 

This pull request adds a new option to pass in TLSv1.3 ciphersuites config - `ssl_ciphersuites`. I've explained its usage in the README. This is intentionally similar to the existing `ssl_cipher_filter` option, which does the same job for TLSv1.2 and below.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [n/a] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
