### PR TITLE
[ci skip] Indicate that `wait_for_less_busy_worker` is enabled by default in DSL docs

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1005,6 +1005,8 @@ module Puma
     # listening on the socket, allowing workers which are not processing any
     # requests to pick up new requests first.
     #
+    # The default is 0.005 seconds.
+    #
     # Only works on MRI. For all other interpreters, this setting does nothing.
     # @see Puma::Server#handle_servers
     # @see Puma::ThreadPool#wait_for_less_busy_worker


### PR DESCRIPTION
### Description

`wait_for_less_busy_worker` was enabled by default with #2940 and included in the [6.0.0 release](https://github.com/puma/puma/releases/tag/v6.0.0). The DSL docs do not reflect this however unlike other config options that are enabled by default.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
