### PR TITLE
[CI] Update stats tests

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -401,6 +401,7 @@ class TestIntegration < Minitest::Test
   def get_stats
     read_pipe = cli_pumactl "stats"
     read_pipe.wait_readable 2
+    # `split("\n", 2).last` removes "Command stats sent success" line
     JSON.parse read_pipe.read.split("\n", 2).last
   end
 

--- a/test/helpers/test_puma/assertions.rb
+++ b/test/helpers/test_puma/assertions.rb
@@ -2,6 +2,10 @@
 
 module TestPuma
   module Assertions
+
+    # iso8601 2022-12-14T00:05:49Z
+    RE_8601 = /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\z/
+
     def assert_start_with(obj, str, msg = nil)
       msg = message(msg) {
         "Expected\n#{obj}\nto start with #{str}"
@@ -28,6 +32,20 @@ module TestPuma
       assert_respond_to matcher, :"=~"
       matcher = Regexp.new Regexp.escape matcher if String === matcher
       assert matcher =~ obj, msg
+    end
+
+    def assert_hash(exp, act)
+      exp.each do |exp_k, exp_v|
+        if exp_v.is_a? Class
+          assert_instance_of exp_v, act[exp_k], "Key #{exp_k} has invalid class"
+        elsif exp_v.is_a? ::Regexp
+          assert_match exp_v, act[exp_k], "Key #{exp_k} has invalid match"
+        elsif exp_v.is_a?(Array) || exp_v.is_a?(Range)
+          assert_includes exp_v, act[exp_k], "Key #{exp_k} isn't included"
+        else
+          assert_equal exp_v, act[exp_k], "Key #{exp_k} bad value"
+        end
+      end
     end
   end
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -46,6 +46,50 @@ class TestCLI < Minitest::Test
     @ready.close
   end
 
+  def check_single_stats(body, check_puma_stats = true)
+    http_hash = JSON.parse body.split("\n", 2).last
+
+    dmt = Puma::Configuration::DEFAULTS[:max_threads]
+
+    expected_single_root_keys = {
+      'started_at' => RE_8601,
+      'backlog'    => 0,
+      'running'    => 0,
+      'pool_capacity'  => dmt,
+      'busy_threads'   => 0,
+      'max_threads'    => dmt,
+      'requests_count' => 0,
+      'versions'       => Hash,
+    }
+
+    assert_hash expected_single_root_keys, http_hash
+
+    #version keys
+    expected_version_hash = {
+      'puma' => Puma::Const::VERSION,
+      'ruby' => Hash,
+    }
+    assert_hash expected_version_hash, http_hash['versions']
+
+    #version ruby keys
+    expected_version_ruby_hash = {
+      'engine'     => RUBY_ENGINE,
+      'version'    => RUBY_VERSION,
+      'patchlevel' => RUBY_PATCHLEVEL,
+    }
+
+    assert_hash expected_version_ruby_hash, http_hash['versions']['ruby']
+
+    if check_puma_stats
+      puma_stats_hash = JSON.parse(Puma.stats)
+      assert_hash expected_single_root_keys, puma_stats_hash
+      assert_hash expected_version_hash, puma_stats_hash['versions']
+      assert_hash expected_version_ruby_hash, puma_stats_hash['versions']['ruby']
+
+      assert_equal Puma.stats_hash, JSON.parse(Puma.stats, symbolize_names: true)
+    end
+  end
+
   def test_control_for_tcp
     control_port = UniquePort.call
     url = "tcp://127.0.0.1:#{control_port}/"
@@ -61,11 +105,8 @@ class TestCLI < Minitest::Test
 
     body = send_http_read_resp_body "GET /stats HTTP/1.0\r\n\r\n", port: control_port
 
-    assert_equal Puma.stats_hash, JSON.parse(Puma.stats, symbolize_names: true)
+    check_single_stats body
 
-    dmt = Puma::Configuration::DEFAULTS[:max_threads]
-    expected_stats = /\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"busy_threads":0,"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
-    assert_match(expected_stats, body)
   ensure
     cli.launcher.stop
     t.join
@@ -92,16 +133,14 @@ class TestCLI < Minitest::Test
     body = send_http_read_resp_body "GET /stats?token=#{token} HTTP/1.0\r\n\r\n",
       port: control_port, ctx: new_ctx
 
-    dmt = Puma::Configuration::DEFAULTS[:max_threads]
-    expected_stats = /{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"busy_threads":0,"max_threads":#{dmt}/
-    assert_match(expected_stats, body)
+    check_single_stats body
   ensure
     # always called, even if skipped
     cli&.launcher&.stop
     t&.join
   end
 
-  def test_control
+  def test_control_for_unix
     skip_unless :unix
     url = "unix://#{@tmp_path}"
 
@@ -116,9 +155,7 @@ class TestCLI < Minitest::Test
 
     body = send_http_read_resp_body "GET /stats HTTP/1.0\r\n\r\n", path: @tmp_path
 
-    dmt = Puma::Configuration::DEFAULTS[:max_threads]
-    expected_stats = /{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"busy_threads":0,"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
-    assert_match(expected_stats, body)
+    check_single_stats body
   ensure
     if UNIX_SKT_EXIST
       cli.launcher.stop

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -47,7 +47,7 @@ class TestCLI < Minitest::Test
   end
 
   def check_single_stats(body, check_puma_stats = true)
-    http_hash = JSON.parse body.split("\n", 2).last
+    http_hash = JSON.parse body
 
     dmt = Puma::Configuration::DEFAULTS[:max_threads]
 

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -197,27 +197,81 @@ class TestIntegrationPumactl < TestIntegration
     skip_unless :fork
     skip_unless :unix
 
+    min_threads = 1
+    max_threads = 2
+
     puma_version_pattern = "\\d+.\\d+.\\d+(\\.[a-z\\d]+)?"
 
-    cli_server "-w2 -t2:2 -q test/rackup/hello.ru #{set_pumactl_args unix: true} -S #{@state_path}"
+    cli_server "-w#{workers} -t#{min_threads}:#{max_threads} -q test/rackup/hello.ru #{set_pumactl_args unix: true} -S #{@state_path}"
 
-    get_worker_pids # waits for workers to boot
+    worker_pids = get_worker_pids # waits for workers to boot
 
-    resp_io = cli_pumactl "stats", unix: true
-
-    status = JSON.parse resp_io.read.split("\n", 2).last
+    status = get_stats
 
     assert_equal 2, status["workers"]
 
     sleep 0.5 # needed for GHA ?
 
-    resp_io = cli_pumactl "stats", unix: true
+    stats_hash = get_stats
 
-    body = resp_io.read.split("\n", 2).last
+    expected_clustered_root_keys = {
+      'started_at' => RE_8601,
+      'workers'    => workers,
+      'phase'      => 0,
+      'booted_workers' => workers,
+      'old_workers'    => 0,
+      'worker_status'  => Array,
+      'versions'       => Hash,
+    }
 
-    expected_stats = /\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","workers":2,"phase":0,"booted_workers":2,"old_workers":0,"worker_status":\[\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":0,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0,"busy_threads":0\}\},\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":1,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0,"busy_threads":0\}\}\],"versions":\{"puma":"#{puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
+    assert_hash expected_clustered_root_keys, stats_hash
 
-    assert_match(expected_stats, body)
+    # worker_status hash
+    expected_status_hash = {
+      'started_at' => RE_8601,
+      'pid'        => worker_pids,
+      'index'      => 0...workers,
+      'phase'      => 0,
+      'booted'     => true,
+      'last_checkin' => RE_8601,
+      'last_status'  => Hash,
+    }
+
+    # worker last_status hash
+    expected_last_status_hash = {
+      'backlog' => 0,
+      'running' => min_threads,
+      'pool_capacity'  => max_threads,
+      'max_threads'    => max_threads,
+      'requests_count' => 0,
+      'busy_threads'   => 0
+    }
+
+    pids = []
+
+    workers.times do |idx|
+      worker_hash = stats_hash['worker_status'][idx]
+      assert_hash expected_status_hash, worker_hash
+      assert_equal idx, worker_hash['index']
+      pids << worker_hash['pid']
+      assert_hash expected_last_status_hash, worker_hash['last_status']
+    end
+    assert_equal pids, pids.uniq # no duplicates
+
+    #version keys
+    expected_version_hash = {
+      'puma' => Puma::Const::VERSION,
+      'ruby' => Hash,
+    }
+    assert_hash expected_version_hash, stats_hash['versions']
+
+    #version ruby keys
+    expected_version_ruby_hash = {
+      'engine'     => RUBY_ENGINE,
+      'version'    => RUBY_VERSION,
+      'patchlevel' => RUBY_PATCHLEVEL,
+    }
+    assert_hash expected_version_ruby_hash, stats_hash['versions']['ruby']
   end
 
   def control_gc_stats(unix: false)


### PR DESCRIPTION
### Description

A few of the stats tests have very long strings/regex's used with assert statements.  These make it difficult to update the tests, and also are quite a pita to work with when a test fails.

The docs state that "[Puma.stats](https://msp-greg.github.io/puma/Puma.html#stats-class_method) produces a JSON string, and the same is returned via `Puma::ControlCLI`.  JSON strings are just that, so we can change the text representation as long as they parse with the same key/value pairs.

Updates the tests to work with 'expectation' hashes, rather than 'expectation' strings/regex's.  Hopefully, others will feel that the updated tests are easier to follow.

Adds a helper method (`assert_hash`) to `test/helpers/test_puma/assertions.rb`

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
