### PR TITLE
Allow to customise plugin's path and name

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -22,6 +22,51 @@ The `tmp_restart` plugin comes with Puma, so it is always available.
 
 To use the `heroku` plugin, add `puma-heroku` to your Gemfile or install it.
 
+### Development
+
+When developing a plugin, there are 2 conventions that must be met:
+- A plugin must be defined using the `Puma::Plugin.create` API;
+- A Ruby file containing the creation of a plugin using the above method must be located under the `puma/plugin` load path.
+
+The name of the file where `Puma::Plugin.create` is called will be used as plugin's name during its registration.
+
+This name can then be used to activate the plugin in the Puma configuration file:
+```ruby
+# In Puma configuration file
+plugin "name"
+```
+
+In case code that defines the plugin was not executed by the time the Puma config file is evaluated, 
+Puma will attempt to load the plugin by requiring `puma/plugin/<plugin_name>`.
+
+This means that, if a Puma plugin is implemented in a 3rd-party gem, it should be defined in `<gem_root>/lib/puma/plugins/<plugin_name>`.
+
+It is also possible to circumvent the conventions around path structure in order to preserve the directory structure of the 3rd-party gem.
+
+First, you can override the name of your plugin during definition:
+
+```ruby
+# In <gem_root>/lib/integrations/puma/plugin.rb
+Puma::Plugin.create(:custom_plugin) do
+  # ...
+end
+```
+
+The above plugin will be registered as `custom_plugin` instead of `plugin`. It will be available for 
+activation in the configuration file using `plugin "custom_plugin"`.
+
+However, it will only be available for activation in case the code that contains its definition 
+is evaluated before the config file. Otherwise Puma will fail to load it by attempting to require 
+non-existent `puma/plugins/custom_plugin`.
+
+In order to make the unconventional directory structure work, the correct path to the plugin 
+definition must be provided during activation:
+
+```ruby
+# In Puma configuration file
+plugin "name", "<gem_root>/lib/integrations/puma/plugin"
+```
+
 ### API
 
 ## Server-wide hooks

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -302,8 +302,8 @@ module Puma
       @options[:environment]
     end
 
-    def load_plugin(name)
-      @plugins.create name
+    def load_plugin(name, path = nil)
+      @plugins.create name, path
     end
 
     # @param key [:Symbol] hook to run

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -167,11 +167,14 @@ module Puma
 
     # Load the named plugin for use by this configuration.
     #
+    # Accepts an optional `path_override` argument, which will be used to
+    # load the plugin in case it was not already registered.
+    #
     # @example
     #   plugin :tmp_restart
     #
-    def plugin(name)
-      @plugins << @config.load_plugin(name)
+    def plugin(name, path_override = nil)
+      @plugins << @config.load_plugin(name, path_override)
     end
 
     # Use an object or block as the rack application. This allows the

--- a/lib/puma/plugin.rb
+++ b/lib/puma/plugin.rb
@@ -8,8 +8,8 @@ module Puma
       @instances = []
     end
 
-    def create(name)
-      if cls = Plugins.find(name)
+    def create(name, path_override = nil)
+      if cls = Plugins.find(name, path_override)
         plugin = cls.new
         @instances << plugin
         return plugin
@@ -37,7 +37,7 @@ module Puma
       @plugins[name] = cls
     end
 
-    def find(name)
+    def find(name, path_override = nil)
       name = name.to_s
 
       if cls = @plugins[name]
@@ -45,7 +45,7 @@ module Puma
       end
 
       begin
-        require "puma/plugin/#{name}"
+        require (path_override || "puma/plugin/#{name}")
       rescue LoadError
         raise UnknownPlugin, "Unable to find plugin: #{name}"
       end
@@ -94,8 +94,12 @@ module Puma
       m[1]
     end
 
-    def self.create(&blk)
-      name = extract_name(caller)
+    # An optional `name_override` argument can be provided
+    # to specify a custom name for the plugin, instead of
+    # letting Puma automatically generate it based on the path.
+    #
+    def self.create(name_override = nil, &blk)
+      name = name_override&.to_s || extract_name(caller)
 
       cls = Class.new(self)
 


### PR DESCRIPTION
### Description

This PR augments the Puma plugin API in order to offer more flexibility to developers of 3rd-party plugins.

It allows to optionally specify a custom override for the plugin's name and the path where its definition is located, instead of having to conform to the expected directory structure and naming.

This is useful when a 3rd-party gem provides a plugin, but for whatever reason does not want to conform to the expected path structure and file naming rules.

I haven't found any tests for the existing surrounding code, otherwise I would have adjusted the specs - let me know if I missed them.

I also understand that this might be too niche of a use-case to warrant a change in the API, so I'm totally fine with this being closed.

### Your checklist for this pull request
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
