### PR TITLE
Add support for EXTEND_TIMEOUT_USEC systemd

### DIFF
--- a/lib/puma/plugin/systemd.rb
+++ b/lib/puma/plugin/systemd.rb
@@ -18,6 +18,12 @@ Puma::Plugin.create do
     launcher.events.on_stopped { Puma::SdNotify.stopping }
     launcher.events.on_restart { Puma::SdNotify.reloading }
 
+    # set extended timeout
+    if Puma::SdNotify.extend_timeout?
+      launcher.log_writer.log "Extending the startup by #{extend_timeout_time}"
+      Puma::SdNotify.extend_timeout(extend_timeout_time)
+    end
+
     # start watchdog
     if Puma::SdNotify.watchdog?
       ping_f = watchdog_sleep_time
@@ -58,6 +64,10 @@ Puma::Plugin.create do
   end
 
   private
+
+  def extend_timeout_time
+    Integer(ENV["EXTEND_TIMEOUT_USEC"])
+  end
 
   def watchdog_sleep_time
     usec = Integer(ENV["WATCHDOG_USEC"])

--- a/lib/puma/sd_notify.rb
+++ b/lib/puma/sd_notify.rb
@@ -48,6 +48,7 @@ module Puma
     MAINPID   = "MAINPID="
     WATCHDOG  = "WATCHDOG=1"
     FDSTORE   = "FDSTORE=1"
+    EXTEND_TIMEOUT_USEC = "EXTEND_TIMEOUT_USEC="
 
     def self.ready(unset_env=false)
       notify(READY, unset_env)
@@ -83,6 +84,31 @@ module Puma
 
     def self.fdstore(unset_env=false)
       notify(FDSTORE, unset_env)
+    end
+
+    # @param usec [Integer]
+    def self.extend_timeout(usec, unset_env=false)
+      notify("#{EXTEND_TIMEOUT_USEC}#{usec}", unset_env)
+    end
+
+    # Notify systemd about extended timeout, via the notification socket, if applicable.
+    # $EXTEND_TIMEOUT_USEC [Integer] The value specified represents the time in microseconds
+    #   for extending the timeout, during which the service must send a new message.
+    #
+    # @return [Boolean] true if $EXTEND_TIMEOUT_USEC is a valid positive integer, otherwise false
+    #
+    # @note A service timeout occurs only if the service runtime exceeds the original maximum times specified
+    #   by TimeoutStartSec=, RuntimeMaxSec=, and TimeoutStopSec=.
+    def self.extend_timeout?
+      extend_timeout_usec = ENV["EXTEND_TIMEOUT_USEC"]
+
+      begin
+        extend_timeout_usec = Integer(extend_timeout_usec)
+      rescue
+        return false
+      end
+
+      extend_timeout_usec.positive?
     end
 
     # @param [Boolean] true if the service manager expects watchdog keep-alive

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -67,6 +67,19 @@ class TestPluginSystemd < TestIntegration
     assert_message "STOPPING=1"
   end
 
+  def test_systemd_extend_timeout_notify
+    notify_env = @env.merge({"EXTEND_TIMEOUT_USEC" => "1_000_001"})
+    cli_server "test/rackup/hello.ru", env: notify_env
+    assert_message "EXTEND_TIMEOUT_USEC=1000001"
+
+    assert_message "READY=1"
+
+    assert_message "STATUS=Puma #{Puma::Const::VERSION}: worker: #{THREAD_LOG}"
+
+    stop_server
+    assert_message "STOPPING=1"
+  end
+
   def test_systemd_cluster_notify
     skip_unless :fork
     cli_server "-w2 test/rackup/hello.ru", env: @env


### PR DESCRIPTION
### Description
Closes https://github.com/puma/puma/issues/3234
add support for the EXTEND_TIMEOUT_USEC systemd. It is sent once at the beginning of launch. Please confirm if there's a need to continuously send EXTEND_TIMEOUT_USEC in a loop during runtime, although it doesn't seem necessary.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
