### PR TITLE
[CI] - fix up test_null_io.rb TruffleRuby failure

### DIFF
--- a/test/test_null_io.rb
+++ b/test/test_null_io.rb
@@ -134,7 +134,8 @@ class TestNullIO < Minitest::Test
       nio.read(-1)
     end
 
-    assert_match(/negative length -1 given/, error.message)
+    # TruffleRuby - length must not be negative
+    assert_match(/negative length -1 given|length must not be negative/, error.message)
   end
 
   def test_sync_returns_true


### PR DESCRIPTION
### Description

CI has been failing on TruffleRuby, one needs to look at the bottom of the main job page to see.  I believe is it stable and passing, but this PR doesn't not remove the 'allow failure' logic.

Error message in TruffleRuby is different.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
