### PR TITLE
Avoid spawning `Threadpool#trim` thread if pool size is fixed

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -253,9 +253,8 @@ module Puma
         @reactor.run
       end
 
-
       @thread_pool.auto_reap! if options[:reaping_time]
-      @thread_pool.auto_trim! if options[:auto_trim_time]
+      @thread_pool.auto_trim! if @min_threads != @max_threads && options[:auto_trim_time]
 
       @check, @notify = Puma::Util.pipe unless @notify
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -40,6 +40,8 @@ class TestPumaServer < Minitest::Test
     @server = Puma::Server.new block || @app, @events, options
     @bind_port = (@server.add_tcp_listener @host, 0).addr[1]
     @server.run
+  ensure
+    @pool = @server.instance_variable_get(:@thread_pool)
   end
 
   def test_normalize_host_header_missing
@@ -2042,5 +2044,38 @@ class TestPumaServer < Minitest::Test
     assert_includes body, "GET /404 HTTP/1.1\r\n"
     assert_includes body, "Content-Length: 144\r\n"
     assert_equal 1, response.scan("HTTP/1.1 200 OK").size
+  end
+
+  def test_auto_trim_with_variable_pool_size
+    auto_trim_time = 3
+    server_run(min_threads: 1, max_threads: 2, auto_trim_time: auto_trim_time)
+    sleep 1 # wait for possible initial trim on run
+    thread_pool_expect true, :trim, nil, after: auto_trim_time
+  end
+
+  def test_auto_trim_with_fixed_pool_size
+    auto_trim_time = 3
+    server_run(min_threads: 2, max_threads: 2, auto_trim_time: auto_trim_time)
+    sleep 1 # wait for possible initial trim on run
+    thread_pool_expect false, :trim, nil, after: auto_trim_time
+  end
+
+  private
+
+  def thread_pool_expect(should_expect, expect_method, *expect_args, after: nil)
+    mock_pool = Minitest::Mock.new
+    mock_pool.expect(expect_method, *expect_args) if should_expect
+
+    @pool.singleton_class.class_eval do
+      define_method(expect_method) do |*args, **kwargs|
+        raise "unexpected #{expect_method} called on Puma::Threadpool" unless should_expect
+
+        mock_pool.public_send(expect_method, *args, **kwargs)
+      end
+    end
+
+    sleep after if after
+
+    assert mock_pool.verify # assert to satisfy proveit
   end
 end


### PR DESCRIPTION
### Description

While working on #3383 I found that a thread was being spawned to trim the server's thread pool's threads every `:auto_trim_time` seconds regardless of whether or not the pool needed trimming, which would only be when the thread count is configured to scale automatically i.e. min != max.

This PR ensures that specific thread is only spawned if the thread count is not fixed.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
