### PR TITLE
CI: disable `concurrent_skipping` for skip-duplicate-actions

### DIFF
--- a/.github/workflows/skip_duplicate_workflow_runs.yml
+++ b/.github/workflows/skip_duplicate_workflow_runs.yml
@@ -28,5 +28,5 @@ jobs:
         with:
           paths_ignore: '["**.md"]'
           paths: ${{ inputs.paths }}
-          concurrent_skipping: 'same_content_newer' # skip newer runs with same content
+          concurrent_skipping: 'never' # this feature has bugs
           skip_after_successful_duplicate: 'true'


### PR DESCRIPTION
From https://github.com/fkirc/skip-duplicate-actions?tab=readme-ov-file#concurrent_skipping

> Skip a workflow run if the same workflow is already running

but it does not seem reliable, for example, this workflow run https://github.com/puma/puma/actions/runs/9386209788 looks 100% green but that is because everything was skipped

https://github.com/fkirc/skip-duplicate-actions/issues has many reports about problems with `concurrent_skipping`

https://github.com/celerity/celerity-runtime/pull/148 is an example of another project disabling it.

[ci skip]