### PR TITLE
CI: bump turbo-rails browser timeouts

### DIFF
--- a/.github/workflows/turbo-rails.yml
+++ b/.github/workflows/turbo-rails.yml
@@ -35,8 +35,8 @@ jobs:
           - { os: ubuntu-22.04 , ruby: head , rails: '7.1' }
     env:
       CI: true
-      FERRUM_PROCESS_TIMEOUT: 25
-      FERRUM_DEFAULT_TIMEOUT: 15
+      FERRUM_PROCESS_TIMEOUT: 60
+      FERRUM_DEFAULT_TIMEOUT: 60
       RAILS_VERSION: "${{ matrix.rails }}"
 
     steps:


### PR DESCRIPTION
Noticed a timeout at https://github.com/puma/puma/actions/runs/10930536404/job/30343630502?pr=3491#step:6:262

Better tests run slow and green than quick and red (they aren't quick anyway so ...)
