### PR TITLE
Headers must not be frozen.

### DIFF
--- a/test/rackup/hello.ru
+++ b/test/rackup/hello.ru
@@ -1,3 +1,3 @@
 hdrs = {'Content-Type'.freeze => 'text/plain'.freeze}.freeze
 body = ['Hello World'.freeze].freeze
-run lambda { |env| [200, hdrs, body] }
+run lambda { |env| [200, hdrs.dup, body] }


### PR DESCRIPTION
Rack 3 requires headers to be an unfrozen hash. This appears to be causing some problems, e.g.

```
  3) Failure:
TestIntegrationSingle#test_usr2_restart [test/test_integration_single.rb:25]:
--- expected
+++ actual
@@ -1 +1,6 @@
-"Hello World"
+"Puma caught this error: can't modify frozen Hash: {\"Content-Type\"=>\"text/plain\"} (FrozenError)
+/home/runner/work/puma/puma/lib/puma/request.rb:111:in `delete'
+/home/runner/work/puma/puma/lib/puma/request.rb:111:in `handle_request'
+/home/runner/work/puma/puma/lib/puma/server.rb:467:in `process_client'
+/home/runner/work/puma/puma/lib/puma/server.rb:248:in `block in run'
+/home/runner/work/puma/puma/lib/puma/thread_pool.rb:155:in `block in spawn_thread'"
```