### PR TITLE
[CI] integration.rb - update @pid value by reading server log, revise BASE

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -21,8 +21,8 @@ class TestIntegration < Minitest::Test
   LOG_ERROR_SLEEP = 0.2
   LOG_ERROR_QTY   = 5
 
-  BASE = defined?(Bundler) ? "bundle exec #{Gem.ruby} -Ilib" :
-    "#{Gem.ruby} -Ilib"
+  # rubyopt requires bundler/setup, so we don't need it here
+  BASE = "#{Gem.ruby} -Ilib"
 
   def setup
     @server = nil
@@ -114,8 +114,8 @@ class TestIntegration < Minitest::Test
     else
       @server = IO.popen(env, cmd)
     end
-    wait_for_server_to_boot(log: log) unless no_wait
     @pid = @server.pid
+    wait_for_server_to_boot(log: log) unless no_wait
     @server
   end
 
@@ -163,6 +163,8 @@ class TestIntegration < Minitest::Test
   # wait for server to say it booted
   # @server and/or @server.gets may be nil on slow CI systems
   def wait_for_server_to_boot(timeout: LOG_TIMEOUT, log: false)
+    @puma_pid = wait_for_server_to_match(/(?:Master|      ) PID: (\d+)$/, 1, timeout: timeout, log: log)&.to_i
+    @pid = @puma_pid if @pid != @puma_pid
     wait_for_server_to_include 'Ctrl-C', timeout: timeout, log: log
   end
 

--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -2,6 +2,11 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestWorkerGemIndependence < TestIntegration
+
+  ENV_RUBYOPT = {
+    'RUBYOPT' => ENV['RUBYOPT']
+  }
+
   def setup
     skip_unless :fork
     super
@@ -95,7 +100,7 @@ class TestWorkerGemIndependence < TestIntegration
       with_unbundled_env do
         silent_and_checked_system_command("bundle config --local path vendor/bundle")
         silent_and_checked_system_command("bundle install")
-        cli_server "--prune-bundler -w 1 #{server_opts}"
+        cli_server "--prune-bundler -w 1 #{server_opts}", env: ENV_RUBYOPT
       end
     end
 


### PR DESCRIPTION
### Description

Updates pid handling.  If `cli_server` fails `wait_for_server_to_boot`, current code errors before `@pid` is set, which means the process can't be shut down.  Added code to set `@pid` equal to the Puma process's pid via the server log.

Refactor `cli_server` command line, since test process sets `RUBYOPT` to load `bundler/setup`.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
