### PR TITLE
[CI] test_integration_cluster - use STDOUT for test_hook_data

### DIFF
--- a/test/config/hook_data.rb
+++ b/test/config/hook_data.rb
@@ -5,5 +5,5 @@ on_worker_boot(:test) do |index, data|
 end
 
 on_worker_shutdown(:test) do |index, data|
-  File.write "hook_data-#{index}.txt", "index #{index} data #{data[:test]}", mode: 'wb:UTF-8'
+  STDOUT.syswrite "\nindex #{index} data #{data[:test]}"
 end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -520,22 +520,16 @@ class TestIntegrationCluster < TestIntegration
   def test_hook_data
     skip_unless_signal_exist? :TERM
 
-    file0 = 'hook_data-0.txt'
-    file1 = 'hook_data-1.txt'
-
     cli_server "-C test/config/hook_data.rb test/rackup/hello.ru"
-    get_worker_pids 0, 2
+    get_worker_pids 0, 2 # make sure workers are booted
     stop_server
 
-    # helpful for non MRI Rubies
-    assert wait_for_server_to_include('puma shutdown')
+    ary = Array.new(2) do |_|
+      wait_for_server_to_match(/(index \d data \d)/, 1)
+    end.sort
 
-    assert_equal 'index 0 data 0', File.read(file0, mode: 'rb:UTF-8')
-    assert_equal 'index 1 data 1', File.read(file1, mode: 'rb:UTF-8')
-
-  ensure
-    File.unlink file0 if File.file? file0
-    File.unlink file1 if File.file? file1
+    assert 'index 0 data 0', ary[0]
+    assert 'index 1 data 1', ary[1]
   end
 
   def test_worker_hook_warning_cli

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -524,7 +524,7 @@ class TestIntegrationCluster < TestIntegration
     get_worker_pids 0, 2 # make sure workers are booted
     stop_server
 
-    ary = Array.new(2) do |_|
+    ary = Array.new(2) do |_index|
       wait_for_server_to_match(/(index \d data \d)/, 1)
     end.sort
 


### PR DESCRIPTION
### Description

There have been intermittent failures reading the files written by the tests.  Update to use `STDOUT` instead of files.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
