### PR TITLE
Add a debug log before running each type of hook

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -313,6 +313,8 @@ module Puma
     # @param arg [Launcher, Int] `:on_restart` passes Launcher
     #
     def run_hooks(key, arg, log_writer, hook_data = nil)
+      log_writer.debug "Running #{key} hooks"
+
       @options.all_of(key).each do |b|
         begin
           if Array === b

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -511,7 +511,7 @@ class TestIntegrationCluster < TestIntegration
     CONFIG
 
     get_worker_pids
-    line = @server_log[/.+on_worker_boot.+/]
+    line = @server_log[/^Warning.+on_worker_boot.+/]
     refute line, "Warning below should not be shown!\n#{line}"
   end
 
@@ -525,8 +525,14 @@ class TestIntegrationCluster < TestIntegration
       CONFIG
 
     get_worker_pids
-    line = @server_log[/.+on_worker_boot.+/]
+    line = @server_log[/^Warning.+.+on_worker_boot.+/]
     refute line, "Warning below should not be shown!\n#{line}"
+  end
+
+  def test_puma_debug_worker_hook
+    cli_server "-w #{workers} test/rackup/hello.ru", puma_debug: true, config: "on_worker_boot {}"
+
+    assert wait_for_server_to_include("Running before_worker_boot hooks")
   end
 
   def test_puma_debug_loaded_exts


### PR DESCRIPTION
### Description

Having enabled debug logs at work I thought it would be useful if there was a generic debug log before all the hooks for a type are run.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
