### PR TITLE
[CI] - fixup failures due to 'error' message changes

### DIFF
--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -161,7 +161,7 @@ class TestIntegrationPumactl < TestIntegration
     end
     sout.rewind
     # windows bad URI(is not URI?)
-    assert_match(/No pid '\d+' found|bad URI\(is not URI\?\)/, sout.readlines.join(""))
+    assert_match(/No pid '\d+' found|bad URI ?\(is not URI\?\)/, sout.readlines.join(""))
     assert_equal(1, e.status)
   end
 

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -122,7 +122,7 @@ class TestIntegrationSingle < TestIntegration
     rejected_curl_wait_thread.join
 
     assert_match(/Slept 10/, curl_stdout.read)
-    assert_match(/Connection refused|Couldn't connect to server/, rejected_curl_stderr.read)
+    assert_match(/Connection refused|(Couldn't|Could not) connect to server/, rejected_curl_stderr.read)
 
     Process.wait(@server.pid)
     @server.close unless @server.closed?


### PR DESCRIPTION
### Description

CI tests often use `assert_match` to check that errors are thrown.  Curl recently changed "Couldn't" to "Could not", and a proper space was added to a Ruby error message.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
