### PR TITLE
[CI] test/test_integration_cluster.rb - fix up test_on_booted_and_on_stopped

### DIFF
--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -138,10 +138,10 @@ class TestIntegrationCluster < TestIntegration
 
   def test_on_booted_and_on_stopped
     skip_unless_signal_exist? :TERM
-    cli_server "-w #{workers} -C test/config/event_on_booted_and_on_stopped.rb -C test/config/event_on_booted_exit.rb test/rackup/hello.ru",
-      no_wait: true
+    cli_server "-w #{workers} -C test/config/event_on_booted_and_on_stopped.rb -C test/config/event_on_booted_exit.rb test/rackup/hello.ru"
 
     assert wait_for_server_to_include('on_booted called')
+    assert wait_for_server_to_include('Goodbye!')
     assert wait_for_server_to_include('on_stopped called')
   end
 


### PR DESCRIPTION
### Description

Running integration tests locally with a ten core Intel i9 and 64 MB of ram (WSL2/Ubuntu 24.04 Ruby head), this occasionally failed.  These changes seemed to stabilize it. 

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
