### PR TITLE
CI: Use random port in `test_on_booted`

### DIFF
--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -22,7 +22,7 @@ module TestRackUp
 
       launcher = nil
       thread = Thread.new do
-        Rack::Handler::Puma.run(app, events: events, Verbose: true, Silent: true) do |l|
+        Rack::Handler::Puma.run(app, events: events, Verbose: true, Silent: true, Port: 0) do |l|
           launcher = l
         end
       end


### PR DESCRIPTION
If you have something running on port 9292 and try to run the Puma tests, they fail like this

```shell
$ ./test/runner test_rack_handler.rb
Run options: --seed 57070

# Running:

...#<Thread:0x00000001201860c0 /Users/dentarg/src/puma/test/test_rack_handler.rb:24 run> terminated with exception (report_on_exception is true):
/Users/dentarg/src/puma/lib/puma/binder.rb:335:in `initialize': Address already in use - bind(2) for "0.0.0.0" port 9292 (Errno::EADDRINUSE)
	from /Users/dentarg/src/puma/lib/puma/binder.rb:335:in `new'
	from /Users/dentarg/src/puma/lib/puma/binder.rb:335:in `add_tcp_listener'
	from /Users/dentarg/src/puma/lib/puma/binder.rb:164:in `block in parse'
	from /Users/dentarg/src/puma/lib/puma/binder.rb:147:in `each'
	from /Users/dentarg/src/puma/lib/puma/binder.rb:147:in `parse'
	from /Users/dentarg/src/puma/lib/puma/runner.rb:168:in `load_and_bind'
	from /Users/dentarg/src/puma/lib/puma/single.rb:44:in `run'
	from /Users/dentarg/src/puma/lib/puma/launcher.rb:196:in `run'
	from /Users/dentarg/src/puma/lib/rack/handler/puma.rb:79:in `run'
	from /Users/dentarg/src/puma/test/test_rack_handler.rb:25:in `block in test_on_booted'
E.................

Fabulous run in 1.456079s, 14.4223 runs/s, 16.4826 assertions/s.
Errors & Failures:

  1) Error:
TestRackUp::TestOnBootedHandler#test_on_booted:
Errno::EADDRINUSE: Address already in use - bind(2) for "0.0.0.0" port 9292
    lib/puma/binder.rb:335:in `initialize'
    lib/puma/binder.rb:335:in `new'
    lib/puma/binder.rb:335:in `add_tcp_listener'
    lib/puma/binder.rb:164:in `block in parse'
    lib/puma/binder.rb:147:in `each'
    lib/puma/binder.rb:147:in `parse'
    lib/puma/runner.rb:168:in `load_and_bind'
    lib/puma/single.rb:44:in `run'
    lib/puma/launcher.rb:196:in `run'
    lib/rack/handler/puma.rb:79:in `run'
    test/test_rack_handler.rb:25:in `block in test_on_booted'

21 runs, 24 assertions, 0 failures, 1 errors, 0 skips
```

This change avoids that:

```shell
$ ./test/runner test_rack_handler.rb
Run options: --seed 51730

# Running:

.....................

Fabulous run in 1.947660s, 10.7822 runs/s, 12.8359 assertions/s.

21 runs, 25 assertions, 0 failures, 0 errors, 0 skips
```