### PR TITLE
extconf.rb - add logging for OpenSSL versions

### DIFF
--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -16,7 +16,7 @@ unless ENV["PUMA_DISABLE_SSL"]
   found_pkg_config = !has_openssl_dir && pkg_config('openssl')
 
   found_ssl = if !$mingw && found_pkg_config
-    puts 'using OpenSSL pkgconfig (openssl.pc)'
+    puts '──── Using OpenSSL pkgconfig (openssl.pc) ────'
     true
   elsif have_library('libcrypto', 'BIO_read') && have_library('libssl', 'SSL_CTX_new')
     true
@@ -33,25 +33,30 @@ unless ENV["PUMA_DISABLE_SSL"]
 
     ssl_h = "openssl/ssl.h".freeze
 
-    # below is  yes for 1.0.2 & later
+    puts "\n──── Below are yes for 1.0.2 & later ────"
     have_func "DTLS_method"                            , ssl_h
     have_func "SSL_CTX_set_session_cache_mode(NULL, 0)", ssl_h
+    have_func "SSL_CTX_set_ecdh_auto(NULL, 0)"         , ssl_h
 
-    # below are yes for 1.1.0 & later
+    puts "\n──── Below are yes for 1.1.0 & later ────"
     have_func "TLS_server_method"                      , ssl_h
     have_func "SSL_CTX_set_min_proto_version(NULL, 0)" , ssl_h
 
-    # below are yes for 1.1.1 & later
-    have_func "SSL_CTX_set_ciphersuites(NULL, \"\")"   , ssl_h
-
+    puts "\n──── Below is yes for 1.1.0 and later, but isn't documented until 1.1.1 ────"
+    # https://github.com/openssl/openssl/blob/OpenSSL_1_1_0/crypto/x509/x509_lu.c#L220
     have_func "X509_STORE_up_ref"
-    have_func "SSL_CTX_set_ecdh_auto(NULL, 0)"         , ssl_h
 
-    # below exists in 1.1.0 and later, but isn't documented until 3.0.0
+    puts "\n──── Below is yes for 1.1.0 and later, but isn't documented until 3.0.0 ────"
+    # https://github.com/openssl/openssl/blob/OpenSSL_1_1_0/include/openssl/ssl.h#L1159
     have_func "SSL_CTX_set_dh_auto(NULL, 0)"           , ssl_h
 
-    # below is yes for 3.0.0 & later
+    puts "\n──── Below is yes for 1.1.1 & later ────"
+    have_func "SSL_CTX_set_ciphersuites(NULL, \"\")"   , ssl_h
+
+    puts "\n──── Below is yes for 3.0.0 & later ────"
     have_func "SSL_get1_peer_certificate"              , ssl_h
+
+    puts ''
 
     # Random.bytes available in Ruby 2.5 and later, Random::DEFAULT deprecated in 3.0
     if Random.respond_to?(:bytes)

--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -36,15 +36,10 @@ unless ENV["PUMA_DISABLE_SSL"]
     puts "\n──── Below are yes for 1.0.2 & later ────"
     have_func "DTLS_method"                            , ssl_h
     have_func "SSL_CTX_set_session_cache_mode(NULL, 0)", ssl_h
-    have_func "SSL_CTX_set_ecdh_auto(NULL, 0)"         , ssl_h
 
     puts "\n──── Below are yes for 1.1.0 & later ────"
     have_func "TLS_server_method"                      , ssl_h
     have_func "SSL_CTX_set_min_proto_version(NULL, 0)" , ssl_h
-
-    puts "\n──── Below is yes for 1.1.0 and later, but isn't documented until 1.1.1 ────"
-    # https://github.com/openssl/openssl/blob/OpenSSL_1_1_0/crypto/x509/x509_lu.c#L220
-    have_func "X509_STORE_up_ref"
 
     puts "\n──── Below is yes for 1.1.0 and later, but isn't documented until 3.0.0 ────"
     # https://github.com/openssl/openssl/blob/OpenSSL_1_1_0/include/openssl/ssl.h#L1159


### PR DESCRIPTION
### Description

This PR only changes logging when compiling with OpenSSL.

Currently, `extconf.rb` has comments about which functions exist in various OpenSSL versions.  This PR changes the comments to ouput logging.  Example below, all lines beginning with three dashes are new:
```
checking for pkg-config for openssl... [" ", "", "-lssl -lcrypto"]
──── Using OpenSSL pkgconfig (openssl.pc) ────
checking for openssl/bio.h... yes

──── Below are yes for 1.0.2 & later ────
checking for DTLS_method() in openssl/ssl.h... yes
checking for SSL_CTX_set_session_cache_mode(NULL, 0) in openssl/ssl.h... yes
checking for SSL_CTX_set_ecdh_auto(NULL, 0) in openssl/ssl.h... yes

──── Below are yes for 1.1.0 & later ────
checking for TLS_server_method() in openssl/ssl.h... yes
checking for SSL_CTX_set_min_proto_version(NULL, 0) in openssl/ssl.h... yes
checking for X509_STORE_up_ref()... yes

──── Below is yes for 1.1.0 and later, but isn't documented until 3.0.0 ────
checking for SSL_CTX_set_dh_auto(NULL, 0) in openssl/ssl.h... yes

──── Below is yes for 1.1.1 & later ────
checking for SSL_CTX_set_ciphersuites(NULL, "") in openssl/ssl.h... yes

──── Below is yes for 3.0.0 & later ────
checking for SSL_get1_peer_certificate() in openssl/ssl.h... yes
```

These comments appear in CI logs, and if one is installing the gem, the log fie is `gem_make.out` in the proper Ruby 'extensions' folder.

### Your checklist for this pull request
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
