### PR TITLE
[CI] test/worker_gem_independence_test - update versions, fix for Ruby 3.4/head

### DIFF
--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -15,16 +15,16 @@ class TestWorkerGemIndependence < TestIntegration
 
   def test_changing_nio4r_version_during_phased_restart
     change_gem_version_during_phased_restart old_app_dir: 'worker_gem_independence_test/old_nio4r',
-                                             old_version: '2.6.0',
+                                             old_version: '2.7.1',
                                              new_app_dir: 'worker_gem_independence_test/new_nio4r',
-                                             new_version: '2.6.1'
+                                             new_version: '2.7.2'
   end
 
   def test_changing_json_version_during_phased_restart
     change_gem_version_during_phased_restart old_app_dir: 'worker_gem_independence_test/old_json',
-                                             old_version: '2.3.1',
+                                             old_version: '2.7.1',
                                              new_app_dir: 'worker_gem_independence_test/new_json',
-                                             new_version: '2.3.0'
+                                             new_version: '2.7.0'
   end
 
   def test_changing_json_version_during_phased_restart_after_querying_stats_from_status_server
@@ -37,9 +37,9 @@ class TestWorkerGemIndependence < TestIntegration
     change_gem_version_during_phased_restart server_opts: server_opts,
                                              before_restart: before_restart,
                                              old_app_dir: 'worker_gem_independence_test/old_json',
-                                             old_version: '2.3.1',
+                                             old_version: '2.7.1',
                                              new_app_dir: 'worker_gem_independence_test/new_json',
-                                             new_version: '2.3.0'
+                                             new_version: '2.7.0'
   end
 
   def test_changing_json_version_during_phased_restart_after_querying_gc_stats_from_status_server
@@ -52,9 +52,9 @@ class TestWorkerGemIndependence < TestIntegration
     change_gem_version_during_phased_restart server_opts: server_opts,
                                              before_restart: before_restart,
                                              old_app_dir: 'worker_gem_independence_test/old_json',
-                                             old_version: '2.3.1',
+                                             old_version: '2.7.1',
                                              new_app_dir: 'worker_gem_independence_test/new_json',
-                                             new_version: '2.3.0'
+                                             new_version: '2.7.0'
   end
 
   def test_changing_json_version_during_phased_restart_after_querying_thread_backtraces_from_status_server
@@ -67,16 +67,16 @@ class TestWorkerGemIndependence < TestIntegration
     change_gem_version_during_phased_restart server_opts: server_opts,
                                              before_restart: before_restart,
                                              old_app_dir: 'worker_gem_independence_test/old_json',
-                                             old_version: '2.3.1',
+                                             old_version: '2.7.1',
                                              new_app_dir: 'worker_gem_independence_test/new_json',
-                                             new_version: '2.3.0'
+                                             new_version: '2.7.0'
   end
 
   def test_changing_json_version_during_phased_restart_after_accessing_puma_stats_directly
     change_gem_version_during_phased_restart old_app_dir: 'worker_gem_independence_test/old_json_with_puma_stats_after_fork',
-                                             old_version: '2.3.1',
+                                             old_version: '2.7.1',
                                              new_app_dir: 'worker_gem_independence_test/new_json_with_puma_stats_after_fork',
-                                             new_version: '2.3.0'
+                                             new_version: '2.7.0'
   end
 
   private

--- a/test/worker_gem_independence_test/new_json/Gemfile
+++ b/test/worker_gem_independence_test/new_json/Gemfile
@@ -1,4 +1,8 @@
 source "https://rubygems.org"
 
 gem 'puma', path: '../../..'
-gem 'json', '= 2.3.0'
+gem 'json', '= 2.7.0'
+
+if RUBY_VERSION > '3.4'
+  gem 'ostruct', '>= 0.6.0'
+end

--- a/test/worker_gem_independence_test/new_json_with_puma_stats_after_fork/Gemfile
+++ b/test/worker_gem_independence_test/new_json_with_puma_stats_after_fork/Gemfile
@@ -1,4 +1,8 @@
 source "https://rubygems.org"
 
 gem 'puma', path: '../../..'
-gem 'json', '= 2.3.0'
+gem 'json', '= 2.7.0'
+
+if RUBY_VERSION > '3.4'
+  gem 'ostruct', '>= 0.6.0'
+end

--- a/test/worker_gem_independence_test/new_nio4r/Gemfile
+++ b/test/worker_gem_independence_test/new_nio4r/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem 'puma', path: '../../..'
-gem 'nio4r', '= 2.6.1'
+gem 'nio4r', '= 2.7.2'

--- a/test/worker_gem_independence_test/old_json/Gemfile
+++ b/test/worker_gem_independence_test/old_json/Gemfile
@@ -1,4 +1,8 @@
 source "https://rubygems.org"
 
 gem 'puma', path: '../../..'
-gem 'json', '= 2.3.1'
+gem 'json', '= 2.7.1'
+
+if RUBY_VERSION > '3.4'
+  gem 'ostruct', '>= 0.6.0'
+end

--- a/test/worker_gem_independence_test/old_json_with_puma_stats_after_fork/Gemfile
+++ b/test/worker_gem_independence_test/old_json_with_puma_stats_after_fork/Gemfile
@@ -1,4 +1,8 @@
 source "https://rubygems.org"
 
 gem 'puma', path: '../../..'
-gem 'json', '= 2.3.1'
+gem 'json', '= 2.7.1'
+
+if RUBY_VERSION > '3.4'
+  gem 'ostruct', '>= 0.6.0'
+end

--- a/test/worker_gem_independence_test/old_nio4r/Gemfile
+++ b/test/worker_gem_independence_test/old_nio4r/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem 'puma', path: '../../..'
-gem 'nio4r', '= 2.6.0'
+gem 'nio4r', '= 2.7.1'


### PR DESCRIPTION
### Description

The files used with the 'worker_gem_independence' tests were added to Puma 5, which was compatible with Ruby 2.2.

Update json & nio4r versions to more current versions, and add checks in Gemfiles to remove Ruby 3.4 (current head) warninga like the below, which is due to the common 'bundled gems' issue:
```text
warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
