### PR TITLE
Add busy threads stat

### DIFF
--- a/docs/stats.md
+++ b/docs/stats.md
@@ -55,10 +55,14 @@ end
 
 When Puma runs in single mode, these stats are available at the top level. When Puma runs in cluster mode, these stats are available within the `worker_status` array in a hash labeled `last_status`, in an array of hashes where one hash represents each worker.
 
-* backlog: requests that are waiting for an available thread to be available. if this is above 0, you need more capacity [always true?]
+* backlog: requests that are waiting for an available thread to be available. if this is frequently above 0, you need more capacity.
 * running: how many threads are spawned. A spawned thread may be busy processing a request or waiting for a new request. If `min_threads` and `max_threads` are set to the same number,
   this will be a never-changing number (other than rare cases when a thread dies, etc).
-* pool_capacity: the number of requests that the server is capable of taking right now. For example, if the number is 5, then it means there are 5 threads sitting idle ready to take a request. If one request comes in, then the value would be 4 until it finishes processing. If the minimum threads allowed is zero, this number will still have a maximum value of the maximum threads allowed.
+* busy_threads: `running` - `how many threads are waiting to receive work` + `how many requests are waiting for a thread to pick them up`.
+  this is a "wholistic" stat reflecting the overall current stat of work to be done and the capacity to do it.
+* pool_capacity: `how many threads are waiting to receive work` + `max_threads` - `running`. In a typical configuration where min_threads
+  and `max_threads` are configured to the same number, this is simply `how many threads are waiting to receive work`. This number exists only as a stat
+  and is not used for any internal decisions, unlike `busy_theads`, which is usually a more useful stat.
 * max_threads: the maximum number of threads Puma is configured to spool per worker
 * requests_count: the number of requests this worker has served since starting
 

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -59,8 +59,8 @@ When Puma runs in single mode, these stats are available at the top level. When 
 * running: how many threads are spawned. A spawned thread may be busy processing a request or waiting for a new request. If `min_threads` and `max_threads` are set to the same number,
   this will be a never-changing number (other than rare cases when a thread dies, etc).
 * busy_threads: `running` - `how many threads are waiting to receive work` + `how many requests are waiting for a thread to pick them up`.
-  this is a "wholistic" stat reflecting the overall current stat of work to be done and the capacity to do it.
-* pool_capacity: `how many threads are waiting to receive work` + `max_threads` - `running`. In a typical configuration where min_threads
+  this is a "wholistic" stat reflecting the overall current state of work to be done and the capacity to do it.
+* pool_capacity: `how many threads are waiting to receive work` + `max_threads` - `running`. In a typical configuration where `min_threads`
   and `max_threads` are configured to the same number, this is simply `how many threads are waiting to receive work`. This number exists only as a stat
   and is not used for any internal decisions, unlike `busy_theads`, which is usually a more useful stat.
 * max_threads: the maximum number of threads Puma is configured to spool per worker

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -126,12 +126,8 @@ module Puma
 
             while true
               begin
-                b = server.backlog || 0
-                r = server.running || 0
-                t = server.pool_capacity || 0
-                m = server.max_threads || 0
-                rc = server.requests_count || 0
-                payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r}, "pool_capacity":#{t}, "max_threads":#{m}, "requests_count":#{rc} }\n!
+                stat_string = Puma::Server::STAT_METHODS.map { |s| "\"#{s}\":#{server.public_send(s) || 0}" }.join(', ')
+                payload = %Q!#{base_payload}{ #{stat_string} }\n!
                 io << payload
               rescue IOError
                 Puma::Util.purge_interrupt_queue

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -131,7 +131,8 @@ module Puma
                 t = server.pool_capacity || 0
                 m = server.max_threads || 0
                 rc = server.requests_count || 0
-                payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r}, "pool_capacity":#{t}, "max_threads":#{m}, "requests_count":#{rc} }\n!
+                bt = server.busy_threads || 0
+                payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r}, "pool_capacity":#{t}, "max_threads":#{m}, "requests_count":#{rc}, "busy_threads":#{bt} }\n!
                 io << payload
               rescue IOError
                 Puma::Util.purge_interrupt_queue

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -126,8 +126,12 @@ module Puma
 
             while true
               begin
-                stat_string = Puma::Server::STAT_METHODS.map { |s| "\"#{s}\":#{server.public_send(s) || 0}" }.join(', ')
-                payload = %Q!#{base_payload}{ #{stat_string} }\n!
+                b = server.backlog || 0
+                r = server.running || 0
+                t = server.pool_capacity || 0
+                m = server.max_threads || 0
+                rc = server.requests_count || 0
+                payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r}, "pool_capacity":#{t}, "max_threads":#{m}, "requests_count":#{rc} }\n!
                 io << payload
               rescue IOError
                 Puma::Util.purge_interrupt_queue

--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -51,7 +51,7 @@ module Puma
         @term
       end
 
-      STATUS_PATTERN = /{ "backlog":(?<backlog>\d*), "running":(?<running>\d*), "pool_capacity":(?<pool_capacity>\d*), "max_threads":(?<max_threads>\d*), "requests_count":(?<requests_count>\d*) }/
+      STATUS_PATTERN = /{ "backlog":(?<backlog>\d*), "running":(?<running>\d*), "pool_capacity":(?<pool_capacity>\d*), "max_threads":(?<max_threads>\d*), "requests_count":(?<requests_count>\d*), "busy_threads":(?<busy_threads>\d*) }/
       private_constant :STATUS_PATTERN
 
       def ping!(status)

--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -51,7 +51,9 @@ module Puma
         @term
       end
 
-      STATUS_PATTERN = /{ "backlog":(?<backlog>\d*), "running":(?<running>\d*), "pool_capacity":(?<pool_capacity>\d*), "max_threads":(?<max_threads>\d*), "requests_count":(?<requests_count>\d*) }/
+      regex_string = Puma::Server::STAT_METHODS.map { |s| "\"#{s}\":(?<#{s}>\\d*)"  }.join(', ')
+      STATUS_PATTERN = /{ #{regex_string} }/
+
       private_constant :STATUS_PATTERN
 
       def ping!(status)

--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -51,9 +51,7 @@ module Puma
         @term
       end
 
-      regex_string = Puma::Server::STAT_METHODS.map { |s| "\"#{s}\":(?<#{s}>\\d*)"  }.join(', ')
-      STATUS_PATTERN = /{ #{regex_string} }/
-
+      STATUS_PATTERN = /{ "backlog":(?<backlog>\d*), "running":(?<running>\d*), "pool_capacity":(?<pool_capacity>\d*), "max_threads":(?<max_threads>\d*), "requests_count":(?<requests_count>\d*) }/
       private_constant :STATUS_PATTERN
 
       def ping!(status)

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -233,6 +233,11 @@ module Puma
       @thread_pool&.pool_capacity
     end
 
+    # @!attribute [r] busy_threads
+    def busy_threads
+      @thread_pool&.busy_threads
+    end
+
     # Runs the server.
     #
     # If +background+ is true (the default) then a thread is spun
@@ -646,7 +651,7 @@ module Puma
 
     # List of methods invoked by #stats.
     # @version 5.0.0
-    STAT_METHODS = [:backlog, :running, :pool_capacity, :max_threads, :requests_count].freeze
+    STAT_METHODS = [:backlog, :running, :pool_capacity, :max_threads, :requests_count, :busy_threads].freeze
 
     # Returns a hash of stats about the running server for reporting purposes.
     # @version 5.0.0

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -233,11 +233,6 @@ module Puma
       @thread_pool&.pool_capacity
     end
 
-    # @!attribute [r] busy_threads
-    def busy_threads
-      @thread_pool&.busy_threads
-    end
-
     # Runs the server.
     #
     # If +background+ is true (the default) then a thread is spun

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -233,6 +233,11 @@ module Puma
       @thread_pool&.pool_capacity
     end
 
+    # @!attribute [r] busy_threads
+    def busy_threads
+      @thread_pool&.busy_threads
+    end
+
     # Runs the server.
     #
     # If +background+ is true (the default) then a thread is spun

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -91,7 +91,8 @@ module Puma
       with_mutex do
         { backlog: @todo.size,
           running: @spawned,
-          pool_capacity: @waiting + (@max - @spawned)
+          pool_capacity: @waiting + (@max - @spawned),
+          busy_threads: @spawned - @waiting + @todo.size
         }
       end
     end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -64,7 +64,7 @@ class TestCLI < Minitest::Test
     assert_equal Puma.stats_hash, JSON.parse(Puma.stats, symbolize_names: true)
 
     dmt = Puma::Configuration::DEFAULTS[:max_threads]
-    expected_stats = /\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"busy_threads":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
+    expected_stats = /\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"busy_threads":0,"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
     assert_match(expected_stats, body)
   ensure
     cli.launcher.stop
@@ -93,7 +93,7 @@ class TestCLI < Minitest::Test
       port: control_port, ctx: new_ctx
 
     dmt = Puma::Configuration::DEFAULTS[:max_threads]
-    expected_stats = /{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt}/
+    expected_stats = /{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"busy_threads":0,"max_threads":#{dmt}/
     assert_match(expected_stats, body)
   ensure
     # always called, even if skipped
@@ -117,7 +117,7 @@ class TestCLI < Minitest::Test
     body = send_http_read_resp_body "GET /stats HTTP/1.0\r\n\r\n", path: @tmp_path
 
     dmt = Puma::Configuration::DEFAULTS[:max_threads]
-    expected_stats = /{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"busy_threads":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
+    expected_stats = /{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"busy_threads":0,"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
     assert_match(expected_stats, body)
   ensure
     if UNIX_SKT_EXIST

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -64,7 +64,7 @@ class TestCLI < Minitest::Test
     assert_equal Puma.stats_hash, JSON.parse(Puma.stats, symbolize_names: true)
 
     dmt = Puma::Configuration::DEFAULTS[:max_threads]
-    expected_stats = /\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
+    expected_stats = /\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"busy_threads":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
     assert_match(expected_stats, body)
   ensure
     cli.launcher.stop
@@ -117,7 +117,7 @@ class TestCLI < Minitest::Test
     body = send_http_read_resp_body "GET /stats HTTP/1.0\r\n\r\n", path: @tmp_path
 
     dmt = Puma::Configuration::DEFAULTS[:max_threads]
-    expected_stats = /{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
+    expected_stats = /{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"busy_threads":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
     assert_match(expected_stats, body)
   ensure
     if UNIX_SKT_EXIST

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -215,7 +215,7 @@ class TestIntegrationPumactl < TestIntegration
 
     body = resp_io.read.split("\n", 2).last
 
-    expected_stats = /\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","workers":2,"phase":0,"booted_workers":2,"old_workers":0,"worker_status":\[\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":0,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\},\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":1,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\}\],"versions":\{"puma":"#{puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
+    expected_stats = /\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","workers":2,"phase":0,"booted_workers":2,"old_workers":0,"worker_status":\[\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":0,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0,"busy_threads":0\}\},\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":1,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0,"busy_threads":0\}\}\],"versions":\{"puma":"#{puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
 
     assert_match(expected_stats, body)
   end


### PR DESCRIPTION
### Description

adds busy_threads to stats and also DRYs related code

the DRYing code (worker_handle.rb and worker.rb) can go into another PR or removed if preferred


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
