### PR TITLE
[CI] integration.rb - catch errors in `restart_thread`

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -472,6 +472,8 @@ class TestIntegration < Minitest::Test
 
     run = true
 
+    thread_error = nil
+
     restart_thread = Thread.new do
       sleep 0.2  # let some connections in before 1st restart
       while run
@@ -486,11 +488,16 @@ class TestIntegration < Minitest::Test
           wait_for_server_to_boot timeout: 5
         rescue Minitest::Assertion # Timeout
           run = false
+        rescue StandardError => e
+          run = false
+          thread_error = e
         end
         restart_count += 1
         sleep(Puma.windows? ? 2.0 : 0.5)
       end
     end
+
+    flunk "Error in restart_thread\n#{thread_error.inspect}" if thread_error
 
     client_threads.each(&:join)
     run = false


### PR DESCRIPTION
### Description

Recently, a job failed due to an error being raised in a thread (abort on exception). When this happens, testing stops, and the job fails.

Catch errors in the `restart_thread` contained in `TestIntegration#hot_restart_does_not_drop_connections`.  This allows tests to continue, retries to work, etc.

Note that these errors are intermittent and often cannot be repro'd locally.

### Your checklist for this pull request
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
