### PR TITLE
server.rb - fixup for `closed_socket?` on JRuby aarch64/ARM64

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -199,6 +199,12 @@ module Puma
           false
         else
           state = tcp_info.unpack(UNPACK_TCP_STATE_FROM_TCP_INFO)[0]
+          # conditional is for JRuby on linux aarch64/ARM64
+          # https://github.com/puma/puma/issues/3465
+          unless state
+            @precheck_closing = false
+            return false
+          end
           # TIME_WAIT: 6, CLOSE: 7, CLOSE_WAIT: 8, LAST_ACK: 9, CLOSING: 11
           (state >= 6 && state <= 9) || state == 11
         end


### PR DESCRIPTION
### Description

JRuby running on aarch64/ARM64 linux may have a bug when using

[`BasicSocket.getsockopt(Socket::IPPROTO_TCP, Socket::TCP_INFO)`](https://msp-greg.github.io/ruby_trunk/socket/BasicSocket.html#getsockopt-instance_method)

This works around the bug.

Closes #3465

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
