### PR TITLE
[CI] test/rackup/sleep*.ru - allow float values

### DIFF
--- a/test/rackup/sleep.ru
+++ b/test/rackup/sleep.ru
@@ -1,9 +1,11 @@
 # call with "GET /sleep<d> HTTP/1.1\r\n\r\n", where <d> is the number of
-# seconds to sleep
+# seconds to sleep, can be a float or an int
 # same as TestApps::SLEEP
 
+regex_delay = /\A\/sleep(\d+(?:\.\d+)?)/
 run lambda { |env|
-  dly = (env['REQUEST_PATH'][/\/sleep(\d+)/,1] || '0').to_i
-  sleep dly
-  [200, {"Content-Type" => "text/plain"}, ["Slept #{dly}"]]
+  delay = (env['REQUEST_PATH'][regex_delay,1] || '0').to_f
+STDOUT.syswrite "\n#{delay}"
+  sleep delay
+  [200, {"Content-Type" => "text/plain"}, ["Slept #{delay}"]]
 }

--- a/test/rackup/sleep_pid.ru
+++ b/test/rackup/sleep_pid.ru
@@ -1,8 +1,9 @@
 # call with "GET /sleep<d> HTTP/1.1\r\n\r\n", where <d> is the number of
-# seconds to sleep, returns process pid
+# seconds to sleep, can be a float or an int, returns process pid
 
+regex_delay = /\A\/sleep(\d+(?:\.\d+)?)/
 run lambda { |env|
-  dly = (env['REQUEST_PATH'][/\/sleep(\d+)/,1] || '0').to_i
-  sleep dly
-  [200, {"Content-Type" => "text/plain"}, ["Slept #{dly} #{Process.pid}"]]
+  delay = (env['REQUEST_PATH'][regex_delay,1] || '0').to_f
+  sleep delay
+  [200, {"Content-Type" => "text/plain"}, ["Slept #{delay} #{Process.pid}"]]
 }

--- a/test/rackup/sleep_step.ru
+++ b/test/rackup/sleep_step.ru
@@ -1,10 +1,11 @@
 # call with "GET /sleep<d>-<s> HTTP/1.1\r\n\r\n", where <d> is the number of
-# seconds to sleep and <s> is the step
+# seconds to sleep (can be a float or an int) and <s> is the step
 
+regex_delay = /\A\/sleep(\d+(?:\.\d+)?)/
 run lambda { |env|
   p = env['REQUEST_PATH']
-  dly = (p[/\/sleep(\d+)/,1] || '0').to_i
+  delay = (p[regex_delay,1] || '0').to_f
   step = p[/(\d+)\z/,1].to_i
-  sleep dly
-  [200, {"Content-Type" => "text/plain"}, ["Slept #{dly} #{step}"]]
+  sleep delay
+  [200, {"Content-Type" => "text/plain"}, ["Slept #{delay} #{step}"]]
 }


### PR DESCRIPTION
### Description

There are three test/rackup/sleep*.ru files, all do not accept a float value.  Modify them to do so.

Since a lot of the recent testing of 'keep-alive' connections has used 200mS app delay, having these in master would make things easier.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
