### PR TITLE
Define the on_stopped method in Puma::DSL

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -822,6 +822,17 @@ module Puma
       @config.options[:events].on_booted(&block)
     end
 
+    # Code to run after puma is stopped (works for both: single and clustered)
+    #
+    # @example
+    #   on_stopped do
+    #     puts 'After stopping...'
+    #   end
+    #
+    def on_stopped(&block)
+      @config.options[:events].on_stopped(&block)
+    end
+
     # When `fork_worker` is enabled, code to run in Worker 0
     # before all other workers are re-forked from this process,
     # after the server has temporarily stopped serving requests

--- a/test/config/event_on_booted.rb
+++ b/test/config/event_on_booted.rb
@@ -1,3 +1,0 @@
-on_booted do
-  puts "on_booted called"
-end

--- a/test/config/event_on_booted_and_on_stopped.rb
+++ b/test/config/event_on_booted_and_on_stopped.rb
@@ -1,0 +1,7 @@
+on_booted do
+  puts "on_booted called"
+end
+
+on_stopped do
+  puts "on_stopped called"
+end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -136,12 +136,13 @@ class TestIntegrationCluster < TestIntegration
     assert_equal 0, status
   end
 
-  def test_on_booted
+  def test_on_booted_and_on_stopped
     skip_unless_signal_exist? :TERM
-    cli_server "-w #{workers} -C test/config/event_on_booted.rb -C test/config/event_on_booted_exit.rb test/rackup/hello.ru",
+    cli_server "-w #{workers} -C test/config/event_on_booted_and_on_stopped.rb -C test/config/event_on_booted_exit.rb test/rackup/hello.ru",
       no_wait: true
 
     assert wait_for_server_to_include('on_booted called')
+    assert wait_for_server_to_include('on_stopped called')
   end
 
   def test_term_worker_clean_exit

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -49,13 +49,14 @@ class TestIntegrationSingle < TestIntegration
     assert_equal 15, status
   end
 
-  def test_on_booted
+  def test_on_booted_and_on_stopped
     skip_unless_signal_exist? :TERM
 
-    cli_server "-C test/config/event_on_booted.rb -C test/config/event_on_booted_exit.rb test/rackup/hello.ru",
+    cli_server "-C test/config/event_on_booted_and_on_stopped.rb -C test/config/event_on_booted_exit.rb test/rackup/hello.ru",
       no_wait: true
 
     assert wait_for_server_to_include('on_booted called')
+    assert wait_for_server_to_include('on_stopped called')
   end
 
   def test_term_suppress


### PR DESCRIPTION
### Description
This is how it is described in [README.md](https://github.com/puma/puma/tree/f027b319bcc72db27841d389d1efc6fc7d921634?tab=readme-ov-file#master-process-lifecycle-hooks)
![image](https://github.com/puma/puma/assets/33079237/2523f819-b8e4-44de-a58a-d7f767e84af9)

However, using `on_stopped` in fact leads to an exception because the `on_stopped` method is not defined in `Puma::DSL`.
![image](https://github.com/puma/puma/assets/33079237/372254d5-0b61-40d9-bc03-ab4c0ccfc315)


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.


_PS: English is not my native language; please excuse typing errors._

Ref: https://github.com/puma/puma/discussions/3379
Close https://github.com/puma/puma/pull/3380
