### PR TITLE
Add parameters to Puma methods to allow CI to change ENV in isolation

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -19,13 +19,14 @@ module Puma
 
     RACK_VERSION = [1,6].freeze
 
-    def initialize(log_writer, conf = Configuration.new)
+    def initialize(log_writer, conf = Configuration.new, env: ENV)
       @log_writer = log_writer
       @conf = conf
       @listeners = []
       @inherited_fds = {}
       @activated_sockets = {}
       @unix_paths = []
+      @env = env
 
       @proto_env = {
         "rack.version".freeze => RACK_VERSION,
@@ -34,7 +35,7 @@ module Puma
         "rack.multiprocess".freeze => conf.options[:workers] >= 1,
         "rack.run_once".freeze => false,
         RACK_URL_SCHEME => conf.options[:rack_url_scheme],
-        "SCRIPT_NAME".freeze => ENV['SCRIPT_NAME'] || "",
+        "SCRIPT_NAME".freeze => env['SCRIPT_NAME'] || "",
 
         # I'd like to set a default CONTENT_TYPE here but some things
         # depend on their not being a default set and inferring
@@ -87,7 +88,7 @@ module Puma
     # @version 5.0.0
     #
     def create_activated_fds(env_hash)
-      @log_writer.debug "ENV['LISTEN_FDS'] #{ENV['LISTEN_FDS'].inspect}  env_hash['LISTEN_PID'] #{env_hash['LISTEN_PID'].inspect}"
+      @log_writer.debug "ENV['LISTEN_FDS'] #{@env['LISTEN_FDS'].inspect}  env_hash['LISTEN_PID'] #{env_hash['LISTEN_PID'].inspect}"
       return [] unless env_hash['LISTEN_FDS'] && env_hash['LISTEN_PID'].to_i == $$
       env_hash['LISTEN_FDS'].to_i.times do |index|
         sock = TCPServer.for_fd(socket_activation_fd(index))

--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -24,7 +24,7 @@ module Puma
     # Create a new CLI object using +argv+ as the command line
     # arguments.
     #
-    def initialize(argv, log_writer = LogWriter.stdio, events = Events.new)
+    def initialize(argv, log_writer = LogWriter.stdio, events = Events.new, env: ENV)
       @debug = false
       @argv = argv.dup
       @log_writer = log_writer
@@ -39,7 +39,7 @@ module Puma
       @control_url = nil
       @control_options = {}
 
-      setup_options
+      setup_options env
 
       begin
         @parser.parse! @argv
@@ -63,7 +63,7 @@ module Puma
         end
       end
 
-      @launcher = Puma::Launcher.new(@conf, :log_writer => @log_writer, :events => @events, :argv => argv)
+      @launcher = Puma::Launcher.new(@conf, env: ENV, log_writer: @log_writer, events: @events, argv: argv)
     end
 
     attr_reader :launcher
@@ -92,8 +92,8 @@ module Puma
     # Build the OptionParser object to handle the available options.
     #
 
-    def setup_options
-      @conf = Configuration.new({}, {events: @events}) do |user_config, file_config|
+    def setup_options(env = ENV)
+      @conf = Configuration.new({}, {events: @events}, env) do |user_config, file_config|
         @parser = OptionParser.new do |o|
           o.on "-b", "--bind URI", "URI to bind to (tcp://, unix://, ssl://)" do |arg|
             user_config.bind arg

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -172,8 +172,8 @@ module Puma
       http_content_length_limit: nil
     }
 
-    def initialize(user_options={}, default_options = {}, &block)
-      default_options = self.puma_default_options.merge(default_options)
+    def initialize(user_options={}, default_options = {}, env = ENV, &block)
+      default_options = self.puma_default_options(env).merge(default_options)
 
       @options     = UserFileDefaultOptions.new(user_options, default_options)
       @plugins     = PluginLoader.new
@@ -184,6 +184,8 @@ module Puma
       if !@options[:prune_bundler]
         default_options[:preload_app] = (@options[:workers] > 1) && Puma.forkable?
       end
+
+      @puma_bundler_pruned = env.key? 'PUMA_BUNDLER_PRUNED'
 
       if block
         configure(&block)
@@ -215,22 +217,22 @@ module Puma
       self
     end
 
-    def puma_default_options
+    def puma_default_options(env = ENV)
       defaults = DEFAULTS.dup
-      puma_options_from_env.each { |k,v| defaults[k] = v if v }
+      puma_options_from_env(env).each { |k,v| defaults[k] = v if v }
       defaults
     end
 
-    def puma_options_from_env
-      min = ENV['PUMA_MIN_THREADS'] || ENV['MIN_THREADS']
-      max = ENV['PUMA_MAX_THREADS'] || ENV['MAX_THREADS']
-      workers = ENV['WEB_CONCURRENCY']
+    def puma_options_from_env(env = ENV)
+      min = env['PUMA_MIN_THREADS'] || env['MIN_THREADS']
+      max = env['PUMA_MAX_THREADS'] || env['MAX_THREADS']
+      workers = env['WEB_CONCURRENCY']
 
       {
         min_threads: min && Integer(min),
         max_threads: max && Integer(max),
         workers: workers && Integer(workers),
-        environment: ENV['APP_ENV'] || ENV['RACK_ENV'] || ENV['RAILS_ENV'],
+        environment: env['APP_ENV'] || env['RACK_ENV'] || env['RAILS_ENV'],
       }
     end
 
@@ -343,7 +345,7 @@ module Puma
     def rack_builder
       # Load bundler now if we can so that we can pickup rack from
       # a Gemfile
-      if ENV.key? 'PUMA_BUNDLER_PRUNED'
+      if @puma_bundler_pruned
         begin
           require 'bundler/setup'
         rescue LoadError

--- a/lib/puma/control_cli.rb
+++ b/lib/puma/control_cli.rb
@@ -37,7 +37,7 @@ module Puma
     # @version 5.0.0
     PRINTABLE_COMMANDS = %w[gc-stats stats thread-backtraces].freeze
 
-    def initialize(argv, stdout=STDOUT, stderr=STDERR)
+    def initialize(argv, stdout=STDOUT, stderr=STDERR, env: ENV)
       @state = nil
       @quiet = false
       @pidfile = nil
@@ -46,7 +46,7 @@ module Puma
       @control_auth_token = nil
       @config_file = nil
       @command = nil
-      @environment = ENV['APP_ENV'] || ENV['RACK_ENV'] || ENV['RAILS_ENV']
+      @environment = env['APP_ENV'] || env['RACK_ENV'] || env['RAILS_ENV']
 
       @argv = argv.dup
       @stdout = stdout
@@ -127,7 +127,7 @@ module Puma
           require_relative 'configuration'
           require_relative 'log_writer'
 
-          config = Puma::Configuration.new({ config_files: [@config_file] }, {})
+          config = Puma::Configuration.new({ config_files: [@config_file] }, {} , env)
           config.load
           @state              ||= config.options[:state]
           @control_url        ||= config.options[:control_url]

--- a/lib/puma/error_logger.rb
+++ b/lib/puma/error_logger.rb
@@ -15,14 +15,14 @@ module Puma
 
     LOG_QUEUE = Queue.new
 
-    def initialize(ioerr)
+    def initialize(ioerr, env: ENV)
       @ioerr = ioerr
 
-      @debug = ENV.key? 'PUMA_DEBUG'
+      @debug = env.key?('PUMA_DEBUG')
     end
 
-    def self.stdio
-      new $stderr
+    def self.stdio(env: ENV)
+      new($stderr, env: env)
     end
 
     # Print occurred error details.

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -46,6 +46,8 @@ module Puma
       @original_argv = @argv.dup
       @config        = conf
 
+      env = launcher_args.delete(:env) || ENV
+
       @config.options[:log_writer] = @log_writer
 
       # Advertise the Configuration
@@ -105,7 +107,7 @@ module Puma
 
       @status = :run
 
-      log_config if ENV['PUMA_LOG_CONFIG']
+      log_config if env['PUMA_LOG_CONFIG']
     end
 
     attr_reader :binder, :log_writer, :events, :config, :options, :restart_dir

--- a/lib/puma/log_writer.rb
+++ b/lib/puma/log_writer.rb
@@ -31,31 +31,31 @@ module Puma
     attr_accessor :formatter, :custom_logger
 
     # Create a LogWriter that prints to +stdout+ and +stderr+.
-    def initialize(stdout, stderr)
+    def initialize(stdout, stderr, env: ENV)
       @formatter = DefaultFormatter.new
       @custom_logger = nil
       @stdout = stdout
       @stderr = stderr
 
-      @debug = ENV.key?('PUMA_DEBUG')
-      @error_logger = ErrorLogger.new(@stderr)
+      @debug = env.key?('PUMA_DEBUG')
+      @error_logger = ErrorLogger.new(@stderr, env: env)
     end
 
     DEFAULT = new(STDOUT, STDERR)
 
     # Returns an LogWriter object which writes its status to
     # two StringIO objects.
-    def self.strings
-      LogWriter.new(StringIO.new, StringIO.new)
+    def self.strings(env: ENV)
+      LogWriter.new(StringIO.new, StringIO.new, env: env)
     end
 
-    def self.stdio
-      LogWriter.new($stdout, $stderr)
+    def self.stdio(env: ENV)
+      LogWriter.new($stdout, $stderr, env: env)
     end
 
-    def self.null
+    def self.null(env: ENV)
       n = NullIO.new
-      LogWriter.new(n, n)
+      LogWriter.new(n, n, env: env)
     end
 
     # Write +str+ to +@stdout+


### PR DESCRIPTION
### Description

Puma makes use of ENV settings in several files.  This can cause isolation issues when running tests.  Add parameters to methods to allow ENV to be set in CI with isolation.

A keyword parameter `env: ENV` has been added where it will work, there are a few methods accepting hash parameters that required a different approach.  Some methods without parameters were changed by adding `env = ENV`.

This passes the 'turbo-rails' and 'rack conform' workflows.  I ran Capybara CI with this branch in my fork, and most jobs using Puma seemed to pass.  There are some issues with RuboCop and warnings.

See https://github.com/MSP-Greg/capybara/actions/runs/10820642778/job/30021090682#step:4:14

**Note:** this PR only includes library file changes and shows that current CI passes.  A later PR with have test file changes that isolate the ENV changes used for testing.

See #3482

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
