### PR TITLE
CI: remove turbo-rails ruby 2.7 job, does not work

### DIFF
--- a/.github/workflows/turbo-rails.yml
+++ b/.github/workflows/turbo-rails.yml
@@ -25,7 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-20.04 , ruby: '2.7', rails: '6.1' }
           - { os: ubuntu-20.04 , ruby: '3.1', rails: '7.0' }
           - { os: ubuntu-20.04 , ruby: '3.2', rails: '7.0' }
           - { os: ubuntu-22.04 , ruby: '3.3', rails: '7.0' }


### PR DESCRIPTION
turbo-rails added Ruby 3.0 syntax: https://github.com/hotwired/turbo-rails/issues/681
