### PR TITLE
lib/rack/handler/puma.rb - fix for rackup v1.0.1, adjust Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,20 +11,16 @@ gem "minitest-retry"
 gem "minitest-proveit"
 gem "minitest-stub-const"
 
-use_rackup = false
-rack_vers =
-  case ENV['PUMA_CI_RACK']&.strip
-  when 'rack2'
-    '~> 2.2'
-  when 'rack1'
-    '~> 1.6'
-  else
-    use_rackup = true
-    '>= 2.2'
-  end
-
-gem "rack", rack_vers
-gem "rackup" if use_rackup
+case ENV['PUMA_CI_RACK']&.strip
+when 'rack2'
+  gem "rackup", '~> 1.0'
+  gem "rack"  , '~> 2.2'
+when 'rack1'
+  gem "rack"  , '~> 1.6'
+else
+  gem "rackup", '>= 2.0'
+  gem "rack"  , '>= 2.2'
+end
 
 gem "jruby-openssl", :platform => "jruby"
 

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -118,7 +118,7 @@ module Puma
 end
 
 # rackup was removed in Rack 3, it is now a separate gem
-if Object.const_defined? :Rackup
+if Object.const_defined?(:Rackup) && ::Rackup.const_defined?(:Handler)
   module Rackup
     module Handler
       module Puma
@@ -130,7 +130,7 @@ if Object.const_defined? :Rackup
     end
   end
 else
-  do_register = Object.const_defined?(:Rack) && Rack.release < '3'
+  do_register = Object.const_defined?(:Rack) && ::Rack.release < '3'
   module Rack
     module Handler
       module Puma


### PR DESCRIPTION
### Description

This almost falls in the category of "Don't get me started...".

It will break things.

Previous versions of `Rackup` also defined `Rackup::Handler`, and Puma assumed that if `Rackup` was defined, so was `Rackup::Handler`.  That is not the case with v1.0.1.  All it defines is `Rackup::VERSION`.  It's simply a Rack 2 compatible version that makes Gemfile logic simpler.  Its gemspec also contains:
```ruby
  spec.add_dependency "rack", "< 3"
  spec.add_dependency "webrick"
```

This PR now checks for the existence of `Rackup::Handler`

Closes #3531


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
