### PR TITLE
Return a client to the reactor if there is any backlog in the thread pool

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -479,10 +479,12 @@ module Puma
             # socket for a short time before returning to the reactor.
             fast_check = @status == :run
 
-            # Always pass the client back to the reactor after a reasonable
-            # number of inline requests if there are other requests pending.
-            fast_check = false if requests >= @max_fast_inline &&
-              @thread_pool.backlog > 0
+            # If we've already attempt our max number of fast inline requests
+            # OR there is a client waiting, we skip doing a fast check of the
+            # client and return it to the reactor.
+            if requests >= @max_fast_inline || @thread_pool.backlog > 0
+              fast_check = false
+            end
 
             next_request_ready = with_force_shutdown(client) do
               client.reset(fast_check)


### PR DESCRIPTION
### Description
Directly following from #3487, instead of having max_fast_inline only be checked if there is a client waiting in the backlog, swing back the other direction entirely and have max_fast_inline only apply when there is no one waiting.

Put another way, if there is another client ever waiting, kick the current client to the reactor to remain fair. In the event that another client isn't waiting, we only attempt max_fast_inline request before going back to the reactor.
 
### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
