### PR TITLE
[CI] test_puma_server.rb - use TestPuma::PumaSocket

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -335,7 +335,8 @@ module TestTempFile
     fio.write data
     fio.flush
     fio.rewind
-    @ios << fio
+    @ios << fio if defined?(@ios)
+    @ios_to_close << fio if defined?(@ios_to_close)
     fio
   end
 end


### PR DESCRIPTION
### Description

Removes client 'helper' methods from `test_puma_server.rb` and replaces with client methods from `test/helpers/test_puma/puma_socket.rb`.  This speeds up a few of the tests, as there is less blocking.

See discussion #3232.  This is the first step.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
