### PR TITLE
CI: give MRI tests more time

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: test
         if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
-        timeout-minutes: 6
+        timeout-minutes: 10
         run: test/runner --verbose
 
   test_non_mri:


### PR DESCRIPTION
This was lowered from 10 to 6 min in https://github.com/puma/puma/pull/3130

Generally this steps takes a little bit over 3 min, but when tests are retried, this steps takes more time, I think CI should account for that.

The one I observed added 2+ min at https://github.com/puma/puma/actions/runs/9928834870/job/27425817733?pr=3426#step:10:213 and it looks like it was canceled mid-flight.

That one would still have been a failure (looks like all retries exhausted for that test case), but I guess in theory if many things are retried (but eventually pass) we could have runs that would pass, being canceled.
