### PR TITLE
CI: bump Ferrum/Chrome timeouts (for turbo-rails tests)

### DIFF
--- a/.github/workflows/turbo-rails.yml
+++ b/.github/workflows/turbo-rails.yml
@@ -35,6 +35,8 @@ jobs:
           - { os: ubuntu-22.04 , ruby: head , rails: '7.1' }
     env:
       CI: true
+      FERRUM_PROCESS_TIMEOUT: 25
+      FERRUM_DEFAULT_TIMEOUT: 15
       RAILS_VERSION: "${{ matrix.rails }}"
 
     steps:


### PR DESCRIPTION
This error is common in CI:

      1) Error:
    BroadcastsTest#test_Message_broadcasts_with_renderable:_render_option:
    Ferrum::ProcessTimeoutError: Browser did not produce websocket url
    within 10 seconds, try to increase `:process_timeout`. See
    https://github.com/rubycdp/ferrum#customization

It is possible to control this timeout (and another one) via ENV vars: https://github.com/rubycdp/ferrum/blob/v0.15/lib/ferrum/browser/options.rb#L10-L11

"timeout" is

> The number of seconds we'll wait for a response when communicating with browser. Default is 5.

"process_timeout" is (defaults to 10)

> How long to wait for the Chrome process to respond on startup.

Both ferrum CI and cuprite CI has the timeouts set to 25 and 15:

* https://github.com/rubycdp/ferrum/blob/19767d0885afbebc95574eda685e04dc9da2b47d/.github/workflows/tests.yml#L16-L18
* https://github.com/rubycdp/cuprite/blob/373b894d723bf9fb1afe31781963fe655a177218/.github/workflows/tests.yml#L16-L18
