### PR TITLE
Implement NullIO#seek and #pos to mimic IO

### DIFF
--- a/lib/puma/null_io.rb
+++ b/lib/puma/null_io.rb
@@ -16,6 +16,10 @@ module Puma
     def each
     end
 
+    def pos
+      0
+    end
+
     # Mimics IO#read with no data.
     #
     def read(length = nil, buffer = nil)
@@ -37,6 +41,11 @@ module Puma
     end
 
     def rewind
+    end
+
+    def seek(pos, whence = 0)
+      raise ArgumentError, "negative length #{pos} given" if pos.negative?
+      0
     end
 
     def close

--- a/test/test_null_io.rb
+++ b/test/test_null_io.rb
@@ -120,6 +120,23 @@ class TestNullIO < Minitest::Test
     assert_equal 0, nio.size
   end
 
+  def test_pos
+    assert_equal 0, nio.pos
+  end
+
+  def test_seek_returns_0
+    assert_equal 0, nio.seek(0)
+    assert_equal 0, nio.seek(100)
+  end
+
+  def test_seek_negative_raises
+    error = assert_raises ArgumentError do
+      nio.read(-1)
+    end
+
+    assert_match(/negative length -1 given/, error.message)
+  end
+
   def test_sync_returns_true
     assert_equal true, nio.sync
   end


### PR DESCRIPTION
### Description

As per the title.

We have code like this in a library I'm working on:

``` ruby
def body
  pos = request.body.pos
  request.body.rewind
  @request_body = request.body.read
ensure
  request.body.rewind
  request.body.seek(pos)
end
```

This works fine for normal request bodies, but chokes on empty requests because `NullIO` does not implement `#seek` or `#pos`. My understanding is that these methods are part of the IO interface, and so should be implemented here. 🤔 

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
