### PR TITLE
Add opt to enable keep-alives

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -130,6 +130,7 @@ module Puma
       binds: ['tcp://0.0.0.0:9292'.freeze],
       clean_thread_locals: false,
       debug: false,
+      disable_keep_alives: false,
       early_hints: nil,
       environment: 'development'.freeze,
       # Number of seconds to wait until we get the first data for the request.

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -130,7 +130,7 @@ module Puma
       binds: ['tcp://0.0.0.0:9292'.freeze],
       clean_thread_locals: false,
       debug: false,
-      disable_keep_alives: false,
+      enable_keep_alives: true,
       early_hints: nil,
       environment: 'development'.freeze,
       # Number of seconds to wait until we get the first data for the request.

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1268,6 +1268,21 @@ module Puma
     def max_fast_inline(num_of_requests)
       @options[:max_fast_inline] = Float(num_of_requests)
     end
+    
+    # When enabled, disables keep-alives on in-bound connections.
+    # This option is the best way to ensure requests are handled by the server
+    # in the order in which they are received. Disabling keep-alives means Puma
+    # will close the connection after each request made, requiring that a new
+    # connection be opened. There is a TCP operations cost for both the client and server
+    # each time a new connection is opened/closed. This option will ensure fairness at the cost
+    # of potentially more time spent in TCP operations.
+    #
+    # @example
+    #   disable_keep_alives true
+    #   
+    def disable_keep_alives(enabled=false)
+      @options[:max_fast_inline] = enabled
+    end
 
     # Specify the backend for the IO selector.
     #

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1268,7 +1268,7 @@ module Puma
     def max_fast_inline(num_of_requests)
       @options[:max_fast_inline] = Float(num_of_requests)
     end
-    
+
     # When enabled, disables keep-alives on in-bound connections.
     # This option is the best way to ensure requests are handled by the server
     # in the order in which they are received. Disabling keep-alives means Puma
@@ -1279,7 +1279,7 @@ module Puma
     #
     # @example
     #   disable_keep_alives true
-    #   
+    #
     def disable_keep_alives(enabled=false)
       @options[:disable_keep_alives] = enabled
     end

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1269,14 +1269,25 @@ module Puma
       @options[:max_fast_inline] = Float(num_of_requests)
     end
 
-    # When true, keep-alives are maintained on in-bound connections. This is the default.
-    # When false, the connection is closed by Puma after each request, requiring that
-    # the client open a new request.
-    # Setting to false is the best way to ensure requests are handled by the server
-    # in the order in which they are received. There is a TCP operations cost for both
-    # the client and server each time a new connection is opened/closed.
-    # This option will ensure fairness at the cost of potentially more time spent in TCP operations.
+    # When `true`, keep-alive connections are maintained on inbound requests. 
+    # Enabling this setting reduces the number of TCP operations, reducing response 
+    # times for connections that can send multiple requests in a single connection.
     #
+    # When Puma receives more incoming connections than available Puma threads, 
+    # enabling the keep-alive behavior may result in processing requests out-of-order, 
+    # increasing overall response time variance. Increased response time variance 
+    # means that the overall average of response times might not change, but more 
+    # outliers will exist. Those long-tail outliers may significantly affect response 
+    # times for some processed requests.
+    # 
+    # When `false`, Puma closes the connection after each request, requiring the 
+    # client to open a new request. Disabling this setting guarantees that requests 
+    # will be processed in the order they are fully received, decreasing response 
+    # variance and eliminating long-tail outliers caused by keep-alive behavior. 
+    # The trade-off is that the number of TCP operations required will increase.
+    #
+    # The default is +true+.
+    # 
     # @example
     #   enable_keep_alives false
     #

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1269,19 +1269,19 @@ module Puma
       @options[:max_fast_inline] = Float(num_of_requests)
     end
 
-    # When enabled, disables keep-alives on in-bound connections.
-    # This option is the best way to ensure requests are handled by the server
-    # in the order in which they are received. Disabling keep-alives means Puma
-    # will close the connection after each request made, requiring that a new
-    # connection be opened. There is a TCP operations cost for both the client and server
-    # each time a new connection is opened/closed. This option will ensure fairness at the cost
-    # of potentially more time spent in TCP operations.
+    # When true, keep-alives are maintained on in-bound connections. This is the default.
+    # When false, the connection is closed by Puma after each request, requiring that
+    # the client open a new request.
+    # Setting to false is the best way to ensure requests are handled by the server
+    # in the order in which they are received. There is a TCP operations cost for both
+    # the client and server each time a new connection is opened/closed.
+    # This option will ensure fairness at the cost of potentially more time spent in TCP operations.
     #
     # @example
-    #   disable_keep_alives true
+    #   enable_keep_alives false
     #
-    def disable_keep_alives(enabled=false)
-      @options[:disable_keep_alives] = enabled
+    def enable_keep_alives(enabled=true)
+      @options[:enable_keep_alives] = enabled
     end
 
     # Specify the backend for the IO selector.

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1281,7 +1281,7 @@ module Puma
     #   disable_keep_alives true
     #   
     def disable_keep_alives(enabled=false)
-      @options[:max_fast_inline] = enabled
+      @options[:disable_keep_alives] = enabled
     end
 
     # Specify the backend for the IO selector.

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1269,21 +1269,21 @@ module Puma
       @options[:max_fast_inline] = Float(num_of_requests)
     end
 
-    # When `true`, keep-alive connections are maintained on inbound requests. 
-    # Enabling this setting reduces the number of TCP operations, reducing response 
+    # When `true`, keep-alive connections are maintained on inbound requests.
+    # Enabling this setting reduces the number of TCP operations, reducing response
     # times for connections that can send multiple requests in a single connection.
     #
-    # When Puma receives more incoming connections than available Puma threads, 
-    # enabling the keep-alive behavior may result in processing requests out-of-order, 
-    # increasing overall response time variance. Increased response time variance 
-    # means that the overall average of response times might not change, but more 
-    # outliers will exist. Those long-tail outliers may significantly affect response 
+    # When Puma receives more incoming connections than available Puma threads,
+    # enabling the keep-alive behavior may result in processing requests out-of-order,
+    # increasing overall response time variance. Increased response time variance
+    # means that the overall average of response times might not change, but more
+    # outliers will exist. Those long-tail outliers may significantly affect response
     # times for some processed requests.
     # 
-    # When `false`, Puma closes the connection after each request, requiring the 
-    # client to open a new request. Disabling this setting guarantees that requests 
-    # will be processed in the order they are fully received, decreasing response 
-    # variance and eliminating long-tail outliers caused by keep-alive behavior. 
+    # When `false`, Puma closes the connection after each request, requiring the
+    # client to open a new request. Disabling this setting guarantees that requests
+    # will be processed in the order they are fully received, decreasing response
+    # variance and eliminating long-tail outliers caused by keep-alive behavior.
     # The trade-off is that the number of TCP operations required will increase.
     #
     # The default is +true+.

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1279,7 +1279,7 @@ module Puma
     # means that the overall average of response times might not change, but more
     # outliers will exist. Those long-tail outliers may significantly affect response
     # times for some processed requests.
-    # 
+    #
     # When `false`, Puma closes the connection after each request, requiring the
     # client to open a new request. Disabling this setting guarantees that requests
     # will be processed in the order they are fully received, decreasing response
@@ -1287,7 +1287,7 @@ module Puma
     # The trade-off is that the number of TCP operations required will increase.
     #
     # The default is +true+.
-    # 
+    #
     # @example
     #   enable_keep_alives false
     #

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -168,6 +168,9 @@ module Puma
         @thread_pool.busy_threads < @max_threads ||
         !client.listener.to_io.wait_readable(0)
 
+      # Always set force_keep_alive to false if the server has keep-alives disabled.
+      force_keep_alive &&= !@disable_keep_alives
+
       resp_info = str_headers(env, status, headers, res_body, io_buffer, force_keep_alive)
 
       close_body = false

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -164,12 +164,14 @@ module Puma
       # if the server is at capacity and the listener has a new connection ready.
       # This allows Puma to service connections fairly when the number
       # of concurrent connections exceeds the size of the threadpool.
-      force_keep_alive = requests < @max_fast_inline ||
+      force_keep_alive = if @enable_keep_alives
+        requests < @max_fast_inline ||
         @thread_pool.busy_threads < @max_threads ||
         !client.listener.to_io.wait_readable(0)
-
-      # Always set force_keep_alive to false if the server has keep-alives disabled.
-      force_keep_alive &&= !@disable_keep_alives
+      else
+        # Always set force_keep_alive to false if the server has keep-alives not enabled.
+        false
+      end
 
       resp_info = str_headers(env, status, headers, res_body, io_buffer, force_keep_alive)
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -95,7 +95,7 @@ module Puma
       @max_threads               = @options[:max_threads]
       @queue_requests            = @options[:queue_requests]
       @max_fast_inline           = @options[:max_fast_inline]
-      @disable_keep_alives       = @options[:disable_keep_alives]
+      @enable_keep_alives        = @options[:enable_keep_alives]
       @io_selector_backend       = @options[:io_selector_backend]
       @http_content_length_limit = @options[:http_content_length_limit]
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -95,6 +95,7 @@ module Puma
       @max_threads               = @options[:max_threads]
       @queue_requests            = @options[:queue_requests]
       @max_fast_inline           = @options[:max_fast_inline]
+      @disable_keep_alives       = @options[:disable_keep_alives]
       @io_selector_backend       = @options[:io_selector_backend]
       @http_content_length_limit = @options[:http_content_length_limit]
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -745,6 +745,24 @@ class TestConfigFileWithFakeEnv < TestConfigFileBase
     assert_equal ['config/puma/fake-env.rb'], conf.config_files
   end
 
+  def test_disable_keep_alives_true
+    conf = Puma::Configuration.new do |c|
+      c.disable_keep_alives true
+    end
+    conf.load
+
+    assert_equal conf.options[:disable_keep_alives], true
+  end
+
+  def test_disable_keep_alives_false
+    conf = Puma::Configuration.new do |c|
+      c.disable_keep_alives false
+    end
+    conf.load
+
+    assert_equal conf.options[:disable_keep_alives], false
+  end
+
   def teardown
     FileUtils.rm_r("config/puma")
   end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -745,22 +745,29 @@ class TestConfigFileWithFakeEnv < TestConfigFileBase
     assert_equal ['config/puma/fake-env.rb'], conf.config_files
   end
 
-  def test_disable_keep_alives_true
-    conf = Puma::Configuration.new do |c|
-      c.disable_keep_alives true
-    end
+  def test_enable_keep_alives_by_default
+    conf = Puma::Configuration.new
     conf.load
 
-    assert_equal conf.options[:disable_keep_alives], true
+    assert_equal conf.options[:enable_keep_alives], true
   end
 
-  def test_disable_keep_alives_false
+  def test_enable_keep_alives_true
     conf = Puma::Configuration.new do |c|
-      c.disable_keep_alives false
+      c.enable_keep_alives true
     end
     conf.load
 
-    assert_equal conf.options[:disable_keep_alives], false
+    assert_equal conf.options[:enable_keep_alives], true
+  end
+
+  def test_enable_keep_alives_false
+    conf = Puma::Configuration.new do |c|
+      c.enable_keep_alives false
+    end
+    conf.load
+
+    assert_equal conf.options[:enable_keep_alives], false
   end
 
   def teardown

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -763,6 +763,16 @@ class TestPumaServer < Minitest::Test
     assert_equal "hello\n", response.body
   end
 
+  def test_http_11_disable_keep_alives_false
+    server_run(disable_keep_alives: false) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
+
+    req  = "GET / HTTP/1.1\r\n\r\n"
+    response = send_http_read_response req
+
+    assert_equal ["Content-Type: plain/text", "Content-Length: 6"], response.headers
+    assert_equal "hello\n", response.body
+  end
+
   def test_http_10_keep_alive_with_body
     server_run { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -763,8 +763,6 @@ class TestPumaServer < Minitest::Test
     assert_equal ["Content-Type: plain/text", "Content-Length: 6"], response.headers
     assert_equal "hello\n", response.body
   end
-
-
   def test_http_11_enable_keep_alives_true
     server_run(enable_keep_alives: true) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 
@@ -782,7 +780,7 @@ class TestPumaServer < Minitest::Test
     req  = "GET / HTTP/1.1\r\n\r\n"
     response = send_http_read_response req
 
-    # No "Connection: close" header.
+    # Assert the "Connection: close" header is present with keep-alives disabled.
     assert_equal ["Content-Type: plain/text", "Connection: close", "Content-Length: 6"], response.headers
     assert_equal "hello\n", response.body
   end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -753,23 +753,37 @@ class TestPumaServer < Minitest::Test
     assert_equal ["Connection: close"], response.headers
   end
 
-  def test_http_11_disable_keep_alives
-    server_run(disable_keep_alives: true) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
+  def test_http_11_enable_keep_alives_by_default
+    server_run(enable_keep_alives: true) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 
     req  = "GET / HTTP/1.1\r\n\r\n"
     response = send_http_read_response req
 
-    assert_equal ["Content-Type: plain/text", "Connection: close", "Content-Length: 6"], response.headers
+    # No "Connection: close" header.
+    assert_equal ["Content-Type: plain/text", "Content-Length: 6"], response.headers
     assert_equal "hello\n", response.body
   end
 
-  def test_http_11_disable_keep_alives_false
-    server_run(disable_keep_alives: false) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
+
+  def test_http_11_enable_keep_alives_true
+    server_run(enable_keep_alives: true) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 
     req  = "GET / HTTP/1.1\r\n\r\n"
     response = send_http_read_response req
 
+    # No "Connection: close" header.
     assert_equal ["Content-Type: plain/text", "Content-Length: 6"], response.headers
+    assert_equal "hello\n", response.body
+  end
+
+  def test_http_11_enable_keep_alives_false
+    server_run(enable_keep_alives: false) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
+
+    req  = "GET / HTTP/1.1\r\n\r\n"
+    response = send_http_read_response req
+
+    # No "Connection: close" header.
+    assert_equal ["Content-Type: plain/text", "Connection: close", "Content-Length: 6"], response.headers
     assert_equal "hello\n", response.body
   end
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -753,6 +753,16 @@ class TestPumaServer < Minitest::Test
     assert_equal ["Connection: close"], response.headers
   end
 
+  def test_http_11_disable_keep_alives
+    server_run(disable_keep_alives: true) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
+
+    req  = "GET / HTTP/1.1\r\n\r\n"
+    response = send_http_read_response req
+
+    assert_equal ["Content-Type: plain/text", "Connection: close", "Content-Length: 6"], response.headers
+    assert_equal "hello\n", response.body
+  end
+
   def test_http_10_keep_alive_with_body
     server_run { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 


### PR DESCRIPTION
### Description

Puma does not currently support a configuration option for enabdling/disabling keep-alive connections to the server. Because a thread can only handle a single connection at a time, the Puma server under default config will end up serving requests out of order, preferring to process requests off it's already in flight connection. See https://github.com/puma/puma/issues/3487 for more details.

To get around this issue, Puma will close connections every `max_fast_inline` requests. When `max_fast_inline=1`, the server should close the connection after each request, but this only happens _most of the time_. It does not happen all the time, due to the following conditional:
https://github.com/puma/puma/blob/48b89b5f595f4cd72b5e60a3cb49f4f2949afec3/lib/puma/request.rb#L163-L169
Thus it's still possible to end up with long tail latencies because a small percentage of requests will sit in the queue for awhile.

Sometimes, the number of busy threads is less than the max and sometimes, there are no new connections to accept on the socket. However, these decisions are made at a point in time and the state of the server is constantly changing. They are subject to race conditions since other threads are concurrently accessing these variables and taking actions that modify their values.

The absolute safest way to ensure a connection is handed back to the reactor class once the request has been handled is to outright disable keep-alives. This PR proposes exposing an `enable_keep_alives` option which defaults to `true`, as to least disrupt the current behavior. Disabling keep-alives may be done by setting `enable_keep_alives: false` in the Puma config.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
