### PR TITLE
Proposal to bump persistent_timeout to 65 seconds

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -151,7 +151,7 @@ module Puma
       mutate_stdout_and_stderr_to_sync_on_write: true,
       out_of_band: [],
       # Number of seconds for another request within a persistent session.
-      persistent_timeout: 20,
+      persistent_timeout: 65,
       queue_requests: true,
       rackup: 'config.ru'.freeze,
       raise_exception_on_sigterm: true,


### PR DESCRIPTION
### Description

I noticed that if Puma's `persistent_timeout` is shorter than the load balancer's timeout, occasional minor service disruptions can occur. For instance, consider the AWS Application Load Balancer (ALB) with a default idle timeout of 60 seconds. If ALB forwards a request to Puma just as Puma is closing the socket, it may result in a broken TCP handshake, leading to a TCP RST/FIN being sent back to ALB. ALB would then handle that RST/FIN and return a 502 error to the client, which is not ideal.

Since most load balancers, like AWS ALB/ELB and Heroku, have default idle timeouts around [60 seconds](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html) and [55 seconds](https://devcenter.heroku.com/articles/limits#:~:text=HTTP%20timeouts&text=After%20the%20initial%20response%2C%20each,an%20H15%20error%20is%20logged.) respectively, I am proposing that we increase Puma's `persistent_timeout` to 65 seconds so that the upstream negotiates and closes the connection before Puma does. 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [X] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed, including Rubocop.
