### PR TITLE
Fix long tail response problem

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1257,8 +1257,7 @@ module Puma
       @options[:fork_worker] = Integer(after_requests)
     end
 
-    # The number of requests to attempt inline before sending a client back to
-    # the reactor to be subject to normal ordering.
+    # The number of requests a keep-alive client can submit before being closed.
     #
     # The default is 10.
     #

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -165,9 +165,8 @@ module Puma
       # This allows Puma to service connections fairly when the number
       # of concurrent connections exceeds the size of the threadpool.
       force_keep_alive = if @enable_keep_alives
-        requests < @max_fast_inline ||
-        @thread_pool.busy_threads < @max_threads ||
-        !client.listener.to_io.wait_readable(0)
+        client.requests_served < @max_fast_inline ||
+        @thread_pool.busy_threads < @max_threads
       else
         # Always set force_keep_alive to false if the server has keep-alives not enabled.
         false

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -72,6 +72,8 @@ module Puma
       @app = app
       @events = events || Events.new
 
+      @clustered = (options[:workers] || 0) > 1
+
       @check, @notify = nil
       @status = :stop
 
@@ -360,7 +362,10 @@ module Puma
               if sock == check
                 break if handle_check
               else
-                pool.wait_until_not_full
+                # uncommenting this may cause 'long tail' response times when all
+                # workers are busy
+                # pool.wait_until_not_full if @clustered
+                sleep 0.001 while pool.out_of_band_running
                 pool.wait_for_less_busy_worker(options[:wait_for_less_busy_worker])
 
                 io = begin
@@ -449,8 +454,7 @@ module Puma
       requests = 0
 
       begin
-        if @queue_requests &&
-          !client.eagerly_finish
+        if @queue_requests && !client.eagerly_finish
 
           client.set_timeout(@first_data_timeout)
           if @reactor.add client
@@ -476,19 +480,19 @@ module Puma
 
             requests += 1
 
-            # As an optimization, try to read the next request from the
-            # socket for a short time before returning to the reactor.
-            fast_check = @status == :run
+            Thread.pass
 
-            # Always pass the client back to the reactor after a reasonable
-            # number of inline requests if there are other requests pending.
-            fast_check = false if requests >= @max_fast_inline &&
-              @thread_pool.backlog > 0
+            client.reset
 
-            next_request_ready = with_force_shutdown(client) do
-              client.reset(fast_check)
+            # This indicates that the socket has pipelined (multiple)
+            # requests on it, so process them
+            next_request_ready = if client.has_buffer
+              with_force_shutdown(client) { client.fast_try_to_finish }
+            else
+              nil
             end
 
+            # Send keep-alive connections back to the reactor
             unless next_request_ready
               break unless @queue_requests
               client.set_timeout @persistent_timeout


### PR DESCRIPTION
### Description

**PR - purpose and issues**

The significant change in this PR affects 'keep-alive' connections/clients.

Currently, these connections may monopolize a thread, causing a small percentage of other clients to not be processed, which results in the 'long-tail' effect on response times (see #3487).  This PR pushes the requests back to the reactor instead of being processed in `Puma::Server`'s `process_client` loop.  This change results in response times that are much more even when Puma is heavily loaded.

Note that all keep-alive connections are closed when the number of requests hits the `max_fast_inline` setting.

I started working on this by first trying to remove the long-tail effect when Puma is heavily loaded, then I checked the code with the test suite.  Three main issues existed.

First, back-to-back/pipelined requests were not being handled properly.  I decided that those requests should stay in `Puma::Server`'s `process_client` loop, similar to how successive keep-alive requests are currently processed.

Secondly, 'out-of-band' hooks were not being handled properly.

Thirdly, some logic existed that delayed processing so as to divide request load among workers if Puma was run clustered.  This delay slows down Puma when under a heavy load.

**Concerns**

* Tools like hey and wrk generate a very fast request stream with almost no delay between the receipt of a response and sending the next request.  Or, results from these tools may not show real world performance.

* I'm not sure if an invalid request that is not the first request on a keep-alive or pipelined connection is always properly handled.

* Check for how well clients are distributed between workers when running clustered.

* Possible need for more tests.

I've left this a draft in the hope of review and testing by others.

Data from using hey will be in another message.

Closes #3487
Closes #3443
Closes #2311

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
