### PR TITLE
Address rubocop TODOs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
   StyleGuideCopsOnly: false
   Exclude:
     - 'tmp/**/*'
+    - '.bundle/**/*'
     - '**/vendor/bundle/**/*'
     - 'examples/**/*'
     - 'pkg/**/*'
@@ -22,8 +23,11 @@ Performance:
 # ————————————————————————————————————————— disabled cops
 
 # ————————————————————————————————————————— enabled cops
+
+# Layout
+
 Layout/AccessModifierIndentation:
-  EnforcedStyle: indent
+  Enabled: true
 
 Layout/IndentationStyle:
   Enabled: true
@@ -35,7 +39,6 @@ Layout/SpaceAroundKeyword:
   Enabled: true
 
 Layout/SpaceBeforeBlockBraces:
-  EnforcedStyleForEmptyBraces: no_space
   Enabled: true
 
 Layout/SpaceBeforeFirstArg:
@@ -50,23 +53,56 @@ Layout/TrailingEmptyLines:
 Layout/TrailingWhitespace:
   Enabled: true
 
+Layout/SpaceAroundOperators:
+  Enabled: true
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+
+Layout/EmptyLines:
+  Enabled: true
+
+Layout/EmptyLinesAroundClassBody:
+  Enabled: true
+  Exclude:
+    - 'test/**/*'
+
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: true
+
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: true
+
+# Lint
+
 Lint/Debugger:
   Enabled: true
 
+# Metrics
+
 Metrics/ParameterLists:
   Max: 7
+
+# Naming
 
 Naming/ConstantName:
   Enabled: true
 
 Naming/MethodName:
   Enabled: true
-  EnforcedStyle: snake_case
   Exclude:
     - 'test/**/**'
 
 Naming/VariableName:
   Enabled: true
+
+# Style
 
 Style/MethodDefParentheses:
   Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,48 +1,6 @@
 inherit_from: "./.rubocop.yml"
 
-# 29 offenses
-Layout/SpaceAroundOperators:
-  Enabled: true
-
-# 21 offenses
-Layout/SpaceInsideBlockBraces:
-  Enabled: true
-
-# 16 offenses
-Layout/SpaceAroundEqualsInParameterDefault:
-  Enabled: true
-  EnforcedStyle: no_space
-
-# 15 offenses
-Layout/SpaceInsideHashLiteralBraces:
-  Enabled: true
-  EnforcedStyle: no_space
-
-# 8 offenses
-Layout/EmptyLines:
-  Enabled: true
-
-# 4 offenses
-Layout/EmptyLinesAroundClassBody:
-  Enabled: true
-  Exclude:
-    - 'test/**/*'
-
-# 6 offenses
-Layout/EmptyLinesAroundMethodBody:
-  Enabled: true
-
-# 5 offenses
-Layout/EmptyLinesAroundModuleBody:
-  Enabled: true
-
-# 5 offenses
-Layout/IndentationWidth:
-  Enabled: true
-  
-# >200 offenses for 80
-# 58 offenses for 100
-# 18 offenses for 120
+# 49 offenses
 Metrics/LineLength:
   Max: 120
   AllowHeredoc: true

--- a/benchmarks/local/bench_base.rb
+++ b/benchmarks/local/bench_base.rb
@@ -3,7 +3,6 @@
 require 'optparse'
 
 module TestPuma
-
   HOST4 = ENV.fetch('PUMA_TEST_HOST4', '127.0.0.1')
   HOST6 = ENV.fetch('PUMA_TEST_HOST6', '::1')
   PORT  = ENV.fetch('PUMA_TEST_PORT', 40001).to_i
@@ -33,7 +32,7 @@ module TestPuma
       suf = format "%04d", len
       fn = format fn_format, len
       unless File.exist? fn
-        body = "Hello World\n#{str}".byteslice(0,1023) + "\n" + (str * (len-1))
+        body = "Hello World\n#{str}".byteslice(0,1023) + "\n" + (str * (len - 1))
         File.write fn, body
       end
     end
@@ -216,12 +215,12 @@ module TestPuma
       read_unit = wrk_data[/ +[\d.]+(GB|KB|MB) +read$/, 1]
       read_mult = mult_for_unit read_unit
 
-      resp_transfer = (transfer * transfer_mult)/rps
-      resp_read = (read * read_mult)/requests.to_f
+      resp_transfer = (transfer * transfer_mult) / rps
+      resp_read = (read * read_mult) / requests.to_f
 
-      mult = transfer/read
+      mult = transfer / read
 
-      hsh[:resp_size] = ((resp_transfer * mult + resp_read)/(mult + 1)).round
+      hsh[:resp_size] = ((resp_transfer * mult + resp_read) / (mult + 1)).round
 
       hsh[:resp_size] = hsh[:resp_size] - 1770 - hsh[:resp_size].to_s.length
 
@@ -256,7 +255,7 @@ module TestPuma
         if t.end_with?('ms')
           t.to_f
         elsif t.end_with?('us')
-          t.to_f/1000
+          t.to_f / 1000
         elsif t.end_with?('s')
           t.to_f * 1000
         else
@@ -390,5 +389,4 @@ module TestPuma
       puts '─' * 69
     end
   end
-
 end

--- a/benchmarks/local/puma_info.rb
+++ b/benchmarks/local/puma_info.rb
@@ -10,7 +10,6 @@ require 'socket'
 require 'json'
 
 module TestPuma
-
   # Similar to puma_ctl.rb, but returns objects.  Command list is minimal.
   #
   class PumaInfo
@@ -21,7 +20,7 @@ module TestPuma
 
     attr_reader :master_pid
 
-    def initialize(argv, stdout=STDOUT, stderr=STDERR)
+    def initialize(argv, stdout = STDOUT, stderr = STDERR)
       @state = nil
       @quiet = false
       @pidfile = nil
@@ -177,7 +176,7 @@ module TestPuma
         raise "Bad response from server: #{@code}"
       end
       return unless PRINTABLE_COMMANDS.include? @command
-      JSON.parse response.last, {symbolize_names: true}
+      JSON.parse response.last, { symbolize_names: true }
     ensure
       if server
         if uri.scheme == 'ssl'

--- a/benchmarks/local/response_time_wrk.rb
+++ b/benchmarks/local/response_time_wrk.rb
@@ -4,7 +4,6 @@ require_relative 'bench_base'
 require_relative 'puma_info'
 
 module TestPuma
-
   # This file is called from `response_time_wrk.sh`.  It requires `wrk`.
   # We suggest using https://github.com/ioquatix/wrk
   #
@@ -32,7 +31,6 @@ module TestPuma
   #   [array, chunk] * [10kb, 50kb, 100kb]
   #
   class ResponseTimeWrk < ResponseTimeBase
-
     WRK = ENV.fetch('WRK', 'wrk')
 
     def run
@@ -100,7 +98,7 @@ module TestPuma
       @puma_info.run 'stop'
       sleep 2
       running_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - time_start
-      puts format("\n%2d:%d Total Time", (running_time/60).to_i, running_time % 60)
+      puts format("\n%2d:%d Total Time", (running_time / 60).to_i, running_time % 60)
     end
 
     # Prints parsed data of each wrk run. Similar to:
@@ -116,7 +114,7 @@ module TestPuma
       digits = [4 - Math.log10(@max_100_time).to_i, 3].min
 
       fmt_vals = +'%-6s %6d'
-      fmt_vals << (digits < 0 ? "  %6d" : "  %6.#{digits}f")*5
+      fmt_vals << (digits < 0 ? "  %6d" : "  %6.#{digits}f") * 5
       fmt_vals << '  %8d'
 
       label = @single_type ? 'Size' : 'Type'
@@ -141,7 +139,6 @@ module TestPuma
           puts format(fmt_vals, desc, hsh[:rps], *times, hsh[:resp_size])
         end
       end
-
     end
 
     # Checks if any body files need to be created, reads all the body files,
@@ -212,7 +209,7 @@ module TestPuma
       end
 
       threads.each(&:join)
-      loops_time = (1_000*(Process.clock_gettime(Process::CLOCK_MONOTONIC) - t_st)).to_i
+      loops_time = (1_000 * (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t_st)).to_i
 
       threads.clear
       threads = nil

--- a/ext/puma_http11/extconf.rb
+++ b/ext/puma_http11/extconf.rb
@@ -20,8 +20,8 @@ unless ENV["PUMA_DISABLE_SSL"]
     true
   elsif have_library('libcrypto', 'BIO_read') && have_library('libssl', 'SSL_CTX_new')
     true
-  elsif %w'crypto libeay32'.find {|crypto| have_library(crypto, 'BIO_read')} &&
-      %w'ssl ssleay32'.find {|ssl| have_library(ssl, 'SSL_CTX_new')}
+  elsif %w'crypto libeay32'.find { |crypto| have_library(crypto, 'BIO_read') } &&
+      %w'ssl ssleay32'.find { |ssl| have_library(ssl, 'SSL_CTX_new') }
     true
   else
     puts '** Puma will be compiled without SSL support'

--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -83,7 +83,7 @@ module Puma
         env['QUERY_STRING'].to_s.split('&;').include? "token=#{@auth_token}"
       end
 
-      def rack_response(status, body, content_type='application/json')
+      def rack_response(status, body, content_type = 'application/json')
         headers = {
           'content-type' => content_type,
           'content-length' => body.bytesize.to_s

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -8,7 +8,6 @@ require_relative 'util'
 require_relative 'configuration'
 
 module Puma
-
   if HAS_SSL
     require_relative 'minissl'
     require_relative 'minissl/context_builder'
@@ -74,7 +73,7 @@ module Puma
 
     # @version 5.0.0
     def create_inherited_fds(env_hash)
-      env_hash.select {|k,v| k =~ /PUMA_INHERIT_\d+/}.each do |_k, v|
+      env_hash.select { |k,v| k =~ /PUMA_INHERIT_\d+/ }.each do |_k, v|
         fd, url = v.split(":", 2)
         @inherited_fds[url] = fd.to_i
       end.keys # pass keys back for removal
@@ -200,7 +199,7 @@ module Puma
               end
 
               if u = params['mode']
-                mode = Integer('0'+u)
+                mode = Integer('0' + u)
               end
 
               if u = params['backlog']
@@ -322,7 +321,7 @@ module Puma
     # +backlog+ indicates how many unaccepted connections the kernel should
     # allow to accumulate before returning connection refused.
     #
-    def add_tcp_listener(host, port, optimize_for_latency=true, backlog=1024)
+    def add_tcp_listener(host, port, optimize_for_latency = true, backlog = 1024)
       if host == "localhost"
         loopback_addresses.each do |addr|
           add_tcp_listener addr, port, optimize_for_latency, backlog
@@ -351,7 +350,7 @@ module Puma
     end
 
     def add_ssl_listener(host, port, ctx,
-                         optimize_for_latency=true, backlog=1024)
+                         optimize_for_latency = true, backlog = 1024)
 
       raise "Puma compiled without SSL support" unless HAS_SSL
       # Puma will try to use local authority context if context is supplied nil
@@ -401,7 +400,7 @@ module Puma
 
     # Tell the server to listen on +path+ as a UNIX domain socket.
     #
-    def add_unix_listener(path, umask=nil, mode=nil, backlog=1024)
+    def add_unix_listener(path, umask = nil, mode = nil, backlog = 1024)
       # Let anyone connect by default
       umask ||= 0
 

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -93,7 +93,7 @@ module Puma
     #
 
     def setup_options
-      @conf = Configuration.new({}, {events: @events}) do |user_config, file_config|
+      @conf = Configuration.new({}, { events: @events }) do |user_config, file_config|
         @parser = OptionParser.new do |o|
           o.on "-b", "--bind URI", "URI to bind to (tcp://, unix://, ssl://)" do |arg|
             user_config.bind arg

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -20,13 +20,11 @@ if Puma::IS_JRUBY
 end
 
 module Puma
-
   class ConnectionError < RuntimeError; end
 
   class HttpParserError501 < IOError; end
 
   #———————————————————————— DO NOT USE — this class is for internal use only ———
-
 
   # An instance of this class represents a unique request from a client.
   # For example, this could be a web request from a browser or from CURL.
@@ -42,7 +40,6 @@ module Puma
   # They can be used to "time out" a response via the `timeout_at` reader.
   #
   class Client # :nodoc:
-
     # this tests all values but the last, which must be chunked
     ALLOWED_TRANSFER_ENCODING = %w[compress deflate gzip].freeze
 
@@ -70,7 +67,7 @@ module Puma
 
     include Puma::Const
 
-    def initialize(io, env=nil)
+    def initialize(io, env = nil)
       @io = io
       @to_io = io.to_io
       @io_buffer = IOBuffer.new
@@ -154,7 +151,7 @@ module Puma
       [@timeout_at - Process.clock_gettime(Process::CLOCK_MONOTONIC), 0].max
     end
 
-    def reset(fast_check=true)
+    def reset(fast_check = true)
       @parser.reset
       @io_buffer.reset
       @read_header = true
@@ -542,7 +539,7 @@ module Puma
       if @partial_part_left > 0
         if @partial_part_left <= chunk.size
           if @partial_part_left > 2
-            write_chunk(chunk[0..(@partial_part_left-3)]) # skip the \r\n
+            write_chunk(chunk[0..(@partial_part_left - 3)]) # skip the \r\n
           end
           chunk = chunk[@partial_part_left..-1]
           @partial_part_left = 0
@@ -550,7 +547,7 @@ module Puma
           if @partial_part_left > 2
             if @partial_part_left == chunk.size + 1
               # Don't include the last \r
-              write_chunk(chunk[0..(@partial_part_left-3)])
+              write_chunk(chunk[0..(@partial_part_left - 3)])
             else
               # don't include the last \r\n
               write_chunk(chunk)
@@ -564,7 +561,7 @@ module Puma
       if @prev_chunk.empty?
         io = StringIO.new(chunk)
       else
-        io = StringIO.new(@prev_chunk+chunk)
+        io = StringIO.new(@prev_chunk + chunk)
         @prev_chunk = ""
       end
 
@@ -591,7 +588,7 @@ module Puma
               start_of_rest = if rest.start_with?(CHUNK_VALID_ENDING)
                 CHUNK_VALID_ENDING_SIZE
               else # we have started a trailer section, which we do not support. skip it!
-                rest.index(CHUNK_VALID_ENDING*2) + CHUNK_VALID_ENDING_SIZE*2
+                rest.index(CHUNK_VALID_ENDING * 2) + CHUNK_VALID_ENDING_SIZE * 2
               end
 
               @buffer = rest[start_of_rest..-1]

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -36,7 +36,7 @@ module Puma
       begin
         loop do
           wait_workers
-          break if @workers.reject {|w| w.pid.nil?}.empty?
+          break if @workers.reject { |w| w.pid.nil? }.empty?
           sleep 0.2
         end
       rescue Interrupt
@@ -373,12 +373,12 @@ module Puma
         if after.size > before.size
           threads = (after - before)
           if threads.first.respond_to? :backtrace
-            log "! WARNING: Detected #{after.size-before.size} Thread(s) started in app boot:"
+            log "! WARNING: Detected #{after.size - before.size} Thread(s) started in app boot:"
             threads.each do |t|
               log "! #{t.inspect} - #{t.backtrace ? t.backtrace.first : ''}"
             end
           else
-            log "! WARNING: Detected #{after.size-before.size} Thread(s) started in app boot"
+            log "! WARNING: Detected #{after.size - before.size} Thread(s) started in app boot"
           end
         end
       else
@@ -492,7 +492,7 @@ module Puma
                     @events.fire(:ping!, w0)
                   end
 
-                  if !booted && @workers.none? {|worker| worker.last_status.empty?}
+                  if !booted && @workers.none? { |worker| worker.last_status.empty? }
                     @events.fire_on_booted!
                     debug_loaded_extensions("Loaded Extensions - master:") if @log_writer.debug?
                     booted = true

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -4,7 +4,6 @@ module Puma
   class Cluster < Puma::Runner
     #—————————————————————— DO NOT USE — this class is for internal use only ———
 
-
     # This class is instantiated by the `Puma::Cluster` and represents a single
     # worker process.
     #

--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -4,7 +4,6 @@ module Puma
   class Cluster < Runner
     #—————————————————————— DO NOT USE — this class is for internal use only ———
 
-
     # This class represents a worker process from the perspective of the puma
     # master process. It contains information about the process and its health
     # and it exposes methods to control the process via IPC. It does not

--- a/lib/puma/commonlogger.rb
+++ b/lib/puma/commonlogger.rb
@@ -37,7 +37,7 @@ module Puma
     REMOTE_USER          = 'REMOTE_USER'
     REQUEST_METHOD       = Const::REQUEST_METHOD
 
-    def initialize(app, logger=nil)
+    def initialize(app, logger = nil)
       @app = app
       @logger = logger
     end

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -172,7 +172,7 @@ module Puma
       http_content_length_limit: nil
     }
 
-    def initialize(user_options={}, default_options = {}, &block)
+    def initialize(user_options = {}, default_options = {}, &block)
       default_options = self.puma_default_options.merge(default_options)
 
       @options     = UserFileDefaultOptions.new(user_options, default_options)

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -99,7 +99,6 @@ module Puma
   # REMOTE_USER, or REMOTE_HOST parameters since those are either a security problem or
   # too taxing on performance.
   module Const
-
     PUMA_VERSION = VERSION = "6.4.2"
     CODE_NAME = "The Eagle of Durango"
 
@@ -112,7 +111,7 @@ module Puma
     WRITE_TIMEOUT = 10
 
     # The original URI requested by the client.
-    REQUEST_URI= "REQUEST_URI"
+    REQUEST_URI = "REQUEST_URI"
     REQUEST_PATH = "REQUEST_PATH"
     QUERY_STRING = "QUERY_STRING"
     CONTENT_LENGTH = "CONTENT_LENGTH"

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -8,7 +8,6 @@ require 'socket'
 
 module Puma
   class ControlCLI
-
     # values must be string or nil
     # value of `nil` means command cannot be processed via signal
     # @version 5.0.3
@@ -37,7 +36,7 @@ module Puma
     # @version 5.0.0
     PRINTABLE_COMMANDS = %w[gc-stats stats thread-backtraces].freeze
 
-    def initialize(argv, stdout=STDOUT, stderr=STDERR)
+    def initialize(argv, stdout = STDOUT, stderr = STDERR)
       @state = nil
       @quiet = false
       @pidfile = nil

--- a/lib/puma/detect.rb
+++ b/lib/puma/detect.rb
@@ -3,7 +3,6 @@
 # This file can be loaded independently of puma.rb, so it cannot have any code
 # that assumes puma.rb is loaded.
 
-
 module Puma
   # @version 5.2.1
   HAS_FORK = ::Process.respond_to? :fork

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -161,7 +161,7 @@ module Puma
       instance_eval(&blk)
     end
 
-    def get(key,default=nil)
+    def get(key,default = nil)
       @options[key.to_sym] || default
     end
 
@@ -193,7 +193,7 @@ module Puma
     #
     # @see Puma::Configuration#app
     #
-    def app(obj=nil, &block)
+    def app(obj = nil, &block)
       obj ||= block
 
       raise "Provide either a #call'able or a block" unless obj
@@ -216,7 +216,7 @@ module Puma
     # @example
     #   activate_control_app 'unix:///var/run/pumactl.sock', { no_token: true }
     #
-    def activate_control_app(url="auto", opts={})
+    def activate_control_app(url = "auto", opts = {})
       if url == "auto"
         path = Configuration.temp_path
         @options[:control_url] = "unix://#{path}"
@@ -314,7 +314,7 @@ module Puma
     # @example Only bind to systemd activated sockets, ignoring other binds
     #   bind_to_activated_sockets 'only'
     #
-    def bind_to_activated_sockets(bind=true)
+    def bind_to_activated_sockets(bind = true)
       @options[:bind_to_activated_sockets] = bind
     end
 
@@ -325,7 +325,7 @@ module Puma
     # @example
     #   port 3000
     #
-    def port(port, host=nil)
+    def port(port, host = nil)
       host ||= default_host
       bind URI::Generic.build(scheme: 'tcp', host: host, port: Integer(port)).to_s
     end
@@ -377,7 +377,7 @@ module Puma
     # @example
     #   clean_thread_locals
     #
-    def clean_thread_locals(which=true)
+    def clean_thread_locals(which = true)
       @options[:clean_thread_locals] = which
     end
 
@@ -387,7 +387,7 @@ module Puma
     #
     # @see Puma::Server#graceful_shutdown
     #
-    def drain_on_shutdown(which=true)
+    def drain_on_shutdown(which = true)
       @options[:drain_on_shutdown] = which
     end
 
@@ -414,7 +414,7 @@ module Puma
     #
     # @see Puma::Server#graceful_shutdown
     #
-    def force_shutdown_after(val=:forever)
+    def force_shutdown_after(val = :forever)
       i = case val
           when :forever
             -1
@@ -469,7 +469,7 @@ module Puma
     # @example
     #   quiet
     #
-    def quiet(which=true)
+    def quiet(which = true)
       @options[:log_requests] = !which
     end
 
@@ -480,7 +480,7 @@ module Puma
     # @example
     #   log_requests
     #
-    def log_requests(which=true)
+    def log_requests(which = true)
       @options[:log_requests] = which
     end
 
@@ -519,7 +519,7 @@ module Puma
     # Only necessary if X-Forwarded-Proto is not being set by your proxy
     # Normal values are 'http' or 'https'.
     #
-    def rack_url_scheme(scheme=nil)
+    def rack_url_scheme(scheme = nil)
       @options[:rack_url_scheme] = scheme
     end
 
@@ -530,7 +530,7 @@ module Puma
     # @example
     #   early_hints
     #
-    def early_hints(answer=true)
+    def early_hints(answer = true)
       @options[:early_hints] = answer
     end
 
@@ -544,7 +544,7 @@ module Puma
     # @example
     #   stdout_redirect '/app/lolcat/log/stdout', '/app/lolcat/log/stderr', true
     #
-    def stdout_redirect(stdout=nil, stderr=nil, append=false)
+    def stdout_redirect(stdout = nil, stderr = nil, append = false)
       @options[:redirect_stdout] = stdout
       @options[:redirect_stderr] = stderr
       @options[:redirect_append] = append
@@ -928,7 +928,7 @@ module Puma
     # @example
     #   preload_app!
     #
-    def preload_app!(answer=true)
+    def preload_app!(answer = true)
       @options[:preload_app] = answer
     end
 
@@ -940,7 +940,7 @@ module Puma
     #     [200, {}, ["error page"]]
     #   end
     #
-    def lowlevel_error_handler(obj=nil, &block)
+    def lowlevel_error_handler(obj = nil, &block)
       obj ||= block
       raise "Provide either a #call'able or a block" unless obj
       @options[:lowlevel_error_handler] = obj
@@ -964,7 +964,7 @@ module Puma
     #
     # @see extra_runtime_dependencies
     #
-    def prune_bundler(answer=true)
+    def prune_bundler(answer = true)
       @options[:prune_bundler] = answer
     end
 
@@ -982,7 +982,7 @@ module Puma
     # @see Puma::Launcher#setup_signals
     # @see Puma::Cluster#setup_signals
     #
-    def raise_exception_on_sigterm(answer=true)
+    def raise_exception_on_sigterm(answer = true)
       @options[:raise_exception_on_sigterm] = answer
     end
 
@@ -1138,7 +1138,7 @@ module Puma
     #
     # @see Puma::Server
     #
-    def queue_requests(answer=true)
+    def queue_requests(answer = true)
       @options[:queue_requests] = answer
     end
 
@@ -1146,10 +1146,9 @@ module Puma
     # threads will be written to $stdout. This can help figure
     # out why shutdown is hanging.
     #
-    def shutdown_debug(val=true)
+    def shutdown_debug(val = true)
       @options[:shutdown_debug] = val
     end
-
 
     # Attempts to route traffic to less-busy workers by causing them to delay
     # listening on the socket, allowing workers which are not processing any
@@ -1164,7 +1163,7 @@ module Puma
     #
     # @version 5.0.0
     #
-    def wait_for_less_busy_worker(val=0.005)
+    def wait_for_less_busy_worker(val = 0.005)
       @options[:wait_for_less_busy_worker] = val.to_f
     end
 
@@ -1198,7 +1197,7 @@ module Puma
     # @example
     #   set_remote_address :localhost
     #
-    def set_remote_address(val=:socket)
+    def set_remote_address(val = :socket)
       case val
       when :socket
         @options[:remote_address] = val
@@ -1241,7 +1240,7 @@ module Puma
     #
     # @version 5.0.0
     #
-    def fork_worker(after_requests=1000)
+    def fork_worker(after_requests = 1000)
       @options[:fork_worker] = Integer(after_requests)
     end
 
@@ -1284,7 +1283,7 @@ module Puma
     # @example
     #   mutate_stdout_and_stderr_to_sync_on_write false
     #
-    def mutate_stdout_and_stderr_to_sync_on_write(enabled=true)
+    def mutate_stdout_and_stderr_to_sync_on_write(enabled = true)
       @options[:mutate_stdout_and_stderr_to_sync_on_write] = enabled
     end
 

--- a/lib/puma/error_logger.rb
+++ b/lib/puma/error_logger.rb
@@ -32,7 +32,7 @@ module Puma
     # - +text+ (default nil) custom string to print in title
     #   and before all remaining info.
     #
-    def info(options={})
+    def info(options = {})
       internal_write title(options)
     end
 
@@ -44,7 +44,7 @@ module Puma
     # - +text+ (default nil) custom string to print in title
     #   and before all remaining info.
     #
-    def debug(options={})
+    def debug(options = {})
       return unless @debug
 
       error = options[:error]
@@ -58,7 +58,7 @@ module Puma
       internal_write string_block.join("\n")
     end
 
-    def title(options={})
+    def title(options = {})
       text = options[:text]
       req = options[:req]
       error = options[:error]

--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 module Puma
-
   # This is an event sink used by `Puma::Server` to handle
   # lifecycle events such as :on_booted, :on_restart, and :on_stopped.
   # Using `Puma::DSL` it is possible to register callback hooks
   # for each event type.
   class Events
-
     def initialize
       @hooks = Hash.new { |h,k| h[k] = [] }
     end
@@ -18,7 +16,7 @@ module Puma
     end
 
     # Register a callback for a given hook
-    def register(hook, obj=nil, &blk)
+    def register(hook, obj = nil, &blk)
       if obj and blk
         raise "Specify either an object or a block, not both"
       end

--- a/lib/puma/json_serialization.rb
+++ b/lib/puma/json_serialization.rb
@@ -2,7 +2,6 @@
 require 'stringio'
 
 module Puma
-
   # Puma deliberately avoids the use of the json gem and instead performs JSON
   # serialization without any external dependencies. In a puma cluster, loading
   # any gem into the puma master process means that operators cannot use a

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -38,7 +38,7 @@ module Puma
     #     end
     #   end
     #   Puma::Launcher.new(conf, log_writer: Puma::LogWriter.stdio).run
-    def initialize(conf, launcher_args={})
+    def initialize(conf, launcher_args = {})
       @runner        = nil
       @log_writer    = launcher_args[:log_writer] || LogWriter::DEFAULT
       @events        = launcher_args[:events] || Events.new

--- a/lib/puma/launcher/bundle_pruner.rb
+++ b/lib/puma/launcher/bundle_pruner.rb
@@ -2,11 +2,9 @@
 
 module Puma
   class Launcher
-
     # This class is used to pickup Gemfile changes during
     # application restarts.
     class BundlePruner
-
       def initialize(original_argv, extra_runtime_dependencies, log_writer)
         @original_argv = Array(original_argv)
         @extra_runtime_dependencies = Array(extra_runtime_dependencies)
@@ -38,7 +36,7 @@ module Puma
           ENV["BUNDLE_APP_CONFIG"] = bundle_app_config
           args = [Gem.ruby, puma_wild_path, '-I', dirs.join(':')] + @original_argv
           # Ruby 2.0+ defaults to true which breaks socket activation
-          args += [{:close_others => false}]
+          args += [{ :close_others => false }]
           Kernel.exec(*args)
         end
       end

--- a/lib/puma/log_writer.rb
+++ b/lib/puma/log_writer.rb
@@ -6,11 +6,9 @@ require 'stringio'
 require 'io/wait' unless Puma::HAS_NATIVE_IO_WAIT
 
 module Puma
-
   # Handles logging concerns for both standard messages
   # (+stdout+) and errors (+stderr+).
   class LogWriter
-
     class DefaultFormatter
       def call(str)
         str
@@ -108,7 +106,7 @@ module Puma
     # +error+ a connection exception, +req+ the request,
     # and +text+ additional info
     # @version 5.0.0
-    def connection_error(error, req, text="HTTP connection error")
+    def connection_error(error, req, text = "HTTP connection error")
       @error_logger.info(error: error, req: req, text: text)
     end
 
@@ -132,7 +130,7 @@ module Puma
     # An unknown error has occurred.
     # +error+ an exception object, +req+ the request,
     # and +text+ additional info
-    def unknown_error(error, req=nil, text="Unknown error")
+    def unknown_error(error, req = nil, text = "Unknown error")
       @error_logger.info(error: error, req: req, text: text)
     end
 
@@ -140,7 +138,7 @@ module Puma
     # +error+ an exception object, +req+ the request,
     # and +text+ additional info
     # @version 5.0.0
-    def debug_error(error, req=nil, text="")
+    def debug_error(error, req = nil, text = "")
       @error_logger.debug(error: error, req: req, text: text)
     end
   end

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -17,7 +17,7 @@ module Puma
     # @version 5.0.0
     HAS_TLS1_3 = IS_JRUBY ||
         ((OPENSSL_VERSION[/ \d+\.\d+\.\d+/].split('.').map(&:to_i) <=> [1,1,1]) != -1 &&
-         (OPENSSL_LIBRARY_VERSION[/ \d+\.\d+\.\d+/].split('.').map(&:to_i) <=> [1,1,1]) !=-1)
+         (OPENSSL_LIBRARY_VERSION[/ \d+\.\d+\.\d+/].split('.').map(&:to_i) <=> [1,1,1]) != -1)
 
     class Socket
       def initialize(socket, engine)
@@ -382,7 +382,6 @@ module Puma
         raise ArgumentError, "Invalid value of no_tlsv1_1=" unless ['true', 'false', true, false].include?(tlsv1_1)
         @no_tlsv1_1 = tlsv1_1
       end
-
     end
 
     VERIFY_NONE = 0

--- a/lib/puma/rack/builder.rb
+++ b/lib/puma/rack/builder.rb
@@ -168,7 +168,7 @@ module Puma::Rack
       [app, options]
     end
 
-    def self.new_from_string(builder_script, file="(rackup)")
+    def self.new_from_string(builder_script, file = "(rackup)")
       eval "Puma::Rack::Builder.new {\n" + builder_script + "\n}.to_app",
         TOPLEVEL_BINDING, file, 0
     end
@@ -244,7 +244,7 @@ module Puma::Rack
     #
     #   use SomeMiddleware
     #   run MyApp
-    def warmup(prc=nil, &block)
+    def warmup(prc = nil, &block)
       @warmup = prc || block
     end
 
@@ -289,7 +289,7 @@ module Puma::Rack
     def generate_map(default_app, mapping)
       require_relative 'urlmap'
 
-      mapped = default_app ? {'/' => default_app} : {}
+      mapped = default_app ? { '/' => default_app } : {}
       mapping.each { |r,b| mapped[r] = self.class.new(default_app, &b).to_app }
       URLMap.new(mapped)
     end

--- a/lib/puma/rack/urlmap.rb
+++ b/lib/puma/rack/urlmap.rb
@@ -70,7 +70,7 @@ module Puma::Rack
         return app.call(env)
       end
 
-      [404, {'Content-Type' => "text/plain", "X-Cascade" => "pass"}, ["Not Found: #{path}"]]
+      [404, { 'Content-Type' => "text/plain", "X-Cascade" => "pass" }, ["Not Found: #{path}"]]
 
     ensure
       env['PATH_INFO'] = path

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -32,7 +32,7 @@ module Puma
     end
 
     # Run the internal select loop, using a background thread by default.
-    def run(background=true)
+    def run(background = true)
       if background
         @thread = Thread.new do
           Puma.set_thread_name "reactor"
@@ -73,10 +73,10 @@ module Puma
           # Wakeup any registered object that receives incoming data.
           # Block until the earliest timeout or Selector#wakeup is called.
           timeout = (earliest = @timeouts.first) && earliest.timeout
-          @selector.select(timeout) {|mon| wakeup!(mon.value)}
+          @selector.select(timeout) { |mon| wakeup!(mon.value) }
 
           # Wakeup all objects that timed out.
-          timed_out = @timeouts.take_while {|t| t.timeout == 0}
+          timed_out = @timeouts.take_while { |t| t.timeout == 0 }
           timed_out.each { |c| wakeup! c }
 
           unless @input.empty?

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -3,7 +3,6 @@
 module Puma
   #———————————————————————— DO NOT USE — this class is for internal use only ———
 
-
   # The methods here are included in Server, but are separated into this file.
   # All the methods here pertain to passing the request to the app, then
   # writing the response back to the client.
@@ -13,7 +12,6 @@ module Puma
   # @version 5.0.3
   #
   module Request # :nodoc:
-
     # Single element array body: smaller bodies are written to io_buffer first,
     # then a single write from io_buffer. Larger sizes are written separately.
     # Also fixes max size of chunked file body read.
@@ -50,9 +48,8 @@ module Puma
     def handle_request(client, requests)
       env = client.env
       io_buffer = client.io_buffer
-      socket  = client.io   # io may be a MiniSSL::Socket
+      socket = client.io   # io may be a MiniSSL::Socket
       app_body = nil
-
 
       return false if closed_socket?(socket)
 
@@ -404,11 +401,11 @@ module Puma
       if host = env[HTTP_HOST]
         # host can be a hostname, ipv4 or bracketed ipv6. Followed by an optional port.
         if colon = host.rindex("]:") # IPV6 with port
-          env[SERVER_NAME] = host[0, colon+1]
-          env[SERVER_PORT] = host[colon+2, host.bytesize]
+          env[SERVER_NAME] = host[0, colon + 1]
+          env[SERVER_PORT] = host[colon + 2, host.bytesize]
         elsif !host.start_with?("[") && colon = host.index(":") # not hostname or IPV4 with port
           env[SERVER_NAME] = host[0, colon]
-          env[SERVER_PORT] = host[colon+1, host.bytesize]
+          env[SERVER_PORT] = host[colon + 1, host.bytesize]
         else
           env[SERVER_NAME] = host
           env[SERVER_PORT] = default_server_port(env)
@@ -569,7 +566,6 @@ module Puma
     # @version 5.0.3
     #
     def str_headers(env, status, headers, res_body, io_buffer, force_keep_alive)
-
       line_ending = LINE_END
       colon = COLON
 

--- a/lib/puma/sd_notify.rb
+++ b/lib/puma/sd_notify.rb
@@ -49,39 +49,39 @@ module Puma
     WATCHDOG  = "WATCHDOG=1"
     FDSTORE   = "FDSTORE=1"
 
-    def self.ready(unset_env=false)
+    def self.ready(unset_env = false)
       notify(READY, unset_env)
     end
 
-    def self.reloading(unset_env=false)
+    def self.reloading(unset_env = false)
       notify(RELOADING, unset_env)
     end
 
-    def self.stopping(unset_env=false)
+    def self.stopping(unset_env = false)
       notify(STOPPING, unset_env)
     end
 
     # @param status [String] a custom status string that describes the current
     #   state of the service
-    def self.status(status, unset_env=false)
+    def self.status(status, unset_env = false)
       notify("#{STATUS}#{status}", unset_env)
     end
 
     # @param errno [Integer]
-    def self.errno(errno, unset_env=false)
+    def self.errno(errno, unset_env = false)
       notify("#{ERRNO}#{errno}", unset_env)
     end
 
     # @param pid [Integer]
-    def self.mainpid(pid, unset_env=false)
+    def self.mainpid(pid, unset_env = false)
       notify("#{MAINPID}#{pid}", unset_env)
     end
 
-    def self.watchdog(unset_env=false)
+    def self.watchdog(unset_env = false)
       notify(WATCHDOG, unset_env)
     end
 
-    def self.fdstore(unset_env=false)
+    def self.fdstore(unset_env = false)
       notify(FDSTORE, unset_env)
     end
 
@@ -129,7 +129,7 @@ module Puma
     #   socket
     #
     # @see https://www.freedesktop.org/software/systemd/man/sd_notify.html
-    def self.notify(state, unset_env=false)
+    def self.notify(state, unset_env = false)
       sock = ENV["NOTIFY_SOCKET"]
 
       return nil if !sock

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -17,7 +17,6 @@ require 'socket'
 require 'io/wait' unless Puma::HAS_NATIVE_IO_WAIT
 
 module Puma
-
   # This method was private on Ruby 2.4 but became public on Ruby 2.5+:
   Thread.send(:attr_accessor, :puma_server)
 
@@ -49,7 +48,6 @@ module Puma
 
     attr_accessor :app
     attr_accessor :binder
-
 
     # Create a server for the rack app +app+.
     #
@@ -219,7 +217,6 @@ module Puma
       @thread_pool&.spawned
     end
 
-
     # This number represents the number of requests that
     # the server is capable of taking right now.
     #
@@ -238,7 +235,7 @@ module Puma
     # up in the background to handle requests. Otherwise requests
     # are handled synchronously.
     #
-    def run(background=true, thread_name: 'srv')
+    def run(background = true, thread_name: 'srv')
       BasicSocket.do_not_reverse_lookup = true
 
       @events.fire :state, :booting
@@ -251,7 +248,6 @@ module Puma
         @reactor = Reactor.new(@io_selector_backend) { |c| reactor_wakeup c }
         @reactor.run
       end
-
 
       @thread_pool.auto_reap! if options[:reaping_time]
       @thread_pool.auto_trim! if options[:auto_trim_time]
@@ -550,7 +546,7 @@ module Puma
 
     # A fallback rack response if +@app+ raises as exception.
     #
-    def lowlevel_error(e, env, status=500)
+    def lowlevel_error(e, env, status = 500)
       if handler = options[:lowlevel_error_handler]
         if handler.arity == 1
           return handler.call(e)
@@ -587,7 +583,7 @@ module Puma
         $stdout.syswrite "#{pid}: === Begin thread backtrace dump ===\n"
 
         threads.each_with_index do |t,i|
-          $stdout.syswrite "#{pid}: Thread #{i+1}/#{total}: #{t.inspect}\n"
+          $stdout.syswrite "#{pid}: Thread #{i + 1}/#{total}: #{t.inspect}\n"
           $stdout.syswrite "#{pid}: #{t.backtrace.join("\n#{pid}: ")}\n\n"
         end
         $stdout.syswrite "#{pid}: === End thread backtrace dump ===\n"
@@ -624,17 +620,17 @@ module Puma
     # Stops the acceptor thread and then causes the worker threads to finish
     # off the request queue before finally exiting.
 
-    def stop(sync=false)
+    def stop(sync = false)
       notify_safely(STOP_COMMAND)
       @thread.join if @thread && sync
     end
 
-    def halt(sync=false)
+    def halt(sync = false)
       notify_safely(HALT_COMMAND)
       @thread.join if @thread && sync
     end
 
-    def begin_restart(sync=false)
+    def begin_restart(sync = false)
       notify_safely(RESTART_COMMAND)
       @thread.join if @thread && sync
     end
@@ -651,12 +647,11 @@ module Puma
     # @version 5.0.0
     # @!attribute [r] stats
     def stats
-      STAT_METHODS.map {|name| [name, send(name) || 0]}.to_h
+      STAT_METHODS.map { |name| [name, send(name) || 0] }.to_h
     end
 
     # below are 'delegations' to binder
     # remove in Puma 7?
-
 
     def add_tcp_listener(host, port, optimize_for_latency = true, backlog = 1024)
       @binder.add_tcp_listener host, port, optimize_for_latency, backlog

--- a/lib/puma/state_file.rb
+++ b/lib/puma/state_file.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module Puma
-
   # Puma::Launcher uses StateFile to write a yaml file for use with Puma::ControlCLI.
   #
   # In previous versions of Puma, YAML was used to read/write the state file.
@@ -12,7 +11,6 @@ module Puma
   # yaml file, and the CI tests parse it with Psych.
   #
   class StateFile
-
     ALLOWED_FIELDS = %w!control_url control_auth_token pid running_from!
 
     def initialize

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -303,7 +303,7 @@ module Puma
     # and exit. If +force+ is true, then a trim request is requested
     # even if all threads are being utilized.
     #
-    def trim(force=false)
+    def trim(force = false)
       with_mutex do
         free = @waiting - @todo.size
         if (force or free > 0) and @spawned - @trim_requested > @min
@@ -357,12 +357,12 @@ module Puma
       end
     end
 
-    def auto_trim!(timeout=@auto_trim_time)
+    def auto_trim!(timeout = @auto_trim_time)
       @auto_trim = Automaton.new(self, timeout, "#{@name} threadpool trimmer", :trim)
       @auto_trim.start!
     end
 
-    def auto_reap!(timeout=@reaping_time)
+    def auto_reap!(timeout = @reaping_time)
       @reaper = Automaton.new(self, timeout, "#{@name} threadpool reaper", :reap)
       @reaper.start!
     end
@@ -385,7 +385,7 @@ module Puma
     # Next, wait an extra +@shutdown_grace_time+ seconds then force-kill remaining
     # threads. Finally, wait 1 second for remaining threads to exit.
     #
-    def shutdown(timeout=-1)
+    def shutdown(timeout = -1)
       threads = with_mutex do
         @shutdown = true
         @trim_requested = @spawned

--- a/lib/puma/util.rb
+++ b/lib/puma/util.rb
@@ -72,11 +72,11 @@ module Puma
     # A case-insensitive Hash that preserves the original case of a
     # header when set.
     class HeaderHash < Hash
-      def self.new(hash={})
+      def self.new(hash = {})
         HeaderHash === hash ? hash : super(hash)
       end
 
-      def initialize(hash={})
+      def initialize(hash = {})
         super()
         @names = {}
         hash.each { |k, v| self[k] = v }

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -29,7 +29,7 @@ module Puma
 
       @events = options[:events] || ::Puma::Events.new
 
-      conf = ::Puma::Configuration.new(options, default_options.merge({events: @events})) do |user_config, file_config, default_config|
+      conf = ::Puma::Configuration.new(options, default_options.merge({ events: @events })) do |user_config, file_config, default_config|
         if options.delete(:Verbose)
           begin
             require 'rack/commonlogger'  # Rack 1.x

--- a/test/bundle_app_config_test/config.ru
+++ b/test/bundle_app_config_test/config.ru
@@ -1,1 +1,1 @@
-run lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Hello World"]] }
+run lambda { |env| [200, { "Content-Type" => "text/plain" }, ["Hello World"]] }

--- a/test/bundle_preservation_test/config.ru
+++ b/test/bundle_preservation_test/config.ru
@@ -1,1 +1,1 @@
-run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [ENV['BUNDLE_GEMFILE'].inspect]] }
+run lambda { |env| [200, { 'Content-Type' => 'text/plain' }, [ENV['BUNDLE_GEMFILE'].inspect]] }

--- a/test/bundle_preservation_test/version1/config.ru
+++ b/test/bundle_preservation_test/version1/config.ru
@@ -1,1 +1,1 @@
-run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [ENV['BUNDLE_GEMFILE'].inspect]] }
+run lambda { |env| [200, { 'Content-Type' => 'text/plain' }, [ENV['BUNDLE_GEMFILE'].inspect]] }

--- a/test/bundle_preservation_test/version2/config.ru
+++ b/test/bundle_preservation_test/version2/config.ru
@@ -1,1 +1,1 @@
-run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [ENV['BUNDLE_GEMFILE'].inspect]] }
+run lambda { |env| [200, { 'Content-Type' => 'text/plain' }, [ENV['BUNDLE_GEMFILE'].inspect]] }

--- a/test/config/cpu_spin.rb
+++ b/test/config/cpu_spin.rb
@@ -13,5 +13,5 @@ app do |env|
     iterations.times { rand }
   end
 
-  [200, {"Content-Type" => "text/plain"}, ["Run for #{duration.total} #{Process.pid}"]]
+  [200, { "Content-Type" => "text/plain" }, ["Run for #{duration.total} #{Process.pid}"]]
 end

--- a/test/config/custom_logger.rb
+++ b/test/config/custom_logger.rb
@@ -1,5 +1,5 @@
 class CustomLogger
-  def initialize(output=STDOUT)
+  def initialize(output = STDOUT)
     @output = output
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -63,7 +63,7 @@ def hit(uris)
         Net::HTTP.get(URI.parse(u))
       else
         url = URI.parse(u[0])
-        Net::HTTP.new(url.host, url.port).start {|h| h.request(u[1]) }
+        Net::HTTP.new(url.host, url.port).start { |h| h.request(u[1]) }
       end
 
     assert response, "Didn't get a response: #{u}"
@@ -143,7 +143,6 @@ if ENV['CI']
 end
 
 module TestSkips
-
   HAS_FORK = ::Process.respond_to? :fork
   UNIX_SKT_EXIST = Object.const_defined?(:UNIXSocket) && !Puma::IS_WINDOWS
 
@@ -289,7 +288,7 @@ module AggregatedResults
     io.puts "Errors & Failures:" unless filtered_results.empty?
 
     filtered_results.each_with_index { |result, i|
-      io.puts "\n%3d) %s" % [i+1, result]
+      io.puts "\n%3d) %s" % [i + 1, result]
     }
     io.puts
     io

--- a/test/helpers/apps.rb
+++ b/test/helpers/apps.rb
@@ -1,12 +1,10 @@
 module TestApps
-
   # call with "GET /sleep<d> HTTP/1.1\r\n\r\n", where is the number of
   # seconds to sleep
   # same as rackup/sleep.ru
   SLEEP = -> (env) do
     dly = (env['REQUEST_PATH'][/\/sleep(\d+)/,1] || '0').to_i
     sleep dly
-    [200, {"Content-Type" => "text/plain"}, ["Slept #{dly}"]]
+    [200, { "Content-Type" => "text/plain" }, ["Slept #{dly}"]]
   end
-
 end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -104,7 +104,7 @@ class TestIntegration < Minitest::Test
     STDOUT.syswrite "\n#{full_name}\n  #{cmd}\n" if log
 
     if merge_err
-      @server = IO.popen(env, cmd, :err=>[:child, :out])
+      @server = IO.popen(env, cmd, :err => [:child, :out])
     else
       @server = IO.popen(env, cmd)
     end
@@ -353,7 +353,7 @@ class TestIntegration < Minitest::Test
 
     cmd = "#{BASE} #{pumactl_path} #{arg}"
 
-    io = IO.popen(cmd, :err=>[:child, :out])
+    io = IO.popen(cmd, :err => [:child, :out])
     @ios_to_close << io
     io
   end
@@ -387,7 +387,7 @@ class TestIntegration < Minitest::Test
     restart_count = 0
     client_threads = []
 
-    num_requests = (total_requests/num_threads).to_i
+    num_requests = (total_requests / num_threads).to_i
 
     num_threads.times do |thread|
       client_threads << Thread.new do

--- a/test/helpers/test_puma.rb
+++ b/test/helpers/test_puma.rb
@@ -3,7 +3,6 @@
 require 'socket'
 
 module TestPuma
-
   RESP_SPLIT = "\r\n\r\n"
   LINE_SPLIT = "\r\n"
 
@@ -29,7 +28,7 @@ module TestPuma
 
   LOCALHOST = ENV.fetch 'PUMA_CI_DFLT_HOST', 'localhost'
 
-  if ENV['PUMA_CI_DFLT_IP'] =='IPv6'
+  if ENV['PUMA_CI_DFLT_IP'] == 'IPv6'
     HOST     = HOST6
     ALT_HOST = HOST4
   else

--- a/test/helpers/test_puma/puma_socket.rb
+++ b/test/helpers/test_puma/puma_socket.rb
@@ -5,7 +5,6 @@ require_relative '../test_puma'
 require_relative 'response'
 
 module TestPuma
-
   # @!macro [new] req
   #   @param req [String, GET_11] request path
 

--- a/test/helpers/test_puma/response.rb
+++ b/test/helpers/test_puma/response.rb
@@ -1,5 +1,4 @@
 module TestPuma
-
   # A subclass of String, allows processing the response returned by
   # `PumaSocket#send_http_read_response` and the `read_response` method added
   # to native socket instances (created with `PumaSocket#new_socket` and
@@ -47,7 +46,7 @@ module TestPuma
         size = size.to_i 16
 
         decoded << body.byteslice(0, size)
-        body = body.byteslice (size+2)..-1       # remove segment ending "\r\n"
+        body = body.byteslice (size + 2)..-1       # remove segment ending "\r\n"
         break if body.empty? || body.nil?
       end
       decoded

--- a/test/helpers/tmp_path.rb
+++ b/test/helpers/tmp_path.rb
@@ -26,7 +26,7 @@ module TmpPath
       end
     end
 
-  def tmp_path(extension=nil)
+  def tmp_path(extension = nil)
     path = Tempfile.create(['', extension], PUMA_TMPDIR) { |f| f.path }
     tmp_paths << path
     path

--- a/test/minitest/verbose_progress_plugin.rb
+++ b/test/minitest/verbose_progress_plugin.rb
@@ -3,7 +3,7 @@ module Minitest
   def self.plugin_verbose_progress_init(options)
     if options[:verbose]
       self.reporter.reporters.
-        delete_if {|r| r.is_a?(ProgressReporter)}.
+        delete_if { |r| r.is_a?(ProgressReporter) }.
         push(VerboseProgressReporter.new(options[:io], options))
     end
   end

--- a/test/rackup/big_file.ru
+++ b/test/rackup/big_file.ru
@@ -3,5 +3,5 @@ File.write(static_file_path, "Hello World" * 100_000)
 
 run lambda { |env|
   f = File.open(static_file_path)
-  [200, {"Content-Type" => "text/plain", "Content-Length" => f.size.to_s}, f]
+  [200, { "Content-Type" => "text/plain", "Content-Length" => f.size.to_s }, f]
 }

--- a/test/rackup/big_response.ru
+++ b/test/rackup/big_response.ru
@@ -1,1 +1,1 @@
-run lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Hello World" * 100_000]] }
+run lambda { |env| [200, { "Content-Type" => "text/plain" }, ["Hello World" * 100_000]] }

--- a/test/rackup/ci_io.ru
+++ b/test/rackup/ci_io.ru
@@ -32,7 +32,7 @@ run lambda { |env|
     sleep dly.to_f
   end
   len = (t = env[hdr_body_conf]) ? t[/\d+\z/].to_i : env_len
-  headers[hdr_content_length] = (1024*len).to_s
+  headers[hdr_content_length] = (1024 * len).to_s
   fn = format fn_format, len
   body = File.open fn
   [200, headers, body]

--- a/test/rackup/ci_select.ru
+++ b/test/rackup/ci_select.ru
@@ -74,7 +74,7 @@ run lambda { |env|
   when :s      # body is a single string in an array
     headers[hdr_content_length] = (1_024 * len).to_s
     body = cache_string[hash_key] ||= begin
-      info << str_1kb.byteslice(0, info_len_adj) << "\n" << (str_1kb * (len-1))
+      info << str_1kb.byteslice(0, info_len_adj) << "\n" << (str_1kb * (len - 1))
       [info]
     end
   end

--- a/test/rackup/ci_string.ru
+++ b/test/rackup/ci_string.ru
@@ -40,7 +40,7 @@ run lambda { |env|
 
   headers[hdr_content_length] = (1_024 * len).to_s
   body = cache_string[hash_key] ||= begin
-    info << str_1kb.byteslice(0, info_len_adj) << "\n" << (str_1kb * (len-1))
+    info << str_1kb.byteslice(0, info_len_adj) << "\n" << (str_1kb * (len - 1))
     [info]
   end
   [200, headers, body]

--- a/test/rackup/env-dump.ru
+++ b/test/rackup/env-dump.ru
@@ -2,5 +2,5 @@ run lambda { |env|
   body = +"#{'─' * 70} Headers\n"
   env.sort.each { |k,v| body << "#{k.ljust 30} #{v}\n" }
   body << "#{'─' * 78}\n"
-  [200, {"Content-Type" => "text/plain"}, [body]]
+  [200, { "Content-Type" => "text/plain" }, [body]]
 }

--- a/test/rackup/hello-bind.ru
+++ b/test/rackup/hello-bind.ru
@@ -1,2 +1,2 @@
 #\ -O bind=tcp://127.0.0.1:9292
-run lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Hello World"]] }
+run lambda { |env| [200, { "Content-Type" => "text/plain" }, ["Hello World"]] }

--- a/test/rackup/hello-bind_rack3.ru
+++ b/test/rackup/hello-bind_rack3.ru
@@ -1,1 +1,1 @@
-run lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Hello World"]] }
+run lambda { |env| [200, { "Content-Type" => "text/plain" }, ["Hello World"]] }

--- a/test/rackup/hello-env.ru
+++ b/test/rackup/hello-env.ru
@@ -1,2 +1,2 @@
 ENV["RAND"] ||= rand.to_s
-run lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Hello RAND #{ENV["RAND"]}"]] }
+run lambda { |env| [200, { "Content-Type" => "text/plain" }, ["Hello RAND #{ENV["RAND"]}"]] }

--- a/test/rackup/hello.ru
+++ b/test/rackup/hello.ru
@@ -1,3 +1,3 @@
-hdrs = {'Content-Type'.freeze => 'text/plain'.freeze}.freeze
+hdrs = { 'Content-Type'.freeze => 'text/plain'.freeze }.freeze
 body = ['Hello World'.freeze].freeze
 run lambda { |env| [200, hdrs, body] }

--- a/test/rackup/hello_with_delay.ru
+++ b/test/rackup/hello_with_delay.ru
@@ -1,4 +1,4 @@
 run lambda { |env|
   sleep 0.001
-  [200, {"Content-Type" => "text/plain"}, ["Hello World"]]
+  [200, { "Content-Type" => "text/plain" }, ["Hello World"]]
 }

--- a/test/rackup/sleep.ru
+++ b/test/rackup/sleep.ru
@@ -5,5 +5,5 @@
 run lambda { |env|
   dly = (env['REQUEST_PATH'][/\/sleep(\d+)/,1] || '0').to_i
   sleep dly
-  [200, {"Content-Type" => "text/plain"}, ["Slept #{dly}"]]
+  [200, { "Content-Type" => "text/plain" }, ["Slept #{dly}"]]
 }

--- a/test/rackup/sleep_pid.ru
+++ b/test/rackup/sleep_pid.ru
@@ -4,5 +4,5 @@
 run lambda { |env|
   dly = (env['REQUEST_PATH'][/\/sleep(\d+)/,1] || '0').to_i
   sleep dly
-  [200, {"Content-Type" => "text/plain"}, ["Slept #{dly} #{Process.pid}"]]
+  [200, { "Content-Type" => "text/plain" }, ["Slept #{dly} #{Process.pid}"]]
 }

--- a/test/rackup/sleep_step.ru
+++ b/test/rackup/sleep_step.ru
@@ -6,5 +6,5 @@ run lambda { |env|
   dly = (p[/\/sleep(\d+)/,1] || '0').to_i
   step = p[/(\d+)\z/,1].to_i
   sleep dly
-  [200, {"Content-Type" => "text/plain"}, ["Slept #{dly} #{step}"]]
+  [200, { "Content-Type" => "text/plain" }, ["Slept #{dly} #{step}"]]
 }

--- a/test/rackup/url_scheme.ru
+++ b/test/rackup/url_scheme.ru
@@ -1,1 +1,1 @@
-run lambda { |env| [200, {"Content-Type" => "text/plain"}, [env["rack.url_scheme"]]] }
+run lambda { |env| [200, { "Content-Type" => "text/plain" }, [env["rack.url_scheme"]]] }

--- a/test/rackup/write_to_stdout.ru
+++ b/test/rackup/write_to_stdout.ru
@@ -1,6 +1,6 @@
 app = lambda do |env|
   $stdout.write "hello\n"
-  [200, {"Content-Type" => "text/plain"}, ["Hello World"]]
+  [200, { "Content-Type" => "text/plain" }, ["Hello World"]]
 end
 
 run app

--- a/test/rackup/write_to_stdout_on_boot.ru
+++ b/test/rackup/write_to_stdout_on_boot.ru
@@ -1,2 +1,2 @@
 puts "Loading app"
-run lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Hello World"]] }
+run lambda { |env| [200, { "Content-Type" => "text/plain" }, ["Hello World"]] }

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -43,7 +43,7 @@ class TestBinderParallel < TestBinderBase
 
   def test_synthesize_binds_from_activated_fds_non_matching_together
     binds = ['tcp://0.0.0.0:3000']
-    sockets = {['tcp', '0.0.0.0', '5000'] => nil}
+    sockets = { ['tcp', '0.0.0.0', '5000'] => nil }
     @binder.instance_variable_set(:@activated_sockets, sockets)
     result = @binder.synthesize_binds_from_activated_fs(binds, false)
 
@@ -52,7 +52,7 @@ class TestBinderParallel < TestBinderBase
 
   def test_synthesize_binds_from_activated_fds_non_matching_only
     binds = ['tcp://0.0.0.0:3000']
-    sockets = {['tcp', '0.0.0.0', '5000'] => nil}
+    sockets = { ['tcp', '0.0.0.0', '5000'] => nil }
     @binder.instance_variable_set(:@activated_sockets, sockets)
     result = @binder.synthesize_binds_from_activated_fs(binds, true)
 
@@ -142,7 +142,7 @@ class TestBinderParallel < TestBinderBase
     @binder.parse ["tcp://localhost:0"], @log_writer
 
     assert_match %r!http://127.0.0.1:(\d+)!, @log_writer.stdout.string
-    if Socket.ip_address_list.any? {|i| i.ipv6_loopback? }
+    if Socket.ip_address_list.any? { |i| i.ipv6_loopback? }
       assert_match %r!http://\[::1\]:(\d+)!, @log_writer.stdout.string
     end
   end
@@ -153,7 +153,7 @@ class TestBinderParallel < TestBinderBase
     @binder.parse ["ssl://localhost:0?#{ssl_query}"], @log_writer
 
     assert_match %r!ssl://127.0.0.1:(\d+)!, @log_writer.stdout.string
-    if Socket.ip_address_list.any? {|i| i.ipv6_loopback? }
+    if Socket.ip_address_list.any? { |i| i.ipv6_loopback? }
       assert_match %r!ssl://\[::1\]:(\d+)!, @log_writer.stdout.string
     end
   end

--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -10,11 +10,11 @@ class TestBusyWorker < Minitest::Test
   def teardown
     return if skipped?
     @server&.stop true
-    @ios.each {|i| i.close unless i.closed?}
+    @ios.each { |i| i.close unless i.closed? }
   end
 
   def new_connection
-    TCPSocket.new('127.0.0.1', @port).tap {|s| @ios << s}
+    TCPSocket.new('127.0.0.1', @port).tap { |s| @ios << s }
   rescue IOError
     Puma::Util.purge_interrupt_queue
     retry

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -248,7 +248,6 @@ class TestCLI < Minitest::Test
     t.join if UNIX_SKT_EXIST
   end
 
-
   def test_tmp_control
     skip_if :jruby, suffix: " - Unknown issue"
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -36,7 +36,7 @@ class TestConfigFile < TestConfigFileBase
       conf.app
     end
 
-    assert_equal [200, {"Content-Type"=>"text/plain"}, ["Hello World"]], conf.app.call({})
+    assert_equal [200, { "Content-Type" => "text/plain" }, ["Hello World"]], conf.app.call({})
 
     assert_equal [bind], conf.options[:binds]
   end
@@ -571,7 +571,7 @@ class TestConfigFile < TestConfigFileBase
   def test_http_content_length_limit
     assert_nil Puma::Configuration.new.options.default_options[:http_content_length_limit]
 
-    conf = Puma::Configuration.new({ http_content_length_limit: 10000})
+    conf = Puma::Configuration.new({ http_content_length_limit: 10000 })
 
     assert_equal 10000, conf.final_options[:http_content_length_limit]
   end

--- a/test/test_error_logger.rb
+++ b/test/test_error_logger.rb
@@ -10,7 +10,6 @@ class TestErrorLogger < Minitest::Test
     assert_equal STDERR, error_logger.ioerr
   end
 
-
   def test_stdio_respects_sync
     error_logger = Puma::ErrorLogger.stdio
 

--- a/test/test_http11.rb
+++ b/test/test_http11.rb
@@ -71,7 +71,6 @@ class Http11ParserTest < Minitest::Test
 
     parser.reset
     assert parser.nread == 0, "Number read after reset should be 0"
-
   end
 
   def test_parse_dumbfuck_headers
@@ -126,8 +125,8 @@ class Http11ParserTest < Minitest::Test
   end
 
   # lame random garbage maker
-  def rand_data(min, max, readable=true)
-    count = min + ((rand(max)+1) *10).to_i
+  def rand_data(min, max, readable = true)
+    count = min + ((rand(max) + 1) * 10).to_i
     res = count.to_s + "/"
 
     if readable
@@ -164,7 +163,7 @@ class Http11ParserTest < Minitest::Test
 
     # then that large header names are caught
     10.times do |c|
-      get = "GET /#{rand_data(10,120)} HTTP/1.1\r\nX-#{rand_data(1024, 1024+(c*1024))}: Test\r\n\r\n"
+      get = "GET /#{rand_data(10,120)} HTTP/1.1\r\nX-#{rand_data(1024, 1024 + (c * 1024))}: Test\r\n\r\n"
       assert_raises Puma::HttpParserError do
         parser.execute({}, get, 0)
         parser.reset
@@ -173,7 +172,7 @@ class Http11ParserTest < Minitest::Test
 
     # then that large mangled field values are caught
     10.times do |c|
-      get = "GET /#{rand_data(10,120)} HTTP/1.1\r\nX-Test: #{rand_data(1024, 1024+(c*1024), false)}\r\n\r\n"
+      get = "GET /#{rand_data(10,120)} HTTP/1.1\r\nX-Test: #{rand_data(1024, 1024 + (c * 1024), false)}\r\n\r\n"
       assert_raises Puma::HttpParserError do
         parser.execute({}, get, 0)
         parser.reset
@@ -190,7 +189,7 @@ class Http11ParserTest < Minitest::Test
 
     # finally just that random garbage gets blocked all the time
     10.times do |c|
-      get = "GET #{rand_data(1024, 1024+(c*1024), false)} #{rand_data(1024, 1024+(c*1024), false)}\r\n\r\n"
+      get = "GET #{rand_data(1024, 1024 + (c * 1024), false)} #{rand_data(1024, 1024 + (c * 1024), false)}\r\n\r\n"
       assert_raises Puma::HttpParserError do
         parser.execute({}, get, 0)
         parser.reset

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -551,7 +551,7 @@ class TestIntegrationCluster < TestIntegration
 
   def test_worker_hook_warning_web_concurrency
     cli_server "test/rackup/hello.ru",
-      env: { 'WEB_CONCURRENCY' => '2'},
+      env: { 'WEB_CONCURRENCY' => '2' },
       config: <<~CONFIG
       on_worker_boot(:test) do |index, data|
         data[:test] = index
@@ -606,13 +606,13 @@ class TestIntegrationCluster < TestIntegration
     41.times.each do |i|
       if i == 10
         threads << Thread.new do
-          sleep i.to_f/div
+          sleep i.to_f / div
           Process.kill :TERM, @pid
           mutex.synchronize { replies[i] = :term_sent }
         end
       else
         threads << Thread.new do
-          thread_run_step replies, i.to_f/div, 1, i, mutex, refused, unix: unix
+          thread_run_step replies, i.to_f / div, 1, i, mutex, refused, unix: unix
         end
       end
     end

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -42,7 +42,7 @@ class TestIntegrationPumactl < TestIntegration
     ctl_unix 'halt'
   end
 
-  def ctl_unix(signal='stop')
+  def ctl_unix(signal = 'stop')
     skip_unless :unix
     stderr = Tempfile.new(%w(stderr .log))
 

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -185,7 +185,7 @@ class TestIntegrationSingle < TestIntegration
 
     system "curl http://localhost:#{@tcp_port}/ > /dev/null 2>&1"
 
-    out=`#{BASE} bin/pumactl -F test/config/t2_conf.rb status`
+    out = `#{BASE} bin/pumactl -F test/config/t2_conf.rb status`
 
     stop_server
 

--- a/test/test_integration_ssl.rb
+++ b/test/test_integration_ssl.rb
@@ -161,7 +161,7 @@ class TestIntegrationSSL < TestIntegration
     skip_if :windows; require 'stringio'
 
     app = lambda { |_| [200, { 'Content-Type' => 'text/plain' }, ["HELLO", ' ', "THERE"]] }
-    opts = {max_threads: 1}
+    opts = { max_threads: 1 }
     server = Puma::Server.new app, nil, opts
     if Puma.jruby?
       ssl_params = {

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -74,7 +74,7 @@ class TestLauncher < Minitest::Test
 
   def test_puma_stats
     conf = Puma::Configuration.new do |c|
-      c.app -> {[200, {}, ['']]}
+      c.app -> { [200, {}, ['']] }
       c.clear_binds!
     end
     launcher = launcher(conf)
@@ -93,7 +93,7 @@ class TestLauncher < Minitest::Test
     skip_unless :fork
 
     conf = Puma::Configuration.new do |c|
-      c.app -> {[200, {}, ['']]}
+      c.app -> { [200, {}, ['']] }
       c.workers 1
       c.clear_binds!
     end
@@ -127,7 +127,7 @@ class TestLauncher < Minitest::Test
 
   def test_fire_on_stopped
     conf = Puma::Configuration.new do |c|
-      c.app -> {[200, {}, ['']]}
+      c.app -> { [200, {}, ['']] }
       c.port UniquePort.call
     end
 

--- a/test/test_log_writer.rb
+++ b/test/test_log_writer.rb
@@ -123,9 +123,9 @@ class TestLogWriter < Minitest::Test
   end
 
   def test_parse_error
-    app = proc { |_env| [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
+    app = proc { |_env| [200, { "Content-Type" => "plain/text" }, ["hello\n"]] }
     log_writer = Puma::LogWriter.strings
-    server = Puma::Server.new app, nil, {log_writer: log_writer}
+    server = Puma::Server.new app, nil, { log_writer: log_writer }
 
     host = '127.0.0.1'
     port = (server.add_tcp_listener host, 0).addr[1]
@@ -133,7 +133,7 @@ class TestLogWriter < Minitest::Test
 
     sock = TCPSocket.new host, port
     path = "/"
-    params = "a"*1024*10
+    params = "a" * 1024 * 10
 
     sock << "GET #{path}?a=#{params} HTTP/1.1\r\nConnection: close\r\n\r\n"
     sock.read
@@ -175,6 +175,5 @@ class TestLogWriter < Minitest::Test
     assert_includes error, "SSL error"
     assert_includes error, "peer: <unknown>"
     assert_includes error, "cert: :"
-
   end if ::Puma::HAS_SSL
 end

--- a/test/test_out_of_band_server.rb
+++ b/test/test_out_of_band_server.rb
@@ -26,7 +26,7 @@ class TestOutOfBandServer < Minitest::Test
   end
 
   def new_connection
-    TCPSocket.new('127.0.0.1', @port).tap {|s| @ios << s}
+    TCPSocket.new('127.0.0.1', @port).tap { |s| @ios << s }
   rescue IOError
     Puma::Util.purge_interrupt_queue
     retry
@@ -95,7 +95,7 @@ class TestOutOfBandServer < Minitest::Test
   def test_stream
     oob_server app_wait: true, max_threads: 2
     n = 100
-    Array.new(n) {send_http("GET / HTTP/1.0\r\n\r\n")}
+    Array.new(n) { send_http("GET / HTTP/1.0\r\n\r\n") }
     Thread.pass until @request_count == n
     @mutex.synchronize do
       @app_finished.signal
@@ -145,7 +145,7 @@ class TestOutOfBandServer < Minitest::Test
     oob_server max_threads: 2
     @mutex.synchronize do
       send_http("GET / HTTP/1.0\r\n\r\n")
-      100.times {new_connection.close}
+      100.times { new_connection.close }
       @oob_finished.wait(@mutex, 1)
     end
     assert_equal 1, @oob_count
@@ -160,7 +160,7 @@ class TestOutOfBandServer < Minitest::Test
     end
     accepted = false
     io = @server.binder.ios.last
-    io.stub(:accept_nonblock, -> {accepted = true; new_connection}) do
+    io.stub(:accept_nonblock, -> { accepted = true; new_connection }) do
       new_connection.close
       sleep 0.01
     end

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -10,7 +10,7 @@ class TestPersistent < Minitest::Test
     @http10_request = "GET / HTTP/1.0\r\nHost: test.com\r\nContent-Type: text/plain\r\n\r\n"
     @keep_request   = "GET / HTTP/1.0\r\nHost: test.com\r\nContent-Type: text/plain\r\nConnection: Keep-Alive\r\n\r\n"
 
-    @valid_post    = "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello"
+    @valid_post = "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello"
     @valid_no_body  = "GET / HTTP/1.1\r\nHost: test.com\r\nX-Status: 204\r\nContent-Type: text/plain\r\n\r\n"
 
     @headers = { "X-Header" => "Works" }
@@ -23,7 +23,7 @@ class TestPersistent < Minitest::Test
       [status, @headers, @body]
     end
 
-    opts = {max_threads: 1}
+    opts = { max_threads: 1 }
     @server = Puma::Server.new @simple, nil, opts
     @port = (@server.add_tcp_listener HOST, 0).addr[1]
     @server.run
@@ -36,7 +36,7 @@ class TestPersistent < Minitest::Test
     @server.stop(true)
   end
 
-  def lines(count, s=@client)
+  def lines(count, s = @client)
     str = +''
     Timeout.timeout(5) do
       count.times { str << (s.gets || "") }
@@ -128,7 +128,6 @@ class TestPersistent < Minitest::Test
     @client << @valid_request
 
     assert_equal "HTTP/1.1 200 OK\r\nX-Header: Works\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n#{str.size.to_s(16)}\r\n#{str}\r\n0\r\n\r\n", lines(10)
-
   end
 
   def test_client11_close
@@ -182,7 +181,7 @@ class TestPersistent < Minitest::Test
   end
 
   def test_allow_app_to_chunk_itself
-    @headers = {'Transfer-Encoding' => "chunked" }
+    @headers = { 'Transfer-Encoding' => "chunked" }
 
     @body = ["5\r\nhello\r\n0\r\n\r\n"]
 
@@ -190,7 +189,6 @@ class TestPersistent < Minitest::Test
 
     assert_equal "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n", lines(7)
   end
-
 
   def test_two_requests_in_one_chunk
     @server.instance_variable_set(:@persistent_timeout, 3)

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -20,7 +20,7 @@ class TestPluginSystemd < TestIntegration
       @socket = Socket.new(:UNIX, :DGRAM, 0)
       socket_ai = Addrinfo.unix(sockaddr)
       @socket.bind(socket_ai)
-      @env = {"NOTIFY_SOCKET" => sockaddr }
+      @env = { "NOTIFY_SOCKET" => sockaddr }
     end
   end
 
@@ -47,7 +47,7 @@ class TestPluginSystemd < TestIntegration
   end
 
   def test_systemd_watchdog
-    wd_env = @env.merge({"WATCHDOG_USEC" => "1_000_000"})
+    wd_env = @env.merge({ "WATCHDOG_USEC" => "1_000_000" })
     cli_server "test/rackup/hello.ru", env: wd_env
     assert_message "READY=1"
 

--- a/test/test_plugin_systemd_jruby.rb
+++ b/test/test_plugin_systemd_jruby.rb
@@ -27,7 +27,7 @@ class TestPluginSystemdJruby < TestIntegration
 
   def test_systemd_plugin_not_loaded
     cli_server "test/rackup/hello.ru",
-      env: {'NOTIFY_SOCKET' => '/tmp/doesntmatter' }, config: <<~CONFIG
+      env: { 'NOTIFY_SOCKET' => '/tmp/doesntmatter' }, config: <<~CONFIG
       app do |_|
         [200, {}, [Puma::Plugins.instance_variable_get(:@plugins)['systemd'].to_s]]
       end

--- a/test/test_puma_localhost_authority.rb
+++ b/test/test_puma_localhost_authority.rb
@@ -28,7 +28,7 @@ class TestPumaLocalhostAuthority < Minitest::Test
     app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
 
     @log_writer = SSLLogWriterHelper.new STDOUT, STDERR
-    @server = Puma::Server.new app, nil, {log_writer: @log_writer}
+    @server = Puma::Server.new app, nil, { log_writer: @log_writer }
     @server.add_ssl_listener LOCALHOST, 0, nil
     @bind_port = @server.connected_ports[0]
     @server.run
@@ -54,7 +54,7 @@ class TestPumaSSLLocalhostAuthority < Minitest::Test
 
     @log_writer = SSLLogWriterHelper.new STDOUT, STDERR
 
-    @server = Puma::Server.new app, nil, {log_writer: @log_writer}
+    @server = Puma::Server.new app, nil, { log_writer: @log_writer }
     @server.app = app
 
     @server.add_ssl_listener LOCALHOST, 0, nil

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -24,7 +24,7 @@ class TestPumaServer < Minitest::Test
 
     @log_writer = Puma::LogWriter.strings
     @events = Puma::Events.new
-    @server = Puma::Server.new @app, @events, {log_writer: @log_writer}
+    @server = Puma::Server.new @app, @events, { log_writer: @log_writer }
   end
 
   def teardown
@@ -105,7 +105,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def new_connection
-    TCPSocket.new(@host, @port).tap {|socket| @ios << socket}
+    TCPSocket.new(@host, @port).tap { |socket| @ios << socket }
   end
 
   def test_normalize_host_header_missing
@@ -322,7 +322,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_HEAD_has_no_body
-    server_run { [200, {"Foo" => "Bar"}, ["hello"]] }
+    server_run { [200, { "Foo" => "Bar" }, ["hello"]] }
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
@@ -386,7 +386,6 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_early_hints_are_ignored_if_connection_lost
-
     server_run(early_hints: true) do |env|
       env['rack.early_hints'].call("Link" => "</script.js>; rel=preload")
       [200, { "X-Hello" => "World" }, ["Hello world!"]]
@@ -445,7 +444,6 @@ class TestPumaServer < Minitest::Test
 
     # Content Too Large
     assert_equal ["HTTP/1.1 413 #{STATUS_CODES[413]}", "Content-Length: 17"], h
-
   end
 
   def test_GET_with_no_body_has_sane_chunking
@@ -476,7 +474,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_force_shutdown_custom_error_message
-    handler = lambda {|err, env, status| [500, {"Content-Type" => "application/json"}, ["{}\n"]]}
+    handler = lambda { |err, env, status| [500, { "Content-Type" => "application/json" }, ["{}\n"]] }
     server_run(lowlevel_error_handler: handler, force_shutdown_after: 2) do
       @server.stop
       sleep 5
@@ -555,7 +553,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_prints_custom_error
-    re = lambda { |err| [302, {'Content-Type' => 'text', 'Location' => 'foo.html'}, ['302 found']] }
+    re = lambda { |err| [302, { 'Content-Type' => 'text', 'Location' => 'foo.html' }, ['302 found']] }
     server_run(lowlevel_error_handler: re) { raise "don't leak me bro" }
 
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
@@ -566,7 +564,7 @@ class TestPumaServer < Minitest::Test
   def test_leh_gets_env_as_well
     re = lambda { |err,env|
       env['REQUEST_PATH'] || raise('where is env?')
-      [302, {'Content-Type' => 'text', 'Location' => 'foo.html'}, ['302 found']]
+      [302, { 'Content-Type' => 'text', 'Location' => 'foo.html' }, ['302 found']]
     }
 
     server_run(lowlevel_error_handler: re) { raise "don't leak me bro" }
@@ -579,7 +577,7 @@ class TestPumaServer < Minitest::Test
   def test_leh_has_status
     re = lambda { |err, env, status|
       raise "Cannot find status" unless status
-      [302, {'Content-Type' => 'text', 'Location' => 'foo.html'}, ['302 found']]
+      [302, { 'Content-Type' => 'text', 'Location' => 'foo.html' }, ['302 found']]
     }
 
     server_run(lowlevel_error_handler: re) { raise "don't leak me bro" }
@@ -606,8 +604,8 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_HEAD_returns_content_headers
-    server_run { [200, {"Content-Type" => "application/pdf",
-                                     "Content-Length" => "4242"}, []] }
+    server_run { [200, { "Content-Type" => "application/pdf",
+                                     "Content-Length" => "4242" }, []] }
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
@@ -615,7 +613,6 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_status_hook_fires_when_server_changes_states
-
     states = []
 
     @events.register(:state) { |s| states << s }
@@ -668,7 +665,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_no_timeout_after_data_received_no_queue
-    @server = Puma::Server.new @app, @events, {log_writer: @log_writer, queue_requests: false}
+    @server = Puma::Server.new @app, @events, { log_writer: @log_writer, queue_requests: false }
     test_no_timeout_after_data_received
   end
 
@@ -802,7 +799,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_http_11_keep_alive_with_body
-    server_run { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
+    server_run { [200, { "Content-Type" => "plain/text" }, ["hello\n"]] }
 
     socket = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\n\r\n"
 
@@ -817,7 +814,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_http_11_close_with_body
-    server_run { [200, {"Content-Type" => "plain/text"}, ["hello"]] }
+    server_run { [200, { "Content-Type" => "plain/text" }, ["hello"]] }
 
     data = send_http_and_read "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
 
@@ -847,7 +844,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_http_10_keep_alive_with_body
-    server_run { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
+    server_run { [200, { "Content-Type" => "plain/text" }, ["hello\n"]] }
 
     socket = send_http "GET / HTTP/1.0\r\nConnection: Keep-Alive\r\n\r\n"
 
@@ -860,7 +857,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_http_10_close_with_body
-    server_run { [200, {"Content-Type" => "plain/text"}, ["hello"]] }
+    server_run { [200, { "Content-Type" => "plain/text" }, ["hello"]] }
 
     data = send_http_and_read "GET / HTTP/1.0\r\nConnection: close\r\n\r\n"
 
@@ -1210,8 +1207,8 @@ class TestPumaServer < Minitest::Test
     socket.wait_readable 5
     resp = socket.sysread 2_048
     assert_equal "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", resp
-    assert_equal 9*1_024, body.bytesize
-    assert_equal 9*1_024, content_length.to_i
+    assert_equal 9 * 1_024, body.bytesize
+    assert_equal 9 * 1_024, content_length.to_i
     assert_equal '012345678', body.delete('x')
   end
 
@@ -1295,7 +1292,7 @@ class TestPumaServer < Minitest::Test
   def test_chunked_keep_alive_two_back_to_back_with_set_remote_address
     body = nil
     content_length = nil
-    remote_addr =nil
+    remote_addr = nil
     server_run(remote_address: :header, remote_address_header: 'HTTP_X_FORWARDED_FOR') { |env|
       body = env['rack.input'].read
       content_length = env['CONTENT_LENGTH']
@@ -1350,7 +1347,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_empty_header_values
-    server_run { [200, {"X-Empty-Header" => ""}, []] }
+    server_run { [200, { "X-Empty-Header" => "" }, []] }
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
@@ -1408,7 +1405,7 @@ class TestPumaServer < Minitest::Test
 
   # Rack may pass a newline in a header expecting us to split it.
   def test_newline_splits
-    server_run { [200, {'X-header' => "first line\nsecond line"}, ["Hello"]] }
+    server_run { [200, { 'X-header' => "first line\nsecond line" }, ["Hello"]] }
 
     data = send_http_and_read "HEAD / HTTP/1.0\r\n\r\n"
 
@@ -1417,7 +1414,7 @@ class TestPumaServer < Minitest::Test
 
   def test_newline_splits_in_early_hint
     server_run(early_hints: true) do |env|
-      env['rack.early_hints'].call({'X-header' => "first line\nsecond line"})
+      env['rack.early_hints'].call({ 'X-header' => "first line\nsecond line" })
       [200, {}, ["Hello world!"]]
     end
 
@@ -1464,10 +1461,10 @@ class TestPumaServer < Minitest::Test
   # There are three different tests because there are three ways to set header
   # content in Puma. Regular (rack env), early hints, and a special case for
   # overriding content-length.
-  {"cr" => "\r", "lf" => "\n", "crlf" => "\r\n"}.each do |suffix, line_ending|
+  { "cr" => "\r", "lf" => "\n", "crlf" => "\r\n" }.each do |suffix, line_ending|
     # The cr-only case for the following test was CVE-2020-5247
     define_method(:"test_prevent_response_splitting_headers_#{suffix}") do
-      app = ->(_) { [200, {'X-header' => "untrusted input#{line_ending}Cookie: hack"}, ["Hello"]] }
+      app = ->(_) { [200, { 'X-header' => "untrusted input#{line_ending}Cookie: hack" }, ["Hello"]] }
       assert_does_not_allow_http_injection(app)
     end
 
@@ -1480,7 +1477,7 @@ class TestPumaServer < Minitest::Test
     end
 
     define_method(:"test_prevent_content_length_injection_#{suffix}") do
-      app = ->(_) { [200, {'content-length' => "untrusted input#{line_ending}Cookie: hack"}, ["Hello"]] }
+      app = ->(_) { [200, { 'content-length' => "untrusted input#{line_ending}Cookie: hack" }, ["Hello"]] }
       assert_does_not_allow_http_injection(app)
     end
   end
@@ -1548,7 +1545,7 @@ class TestPumaServer < Minitest::Test
 
   # Shutdown should allow pending requests and app-responses to complete.
   def test_shutdown_requests
-    opts = {s1_response: /204/, s2_response: /204/}
+    opts = { s1_response: /204/, s2_response: /204/ }
     shutdown_requests(**opts)
     shutdown_requests(**opts, queue_requests: false)
   end
@@ -1556,7 +1553,7 @@ class TestPumaServer < Minitest::Test
   # Requests still pending after `force_shutdown_after` should have connection closed (408 w/pending POST body).
   # App-responses still pending should return 503 (uncaught Puma::ThreadPool::ForceShutdown exception).
   def test_force_shutdown
-    opts = {s1_complete: false, s1_response: /503/, s2_response: nil, force_shutdown_after: 0}
+    opts = { s1_complete: false, s1_response: /503/, s2_response: nil, force_shutdown_after: 0 }
     shutdown_requests(**opts)
     shutdown_requests(**opts, queue_requests: false)
     shutdown_requests(**opts, post: true, s2_response: /408/)
@@ -1623,7 +1620,7 @@ class TestPumaServer < Minitest::Test
   # Retryable errors such as ECONNABORTED should be silently swallowed by accept loop.
   def test_accept_econnaborted
     # Match Ruby #accept_nonblock implementation, ECONNABORTED error is extended by IO::WaitReadable.
-    error = Errno::ECONNABORTED.new('accept(2) would block').tap {|e| e.extend IO::WaitReadable}
+    error = Errno::ECONNABORTED.new('accept(2) would block').tap { |e| e.extend IO::WaitReadable }
     stub_accept_nonblock(error)
     assert_empty @log_writer.stderr.string
   end
@@ -1634,7 +1631,7 @@ class TestPumaServer < Minitest::Test
   def test_client_quick_close_no_lowlevel_error_handler_call
     handler = ->(err, env, status) {
       @log_writer.stdout.write "LLEH #{err.message}"
-      [500, {"Content-Type" => "application/json"}, ["{}\n"]]
+      [500, { "Content-Type" => "application/json" }, ["{}\n"]]
     }
 
     server_run(lowlevel_error_handler: handler) { [200, {}, ['Hello World']] }
@@ -1698,7 +1695,7 @@ class TestPumaServer < Minitest::Test
   def test_custom_io_selector
     backend = NIO::Selector.backends.first
 
-    @server = Puma::Server.new @app, @events, {log_writer: @log_writer, :io_selector_backend => backend}
+    @server = Puma::Server.new @app, @events, { log_writer: @log_writer, :io_selector_backend => backend }
     @server.run
 
     selector = @server.instance_variable_get(:@reactor).instance_variable_get(:@selector)
@@ -1706,7 +1703,7 @@ class TestPumaServer < Minitest::Test
     assert_equal selector.backend, backend
   end
 
-  def test_drain_on_shutdown(drain=true)
+  def test_drain_on_shutdown(drain = true)
     num_connections = 10
 
     wait = Queue.new
@@ -1714,7 +1711,7 @@ class TestPumaServer < Minitest::Test
       wait.pop
       [200, {}, ["DONE"]]
     end
-    connections = Array.new(num_connections) {send_http "GET / HTTP/1.0\r\n\r\n"}
+    connections = Array.new(num_connections) { send_http "GET / HTTP/1.0\r\n\r\n" }
     @server.stop
     wait.close
     bad = 0
@@ -1823,7 +1820,7 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_empty_body_array_content_length_0
-    server_run { |env| [404, {'Content-Length' => '0'}, []] }
+    server_run { |env| [404, { 'Content-Length' => '0' }, []] }
 
     resp = send_http_and_sysread "GET / HTTP/1.1\r\n\r\n"
     # Not Found
@@ -1947,7 +1944,6 @@ class TestPumaServer < Minitest::Test
     resp = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
     assert_match(/\AHTTP\/1\.0 501 Not Implemented/, resp)
   end
-
 
   def spawn_cmd(env = {}, cmd)
     opts = {}

--- a/test/test_puma_server_current.rb
+++ b/test/test_puma_server_current.rb
@@ -9,7 +9,7 @@ require "puma/server"
 
 class PumaServerCurrentApplication
   def call(env)
-    [200, {"Content-Type" => "text/plain"}, [Puma::Server.current.to_s]]
+    [200, { "Content-Type" => "text/plain" }, [Puma::Server.current.to_s]]
   end
 end
 
@@ -18,7 +18,7 @@ class PumaServerCurrentTest < Minitest::Test
 
   def setup
     @tester = PumaServerCurrentApplication.new
-    @server = Puma::Server.new @tester, nil, {log_writer: Puma::LogWriter.strings, clean_thread_locals: true}
+    @server = Puma::Server.new @tester, nil, { log_writer: Puma::LogWriter.strings, clean_thread_locals: true }
     @port = (@server.add_tcp_listener "127.0.0.1", 0).addr[1]
     @tcp = "http://127.0.0.1:#{@port}"
     @url = URI.parse(@tcp)
@@ -40,6 +40,6 @@ class PumaServerCurrentTest < Minitest::Test
       end
     end
 
-    assert_equal [server_string]*3, responses
+    assert_equal [server_string] * 3, responses
   end
 end

--- a/test/test_puma_server_hijack.rb
+++ b/test/test_puma_server_hijack.rb
@@ -70,7 +70,7 @@ class TestPumaServerHijack < Minitest::Test
   end
 
   def new_connection
-    TCPSocket.new(@host, @port).tap {|sock| @ios << sock}
+    TCPSocket.new(@host, @port).tap { |sock| @ios << sock }
   end
 
   # Full hijack does not return headers
@@ -163,7 +163,7 @@ class TestPumaServerHijack < Minitest::Test
         io.write(body_parts[1])
         io.close
       end
-      [200, {"Content-Length" => "5", 'rack.hijack' => hijack_lambda}, nil]
+      [200, { "Content-Length" => "5", 'rack.hijack' => hijack_lambda }, nil]
     end
 
     # using sysread may only receive part of the response
@@ -187,7 +187,7 @@ class TestPumaServerHijack < Minitest::Test
       io.syswrite 'incorrect body.call'
       io.close
     }
-    hdrs = { 'Content-Type' => 'text/plain', 'rack.hijack' => HIJACK_LAMBDA}
+    hdrs = { 'Content-Type' => 'text/plain', 'rack.hijack' => HIJACK_LAMBDA }
     body = ::Rack::BodyProxy.new(incorrect_lambda) { @available = true }
     partial_hijack_closes_body(hdrs, body)
   end

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -50,10 +50,10 @@ class TestPumaServerSSL < Minitest::Test
     ctx = Puma::MiniSSL::Context.new
 
     if Puma.jruby?
-      ctx.keystore =  File.expand_path "../examples/puma/keystore.jks", __dir__
+      ctx.keystore = File.expand_path "../examples/puma/keystore.jks", __dir__
       ctx.keystore_pass = 'jruby_puma'
     else
-      ctx.key  =  File.expand_path "../examples/puma/puma_keypair.pem", __dir__
+      ctx.key = File.expand_path "../examples/puma/puma_keypair.pem", __dir__
       ctx.cert = File.expand_path "../examples/puma/cert_puma.pem", __dir__
     end
 
@@ -62,7 +62,7 @@ class TestPumaServerSSL < Minitest::Test
     yield ctx if block_given?
 
     @log_writer = SSLLogWriterHelper.new STDOUT, STDERR
-    @server = Puma::Server.new app, nil, {log_writer: @log_writer}
+    @server = Puma::Server.new app, nil, { log_writer: @log_writer }
     @port = (@server.add_ssl_listener HOST, 0, ctx).addr[1]
     @bind_port = @port
     @server.run
@@ -258,7 +258,7 @@ class TestPumaServerSSL < Minitest::Test
       @server&.stop true
 
       cipher_suite = 'TLS_CHACHA20_POLY1305_SHA256'
-      start_server { |ctx| ctx.ssl_ciphersuites = cipher_suite}
+      start_server { |ctx| ctx.ssl_ciphersuites = cipher_suite }
 
       cipher = send_http(ctx: new_ctx).cipher
 
@@ -281,7 +281,7 @@ class TestPumaServerSSLClient < Minitest::Test
   # Context can be shared, may help with JRuby
   CTX = Puma::MiniSSL::Context.new.tap { |ctx|
     if Puma.jruby?
-      ctx.keystore =  "#{CERT_PATH}/keystore.jks"
+      ctx.keystore = "#{CERT_PATH}/keystore.jks"
       ctx.keystore_pass = 'jruby_puma'
     else
       ctx.key  = "#{CERT_PATH}/server.key"
@@ -297,7 +297,7 @@ class TestPumaServerSSLClient < Minitest::Test
     app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
 
     log_writer = SSLLogWriterHelper.new STDOUT, STDERR
-    server = Puma::Server.new app, nil, {log_writer: log_writer}
+    server = Puma::Server.new app, nil, { log_writer: log_writer }
     server.add_ssl_listener LOCALHOST, port, context
     host_addrs = server.binder.ios.map { |io| io.to_io.addr[2] }
     @bind_port = server.connected_ports[0]
@@ -502,7 +502,7 @@ class TestPumaServerSSLWithCertPemAndKeyPem < Minitest::Test
 
     app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
     log_writer = SSLLogWriterHelper.new STDOUT, STDERR
-    server = Puma::Server.new app, nil, {log_writer: log_writer}
+    server = Puma::Server.new app, nil, { log_writer: log_writer }
     server.add_ssl_listener LOCALHOST, 0, ctx
     @bind_port = server.connected_ports[0]
     server.run
@@ -544,10 +544,10 @@ class TestPumaSSLCertChain < Minitest::Test
     app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
 
     @log_writer = SSLLogWriterHelper.new STDOUT, STDERR
-    @server = Puma::Server.new app, nil, {log_writer: @log_writer}
+    @server = Puma::Server.new app, nil, { log_writer: @log_writer }
 
     mini_ctx = Puma::MiniSSL::Context.new
-    mini_ctx.key  = "#{CHAIN_DIR}/cert.key"
+    mini_ctx.key = "#{CHAIN_DIR}/cert.key"
     yield mini_ctx
 
     @bind_port = (@server.add_ssl_listener HOST, 0, mini_ctx).addr[1]
@@ -579,7 +579,7 @@ class TestPumaSSLCertChain < Minitest::Test
   def test_single_cert_string_with_ca
     cert_chain { |mini_ctx|
       mini_ctx.cert_pem = File.read "#{CHAIN_DIR}/cert.crt"
-      mini_ctx.ca   = "#{CHAIN_DIR}/ca_chain.pem"
+      mini_ctx.ca = "#{CHAIN_DIR}/ca_chain.pem"
     }
   end
 

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -254,7 +254,6 @@ class TestPumaControlCli < TestConfigFileBase
     assert_kind_of Thread, t.join, "server didn't stop"
   end
 
-
   def test_control_ssl_ipv4
     skip_unless :ssl
     control_ssl '127.0.0.1'

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -8,7 +8,7 @@ module TestRackUp
 
   class TestOnBootedHandler < Minitest::Test
     def app
-      Proc.new {|env| @input = env; [200, {}, ["hello world"]]}
+      Proc.new { |env| @input = env; [200, {}, ["hello world"]] }
     end
 
     # `Verbose: true` is included for `NameError`,
@@ -42,7 +42,7 @@ module TestRackUp
 
   class TestPathHandler < Minitest::Test
     def app
-      Proc.new {|env| @input = env; [200, {}, ["hello world"]]}
+      Proc.new { |env| @input = env; [200, {}, ["hello world"]] }
     end
 
     def setup
@@ -99,7 +99,7 @@ module TestRackUp
           File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
           @options[:Port] = user_port
-          conf = ::Rack::Handler::Puma.config(->{}, @options)
+          conf = ::Rack::Handler::Puma.config(-> {}, @options)
           conf.load
 
           assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
@@ -120,7 +120,7 @@ module TestRackUp
 
       @options[:Host] = user_host
       @options[:Port] = user_port
-      conf = ::Rack::Handler::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(-> {}, @options)
       conf.load
 
       assert_equal ["tcp://#{user_host}:#{user_port}"], conf.options[:binds]
@@ -128,7 +128,7 @@ module TestRackUp
 
     def test_ipv6_host_supplied_port_default
       @options[:Host] = "::1"
-      conf = ::Rack::Handler::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(-> {}, @options)
       conf.load
 
       assert_equal ["tcp://[::1]:9292"], conf.options[:binds]
@@ -151,7 +151,7 @@ module TestRackUp
           File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
           @options[:Port] = user_port
-          conf = ::Rack::Handler::Puma.config(->{}, @options)
+          conf = ::Rack::Handler::Puma.config(-> {}, @options)
           conf.load
 
           assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
@@ -170,7 +170,7 @@ module TestRackUp
 
           @options[:Host] = "localhost"
           @options[:Port] = user_port
-          conf = ::Rack::Handler::Puma.config(->{}, @options)
+          conf = ::Rack::Handler::Puma.config(-> {}, @options)
           conf.load
 
           assert_equal ["tcp://localhost:#{file_port}"], conf.options[:binds]
@@ -189,7 +189,7 @@ module TestRackUp
 
           @options[:Host] = "localhost"
           @options[:Port] = user_port
-          conf = ::Rack::Handler::Puma.config(->{}, @options)
+          conf = ::Rack::Handler::Puma.config(-> {}, @options)
           conf.load
 
           assert_equal ["tcp://1.2.3.4:#{file_port}"], conf.options[:binds]
@@ -204,7 +204,7 @@ module TestRackUp
     end
 
     def test_default_port_when_no_config_file
-      conf = ::Rack::Handler::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(-> {}, @options)
       conf.load
 
       assert_equal ["tcp://0.0.0.0:9292"], conf.options[:binds]
@@ -218,7 +218,7 @@ module TestRackUp
           FileUtils.mkdir("config")
           File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
-          conf = ::Rack::Handler::Puma.config(->{}, @options)
+          conf = ::Rack::Handler::Puma.config(-> {}, @options)
           conf.load
 
           assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
@@ -230,7 +230,7 @@ module TestRackUp
       user_port = 5001
       @options[:user_supplied_options] = []
       @options[:Port] = user_port
-      conf = ::Rack::Handler::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(-> {}, @options)
       conf.load
 
       assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
@@ -239,7 +239,7 @@ module TestRackUp
     def test_user_port_wins_over_default
       user_port = 5001
       @options[:Port] = user_port
-      conf = ::Rack::Handler::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(-> {}, @options)
       conf.load
 
       assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
@@ -255,7 +255,7 @@ module TestRackUp
           File.open("config/puma.rb", "w") { |f| f << "port #{file_port}" }
 
           @options[:Port] = user_port
-          conf = ::Rack::Handler::Puma.config(->{}, @options)
+          conf = ::Rack::Handler::Puma.config(-> {}, @options)
           conf.load
 
           assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
@@ -264,7 +264,7 @@ module TestRackUp
     end
 
     def test_default_log_request_when_no_config_file
-      conf = ::Rack::Handler::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(-> {}, @options)
       conf.load
 
       assert_equal false, conf.options[:log_requests]
@@ -277,7 +277,7 @@ module TestRackUp
         'test/config/t1_conf.rb'
       ]
 
-      conf = ::Rack::Handler::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(-> {}, @options)
       conf.load
 
       assert_equal file_log_requests_config, conf.options[:log_requests]
@@ -291,7 +291,7 @@ module TestRackUp
         'test/config/t1_conf.rb'
       ]
 
-      conf = ::Rack::Handler::Puma.config(->{}, @options)
+      conf = ::Rack::Handler::Puma.config(-> {}, @options)
       conf.load
 
       assert_equal user_log_requests_config, conf.options[:log_requests]

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -197,7 +197,7 @@ class TestRackServer < Minitest::Test
     str_ary = %w[0123456789 0123456789 0123456789 0123456789]
     str_ary_bytes = str_ary.to_ary.inject(0) { |sum, el| sum + el.bytesize }
 
-    body = Rack::BodyProxy.new(str_ary) { }
+    body = Rack::BodyProxy.new(str_ary) {}
 
     @server.app = lambda { |env| [200, { "X-Header" => "Works" }, body] }
 

--- a/test/test_redirect_io.rb
+++ b/test/test_redirect_io.rb
@@ -22,7 +22,6 @@ class TestRedirectIO < TestIntegration
       '--redirect-stderr', @err_file_path,
       'test/rackup/hello.ru'
     ]
-
   end
 
   def teardown

--- a/test/test_request_invalid.rb
+++ b/test/test_request_invalid.rb
@@ -35,7 +35,7 @@ class TestRequestInvalid < Minitest::Test
     }
 
     @log_writer = Puma::LogWriter.strings
-    @server = Puma::Server.new app, nil, {log_writer: @log_writer}
+    @server = Puma::Server.new app, nil, { log_writer: @log_writer }
     @port = (@server.add_tcp_listener @host, 0).addr[1]
     @server.run
     sleep 0.15 if Puma.jruby?
@@ -55,7 +55,7 @@ class TestRequestInvalid < Minitest::Test
   end
 
   def new_connection
-    TCPSocket.new(@host, @port).tap {|sock| @ios << sock}
+    TCPSocket.new(@host, @port).tap { |sock| @ios << sock }
   end
 
   def assert_status(str, status = 400)
@@ -156,7 +156,7 @@ class TestRequestInvalid < Minitest::Test
 
   def test_chunked_size_bad_characters_1
     te = 'Transfer-Encoding: chunked'
-    chunked ='5.01'
+    chunked = '5.01'
 
     data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
 
@@ -165,7 +165,7 @@ class TestRequestInvalid < Minitest::Test
 
   def test_chunked_size_bad_characters_2
     te = 'Transfer-Encoding: chunked'
-    chunked ='+5'
+    chunked = '+5'
 
     data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
 
@@ -174,7 +174,7 @@ class TestRequestInvalid < Minitest::Test
 
   def test_chunked_size_bad_characters_3
     te = 'Transfer-Encoding: chunked'
-    chunked ='5 bad'
+    chunked = '5 bad'
 
     data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
 
@@ -183,7 +183,7 @@ class TestRequestInvalid < Minitest::Test
 
   def test_chunked_size_bad_characters_4
     te = 'Transfer-Encoding: chunked'
-    chunked ='0xA'
+    chunked = '0xA'
 
     data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHelloHello\r\n0\r\n\r\n"
 

--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -17,7 +17,7 @@ class TestResponseHeader < Minitest::Test
     @app = ->(env) { [200, {}, [env['rack.url_scheme']]] }
 
     @log_writer = Puma::LogWriter.strings
-    @server = Puma::Server.new @app, ::Puma::Events.new, {log_writer: @log_writer, min_threads: 1}
+    @server = Puma::Server.new @app, ::Puma::Events.new, { log_writer: @log_writer, min_threads: 1 }
   end
 
   def teardown
@@ -41,12 +41,12 @@ class TestResponseHeader < Minitest::Test
   end
 
   def new_connection
-    TCPSocket.new(@host, @port).tap {|sock| @ios << sock}
+    TCPSocket.new(@host, @port).tap { |sock| @ios << sock }
   end
 
   # The header keys must be Strings
   def test_integer_key
-    server_run app: ->(env) { [200, { 1 => 'Boo'}, []] }
+    server_run app: ->(env) { [200, { 1 => 'Boo' }, []] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
     assert_match(/Puma caught this error/, data)
@@ -62,13 +62,13 @@ class TestResponseHeader < Minitest::Test
 
   # The values of the header must be Strings
   def test_integer_value
-    server_run app: ->(env) { [200, {'Content-Length' => 500}, []] }
+    server_run app: ->(env) { [200, { 'Content-Length' => 500 }, []] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
     assert_match(/HTTP\/1.0 200 OK\r\nContent-Length: 500\r\n\r\n/, data)
   end
 
-  def assert_ignore_header(name, value, opts={})
+  def assert_ignore_header(name, value, opts = {})
     header = { name => value }
 
     if opts[:early_hints]
@@ -77,7 +77,7 @@ class TestResponseHeader < Minitest::Test
         [200, {}, ['Hello']]
       end
     else
-      app = -> (env) { [200, header, ['hello']]}
+      app = -> (env) { [200, header, ['hello']] }
     end
 
     server_run(app: app, early_hints: opts[:early_hints])
@@ -97,7 +97,7 @@ class TestResponseHeader < Minitest::Test
 
   # The header key can contain the word status.
   def test_key_containing_status
-    server_run app: ->(env) { [200, {'Teapot-Status' => 'Boiling'}, []] }
+    server_run app: ->(env) { [200, { 'Teapot-Status' => 'Boiling' }, []] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
     assert_match(/HTTP\/1.0 200 OK\r\nTeapot-Status: Boiling\r\nContent-Length: 0\r\n\r\n/, data)
@@ -110,7 +110,7 @@ class TestResponseHeader < Minitest::Test
 
   # The header key can still start with the word rack
   def test_racket_key
-    server_run app: ->(env) { [200, {'Racket' => 'Bouncy'}, []] }
+    server_run app: ->(env) { [200, { 'Racket' => 'Bouncy' }, []] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
     assert_match(/HTTP\/1.0 200 OK\r\nRacket: Bouncy\r\nContent-Length: 0\r\n\r\n/, data)
@@ -144,14 +144,14 @@ class TestResponseHeader < Minitest::Test
   end
 
   def test_illegal_character_in_value_when_newline
-    server_run app: ->(env) { [200, {'X-header' => "First\000 line\nSecond Lin\037e"}, ["Hello"]] }
+    server_run app: ->(env) { [200, { 'X-header' => "First\000 line\nSecond Lin\037e" }, ["Hello"]] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
     refute_match("X-header: First\000 line\r\nX-header: Second Lin\037e\r\n", data)
   end
 
   def test_header_value_array
-    server_run app: ->(env) { [200, {'set-cookie' => ['z=1', 'a=2']}, ['Hello']] }
+    server_run app: ->(env) { [200, { 'set-cookie' => ['z=1', 'a=2'] }, ['Hello']] }
     data = send_http_and_read "GET / HTTP/1.1\r\n\r\n"
 
     resp = "HTTP/1.1 200 OK\r\nset-cookie: z=1\r\nset-cookie: a=2\r\nContent-Length: 5\r\n\r\n"

--- a/test/test_state_file.rb
+++ b/test/test_state_file.rb
@@ -22,6 +22,5 @@ running_from: "/path/to/app"
     assert_equal '/path/to/app', sf.running_from
     assert_nil sf.control_url
     assert_nil sf.control_auth_token
-
   end
 end

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -9,7 +9,7 @@ class TestThreadPool < Minitest::Test
   end
 
   def new_pool(min, max, &block)
-    block = proc { } unless block
+    block = proc {} unless block
     options = {
       min_threads: min,
       max_threads: max
@@ -18,7 +18,7 @@ class TestThreadPool < Minitest::Test
   end
 
   def mutex_pool(min, max, &block)
-    block = proc { } unless block
+    block = proc {} unless block
     options = {
       min_threads: min,
       max_threads: max
@@ -34,7 +34,7 @@ class TestThreadPool < Minitest::Test
     def <<(work, &block)
       work = [work] unless work.is_a?(Array)
       with_mutex do
-        work.each {|arg| super arg}
+        work.each { |arg| super arg }
         yield if block
         @not_full.wait(@mutex)
       end
@@ -45,7 +45,7 @@ class TestThreadPool < Minitest::Test
     end
 
     # If +wait+ is true, wait until the trim request is completed before returning.
-    def trim(force=false, wait: true)
+    def trim(force = false, wait: true)
       super(force)
       Thread.pass until @trim_requested == 0 if wait
     end
@@ -65,7 +65,7 @@ class TestThreadPool < Minitest::Test
   def test_thread_name
     skip 'Thread.name not supported' unless Thread.current.respond_to?(:name)
     thread_name = nil
-    pool = mutex_pool(0, 1) {thread_name = Thread.current.name}
+    pool = mutex_pool(0, 1) { thread_name = Thread.current.name }
     pool << 1
     assert_equal('puma tst tp 001', thread_name)
   end
@@ -80,7 +80,7 @@ class TestThreadPool < Minitest::Test
     found_thread = false
     pool = mutex_pool(0, 1) do
       # Read every /proc/<pid>/task/<tid>/comm file to find the thread name
-      Dir.entries(task_dir).select {|tid| File.directory?(File.join(task_dir, tid))}.each do |tid|
+      Dir.entries(task_dir).select { |tid| File.directory?(File.join(task_dir, tid)) }.each do |tid|
         comm_file = File.join(task_dir, tid, 'comm')
         next unless File.file?(comm_file) && File.readable?(comm_file)
 
@@ -128,7 +128,7 @@ class TestThreadPool < Minitest::Test
         end
       ]
     }
-    block = proc { }
+    block = proc {}
     pool = MutexPool.new('tst', options, &block)
 
     pool << 1
@@ -194,7 +194,7 @@ class TestThreadPool < Minitest::Test
       max_threads: 1,
       before_thread_exit: [ -> { exited << 1 } ]
     }
-    block = proc { }
+    block = proc {}
     pool = MutexPool.new('tst', options, &block)
 
     pool << 1
@@ -248,7 +248,7 @@ class TestThreadPool < Minitest::Test
   def test_reap_only_dead_threads
     pool = mutex_pool(2,2) do
       th = Thread.current
-      Thread.new {th.join; pool.signal}
+      Thread.new { th.join; pool.signal }
       th.kill
     end
 
@@ -274,7 +274,7 @@ class TestThreadPool < Minitest::Test
   def test_auto_reap_dead_threads
     pool = mutex_pool(2,2) do
       th = Thread.current
-      Thread.new {th.join; pool.signal}
+      Thread.new { th.join; pool.signal }
       th.kill
     end
 

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -12,7 +12,7 @@ class TestHandler
   def call(env)
     @ran_test = true
 
-    [200, {"Content-Type" => "text/plain"}, ["hello!"]]
+    [200, { "Content-Type" => "text/plain" }, ["hello!"]]
   end
 end
 
@@ -23,7 +23,7 @@ class WebServerTest < Minitest::Test
 
   def setup
     @tester = TestHandler.new
-    @server = Puma::Server.new @tester, nil, {log_writer: Puma::LogWriter.strings}
+    @server = Puma::Server.new @tester, nil, { log_writer: Puma::LogWriter.strings }
     @port = (@server.add_tcp_listener "127.0.0.1", 0).addr[1]
     @tcp = "http://127.0.0.1:#{@port}"
     @server.run
@@ -76,7 +76,7 @@ class WebServerTest < Minitest::Test
   def test_header_is_too_long
     long = "GET /test HTTP/1.1\r\n" + ("X-Big: stuff\r\n" * 15000) + "\r\n"
     assert_raises Errno::ECONNRESET, Errno::EPIPE, Errno::ECONNABORTED, Errno::EINVAL, IOError do
-      do_test_raise(long, long.length/2, 10)
+      do_test_raise(long, long.length / 2, 10)
     end
   end
 

--- a/test/worker_gem_independence_test/new_json/config.ru
+++ b/test/worker_gem_independence_test/new_json/config.ru
@@ -1,2 +1,2 @@
 require 'json'
-run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [JSON::VERSION]] }
+run lambda { |env| [200, { 'Content-Type' => 'text/plain' }, [JSON::VERSION]] }

--- a/test/worker_gem_independence_test/new_json_with_puma_stats_after_fork/config.ru
+++ b/test/worker_gem_independence_test/new_json_with_puma_stats_after_fork/config.ru
@@ -1,2 +1,2 @@
 require 'json'
-run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [JSON::VERSION]] }
+run lambda { |env| [200, { 'Content-Type' => 'text/plain' }, [JSON::VERSION]] }

--- a/test/worker_gem_independence_test/new_nio4r/config.ru
+++ b/test/worker_gem_independence_test/new_nio4r/config.ru
@@ -1,1 +1,1 @@
-run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [NIO::VERSION]] }
+run lambda { |env| [200, { 'Content-Type' => 'text/plain' }, [NIO::VERSION]] }

--- a/test/worker_gem_independence_test/old_json/config.ru
+++ b/test/worker_gem_independence_test/old_json/config.ru
@@ -1,2 +1,2 @@
 require 'json'
-run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [JSON::VERSION]] }
+run lambda { |env| [200, { 'Content-Type' => 'text/plain' }, [JSON::VERSION]] }

--- a/test/worker_gem_independence_test/old_json_with_puma_stats_after_fork/config.ru
+++ b/test/worker_gem_independence_test/old_json_with_puma_stats_after_fork/config.ru
@@ -1,2 +1,2 @@
 require 'json'
-run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [JSON::VERSION]] }
+run lambda { |env| [200, { 'Content-Type' => 'text/plain' }, [JSON::VERSION]] }

--- a/test/worker_gem_independence_test/old_nio4r/config.ru
+++ b/test/worker_gem_independence_test/old_nio4r/config.ru
@@ -1,1 +1,1 @@
-run lambda { |env| [200, {'Content-Type'=>'text/plain'}, [NIO::VERSION]] }
+run lambda { |env| [200, { 'Content-Type' => 'text/plain' }, [NIO::VERSION]] }

--- a/tools/trickletest.rb
+++ b/tools/trickletest.rb
@@ -41,4 +41,4 @@ ARGV[1].to_i.times do
   threads << t
 end
 
-threads.each {|t|  t.join}
+threads.each { |t|  t.join }


### PR DESCRIPTION
### Description

Ref: https://github.com/puma/puma/pull/1325

Addresses most of the cops in `.rubocop_todo.yml` using safe autocorrect (`-a`).

Most of those cops were set up to use the default config except for:

- `Layout/SpaceBeforeBlockBraces`
- `Layout/SpaceAroundEqualsInParameterDefault`
- `Layout/SpaceInsideHashLiteralBraces`

which all enforced `no_space`. I've changed these to use the default (`space`) for both consistency with other defaults (e.g. `SpaceAroundOperators`) and (imo) better readability. Let me know if `no_space` is prefered and I can revert back.

The only one I removed from the original TODO config was `Layout/IndentationWidth` which yields multiple inconsistent results when flagging and autocorrecting, even when paired with `Layout/IndentationConsistency` which the rubocop docs recommend. For example, it does this with indented condition assignments:

```ruby
          indented_var = if foo
                           "foo"
          else
            "bar"
          end
```

Also, the only existing cop amended was `Layout/SpaceBeforeBlockBraces`. It now uses the default (`space`) for `EnforcedStyleForEmptyBraces`. My argument is once again consistency, and that the default makes it easier to tell an empty block apart from an empty hash arg when parenthesis are excluded. E.g.

```ruby
# arg
method_call {}

# empty block
method_call { }
```

This also now makes is consistent with the other block cops.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
