### PR TITLE
Implement support for `rack.protocol`.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Support for Rack 3 `rack.protocol` ([#3399])
+
 ## 6.4.2 / 2024-01-08
 
 * Security
@@ -2063,6 +2067,7 @@ be added back in a future date when a java Puma::MiniSSL is added.
 * Bugfixes
   * Your bugfix goes here <Most recent on the top, like GitHub> (#Github Number)
 
+[#3399]:https://github.com/puma/puma/pull/3399     "PR by @ioquatix"
 [#3256]:https://github.com/puma/puma/pull/3256     "PR by @MSP-Greg, merged 2023-10-16"
 [#3235]:https://github.com/puma/puma/pull/3235     "PR by @joshuay03, merged 2023-10-03"
 [#3228]:https://github.com/puma/puma/issues/3228   "Issue by @davidalejandroaguilar, closed 2023-10-03"

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -230,6 +230,10 @@ module Puma
     RACK_INPUT = "rack.input"
     RACK_URL_SCHEME = "rack.url_scheme"
     RACK_AFTER_REPLY = "rack.after_reply"
+
+    RACK_PROTOCOL = "rack.protocol"
+    HTTP_UPGRADE = "HTTP_UPGRADE"
+
     PUMA_SOCKET = "puma.socket"
     PUMA_CONFIG = "puma.config"
     PUMA_PEERCERT = "puma.peercert"

--- a/test/test_puma_rack_protocol.rb
+++ b/test/test_puma_rack_protocol.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
+require_relative "helper"
+
+require "puma/server"
+
+class RackProtocolApplication
+  def call(env)
+    if env['rack.protocol'].include?('echo')
+      [200, {'rack.protocol' => 'echo'}, self.method(:echo)]
+    end
+  end
+
+  def echo(stream)
+    while line = stream.gets
+      stream.write(line)
+    end
+  end
+end
+
+class RackProtocolApplicationTest < Minitest::Test
+  parallelize_me!
+
+  def setup
+    @tester = RackProtocolApplication.new
+    @server = Puma::Server.new @tester, nil, {log_writer: Puma::LogWriter.strings}
+    @host = "127.0.0.1"
+    @port = @server.add_tcp_listener(@host, 0).addr[1]
+    @server.run
+  end
+
+  def teardown
+    @server.stop(true)
+  end
+
+  def make_client
+    TCPSocket.new(@host, @port)
+  end
+
+  def test_rack_protocol_valid
+    client = make_client
+    client.write "GET / HTTP/1.1\r\n" +
+      "Host: localhost\r\n" +
+      "Upgrade: echo\r\n" +
+      "\r\n"
+
+    assert_equal "HTTP/1.1 101 Switching Protocols\r\n", client.gets
+    assert_equal "upgrade: echo\r\n", client.gets
+    assert_equal "connection: upgrade\r\n", client.gets
+    assert_equal "\r\n", client.gets
+
+    client.write "hello world\n"
+    assert_equal "hello world\n", client.gets
+  ensure
+    client.close
+  end
+end


### PR DESCRIPTION
### Description

Implement support for `rack.protocol` which is an optional feature of Rack 3.1, required to support `protocol-websocket`.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
