### PR TITLE
rack/handler/puma.rb - ssl - use `start_with?`, add test

### DIFF
--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -98,7 +98,7 @@ module Puma
 
       if host&.start_with? '.', '/', '@'
         config.bind "unix://#{host}"
-      elsif host && host =~ /^ssl:\/\//
+      elsif host&.start_with? 'ssl://'
         uri = URI.parse(host)
         uri.port ||= port || ::Puma::Configuration::DEFAULTS[:tcp_port]
         config.bind uri.to_s

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -134,6 +134,14 @@ module TestRackUp
       assert_equal ["tcp://[::1]:9292"], conf.options[:binds]
     end
 
+    def test_ssl_host_supplied_port_default
+      @options[:Host] = "ssl://127.0.0.1"
+      conf = ::Rack::Handler::Puma.config(->{}, @options)
+      conf.load
+
+      assert_equal ["ssl://127.0.0.1:9292"], conf.options[:binds]
+    end
+
     def test_relative_unix_host
       @options[:Host] = "./relative.sock"
       conf = ::Rack::Handler::Puma.config(->{}, @options)


### PR DESCRIPTION
### Description

There is currently no test in `test_rack_handler` for an ssl connection/host.

Add a test, and replace
```ruby
elsif host && host =~ /^ssl:\/\//
```

with
```ruby
elsif host&.start_with? 'ssl://'
```
in lib/rack/handler/puma.rb

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
