### PR TITLE
[CI] test_puma_server.rb - add HTTP/1.0 & HTTP/1.1 checks thru to app env

### DIFF
--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -42,6 +42,23 @@ class TestPumaServer < Minitest::Test
     @server.run
   end
 
+  def test_http10_req_to_http10_resp
+    server_run do |env|
+      [200, {}, [env["SERVER_PROTOCOL"]]]
+    end
+    response = send_http_read_response GET_10
+    assert_equal "HTTP/1.0 200 OK", response.status
+    assert_equal "HTTP/1.0"       , response.body
+  end
+  def test_http11_req_to_http11_resp
+    server_run do |env|
+      [200, {}, [env["SERVER_PROTOCOL"]]]
+    end
+    response = send_http_read_response GET_11
+    assert_equal "HTTP/1.1 200 OK", response.status
+    assert_equal "HTTP/1.1"       , response.body
+  end
+
   def test_normalize_host_header_missing
     server_run do |env|
       [200, {}, [env["SERVER_NAME"], "\n", env["SERVER_PORT"]]]


### PR DESCRIPTION
### Description

This PR contains two tests from PR #3251 as mentioned in https://github.com/puma/puma/pull/3251#issuecomment-2365181689

The two tests are simple tests that checked `env['SERVER_PROTOCOL']` for both HTTP/1.0 & HTTP/1.1.  They checked thru to the values passed to the app.

PR #3251 also duplicates some of the work already done in #3470, which has been merged.

Similar tests also exist in the `test_http10.rb` and `test_http10.rb`, but those check the return from the parser.  Not sure if these are needed, but they don't take long to run.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
