### PR TITLE
Set the worker process count automatically with WEB_CONCURRENCY=auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ $ WEB_CONCURRENCY=3 puma -t 8:32
 
 Note that threads are still used in clustered mode, and the `-t` thread flag setting is per worker, so `-w 2 -t 16:16` will spawn 32 threads in total, with 16 in each worker process.
 
+If the `WEB_CONCURRENCY` environment variable is set to `"auto"` and the `concurrent-ruby` gem is available in your application, Puma will set the worker process count to the result of [available processors](https://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent.html#available_processor_count-class_method).
+
 For an in-depth discussion of the tradeoffs of thread and process count settings, [see our docs](https://github.com/puma/puma/blob/9282a8efa5a0c48e39c60d22ca70051a25df9f55/docs/kubernetes.md#workers-per-pod-and-other-config-issues).
 
 In clustered mode, Puma can "preload" your application. This loads all the application code *prior* to forking. Preloading reduces total memory usage of your application via an operating system feature called [copy-on-write](https://en.wikipedia.org/wiki/Copy-on-write).

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -76,6 +76,15 @@ class TestIntegration < Minitest::Test
     assert(system(*args, out: File::NULL, err: File::NULL))
   end
 
+  def with_unbundled_env
+    bundler_ver = Gem::Version.new(Bundler::VERSION)
+    if bundler_ver < Gem::Version.new('2.1.0')
+      Bundler.with_clean_env { yield }
+    else
+      Bundler.with_unbundled_env { yield }
+    end
+  end
+
   def cli_server(argv,  # rubocop:disable Metrics/ParameterLists
       unix: false,      # uses a UNIXSocket for the server listener when true
       config: nil,      # string to use for config file

--- a/test/test_web_concurrency_auto.rb
+++ b/test/test_web_concurrency_auto.rb
@@ -1,0 +1,29 @@
+require_relative "helper"
+require_relative "helpers/integration"
+
+class TestWebConcurrencyAuto < TestIntegration
+
+  def teardown
+    return if skipped?
+    super
+  end
+
+  def test_web_concurrency_with_concurrent_ruby_available
+    skip_unless :fork
+    env = {
+      "BUNDLE_GEMFILE" => "#{__dir__}/web_concurrency_test/Gemfile",
+      "WEB_CONCURRENCY" => "auto"
+    }
+    Dir.chdir("#{__dir__}/web_concurrency_test") do
+      with_unbundled_env do
+        silent_and_checked_system_command("bundle config --local path vendor/bundle")
+        silent_and_checked_system_command("bundle install")
+      end
+      cli_server set_pumactl_args, env: env
+    end
+
+    connection = connect("/worker_count")
+    body = read_body(connection, 1)
+    assert_equal(get_stats.fetch("workers").to_s, body)
+  end
+end

--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -138,13 +138,4 @@ class TestWorkerGemIndependence < TestIntegration
 
     true while @server.gets !~ /booted in [.0-9]+s, phase: 1/
   end
-
-  def with_unbundled_env
-    bundler_ver = Gem::Version.new(Bundler::VERSION)
-    if bundler_ver < Gem::Version.new('2.1.0')
-      Bundler.with_clean_env { yield }
-    else
-      Bundler.with_unbundled_env { yield }
-    end
-  end
 end

--- a/test/web_concurrency_test/Gemfile
+++ b/test/web_concurrency_test/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'puma', path: '../..'
+
+gem 'concurrent-ruby', '~> 1.0'

--- a/test/web_concurrency_test/config.ru
+++ b/test/web_concurrency_test/config.ru
@@ -1,0 +1,5 @@
+map "/worker_count" do
+  run ->(env) {
+    [200, {}, [Concurrent.available_processor_count.to_i.to_s]]
+  }
+end


### PR DESCRIPTION
### Description

Implements the `WEB_CONCURRENCY=auto` feature described in #3437.

This implementation does not `require` `concurrent-ruby` at all (in puma).

An alternative could be to `require "concurrent/utility/processor_counter"` inline. I'd be happy to adapt 👍

Closes #3437.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
