### PR TITLE
[CI] rack_conform.yml - change Ruby 2.7 job to 3.1

### DIFF
--- a/.github/workflows/rack_conform.yml
+++ b/.github/workflows/rack_conform.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-20.04 , ruby: '2.7' }
+          - { os: ubuntu-20.04 , ruby: '3.1' }
           - { os: ubuntu-20.04 , ruby: '3.2' }
           - { os: ubuntu-22.04 , ruby: '3.3' }
           - { os: ubuntu-22.04 , ruby: head  }

--- a/.github/workflows/rack_conform.yml
+++ b/.github/workflows/rack_conform.yml
@@ -49,6 +49,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          rubygems: latest
           bundler-cache: true
         timeout-minutes: 10
 


### PR DESCRIPTION
### Description

CI message from rack_conform:

> Because every version of rack-conform depends on Ruby >= 3.1

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
