### PR TITLE
Shorten `ThreadPool` trimmer and reaper thread names

### DIFF
--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -358,12 +358,12 @@ module Puma
     end
 
     def auto_trim!(timeout=@auto_trim_time)
-      @auto_trim = Automaton.new(self, timeout, "#{@name} threadpool trimmer", :trim)
+      @auto_trim = Automaton.new(self, timeout, "#{@name} tp trim", :trim)
       @auto_trim.start!
     end
 
     def auto_reap!(timeout=@reaping_time)
-      @reaper = Automaton.new(self, timeout, "#{@name} threadpool reaper", :reap)
+      @reaper = Automaton.new(self, timeout, "#{@name} tp reap", :reap)
       @reaper.start!
     end
 


### PR DESCRIPTION
### Description

Similar to https://github.com/puma/puma/pull/2733

Here's an example `htop` output for 2 workers and 2 threads:
<img width="1728" alt="Screenshot 2024-05-19 at 10 55 58 AM" src="https://github.com/puma/puma/assets/54629302/a6d6615a-8b6f-4658-9c28-51f77c56d341">

Notice the two `puma srv thread` names which are really `puma srv threadpool trimmer` and `puma srv threadpool reaper`. This PR simply shortens the names to keep them under 15 chars while keeping the naming consistent with the main thread pool threads (e.g. `puma srv tp 001`).

**Note:** `Puma::Server#run` (which initializes a `Threadpool`) is only every initialised with [`srv`](https://github.com/puma/puma/blob/2f284bd5810b4cc6771887c28c287da6468adbc3/lib/puma/server.rb#L241) and [`ctl`](https://github.com/puma/puma/blob/2f284bd5810b4cc6771887c28c287da6468adbc3/lib/puma/runner.rb#L84) so this new length works in both cases.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
