### PR TITLE
CI: use `macos-12` in ragel workflow

### DIFF
--- a/.github/workflows/ragel.yml
+++ b/.github/workflows/ragel.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - { os: ubuntu-20.04 , ruby: head }
-          - { os: macos-11     , ruby: head }
+          - { os: macos-12     , ruby: head }
           # Dec-2023 - incorrect line directives with Windows
           # occurs with both MSYS2 and MSFT/vpkg versions of ragel
           # - { os: windows-2022 , ruby: ucrt } 


### PR DESCRIPTION
From https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

> The macos-11 label has been deprecated and will no longer be available
> after 28 June 2024.
