### PR TITLE
Fixup jruby_restart.rb & launcher.rb to work with ARM64 macOS JRuby

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,6 +163,7 @@ jobs:
           - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby, allow-failure: true } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
           - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby-head, allow-failure: true }
           - { tto: 8 , os: macos-13     , ruby: jruby }
+          - { tto: 8 , os: macos-14     , ruby: jruby }
           - { tto: 8 , os: macos-13     , ruby: truffleruby, allow-failure: true }
 
     steps:

--- a/lib/puma/jruby_restart.rb
+++ b/lib/puma/jruby_restart.rb
@@ -6,22 +6,6 @@ module Puma
   module JRubyRestart
     extend FFI::Library
     ffi_lib 'c'
-
-    attach_function :execlp, [:string, :varargs], :int
     attach_function :chdir, [:string], :int
-    attach_function :fork, [], :int
-    attach_function :exit, [:int], :void
-    attach_function :setsid, [], :int
-
-    def self.chdir_exec(dir, argv)
-      chdir(dir)
-      cmd = argv.first
-      argv = ([:string] * argv.size).zip(argv)
-      argv.flatten!
-      argv << :string
-      argv << nil
-      execlp(cmd, *argv)
-      raise SystemCallError.new(FFI.errno)
-    end
   end
 end

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -287,7 +287,9 @@ module Puma
         close_binder_listeners
 
         require_relative 'jruby_restart'
-        JRubyRestart.chdir_exec(@restart_dir, restart_args)
+        argv = restart_args
+        JRubyRestart.chdir(@restart_dir)
+        Kernel.exec(*argv)
       elsif Puma.windows?
         close_binder_listeners
 


### PR DESCRIPTION
### Description

Also adds macos-14 jruby job to the CI, which is running on ARM64.

See https://github.com/puma/puma/issues/3446

Thanks to @headius for the help.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
