### PR TITLE
[CI] test/integration.rb - catch 'exception in thread'

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -453,6 +453,7 @@ class TestIntegration < Minitest::Test
         begin
           wait_for_server_to_boot timeout: 5
         rescue Minitest::Assertion # Timeout
+          run = false
         end
         restart_count += 1
         sleep(Puma.windows? ? 2.0 : 0.5)
@@ -464,7 +465,7 @@ class TestIntegration < Minitest::Test
     restart_thread.join
     if Puma.windows?
       cli_pumactl 'stop'
-      Process.wait @server.pid
+      Process.wait @pid
     else
       stop_server
     end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -150,8 +150,8 @@ class TestIntegration < Minitest::Test
 
   # wait for server to say it booted
   # @server and/or @server.gets may be nil on slow CI systems
-  def wait_for_server_to_boot(log: false)
-    wait_for_server_to_include 'Ctrl-C', log: log
+  def wait_for_server_to_boot(timeout: LOG_TIMEOUT, log: false)
+    wait_for_server_to_include 'Ctrl-C', timeout: timeout, log: log
   end
 
   # Returns true if and when server log includes str.  Will timeout otherwise.
@@ -449,7 +449,11 @@ class TestIntegration < Minitest::Test
           Process.kill :USR2, @pid
         end
         sleep 0.5
-        wait_for_server_to_boot
+        # If 'wait_for_server_to_boot' times out, error in thread shuts down CI
+        begin
+          wait_for_server_to_boot timeout: 5
+        rescue Minitest::Assertion # Timeout
+        end
         restart_count += 1
         sleep(Puma.windows? ? 2.0 : 0.5)
       end


### PR DESCRIPTION
### Description

`TestIntegration#hot_restart_does_not_drop_connections` cycles thru server 'restart' commands and checks request handling.  A thread (`restart_thread`) does the cycling.  It calls `wait_for_server_to_boot`, checking for a log of `Ctrl-C`.  This may timeout on CI servers, and raises an error inside the thread.  `abort on exception` is true, so CI stops cold.

This PR catches the error, and retries seem to pass.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
