### PR TITLE
[CI] Update test_example_cert_expiration.rb

### DIFF
--- a/test/test_example_cert_expiration.rb
+++ b/test/test_example_cert_expiration.rb
@@ -5,39 +5,44 @@ require 'openssl'
 # Thes are tests to ensure that the checked in certs in the ./examples/
 # directory are valid and work as expected.
 #
-# These tets will start to fail 1 month before the certs expire
+# These tests will start to fail 1 month before the certs expire
 #
 class TestExampleCertExpiration < Minitest::Test
-  EXAMPLES_DIR = File.expand_path '../examples', __dir__
+  EXAMPLES_DIR = File.expand_path '../examples/puma', __dir__
   EXPIRE_THRESHOLD = Time.now.utc - (60 * 60 * 24 * 30) # 30 days
 
   # Explicitly list the files to test
   TEST_FILES = %w[
-    puma/cert_puma.pem
-    puma/client_certs/client.crt
-    puma/client_certs/ca.crt
-    puma/client_certs/client_unknown.crt
-    puma/client_certs/server.crt
-    puma/client_certs/unknown_ca.crt
-    puma/chain_cert/ca.crt
-    puma/chain_cert/cert.crt
-    puma/chain_cert/intermediate.crt
+    cert_puma.pem
+    client_certs/ca.crt
+    client_certs/client.crt
+    client_certs/client_unknown.crt
+    client_certs/server.crt
+    client_certs/unknown_ca.crt
+    chain_cert/ca.crt
+    chain_cert/cert.crt
+    chain_cert/intermediate.crt
   ]
 
-  # TODO: Add these files to the list above if they are not supposed to be expired
-  # CA/newcerts/cert_1.pem
-  # CA/newcerts/cert_2.pem
-  # CA/cacert.pem
-
   def test_certs_not_expired
-    TEST_FILES.each do |path|
+    expiration_data = TEST_FILES.map do |path|
       full_path  = File.join(EXAMPLES_DIR, path)
-      cert       = OpenSSL::X509::Certificate.new File.read(full_path)
+      not_after  = OpenSSL::X509::Certificate.new(File.read(full_path)).not_after
       parent_dir = File.dirname(path)
+      [not_after, path]
+    end
 
-      msg = "Cert #{path} has expired. Check the #{parent_dir} for a `.rb` with instructions on how to regenerate."
+    failed = expiration_data.select { |ary| ary[0] <= EXPIRE_THRESHOLD }
 
-      assert(cert.not_after > EXPIRE_THRESHOLD, msg)
+    if failed.empty?
+      assert true
+    else
+      msg = +"\n** The below certs in the 'examples/puma' folder are expiring soon.\n" \
+        "   See 'examples/generate_all_certs.md' for instructions on how to regenerate.\n\n"
+      failed.each do |ary|
+        msg << "     #{ary[1]}\n"
+      end
+      assert false, msg
     end
   end
 end


### PR DESCRIPTION
### Description
`test/test_example_cert_expiration.rb` checks for expiring certs.

1. Updated to show the addition of the the 'generate_all_certs' scritp and md file.

2. Currently, it generates an error for each expired cert.  Updated to only generate one error, example:

   ```text
     1) Failure:
   TestExampleCertExpiration#test_certs_not_expired [test/test_example_cert_expiration.rb:45]:
   
   ** The below certs in the 'examples/puma' folder are expiring soon.
      See 'examples/generate_all_certs.md' for instructions on how to regenerate.
   
        cert_puma.pem
        client_certs/ca.crt
        client_certs/client.crt
        client_certs/client_unknown.crt
        client_certs/server.crt
        client_certs/unknown_ca.crt
        chain_cert/ca.crt
        chain_cert/cert.crt
        chain_cert/intermediate.crt
   ```

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
