### PR TITLE
Add `#on_stopped` DSL (re: discussion/3379)

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -712,6 +712,17 @@ module Puma
       @config.options[:events].on_booted(&block)
     end
 
+    # Code to run when Puma is stopped (works for both: single and clustered)
+    #
+    # @example
+    #   on_stopped do
+    #     puts 'Shutting down...'
+    #   end
+    def on_stopped(&block)
+      @options[:on_stopped] ||= []
+      @options[:on_stopped] << block
+    end
+
     # When `fork_worker` is enabled, code to run in Worker 0
     # before all other workers are re-forked from this process,
     # after the server has temporarily stopped serving requests

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -473,6 +473,10 @@ class TestConfigFile < TestConfigFileBase
     assert_run_hooks :on_restart
   end
 
+  def test_run_hooks_on_stopped_hook
+    assert_run_hooks :on_stopped
+  end
+
   def test_run_hooks_before_worker_fork
     assert_run_hooks :before_worker_fork, configured_with: :on_worker_fork
 


### PR DESCRIPTION
### Description

This change adds the `#on_stopped` method to Puma's DSL, to match the functionality provided by `#on_booted`. Since this DSL method is documented, its absence appears to be a simple oversight, and it seems appropriate to have.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
