### PR TITLE
[CI] integration.rb - update `thread_run_refused` for additional errors

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -328,7 +328,7 @@ class TestIntegration < Minitest::Test
   # used to define correct 'refused' errors
   def thread_run_refused(unix: false)
     if unix
-      DARWIN ? [IOError, Errno::ENOENT, Errno::EPIPE] :
+      DARWIN ? [IOError, Errno::ENOENT, Errno::EPIPE, Errno::EBADF] :
                [IOError, Errno::ENOENT]
     else
       # Errno::ECONNABORTED is thrown intermittently on TCPSocket.new

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -332,8 +332,9 @@ class TestIntegration < Minitest::Test
                [IOError, Errno::ENOENT]
     else
       # Errno::ECONNABORTED is thrown intermittently on TCPSocket.new
+      # Errno::ECONNABORTED is thrown by Windows on read or write
       DARWIN ? [IOError, Errno::ECONNREFUSED, Errno::EPIPE, Errno::EBADF, EOFError, Errno::ECONNABORTED] :
-               [IOError, Errno::ECONNREFUSED, Errno::EPIPE]
+               [IOError, Errno::ECONNREFUSED, Errno::EPIPE, Errno::ECONNABORTED]
     end
   end
 


### PR DESCRIPTION
### Description

Adds `Errno::EBADF` to `thread_run_refused` in `integration.rb` as allowed error to macos unix socket tests.

Some tests create client http requests in threads, and every error needs to be caught, otherwise the CI favorite message of 
```text
terminated with exception (report_on_exception is true)
```

occurs, which stops the tests from completing.  Currently, an array of socket related errors is used.

To make things interesting, different OS/Platform combinations may raise different errors, and it also may depend on the socket type.

I've wondered if there is a better way, maybe we could simplify `thread_run_refused` to simply be an array of socket errors.  Not.sure.  The code hasn't been touched for approx two years.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
