### PR TITLE
normalize whitespace in worker stats string

### DIFF
--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -131,7 +131,7 @@ module Puma
                 t = server.pool_capacity || 0
                 m = server.max_threads || 0
                 rc = server.requests_count || 0
-                payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r}, "pool_capacity":#{t}, "max_threads": #{m}, "requests_count": #{rc} }\n!
+                payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r}, "pool_capacity":#{t}, "max_threads":#{m}, "requests_count":#{rc} }\n!
                 io << payload
               rescue IOError
                 Puma::Util.purge_interrupt_queue

--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -51,7 +51,7 @@ module Puma
         @term
       end
 
-      STATUS_PATTERN = /{ "backlog":(?<backlog>\d*), "running":(?<running>\d*), "pool_capacity":(?<pool_capacity>\d*), "max_threads": (?<max_threads>\d*), "requests_count": (?<requests_count>\d*) }/
+      STATUS_PATTERN = /{ "backlog":(?<backlog>\d*), "running":(?<running>\d*), "pool_capacity":(?<pool_capacity>\d*), "max_threads":(?<max_threads>\d*), "requests_count":(?<requests_count>\d*) }/
       private_constant :STATUS_PATTERN
 
       def ping!(status)


### PR DESCRIPTION
### Description

i was making another PR to add another type of stat (busy_threads), and noticed this

it's the heroes like me which keep this project afloat.


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x ] I have updated the documentation accordingly.
- [? ] All new and existing tests passed, including Rubocop.
