### PR TITLE
add support in rack handler & fix regression in binder for linux abstract namespace sockets

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -184,7 +184,7 @@ module Puma
             io = inherit_unix_listener path, fd
             log_writer.log "* Inherited #{str}"
           elsif sock = @activated_sockets.delete([ :unix, path ]) ||
-              @activated_sockets.delete([ :unix, File.realdirpath(path) ])
+              !abstract && @activated_sockets.delete([ :unix, File.realdirpath(path) ])
             @unix_paths << path unless abstract || File.exist?(path)
             io = inherit_unix_listener path, sock
             log_writer.log "* Activated #{str}"

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -96,7 +96,7 @@ module Puma
     def set_host_port_to_config(host, port, config)
       config.clear_binds! if host || port
 
-      if host && (host[0,1] == '.' || host[0,1] == '/')
+      if host && (host[0,1] == '.' || host[0,1] == '/' || host[0,1] == '@')
         config.bind "unix://#{host}"
       elsif host && host =~ /^ssl:\/\//
         uri = URI.parse(host)

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -96,7 +96,7 @@ module Puma
     def set_host_port_to_config(host, port, config)
       config.clear_binds! if host || port
 
-      if host && (host[0,1] == '.' || host[0,1] == '/' || host[0,1] == '@')
+      if host&.start_with? '.', '/', '@'
         config.bind "unix://#{host}"
       elsif host && host =~ /^ssl:\/\//
         uri = URI.parse(host)

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -134,7 +134,7 @@ module TestRackUp
       assert_equal ["tcp://[::1]:9292"], conf.options[:binds]
     end
 
-    def test_abstract_unix_host_relative
+    def test_relative_unix_host
       @options[:Host] = "./relative.sock"
       conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.load
@@ -142,7 +142,7 @@ module TestRackUp
       assert_equal ["unix://./relative.sock"], conf.options[:binds]
     end
 
-    def test_abstract_unix_host_absolute
+    def test_absolute_unix_host
       @options[:Host] = "/absolute.sock"
       conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.load
@@ -150,7 +150,7 @@ module TestRackUp
       assert_equal ["unix:///absolute.sock"], conf.options[:binds]
     end
 
-    def test_abstract_unix_host_abstract
+    def test_abstract_unix_host
       @options[:Host] = "@abstract.sock"
       conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.load

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -133,6 +133,30 @@ module TestRackUp
 
       assert_equal ["tcp://[::1]:9292"], conf.options[:binds]
     end
+
+    def test_abstract_unix_host_relative
+      @options[:Host] = "./relative.sock"
+      conf = ::Rack::Handler::Puma.config(->{}, @options)
+      conf.load
+    
+      assert_equal ["unix://./relative.sock"], conf.options[:binds]
+    end
+
+    def test_abstract_unix_host_absolute
+      @options[:Host] = "/absolute.sock"
+      conf = ::Rack::Handler::Puma.config(->{}, @options)
+      conf.load
+    
+      assert_equal ["unix:///absolute.sock"], conf.options[:binds]
+    end
+
+    def test_abstract_unix_host_abstract
+      @options[:Host] = "@abstract.sock"
+      conf = ::Rack::Handler::Puma.config(->{}, @options)
+      conf.load
+    
+      assert_equal ["unix://@abstract.sock"], conf.options[:binds]
+    end
   end
 
   class TestUserSuppliedOptionsIsEmpty < Minitest::Test

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -138,7 +138,7 @@ module TestRackUp
       @options[:Host] = "./relative.sock"
       conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.load
-    
+
       assert_equal ["unix://./relative.sock"], conf.options[:binds]
     end
 
@@ -146,7 +146,7 @@ module TestRackUp
       @options[:Host] = "/absolute.sock"
       conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.load
-    
+
       assert_equal ["unix:///absolute.sock"], conf.options[:binds]
     end
 
@@ -154,7 +154,7 @@ module TestRackUp
       @options[:Host] = "@abstract.sock"
       conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.load
-    
+
       assert_equal ["unix://@abstract.sock"], conf.options[:binds]
     end
   end


### PR DESCRIPTION
### Description
allows binding to abstract namespace sockets from rack as implemented in https://github.com/puma/puma/pull/2564. rails example: `bin/rails server -b "@/socks/rails.sock"`

errors without either change:

```
/usr/local/lib/ruby/3.3.0/uri/generic.rb:601:in `check_host': bad component(expected host component): [unix://@/socks/rails.sock] (URI::InvalidComponentError)
```

```
/usr/local/bundle/gems/puma-6.4.3/lib/puma/binder.rb:186:in `realdirpath': No such file or directory @ realpath_rec - /usr/src/rails/@ (Errno::ENOENT)
```

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.

