### PR TITLE
[CI] test/helpers/integration.rb - add wait_server, use in other test files

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -133,6 +133,18 @@ class TestIntegration < Minitest::Test
     end
   end
 
+  # Most integration tests do not stop/shutdown the server, which is handled by
+  # `teardown` in this file.
+  # For tests that do stop/shutdown the server, use this method to check with `wait2`,
+  # and also clear variables so `teardown` will not run its code.
+  def wait_server(exit_code = 0, pid: @pid)
+    return unless pid
+    _, status = Process.wait2 pid
+    assert_equal exit_code, status
+    @server.close unless @server.closed?
+    @server = nil
+  end
+
   def restart_server_and_listen(argv, log: false)
     cli_server argv
     connection = connect

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -28,10 +28,7 @@ class TestIntegrationPumactl < TestIntegration
 
     cli_pumactl "stop"
 
-    _, status = Process.wait2(@pid)
-    assert_equal 0, status
-
-    @server = nil
+    wait_server
   end
 
   def test_stop_unix
@@ -52,10 +49,9 @@ class TestIntegrationPumactl < TestIntegration
 
     cli_pumactl signal, unix: true
 
-    _, status = Process.wait2(@pid)
-    assert_equal 0, status
+    wait_server
+
     refute_match 'error', File.read(stderr.path)
-    @server = nil
   end
 
   def test_phased_restart_cluster
@@ -87,10 +83,8 @@ class TestIntegrationPumactl < TestIntegration
 
     cli_pumactl "stop", unix: true
 
-    _, status = Process.wait2(@pid)
-    assert_equal 0, status
+    wait_server
     assert_operator Process.clock_gettime(Process::CLOCK_MONOTONIC) - start, :<, (DARWIN ? 8 : 7)
-    @server = nil
   end
 
   def test_refork_cluster
@@ -122,10 +116,8 @@ class TestIntegrationPumactl < TestIntegration
 
     cli_pumactl "stop", unix: true
 
-    _, status = Process.wait2(@pid)
-    assert_equal 0, status
+    wait_server
     assert_operator Time.now - start, :<, 60
-    @server = nil
   end
 
   def test_prune_bundler_with_multiple_workers
@@ -141,8 +133,7 @@ class TestIntegrationPumactl < TestIntegration
 
     cli_pumactl "stop", unix: true
 
-    _, _ = Process.wait2(@pid)
-    @server = nil
+    wait_server
   end
 
   def test_kill_unknown

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -124,9 +124,7 @@ class TestIntegrationSingle < TestIntegration
     assert_match(/Slept 10/, curl_stdout.read)
     assert_match(/Connection refused|(Couldn't|Could not) connect to server/, rejected_curl_stderr.read)
 
-    Process.wait(@server.pid)
-    @server.close unless @server.closed?
-    @server = nil # prevent `#teardown` from killing already killed server
+    wait_server 15
   end
 
   def test_int_refuse
@@ -142,7 +140,7 @@ class TestIntegrationSingle < TestIntegration
     end
 
     Process.kill :INT, @pid
-    Process.wait @pid
+    wait_server
 
     assert_raises(Errno::ECONNREFUSED) { TCPSocket.new(HOST, @tcp_port) }
   end
@@ -207,10 +205,9 @@ class TestIntegrationSingle < TestIntegration
     cli_pumactl 'stop'
 
     assert wait_for_server_to_include("hello\n")
-    assert_includes @server.read, 'Goodbye!'
+    assert wait_for_server_to_include("Goodbye!")
 
-    @server.close unless @server.closed?
-    @server = nil
+    wait_server
   end
 
   # listener is closed 'externally' while Puma is in the IO.select statement
@@ -220,13 +217,9 @@ class TestIntegrationSingle < TestIntegration
     cli_server "test/rackup/close_listeners.ru", merge_err: true
     connection = fast_connect
 
-    if DARWIN && RUBY_VERSION < '2.5'
-      begin
-        read_body connection
-      rescue EOFError
-      end
-    else
+    begin
       read_body connection
+    rescue EOFError
     end
 
     begin
@@ -253,6 +246,8 @@ class TestIntegrationSingle < TestIntegration
     assert wait_for_server_to_include('Loaded Extensions:')
 
     cli_pumactl 'stop'
+    assert wait_for_server_to_include('Goodbye!')
+    wait_server
   end
 
   def test_idle_timeout

--- a/test/test_integration_ssl.rb
+++ b/test/test_integration_ssl.rb
@@ -151,6 +151,7 @@ class TestIntegrationSSL < TestIntegration
     assert_equal client_cert, body
   ensure
     cli_pumactl 'stop'
+    wait_server
   end
 
   def test_verify_client_cert_roundtrip_tls1_2


### PR DESCRIPTION
### Description

The comments for the new `wait_server` method:

Most integration tests do not stop/shutdown the server, which is handled by `teardown` in this file.
For tests that do stop/shutdown the server, use this method to check with `wait2`, and also clear variables so `teardown` will not run its code.

Close https://github.com/puma/puma/pull/3457

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
