### PR TITLE
Move fork_worker to parent thread

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -81,7 +81,7 @@ module Puma
           pid = spawn_worker(idx, master)
         end
 
-        debug "Spawned worker: #{pid}"
+        log "Spawned worker: #{pid}, phase: #{@phase}"
         @workers << WorkerHandle.new(idx, pid, @phase, @options)
       end
 

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -177,8 +177,10 @@ module Puma
           while (widx = new_workers.pop(non_block=true))
             log "spawn_sub_workers #{widx}\n"
             worker_pids << pid = spawn_worker(widx)
-            log "f#{pid}:#{widx}\n"
-            @worker_write << "#{Puma::Const::PipeRequest::FORK}#{pid}:#{idx}\n" rescue nil
+            # log "f#{pid}:#{widx}\n"
+            msg = "#{Puma::Const::PipeRequest::FORK}#{pid}:#{widx}\n"
+            log msg
+            @worker_write << msg rescue nil
           end
         rescue ThreadError
           log "queue is empty"
@@ -189,6 +191,7 @@ module Puma
 
 
       def spawn_worker(idx)
+        log "spawning new worker from worker-0: #{idx}"
         @config.run_hooks(:before_worker_fork, idx, @log_writer, @hook_data)
 
         pid = fork do
@@ -200,6 +203,8 @@ module Puma
                                   server: @server
           new_worker.run
         end
+        log "new worker spawned from worker-0: with pid #{pid}"
+
 
         if !pid
           log "! Complete inability to spawn new workers detected"

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -303,5 +303,11 @@ module Puma
       PING = "p"
       IDLE = "i"
     end
+
+    module WorkerCmd
+      RESTART = "restart"
+      STOPPED = "stopped"
+      SPAWN = "spawn"
+    end
   end
 end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -239,6 +239,7 @@ class TestIntegrationCluster < TestIntegration
 
   def test_worker_timeout
     skip 'Thread#name not available' unless Thread.current.respond_to?(:name)
+    puts "touch test again"
     timeout = Puma::Configuration::DEFAULTS[:worker_check_interval] + 1
     config = <<~CONFIG
       worker_timeout #{timeout}

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -299,18 +299,19 @@ class TestIntegrationCluster < TestIntegration
   def test_fork_worker_on_refork
     refork = Tempfile.new 'refork'
     wrkrs = 3
-    cli_server "-w #{wrkrs} test/rackup/hello_with_delay.ru", config: <<~CONFIG
+    cli_server "-w #{wrkrs} test/rackup/hello_with_delay.ru", log: true, puma_debug: true, config: <<~CONFIG
       fork_worker 20
       on_refork { File.write '#{refork.path}', 'Reforked' }
     CONFIG
 
-    pids = get_worker_pids 0, wrkrs
+    pids = get_worker_pids 0, wrkrs, log: true
 
     socks = []
     until refork.read == 'Reforked'
       socks << fast_connect
       sleep 0.004
     end
+    puts "message reforked!"
 
     100.times {
       socks << fast_connect
@@ -319,7 +320,7 @@ class TestIntegrationCluster < TestIntegration
 
     socks.each { |s| read_body s }
 
-    refute_includes pids, get_worker_pids(1, wrkrs - 1)
+    refute_includes pids, get_worker_pids(1, wrkrs - 1), log: true
   end
 
   def test_fork_worker_spawn
@@ -519,10 +520,10 @@ class TestIntegrationCluster < TestIntegration
     cli_server "test/rackup/hello.ru",
       env: { 'WEB_CONCURRENCY' => '2'},
       config: <<~CONFIG
-        on_worker_boot(:test) do |index, data|
-          data[:test] = index
-        end
-      CONFIG
+                 on_worker_boot(:test) do |index, data|
+                   data[:test] = index
+                 end
+               CONFIG
 
     get_worker_pids
     line = @server_log[/.+on_worker_boot.+/]

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -472,12 +472,13 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_culling_strategy_oldest_fork_worker
-    cli_server "-w 2 test/rackup/hello.ru", config: <<~CONFIG
+    cli_server "-w 2 test/rackup/hello.ru", puma_debug: true, config: <<~CONFIG
       worker_culling_strategy :oldest
       fork_worker
     CONFIG
 
     get_worker_pids # to consume server logs
+    assert wait_for_server_to_match(/Server started - worker 0/) # ensure server is started for worker-0
 
     Process.kill :TTIN, @pid
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -239,7 +239,6 @@ class TestIntegrationCluster < TestIntegration
 
   def test_worker_timeout
     skip 'Thread#name not available' unless Thread.current.respond_to?(:name)
-    puts "touch test again"
     timeout = Puma::Configuration::DEFAULTS[:worker_check_interval] + 1
     config = <<~CONFIG
       worker_timeout #{timeout}


### PR DESCRIPTION
### Description
I'm shifting worker forking back to the same thread as `worker-0` for `refork` mode. This change is necessary to ensure compatibility with gRPC, which restricts forking in a different thread than its parent process.

Discussion reference: https://github.com/puma/puma/discussions/3480
Issue: https://github.com/puma/puma/issues/3503

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
