### PR TITLE
[CI] Fixes for Minitest 5.25.0 - used with Ruby 2.6 and later

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
       PUMA_TEST_DEBUG: true
       TESTOPTS: -v
       PUMA_NO_RUBOCOP: true
+      TERM: BugMinitest
 
     runs-on: ${{ matrix.os }}
     if: |
@@ -143,6 +144,7 @@ jobs:
       PUMA_TEST_DEBUG: true
       TESTOPTS: -v
       PUMA_NO_RUBOCOP: true
+      TERM: BugMinitest
 
     runs-on: ${{ matrix.os }}
     if: |


### PR DESCRIPTION
### Description

CI broke with the release of Minitest 5.25.0.

Two commits:

1. test/helper.rb - allow to run with new and old Minitest - See https://github.com/minitest/minitest/commit/8cd3b1c749c778038ead3ddf7894dc19c1fe4797.  This conflicts with our prepending a method to allow our tests to fail on a timeout.

2. [CI] fix Minitest bug - revert when Minitest 5.25.1 is released - See https://github.com/minitest/minitest/pull/1010.  Previously Minitest had code that could be equivalent to:
   ```ruby
   nil ~= /broken/
   ```
   it was replaced by:
   ```ruby
   nil.match?(/broken/)
   ```

   `match?` is not defined on `nil`, so an error is thrown.  This commit is a temporary fix until the next Minitest release.  It defines an `ENV` variable in the Actions workflow so that the value isn't `nil`.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
