### PR TITLE
[CI] tests.yml - remove step setting JDK version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,10 +168,6 @@ jobs:
         if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
         uses: actions/checkout@v4
 
-      - name: set JAVA_HOME to JDK 17
-        if: (needs.skip_duplicate_runs.outputs.should_skip != 'true')
-        run: echo JAVA_HOME=$JAVA_HOME_17_X64 >> $GITHUB_ENV
-
       - name: load ruby, ragel
         if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
         uses: ruby/setup-ruby-pkgs@v1


### PR DESCRIPTION
### Description

The most recent workflow run in a PR failed on the [NON MRI: macos-13 jruby](https://github.com/puma/puma/actions/runs/10374918870/job/28723479842) job.  Currently, there is a step in the workflow setting the JDK version to 17.  After reviewing code in the build repos, this code is no longer proper, and will cause issues when we move/add jobs using macos arm64 runners.  Additionally, new OS's have been added, and they default to newer JDK versions.

Hence, remove the step code.  I ran it four times in my fork, and the 'NON MRI: macos-13 jruby' job passed four times.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
