### PR TITLE
Make preload app compatible with phased restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,6 @@ workers 3
 preload_app!
 ```
 
-Preloading can’t be used with phased restart, since phased restart kills and restarts workers one-by-one, and preloading copies the code of master into the workers.
-
 #### Clustered mode hooks
 
 When using clustered mode, Puma's configuration DSL provides `before_fork` and `on_worker_boot`
@@ -167,7 +165,7 @@ on_refork do
 end
 ```
 
-Importantly, note the following considerations when Ruby forks a child process: 
+Importantly, note the following considerations when Ruby forks a child process:
 
 1. File descriptors such as network sockets **are** copied from the parent to the forked
    child process. Dual-use of the same sockets by parent and child will result in I/O conflicts

--- a/docs/fork_worker.md
+++ b/docs/fork_worker.md
@@ -12,7 +12,7 @@ Puma 5 introduces an experimental new cluster-mode configuration option, `fork_w
 
 The `fork_worker` option allows your application to be initialized only once for copy-on-write memory savings, and it has two additional advantages:
 
-1. **Compatible with phased restart.** Because the master process itself doesn't preload the application, this mode works with phased restart (`SIGUSR1` or `pumactl phased-restart`). When worker 0 reloads as part of a phased restart, it initializes a new copy of your application first, then the other workers reload by forking from this new worker already containing the new preloaded application.
+1. **Compatible with phased restart.** This mode works with phased restart (`SIGUSR1` or `pumactl phased-restart`). When worker 0 reloads as part of a phased restart, it initializes a new copy of your application unless the master process has done so already (`preload_app!` is enabled), then the other workers reload by forking from this new worker already containing the new preloaded application.
 
    This allows a phased restart to complete as quickly as a hot restart (`SIGUSR2` or `pumactl restart`), while still minimizing downtime by staggering the restart across cluster workers.
 

--- a/docs/restart.md
+++ b/docs/restart.md
@@ -8,7 +8,7 @@ If the new process is unable to load, it will simply exit. You should therefore 
 
 ### How-to
 
-Any of the following will cause a Puma server to perform a hot restart: 
+Any of the following will cause a Puma server to perform a hot restart:
 
 * Send the `puma` process the `SIGUSR2` signal
 * Issue a `GET` request to the Puma status/control server with the path `/restart`
@@ -37,7 +37,7 @@ Phased restarts replace all running workers in a Puma cluster. This is a useful 
 
 ### How-to
 
-Any of the following will cause a Puma server to perform a phased restart: 
+Any of the following will cause a Puma server to perform a phased restart:
 
 * Send the `puma` process the `SIGUSR1` signal
 * Issue a `GET` request to the Puma status/control server with the path `/phased-restart`
@@ -46,7 +46,7 @@ Any of the following will cause a Puma server to perform a phased restart:
 ### Supported configurations
 
 * Works in cluster mode only
-* To support upgrading the application that Puma is serving, ensure `prune_bundler` is enabled and that `preload_app!` is disabled
+* To support upgrading the application that Puma is serving, ensure that either `prune_bundler` or `preload_app!` is enabled
 * Supported on all platforms where cluster mode is supported
 
 ### Client experience

--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -50,13 +50,17 @@ module Puma
       @ios = []
     end
 
-    attr_reader :ios
+    attr_reader :ios, :listening
 
     # @version 5.0.0
     attr_reader :activated_sockets, :envs, :inherited_fds, :listeners, :proto_env, :unix_paths
 
     # @version 5.0.0
     attr_writer :ios, :listeners
+
+    def listening?
+      @listening
+    end
 
     def env(sock)
       @envs.fetch(sock, @proto_env)
@@ -264,6 +268,7 @@ module Puma
           log_writer.error "Invalid URI: #{str}"
         end
       end
+      @listening = true
 
       # If we inherited fds but didn't use them (because of a
       # configuration change), then be sure to close them.
@@ -459,6 +464,7 @@ module Puma
         rescue Errno::EBADF
         end
       end
+      @listening = false
     end
 
     def redirects_for_restart

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -181,9 +181,7 @@ module Puma
       @file_dsl    = DSL.new(@options.file_options, self)
       @default_dsl = DSL.new(@options.default_options, self)
 
-      if !@options[:prune_bundler]
-        default_options[:preload_app] = (@options[:workers] > 1) && Puma.forkable?
-      end
+      default_options[:preload_app] = (@options[:workers] > 1) && Puma.forkable?
 
       if block
         configure(&block)

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -660,7 +660,7 @@ module Puma
       @options[:state_permission] = permission
     end
 
-    # How many worker processes to run.  Typically this is set to
+    # How many worker processes to run. Typically this is set to
     # the number of available cores.
     #
     # The default is the value of the environment variable +WEB_CONCURRENCY+ if
@@ -970,8 +970,8 @@ module Puma
     # new Bundler context and thus can float around as the release
     # dictates.
     #
-    # @note This is incompatible with +preload_app!+.
-    # @note This is only supported for RubyGems 2.2+
+    # @note Cluster mode only.
+    # @note This is only supported for RubyGems 2.2+.
     #
     # @see extra_runtime_dependencies
     #
@@ -1239,8 +1239,7 @@ module Puma
     end
 
     # When enabled, workers will be forked from worker 0 instead of from the master process.
-    # This option is similar to `preload_app` because the app is preloaded before forking,
-    # but it is compatible with phased restart.
+    # This option is similar to `preload_app` because the app is preloaded before forking.
     #
     # This option also enables the `refork` command (SIGURG), which optimizes copy-on-write performance
     # in a running app.

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -354,7 +354,7 @@ module Puma
     end
 
     def prune_bundler?
-      @options[:prune_bundler] && clustered? && !@options[:preload_app]
+      @options[:prune_bundler] && clustered?
     end
 
     def prune_bundler!

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -165,7 +165,7 @@ module Puma
         raise e
       end
 
-      @launcher.binder.parse @options[:binds]
+      @launcher.binder.parse @options[:binds] unless @launcher.binder.listening?
     end
 
     # @!attribute [r] app

--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -19,14 +19,32 @@ class TestWorkerGemIndependence < TestIntegration
   end
 
   def test_changing_nio4r_version_during_phased_restart
-    change_gem_version_during_phased_restart old_app_dir: 'worker_gem_independence_test/old_nio4r',
+    change_gem_version_during_phased_restart server_opts: "--prune-bundler",
+                                             old_app_dir: 'worker_gem_independence_test/old_nio4r',
+                                             old_version: '2.7.1',
+                                             new_app_dir: 'worker_gem_independence_test/new_nio4r',
+                                             new_version: '2.7.2'
+  end
+
+  def test_changing_nio4r_version_during_phased_restart_with_preload_app
+    change_gem_version_during_phased_restart server_opts: "--preload",
+                                             old_app_dir: 'worker_gem_independence_test/old_nio4r',
+                                             old_version: '2.7.1',
+                                             new_app_dir: 'worker_gem_independence_test/new_nio4r',
+                                             new_version: '2.7.2'
+  end
+
+  def test_changing_nio4r_version_during_phased_restart_with_prune_bundler_and_preload_app
+    change_gem_version_during_phased_restart server_opts: "--prune-bundler --preload",
+                                             old_app_dir: 'worker_gem_independence_test/old_nio4r',
                                              old_version: '2.7.1',
                                              new_app_dir: 'worker_gem_independence_test/new_nio4r',
                                              new_version: '2.7.2'
   end
 
   def test_changing_json_version_during_phased_restart
-    change_gem_version_during_phased_restart old_app_dir: 'worker_gem_independence_test/old_json',
+    change_gem_version_during_phased_restart server_opts: "--prune-bundler",
+                                             old_app_dir: 'worker_gem_independence_test/old_json',
                                              old_version: '2.7.1',
                                              new_app_dir: 'worker_gem_independence_test/new_json',
                                              new_version: '2.7.0'
@@ -34,7 +52,7 @@ class TestWorkerGemIndependence < TestIntegration
 
   def test_changing_json_version_during_phased_restart_after_querying_stats_from_status_server
     @control_tcp_port = UniquePort.call
-    server_opts = "--control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN}"
+    server_opts = "--control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN} --prune-bundler"
     before_restart = ->() do
       cli_pumactl "stats"
     end
@@ -49,7 +67,7 @@ class TestWorkerGemIndependence < TestIntegration
 
   def test_changing_json_version_during_phased_restart_after_querying_gc_stats_from_status_server
     @control_tcp_port = UniquePort.call
-    server_opts = "--control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN}"
+    server_opts = "--control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN} --prune-bundler"
     before_restart = ->() do
       cli_pumactl "gc-stats"
     end
@@ -64,7 +82,7 @@ class TestWorkerGemIndependence < TestIntegration
 
   def test_changing_json_version_during_phased_restart_after_querying_thread_backtraces_from_status_server
     @control_tcp_port = UniquePort.call
-    server_opts = "--control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN}"
+    server_opts = "--control-url tcp://#{HOST}:#{@control_tcp_port} --control-token #{TOKEN} --prune-bundler"
     before_restart = ->() do
       cli_pumactl "thread-backtraces"
     end
@@ -78,7 +96,8 @@ class TestWorkerGemIndependence < TestIntegration
   end
 
   def test_changing_json_version_during_phased_restart_after_accessing_puma_stats_directly
-    change_gem_version_during_phased_restart old_app_dir: 'worker_gem_independence_test/old_json_with_puma_stats_after_fork',
+    change_gem_version_during_phased_restart server_opts: "--prune-bundler",
+                                             old_app_dir: 'worker_gem_independence_test/old_json_with_puma_stats_after_fork',
                                              old_version: '2.7.1',
                                              new_app_dir: 'worker_gem_independence_test/new_json_with_puma_stats_after_fork',
                                              new_version: '2.7.0'
@@ -100,7 +119,7 @@ class TestWorkerGemIndependence < TestIntegration
       with_unbundled_env do
         silent_and_checked_system_command("bundle config --local path vendor/bundle")
         silent_and_checked_system_command("bundle install")
-        cli_server "--prune-bundler -w 1 #{server_opts}", env: ENV_RUBYOPT
+        cli_server "-w 1 #{server_opts}", env: ENV_RUBYOPT
       end
     end
 


### PR DESCRIPTION
### Description

Phased restart is currently not performed if `preload_app` is enabled, as described [here](https://github.com/puma/puma/pull/3477/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L139). The goal here is to remove this restriction by (re-)preloading the app in the master process before workers are forked for the new phase.

This means that both the initial boot and restarts to serve the new application can benefit from [copy-on-write](https://en.wikipedia.org/wiki/Copy-on-write) (and other custom configs like heap compaction via [`Process.warmup`](https://ruby-doc.org/3.3.4/Process.html#method-c-warmup) before fork), thereby reducing overall memory consumption.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.