### PR TITLE
Use actual thread local for `Puma::Server.current`.

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -18,6 +18,9 @@ require 'io/wait' unless Puma::HAS_NATIVE_IO_WAIT
 
 module Puma
 
+  # This method was private on Ruby 2.4 but became public on Ruby 2.5+:
+  Thread.send(:attr_accessor, :puma_server)
+
   # The HTTP Server itself. Serves out a single Rack app.
   #
   # This class is used by the `Puma::Single` and `Puma::Cluster` classes
@@ -47,7 +50,6 @@ module Puma
     attr_accessor :app
     attr_accessor :binder
 
-    THREAD_LOCAL_KEY = :puma_server
 
     # Create a server for the rack app +app+.
     #
@@ -131,7 +133,7 @@ module Puma
     class << self
       # @!attribute [r] current
       def current
-        Thread.current[THREAD_LOCAL_KEY]
+        Thread.current.puma_server
       end
 
       # :nodoc:
@@ -438,7 +440,7 @@ module Puma
     # Return true if one or more requests were processed.
     def process_client(client)
       # Advertise this server into the thread
-      Thread.current[THREAD_LOCAL_KEY] = self
+      Thread.current.puma_server = self
 
       clean_thread_locals = options[:clean_thread_locals]
       close_socket = true

--- a/test/test_puma_server_current.rb
+++ b/test/test_puma_server_current.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023, by Samuel Williams.
+
+require_relative "helper"
+
+require "puma/server"
+
+class PumaServerCurrentApplication
+  def call(env)
+    [200, {"Content-Type" => "text/plain"}, [Puma::Server.current.to_s]]
+  end
+end
+
+class PumaServerCurrentTest < Minitest::Test
+  parallelize_me!
+
+  def setup
+    @tester = PumaServerCurrentApplication.new
+    @server = Puma::Server.new @tester, nil, {log_writer: Puma::LogWriter.strings, clean_thread_locals: true}
+    @port = (@server.add_tcp_listener "127.0.0.1", 0).addr[1]
+    @tcp = "http://127.0.0.1:#{@port}"
+    @url = URI.parse(@tcp)
+    @server.run
+  end
+
+  def teardown
+    @server.stop(true)
+  end
+
+  def test_clean_thread_locals
+    server_string = @server.to_s
+    responses = []
+
+    # This must be a persistent connection to hit the `clean_thread_locals` code path.
+    Net::HTTP.new(@url.host, @url.port).start do |connection|
+      3.times do
+        responses << connection.get("/").body
+      end
+    end
+
+    assert_equal [server_string]*3, responses
+  end
+end


### PR DESCRIPTION
The current implementation of `Puma::Server.current` will break inside fibers, e.g. lazy enumerators because it's fiber local, not thread local. If the intention is to have an actual thread local, this is the best fix.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
