### PR TITLE
[doc] control_cli.rb: Harmonize help message for -Q with bin/puma [ci skip]

### DIFF
--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -60,7 +60,7 @@ module Puma
           @state = arg
         end
 
-        o.on "-Q", "--quiet", "Not display messages" do |arg|
+        o.on "-Q", "--quiet", "Do not display messages" do |arg|
           @quiet = true
         end
 


### PR DESCRIPTION


### Description

This PR changes the help output for pumactl's --quiet option to match the way it reads puma --help.

This cosmetic wording fix makes the line perhaps read easier.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] All new and existing tests passed, including Rubocop.
