### PR TITLE
Add ThreadPool#stats and adjust Server#stats to use it

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -651,8 +651,12 @@ module Puma
     # Returns a hash of stats about the running server for reporting purposes.
     # @version 5.0.0
     # @!attribute [r] stats
+    # @return [Hash] hash containing stat info from `Server` and `ThreadPool`
     def stats
-      STAT_METHODS.map {|name| [name, send(name) || 0]}.to_h
+      stats = @thread_pool&.stats || {}
+      stats[:max_threads]    = @max_threads
+      stats[:requests_count] = @requests_count
+      stats
     end
 
     # below are 'delegations' to binder

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -85,6 +85,17 @@ module Puma
       end
     end
 
+    # generate stats hash so as not to perform multiple locks
+    # @return [Hash] hash containing stat info from ThreadPool
+    def stats
+      with_mutex do
+        { backlog: @todo.size,
+          running: @spawned,
+          pool_capacity: @waiting + (@max - @spawned)
+        }
+      end
+    end
+
     # How many objects have yet to be processed by the pool?
     #
     def backlog


### PR DESCRIPTION
### Description

Many of the variables in ThreadPool are locked when changing their values.  Current stats code may enter that lock more than once. See https://github.com/puma/puma/pull/3517#discussion_r1799652829.

This PR creates a `ThreadPool#stats` method that returns a hash of the stats data that comes from ThreadPool, using a single lock.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.