### PR TITLE
Only `wait_for_less_busy_worker` in cluster mode

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -360,7 +360,7 @@ module Puma
                 break if handle_check
               else
                 pool.wait_until_not_full
-                pool.wait_for_less_busy_worker(options[:wait_for_less_busy_worker])
+                pool.wait_for_less_busy_worker(options[:wait_for_less_busy_worker]) if @clustered
 
                 io = begin
                   sock.accept_nonblock


### PR DESCRIPTION
### Description

Refs: #2079 and #2940

It looks like the `wait_for_less_busy_worker` logic also runs in single mode. This means that when a thread becomes available, the server unnecessarily delays handling the request as there are no other workers whose threads can pick it up instead.

This PR ensures `wait_for_less_busy_worker` only happens if puma is running in cluster mode.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
