### PR TITLE
[CI] test_persistent.rb - fix intermittent fail in test_no_chunked_in_http10

### DIFF
--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -121,7 +121,11 @@ class TestPersistent < Minitest::Test
     @body << "Chunked"
     @body = @body.to_enum
 
-    response = send_http_read_response GET_10
+    socket = send_http GET_10
+
+    sleep 0.01 if ::Puma::IS_JRUBY
+
+    response = socket.read_response
 
     assert_equal "HTTP/1.0 200 OK\r\nX-Header: Works\r\n\r\n" \
       "HelloChunked", response


### PR DESCRIPTION
### Description

I've seen intermittent failures in JRuby, as below:
```text
  1) Failure:
TestPersistent#test_no_chunked_in_http10 [test/test_persistent.rb:126]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
+# encoding: ASCII-8BIT
+#    valid: true
 "HTTP/1.0 200 OK\r
 X-Header: Works\r
 \r
-HelloChunked"
+Hello"
```

This test sets the body as an enumeration, and JRuby intermittently reads only the first element.  Split the write and read operations, and add a small delay only for JRuby jobs.

Note that I ran the test several times locally, it never failed.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
