### PR TITLE
[]CI] Fix up test_puma_server_ssl.rb - protocol rejection and log_writer setup

### DIFF
--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -61,7 +61,9 @@ class TestPumaServerSSL < Minitest::Test
 
     yield ctx if server_ctx
 
-    @log_writer = SSLLogWriterHelper.new STDOUT, STDERR
+    @log_stdout = StringIO.new
+    @log_stderr = StringIO.new
+    @log_writer = SSLLogWriterHelper.new @log_stdout, @log_stderr
     @server = Puma::Server.new app, nil, {log_writer: @log_writer}
     @port = (@server.add_ssl_listener HOST, 0, ctx).addr[1]
     @bind_port = @port
@@ -541,7 +543,9 @@ class TestPumaSSLCertChain < Minitest::Test
   def cert_chain(&blk)
     app = lambda { |env| [200, {}, [env['rack.url_scheme']]] }
 
-    @log_writer = SSLLogWriterHelper.new STDOUT, STDERR
+    @log_stdout = StringIO.new
+    @log_stderr = StringIO.new
+    @log_writer = SSLLogWriterHelper.new @log_stdout, @log_stderr
     @server = Puma::Server.new app, nil, {log_writer: @log_writer}
 
     mini_ctx = Puma::MiniSSL::Context.new


### PR DESCRIPTION
### Description

test_puma_server_ssl.rb - add rejection helper, use for protocol rejection tests

test_puma_server_ssl.rb - don't share STDOUT & STDERR for logging when running parallel

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
