### PR TITLE
Don't let the config file go out of scope while it's still in use.

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -26,6 +26,7 @@ class TestIntegration < Minitest::Test
 
   def setup
     @server = nil
+    @config_file = nil
     @server_log = +''
     @pid = nil
     @ios_to_close = []
@@ -60,6 +61,11 @@ class TestIntegration < Minitest::Test
       rescue
       ensure
         @server = nil
+
+        if @config_file
+          @config_file.unlink
+          @config_file = nil
+        end
       end
     end
   end
@@ -81,6 +87,7 @@ class TestIntegration < Minitest::Test
       env: {})          # pass env setting to Puma process in IO.popen
 
     if config
+      # Don't let the config file be GC'd until the server is stopped:
       @config_file = Tempfile.new(%w(config .rb))
       @config_file.write config
       @config_file.close

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -81,10 +81,10 @@ class TestIntegration < Minitest::Test
       env: {})          # pass env setting to Puma process in IO.popen
 
     if config
-      config_file = Tempfile.new(%w(config .rb))
-      config_file.write config
-      config_file.close
-      config = "-C #{config_file.path}"
+      @config_file = Tempfile.new(%w(config .rb))
+      @config_file.write config
+      @config_file.close
+      config = "-C #{@config_file.path}"
     end
 
     puma_path = File.expand_path '../../../bin/puma', __FILE__


### PR DESCRIPTION
This is another experimental branch to try and fix race conditions in CI.

```
/home/runner/work/puma/puma/lib/puma/dsl.rb:135:in `read': No such file or directory @ rb_sysopen - /home/runner/work/_temp/config20240605-2615-l1fl0k.rb (Errno::ENOENT)
	from /home/runner/work/puma/puma/lib/puma/dsl.rb:135:in `_load_from'
	from /home/runner/work/puma/puma/lib/puma/configuration.rb:238:in `block in load'
	from /home/runner/work/puma/puma/lib/puma/configuration.rb:238:in `each'
	from /home/runner/work/puma/puma/lib/puma/configuration.rb:238:in `load'
	from /home/runner/work/puma/puma/lib/puma/launcher.rb:54:in `initialize'
	from /home/runner/work/puma/puma/lib/puma/cli.rb:66:in `new'
	from /home/runner/work/puma/puma/lib/puma/cli.rb:66:in `initialize'
	from /home/runner/work/puma/puma/bin/puma:8:in `new'
	from /home/runner/work/puma/puma/bin/puma:8:in `<main>'
```