### PR TITLE
[CI] Add macOS 14, remove 11, adjust so tests.yml runs 15 macOS jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, macos-13, windows-2022 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, macos-12, macos-13, macos-14, windows-2022 ]
         ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, head ]
         no-ssl: ['']
         rack-v: ['']
@@ -59,17 +59,20 @@ jobs:
           - { os: ubuntu-22.04 , ruby:  2.6  }
           - { os: ubuntu-22.04 , ruby:  2.7  }
           - { os: ubuntu-22.04 , ruby:  3.0  }
-          - { os: macos-11     , ruby:  2.5  }
-          - { os: macos-11     , ruby:  2.6  }
-          - { os: macos-11     , ruby: '3.0' }
-          - { os: macos-11     , ruby:  3.1  }
-          - { os: macos-11     , ruby:  head }
+          - { os: macos-12     , ruby:  2.7  }
+          - { os: macos-12     , ruby: '3.0' }
+          - { os: macos-12     , ruby:  3.1  }
+          - { os: macos-12     , ruby:  3.3  }
+          - { os: macos-12     , ruby:  head }
+          - { os: macos-13     , ruby:  2.4  }
           - { os: macos-13     , ruby:  2.5  }
           - { os: macos-13     , ruby:  2.6  }
-          - { os: macos-13     , ruby: '3.0' }
-          - { os: macos-13     , ruby:  3.1  }
-          - { os: macos-13     , ruby:  2.6  }
-          - { os: macos-13     , ruby:  head }
+          - { os: macos-13     , ruby:  2.7  }
+          - { os: macos-13     , ruby:  3.0  }
+          - { os: macos-14     , ruby:  2.4  }
+          - { os: macos-14     , ruby:  2.5  }
+          - { os: macos-14     , ruby:  2.6  }
+          - { os: macos-14     , ruby:  2.7  }
           - { os: windows-2022 , ruby: head  }
 
     steps:
@@ -152,8 +155,8 @@ jobs:
           - { tto: 8 , os: ubuntu-20.04 , ruby: truffleruby-head, allow-failure: true }
           - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby, allow-failure: true } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
           - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby-head, allow-failure: true }
-          - { tto: 8 , os: macos-12     , ruby: jruby }
-          - { tto: 8 , os: macos-12     , ruby: truffleruby, allow-failure: true }
+          - { tto: 8 , os: macos-13     , ruby: jruby }
+          - { tto: 8 , os: macos-13     , ruby: truffleruby, allow-failure: true }
 
     steps:
       - name: repo checkout


### PR DESCRIPTION
### Description

This PR only changes the tests.yml workflow file.

GitHub Actions has deprecated macOS 11, and macOS 14 is now available and runs on arm systems.

1. Add macOS 14, drop macOS 11
2. Standard GHA allow 5 concurrent macOS jobs to run.  Adjust jobs so we run 15 macOS jobs.  Currently, the last jobs running are macOS jobs.

Interestingly, the tests.yml workflow in my fork passed...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
