### PR TITLE
Clean up minitest usage: use a subclass of Minitest::Test, hook run_one_method not run, etc

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,6 @@ jobs:
       PUMA_TEST_DEBUG: true
       TESTOPTS: -v
       PUMA_NO_RUBOCOP: true
-      TERM: BugMinitest
 
     runs-on: ${{ matrix.os }}
     if: |
@@ -144,7 +143,6 @@ jobs:
       PUMA_TEST_DEBUG: true
       TESTOPTS: -v
       PUMA_NO_RUBOCOP: true
-      TERM: BugMinitest
 
     runs-on: ${{ matrix.os }}
     if: |

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -81,67 +81,22 @@ end
 
 require "timeout"
 
-if Minitest::VERSION < '5.25'
-  module TimeoutEveryTestCase
-    # our own subclass so we never confuse different timeouts
-    class TestTookTooLong < Timeout::Error
-    end
+class TimeoutTestCase < Minitest::Test
+  # our own subclass so we never confuse different timeouts
+  class TestTookTooLong < Timeout::Error
+  end
 
-    def run
-      with_info_handler do
-        time_it do
-          capture_exceptions do
-            ::Timeout.timeout($test_case_timeout, TestTookTooLong) do
-              before_setup; setup; after_setup
-              self.send self.name
-            end
-          end
-
-          capture_exceptions do
-            ::Timeout.timeout($test_case_timeout, TestTookTooLong) do
-              Minitest::Test::TEARDOWN_METHODS.each { |hook| self.send hook }
-            end
-          end
-          if respond_to? :clean_tmp_paths
-            clean_tmp_paths
-          end
-        end
-      end
-
-      Minitest::Result.from self # per contract
+  def self.run_one_method(klass, method_name, reporter)
+    ::Timeout.timeout($test_case_timeout, TestTookTooLong) do
+      super
     end
   end
-else
-  module TimeoutEveryTestCase
-    # our own subclass so we never confuse different timeouts
-    class TestTookTooLong < Timeout::Error
-    end
 
-    def run
-      time_it do
-        capture_exceptions do
-          ::Timeout.timeout($test_case_timeout, TestTookTooLong) do
-            Minitest::Test::SETUP_METHODS.each { |hook| self.send hook }
-            self.send self.name
-          end
-        end
-
-        capture_exceptions do
-          ::Timeout.timeout($test_case_timeout, TestTookTooLong) do
-            Minitest::Test::TEARDOWN_METHODS.each { |hook| self.send hook }
-          end
-        end
-        if respond_to? :clean_tmp_paths
-          clean_tmp_paths
-        end
-      end
-
-      Minitest::Result.from self # per contract
-    end
+  def teardown
+    super
+    clean_tmp_paths if respond_to? :clean_tmp_paths
   end
 end
-
-Minitest::Test.prepend TimeoutEveryTestCase
 
 if ENV['CI']
   require 'minitest/retry'

--- a/test/helpers/config_file.rb
+++ b/test/helpers/config_file.rb
@@ -1,4 +1,4 @@
-class TestConfigFileBase < Minitest::Test
+class TestConfigFileBase < TimeoutTestCase
   private
 
   def with_env(env = {})

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -7,7 +7,7 @@ require_relative 'tmp_path'
 
 # Only single mode tests go here. Cluster and pumactl tests
 # have their own files, use those instead
-class TestIntegration < Minitest::Test
+class TestIntegration < TimeoutTestCase
   include TmpPath
   HOST  = "127.0.0.1"
   TOKEN = "xxyyzz"

--- a/test/test_app_status.rb
+++ b/test/test_app_status.rb
@@ -5,7 +5,7 @@ require_relative "helper"
 require "puma/app/status"
 require "rack"
 
-class TestAppStatus < Minitest::Test
+class TestAppStatus < TimeoutTestCase
   parallelize_me!
 
   class FakeServer

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -8,7 +8,7 @@ require "puma/binder"
 require "puma/events"
 require "puma/configuration"
 
-class TestBinderBase < Minitest::Test
+class TestBinderBase < TimeoutTestCase
   include SSLHelper if ::Puma::HAS_SSL
   include TmpPath
 

--- a/test/test_bundle_pruner.rb
+++ b/test/test_bundle_pruner.rb
@@ -2,7 +2,7 @@ require_relative 'helper'
 
 require 'puma/events'
 
-class TestBundlePruner < Minitest::Test
+class TestBundlePruner < TimeoutTestCase
 
   PUMA_VERS = "puma-#{Puma::Const::PUMA_VERSION}"
 

--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -1,6 +1,6 @@
 require_relative "helper"
 
-class TestBusyWorker < Minitest::Test
+class TestBusyWorker < TimeoutTestCase
   def setup
     skip_unless :mri # This feature only makes sense on MRI
     @ios = []

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -7,7 +7,7 @@ require "puma/cli"
 require "json"
 require "psych"
 
-class TestCLI < Minitest::Test
+class TestCLI < TimeoutTestCase
   include SSLHelper if ::Puma::HAS_SSL
   include TmpPath
   include TestPuma::PumaSocket

--- a/test/test_error_logger.rb
+++ b/test/test_error_logger.rb
@@ -1,7 +1,7 @@
 require 'puma/error_logger'
 require_relative "helper"
 
-class TestErrorLogger < Minitest::Test
+class TestErrorLogger < TimeoutTestCase
   Req = Struct.new(:env, :body)
 
   def test_stdio

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -1,7 +1,7 @@
 require 'puma/events'
 require_relative "helper"
 
-class TestEvents < Minitest::Test
+class TestEvents < TimeoutTestCase
   def test_register_callback_with_block
     res = false
 

--- a/test/test_example_cert_expiration.rb
+++ b/test/test_example_cert_expiration.rb
@@ -7,7 +7,7 @@ require 'openssl'
 #
 # These tests will start to fail 1 month before the certs expire
 #
-class TestExampleCertExpiration < Minitest::Test
+class TestExampleCertExpiration < TimeoutTestCase
   EXAMPLES_DIR = File.expand_path '../examples/puma', __dir__
   EXPIRE_THRESHOLD = Time.now.utc - (60 * 60 * 24 * 30) # 30 days
 

--- a/test/test_http10.rb
+++ b/test/test_http10.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 
 require "puma/puma_http11"
 
-class Http10ParserTest < Minitest::Test
+class Http10ParserTest < TimeoutTestCase
   def test_parse_simple
     parser = Puma::HttpParser.new
     req = {}

--- a/test/test_http11.rb
+++ b/test/test_http11.rb
@@ -6,7 +6,7 @@ require "digest"
 
 require "puma/puma_http11"
 
-class Http11ParserTest < Minitest::Test
+class Http11ParserTest < TimeoutTestCase
 
   parallelize_me!
 

--- a/test/test_iobuffer.rb
+++ b/test/test_iobuffer.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 
 require "puma/io_buffer"
 
-class TestIOBuffer < Minitest::Test
+class TestIOBuffer < TimeoutTestCase
   attr_accessor :iobuf
   def setup
     self.iobuf = Puma::IOBuffer.new

--- a/test/test_json_serialization.rb
+++ b/test/test_json_serialization.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 require "json"
 require "puma/json_serialization"
 
-class TestJSONSerialization < Minitest::Test
+class TestJSONSerialization < TimeoutTestCase
   parallelize_me! unless JRUBY_HEAD
 
   def test_json_generates_string_for_hash_with_string_keys

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -4,7 +4,7 @@ require_relative "helpers/tmp_path"
 require "puma/configuration"
 require 'puma/log_writer'
 
-class TestLauncher < Minitest::Test
+class TestLauncher < TimeoutTestCase
   include TmpPath
 
   def test_prints_thread_traces

--- a/test/test_log_writer.rb
+++ b/test/test_log_writer.rb
@@ -2,7 +2,7 @@ require 'puma/detect'
 require 'puma/log_writer'
 require_relative "helper"
 
-class TestLogWriter < Minitest::Test
+class TestLogWriter < TimeoutTestCase
   def test_null
     log_writer = Puma::LogWriter.null
 

--- a/test/test_minissl.rb
+++ b/test/test_minissl.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 
 require "puma/minissl" if ::Puma::HAS_SSL
 
-class TestMiniSSL < Minitest::Test
+class TestMiniSSL < TimeoutTestCase
 
   if Puma.jruby?
     def test_raises_with_invalid_keystore_file

--- a/test/test_null_io.rb
+++ b/test/test_null_io.rb
@@ -4,7 +4,7 @@ require_relative "helper"
 
 require "puma/null_io"
 
-class TestNullIO < Minitest::Test
+class TestNullIO < TimeoutTestCase
   parallelize_me!
 
   attr_accessor :nio

--- a/test/test_out_of_band_server.rb
+++ b/test/test_out_of_band_server.rb
@@ -1,6 +1,6 @@
 require_relative "helper"
 
-class TestOutOfBandServer < Minitest::Test
+class TestOutOfBandServer < TimeoutTestCase
   parallelize_me!
 
   def setup

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -1,6 +1,6 @@
 require_relative "helper"
 
-class TestPersistent < Minitest::Test
+class TestPersistent < TimeoutTestCase
 
   HOST = "127.0.0.1"
 

--- a/test/test_puma_localhost_authority.rb
+++ b/test/test_puma_localhost_authority.rb
@@ -11,7 +11,7 @@ if ::Puma::HAS_SSL && !Puma::IS_JRUBY
   require "openssl" unless Object.const_defined? :OpenSSL
 end
 
-class TestPumaLocalhostAuthority < Minitest::Test
+class TestPumaLocalhostAuthority < TimeoutTestCase
   include TestPuma
   include TestPuma::PumaSocket
 
@@ -45,7 +45,7 @@ class TestPumaLocalhostAuthority < Minitest::Test
 
 end if ::Puma::HAS_SSL && !Puma::IS_JRUBY
 
-class TestPumaSSLLocalhostAuthority < Minitest::Test
+class TestPumaSSLLocalhostAuthority < TimeoutTestCase
   include TestPuma
   include TestPuma::PumaSocket
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -10,7 +10,7 @@ class WithoutBacktraceError < StandardError
   def message; "no backtrace error"; end
 end
 
-class TestPumaServer < Minitest::Test
+class TestPumaServer < TimeoutTestCase
   parallelize_me!
 
   STATUS_CODES = ::Puma::HTTP_STATUS_CODES

--- a/test/test_puma_server_current.rb
+++ b/test/test_puma_server_current.rb
@@ -13,7 +13,7 @@ class PumaServerCurrentApplication
   end
 end
 
-class PumaServerCurrentTest < Minitest::Test
+class PumaServerCurrentTest < TimeoutTestCase
   parallelize_me!
 
   def setup

--- a/test/test_puma_server_hijack.rb
+++ b/test/test_puma_server_hijack.rb
@@ -14,7 +14,7 @@ require "rack/body_proxy"
 # The sleep statements may not be needed for local CI, but are needed
 # for use with GitHub Actions...
 
-class TestPumaServerHijack < Minitest::Test
+class TestPumaServerHijack < TimeoutTestCase
   parallelize_me!
 
   def setup

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -24,7 +24,7 @@ if ::Puma::HAS_SSL
   end
 end
 
-class TestPumaServerSSL < Minitest::Test
+class TestPumaServerSSL < TimeoutTestCase
   parallelize_me!
 
   include TestPuma
@@ -270,7 +270,7 @@ class TestPumaServerSSL < Minitest::Test
 end if ::Puma::HAS_SSL
 
 # client-side TLS authentication tests
-class TestPumaServerSSLClient < Minitest::Test
+class TestPumaServerSSLClient < TimeoutTestCase
   parallelize_me! unless ::Puma.jruby?
 
   include TestPuma
@@ -489,7 +489,7 @@ class TestPumaServerSSLClient < Minitest::Test
 
 end if ::Puma::HAS_SSL
 
-class TestPumaServerSSLWithCertPemAndKeyPem < Minitest::Test
+class TestPumaServerSSLWithCertPemAndKeyPem < TimeoutTestCase
   include TestPuma
   include TestPuma::PumaSocket
 
@@ -531,7 +531,7 @@ end if ::Puma::HAS_SSL && !Puma::IS_JRUBY
 #
 #   bundle exec ruby ../examples/puma/chain_cert/generate_chain_test.rb
 #
-class TestPumaSSLCertChain < Minitest::Test
+class TestPumaSSLCertChain < TimeoutTestCase
   include TestPuma
   include TestPuma::PumaSocket
 

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -6,7 +6,7 @@ module TestRackUp
   require "rack/handler/puma"
   require "puma/events"
 
-  class TestOnBootedHandler < Minitest::Test
+  class TestOnBootedHandler < TimeoutTestCase
     def app
       Proc.new {|env| @input = env; [200, {}, ["hello world"]]}
     end
@@ -40,7 +40,7 @@ module TestRackUp
     end
   end
 
-  class TestPathHandler < Minitest::Test
+  class TestPathHandler < TimeoutTestCase
     def app
       Proc.new {|env| @input = env; [200, {}, ["hello world"]]}
     end
@@ -83,7 +83,7 @@ module TestRackUp
     end
   end
 
-  class TestUserSuppliedOptionsPortIsSet < Minitest::Test
+  class TestUserSuppliedOptionsPortIsSet < TimeoutTestCase
     def setup
       @options = {}
       @options[:user_supplied_options] = [:Port]
@@ -108,7 +108,7 @@ module TestRackUp
     end
   end
 
-  class TestUserSuppliedOptionsHostIsSet < Minitest::Test
+  class TestUserSuppliedOptionsHostIsSet < TimeoutTestCase
     def setup
       @options = {}
       @options[:user_supplied_options] = [:Host]
@@ -135,7 +135,7 @@ module TestRackUp
     end
   end
 
-  class TestUserSuppliedOptionsIsEmpty < Minitest::Test
+  class TestUserSuppliedOptionsIsEmpty < TimeoutTestCase
     def setup
       @options = {}
       @options[:user_supplied_options] = []
@@ -198,7 +198,7 @@ module TestRackUp
     end
   end
 
-  class TestUserSuppliedOptionsIsNotPresent < Minitest::Test
+  class TestUserSuppliedOptionsIsNotPresent < TimeoutTestCase
     def setup
       @options = {}
     end
@@ -299,7 +299,7 @@ module TestRackUp
   end
 
   # Run using IO.popen so we don't load Rack and/or Rackup in the main process
-  class RackUp < Minitest::Test
+  class RackUp < TimeoutTestCase
     def setup
       FileUtils.copy_file 'test/rackup/hello.ru', 'config.ru'
     end

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -18,7 +18,7 @@ require "rack/chunked" if Rack.release.start_with? '3.0'
 
 require "nio"
 
-class TestRackServer < Minitest::Test
+class TestRackServer < TimeoutTestCase
   parallelize_me!
 
   HOST = '127.0.0.1'

--- a/test/test_request_invalid.rb
+++ b/test/test_request_invalid.rb
@@ -10,7 +10,7 @@ require_relative "helper"
 # https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.1 Transfer-Encoding
 # https://datatracker.ietf.org/doc/html/rfc7230#section-4.1   chunked body size
 #
-class TestRequestInvalid < Minitest::Test
+class TestRequestInvalid < TimeoutTestCase
   # running parallel seems to take longer...
   # parallelize_me! unless JRUBY_HEAD
 

--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -3,7 +3,7 @@ require "puma/events"
 require "net/http"
 require "nio"
 
-class TestResponseHeader < Minitest::Test
+class TestResponseHeader < TimeoutTestCase
   parallelize_me!
 
   # this file has limited response length, so 10kB works.

--- a/test/test_state_file.rb
+++ b/test/test_state_file.rb
@@ -3,7 +3,7 @@ require_relative "helpers/tmp_path"
 
 require 'puma/state_file'
 
-class TestStateFile < Minitest::Test
+class TestStateFile < TimeoutTestCase
   include TmpPath
 
   def test_load_empty_value_as_nil

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 
 require "puma/thread_pool"
 
-class TestThreadPool < Minitest::Test
+class TestThreadPool < TimeoutTestCase
 
   def teardown
     @pool.shutdown(1) if defined?(@pool)

--- a/test/test_unix_socket.rb
+++ b/test/test_unix_socket.rb
@@ -3,7 +3,7 @@
 require_relative "helper"
 require_relative "helpers/tmp_path"
 
-class TestPumaUnixSocket < Minitest::Test
+class TestPumaUnixSocket < TimeoutTestCase
   include TmpPath
 
   App = lambda { |env| [200, {}, ["Works"]] }

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -16,7 +16,7 @@ class TestHandler
   end
 end
 
-class WebServerTest < Minitest::Test
+class WebServerTest < TimeoutTestCase
   parallelize_me!
 
   VALID_REQUEST = "GET / HTTP/1.1\r\nHost: www.zedshaw.com\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n"


### PR DESCRIPTION
### Description

This changes the test class in every file, so it looks ugly, but it
should make things cleaner in the long run.

test_helper.rb could use some more cleanup. It is still including into
Minitest::Test when it could just PUT everything in TimeoutTestCase
now.

I can take this further... just say the word.