### PR TITLE
Fix multi-delimiter split to get status app token

### DIFF
--- a/lib/puma/app/status.rb
+++ b/lib/puma/app/status.rb
@@ -80,7 +80,7 @@ module Puma
 
       def authenticate(env)
         return true unless @auth_token
-        env['QUERY_STRING'].to_s.split('&;').include? "token=#{@auth_token}"
+        env['QUERY_STRING'].to_s.split(/[&;]/).include? "token=#{@auth_token}"
       end
 
       def rack_response(status, body, content_type='application/json')

--- a/test/test_app_status.rb
+++ b/test/test_app_status.rb
@@ -54,6 +54,14 @@ class TestAppStatus < Minitest::Test
     assert_equal 404, status
   end
 
+  def test_multiple_params
+    @app.instance_variable_set(:@auth_token, "abcdef")
+
+    status, _, _ = lint('/whatever?foo=bar&token=abcdef')
+
+    assert_equal 404, status
+  end
+
   def test_unsupported
     status, _, _ = lint('/not-real')
 


### PR DESCRIPTION
### Description
Originally added back in https://github.com/puma/puma/commit/a91d64a560743d130ec0930640aa364ab187ce36 - I believe the intention is to support splitting on either `&` or `;` between query params.

If nobody has run into a problem with this maybe it can be simplified down to only support the single param, but as I stumbled across it reading through the code I thought I'd propose this change as something simple.

~I did hit a CI error due to https://github.com/hotwired/turbo-rails/issues/681 in the [ubuntu-20.04 Ruby 2.7 Rails 6.1](https://github.com/AnthonyClark/puma/actions/runs/11085382537/job/30801738684#logs) run~ Heh, of course I was just behind on the rebase and it was already taken care of.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
