### PR TITLE
Make HTTP length constants configurable for JRuby

### DIFF
--- a/docs/java_options.md
+++ b/docs/java_options.md
@@ -1,0 +1,48 @@
+# Java Options
+
+`System Properties` or `Environment Variables` can be used to change Puma's
+default configuration for its Java extension. The provided values are evaluated
+during initialization, and changes while running the app have no effect.
+Moreover, default values may be used in case of invalid inputs.
+
+## Supported Options
+
+| ENV Name                     | Default Value |        Validation        |
+|------------------------------|:-------------:|:------------------------:|
+| PUMA_QUERY_STRING_MAX_LENGTH |   1024 * 10   | Positive natural number  |
+| PUMA_REQUEST_PATH_MAX_LENGTH |     8192      | Positive natural number  |
+| PUMA_REQUEST_URI_MAX_LENGTH  |   1024 * 12   | Positive natural number  |
+
+## Examples
+
+### Invalid inputs
+
+An empty string will be handled as missing, and the default value will be used instead.
+Puma will print an error message for other invalid values.
+
+```
+foo@bar:~/puma$ PUMA_QUERY_STRING_MAX_LENGTH=abc PUMA_REQUEST_PATH_MAX_LENGTH='' PUMA_REQUEST_URI_MAX_LENGTH=0 bundle exec bin/puma test/rackup/hello.ru
+
+The value 0 for PUMA_REQUEST_URI_MAX_LENGTH is invalid. Using default value 12288 instead.
+The value abc for PUMA_QUERY_STRING_MAX_LENGTH is invalid. Using default value 10240 instead.
+Puma starting in single mode...
+```
+
+### Valid inputs
+
+```
+foo@bar:~/puma$ PUMA_REQUEST_PATH_MAX_LENGTH=9 bundle exec bin/puma test/rackup/hello.ru
+
+Puma starting in single mode...
+```
+```
+foo@bar:~ export path=/123456789 # 10 chars
+foo@bar:~ curl "http://localhost:9292${path}"
+
+Puma caught this error: HTTP element REQUEST_PATH is longer than the 9 allowed length. (Puma::HttpParserError)
+
+foo@bar:~ export path=/12345678 # 9 chars
+foo@bar:~ curl "http://localhost:9292${path}"
+Hello World
+```
+

--- a/ext/puma_http11/org/jruby/puma/Http11.java
+++ b/ext/puma_http11/org/jruby/puma/Http11.java
@@ -26,14 +26,14 @@ public class Http11 extends RubyObject {
     public final static String MAX_FIELD_NAME_LENGTH_ERR = "HTTP element FIELD_NAME is longer than the 256 allowed length.";
     public final static int MAX_FIELD_VALUE_LENGTH = 80 * 1024;
     public final static String MAX_FIELD_VALUE_LENGTH_ERR = "HTTP element FIELD_VALUE is longer than the 81920 allowed length.";
-    public final static int MAX_REQUEST_URI_LENGTH = 1024 * 12;
-    public final static String MAX_REQUEST_URI_LENGTH_ERR = "HTTP element REQUEST_URI is longer than the 12288 allowed length.";
+    public final static int MAX_REQUEST_URI_LENGTH = getConstLength("PUMA_REQUEST_URI_MAX_LENGTH", 1024 * 12);
+    public final static String MAX_REQUEST_URI_LENGTH_ERR = "HTTP element REQUEST_URI is longer than the " + MAX_REQUEST_URI_LENGTH + " allowed length.";
     public final static int MAX_FRAGMENT_LENGTH = 1024;
     public final static String MAX_FRAGMENT_LENGTH_ERR = "HTTP element REQUEST_PATH is longer than the 1024 allowed length.";
-    public final static int MAX_REQUEST_PATH_LENGTH = 8192;
-    public final static String MAX_REQUEST_PATH_LENGTH_ERR = "HTTP element REQUEST_PATH is longer than the 8192 allowed length.";
-    public final static int MAX_QUERY_STRING_LENGTH = 1024 * 10;
-    public final static String MAX_QUERY_STRING_LENGTH_ERR = "HTTP element QUERY_STRING is longer than the 10240 allowed length.";
+    public final static int MAX_REQUEST_PATH_LENGTH = getConstLength("PUMA_REQUEST_PATH_MAX_LENGTH", 8192);
+    public final static String MAX_REQUEST_PATH_LENGTH_ERR = "HTTP element REQUEST_PATH is longer than the " + MAX_REQUEST_PATH_LENGTH + " allowed length.";
+    public final static int MAX_QUERY_STRING_LENGTH = getConstLength("PUMA_QUERY_STRING_MAX_LENGTH", 10 * 1024);
+    public final static String MAX_QUERY_STRING_LENGTH_ERR = "HTTP element QUERY_STRING is longer than the " + MAX_QUERY_STRING_LENGTH +" allowed length.";
     public final static int MAX_HEADER_LENGTH = 1024 * (80 + 32);
     public final static String MAX_HEADER_LENGTH_ERR = "HTTP element HEADER is longer than the 114688 allowed length.";
 
@@ -47,6 +47,23 @@ public class Http11 extends RubyObject {
     public static final ByteList REQUEST_PATH_BYTELIST = new ByteList(ByteList.plain("REQUEST_PATH"));
     public static final ByteList QUERY_STRING_BYTELIST = new ByteList(ByteList.plain("QUERY_STRING"));
     public static final ByteList SERVER_PROTOCOL_BYTELIST = new ByteList(ByteList.plain("SERVER_PROTOCOL"));
+
+    public static String getEnvOrProperty(String name) {
+        String envValue = System.getenv(name);
+        return (envValue != null) ? envValue : System.getProperty(name);
+    }
+
+    public static int getConstLength(String name, Integer defaultValue) throws NumberFormatException {
+        String stringValue = getEnvOrProperty(name);
+        if (stringValue == null || stringValue.isEmpty()) return defaultValue;
+
+        try {
+            return Integer.parseInt(stringValue);
+        } catch (NumberFormatException e) {
+            System.err.println(String.format("The value %s for %s is invalid. Using default value %d instead.", stringValue, name, defaultValue));
+            return defaultValue;
+        }
+    }
 
     private static ObjectAllocator ALLOCATOR = new ObjectAllocator() {
         public IRubyObject allocate(Ruby runtime, RubyClass klass) {

--- a/ext/puma_http11/org/jruby/puma/Http11.java
+++ b/ext/puma_http11/org/jruby/puma/Http11.java
@@ -53,12 +53,16 @@ public class Http11 extends RubyObject {
         return (envValue != null) ? envValue : System.getProperty(name);
     }
 
-    public static int getConstLength(String name, Integer defaultValue) throws NumberFormatException {
+    public static int getConstLength(String name, Integer defaultValue) {
         String stringValue = getEnvOrProperty(name);
         if (stringValue == null || stringValue.isEmpty()) return defaultValue;
 
         try {
-            return Integer.parseInt(stringValue);
+            int value = Integer.parseUnsignedInt(stringValue);
+            if (value <= 0) {
+                throw new NumberFormatException("The number is not positive.");
+            }
+            return value;
         } catch (NumberFormatException e) {
             System.err.println(String.format("The value %s for %s is invalid. Using default value %d instead.", stringValue, name, defaultValue));
             return defaultValue;


### PR DESCRIPTION
### Description

Refactor the code to configure HTTP length constants through environment variables or system properties. 
For this purpose, I added helper methods `getEnvOrProperty` and `getConstLength`, with default values and error handling for invalid inputs.

The changes consider the following three constants described in [docs/compile_options.md](https://github.com/puma/puma/blob/master/docs/compile_options.md):

- PUMA_QUERY_STRING_MAX_LENGTH
- PUMA_REQUEST_PATH_MAX_LENGTH
- PUMA_REQUEST_URI_MAX_LENGTH

Documentation added as **/docs/java_options.md**

closes #3512 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
