### PR TITLE
Raise an `ArgumentError` unless a hook is called with a block

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1418,6 +1418,8 @@ module Puma
     end
 
     def process_hook(options_key, key, block, meth)
+      raise ArgumentError, "expected #{meth} to be given a block" unless block
+
       @options[options_key] ||= []
       if ON_WORKER_KEY.include? key.class
         @options[options_key] << [block, key.to_sym]

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -478,54 +478,68 @@ class TestConfigFile < PumaTest
 
   def test_run_hooks_on_restart_hook
     assert_run_hooks :on_restart
+
+    assert_raise_on_hooks_without_block :on_restart
   end
 
   def test_run_hooks_before_worker_fork
     assert_run_hooks :before_worker_fork, configured_with: :on_worker_fork
 
+    assert_raise_on_hooks_without_block :on_worker_fork
     assert_warning_for_hooks_defined_in_single_mode :on_worker_fork
   end
 
   def test_run_hooks_after_worker_fork
     assert_run_hooks :after_worker_fork
 
+    assert_raise_on_hooks_without_block :after_worker_fork
     assert_warning_for_hooks_defined_in_single_mode :after_worker_fork
   end
 
   def test_run_hooks_before_worker_boot
     assert_run_hooks :before_worker_boot, configured_with: :on_worker_boot
 
+    assert_raise_on_hooks_without_block :on_worker_boot
     assert_warning_for_hooks_defined_in_single_mode :on_worker_boot
   end
 
   def test_run_hooks_before_worker_shutdown
     assert_run_hooks :before_worker_shutdown, configured_with: :on_worker_shutdown
 
+    assert_raise_on_hooks_without_block :on_worker_shutdown
     assert_warning_for_hooks_defined_in_single_mode :on_worker_shutdown
   end
 
   def test_run_hooks_before_fork
     assert_run_hooks :before_fork
 
+    assert_raise_on_hooks_without_block :before_fork
     assert_warning_for_hooks_defined_in_single_mode :before_fork
   end
 
   def test_run_hooks_before_refork
     assert_run_hooks :before_refork, configured_with: :on_refork
 
+    assert_raise_on_hooks_without_block :on_refork
     assert_warning_for_hooks_defined_in_single_mode :on_refork
   end
 
   def test_run_hooks_before_thread_start
     assert_run_hooks :before_thread_start, configured_with: :on_thread_start
+
+    assert_raise_on_hooks_without_block :on_thread_start
   end
 
   def test_run_hooks_before_thread_exit
     assert_run_hooks :before_thread_exit, configured_with: :on_thread_exit
+
+    assert_raise_on_hooks_without_block :on_thread_exit
   end
 
   def test_run_hooks_out_of_band
     assert_run_hooks :out_of_band
+
+    assert_raise_on_hooks_without_block :out_of_band
   end
 
   def test_run_hooks_and_exception
@@ -629,10 +643,19 @@ class TestConfigFile < PumaTest
     assert_equal messages, ["#{hook_name} is called with ARG one time", "#{hook_name} is called with ARG a second time"]
   end
 
+  def assert_raise_on_hooks_without_block(hook_name)
+    error = assert_raises ArgumentError do
+      Puma::Configuration.new { |c| c.send(hook_name) }.load
+    end
+    assert_equal "expected #{hook_name} to be given a block", error.message
+  end
+
   def assert_warning_for_hooks_defined_in_single_mode(hook_name)
     out, _ = capture_io do
       Puma::Configuration.new do |c|
-        c.send(hook_name)
+        c.send(hook_name) do
+          # noop
+        end
       end
     end
 


### PR DESCRIPTION
### Description

Prerequisite: https://github.com/puma/puma/pull/3376

I don't see why hooks should be processed if a block is not given, and if it's being called that way it could be due to user error. This ensures an `ArgumentError` is raised unless a block is given when configuring hooks.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
