### PR TITLE
[CI] tests.yml - remove 'MRI' and 'NON-MRI' from job titles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
 
   test_mri:
     name: >-
-      MRI: ${{ matrix.os }} ${{ matrix.ruby }}${{ matrix.no-ssl }}${{ matrix.yjit }}${{ matrix.rack-v }}
+      ${{ matrix.os }} ${{ matrix.ruby }}${{ matrix.no-ssl }}${{ matrix.yjit }}${{ matrix.rack-v }}
     needs: [rubocop, skip_duplicate_runs]
     env:
       CI: true
@@ -133,7 +133,7 @@ jobs:
 
   test_non_mri:
     name: >-
-      NON-MRI: ${{ matrix.os }} ${{ matrix.ruby }}${{ matrix.no-ssl }}
+      ${{ matrix.os }} ${{ matrix.ruby }}${{ matrix.no-ssl }}
     needs: [rubocop, skip_duplicate_runs]
     env:
       CI: true


### PR DESCRIPTION
### Description

Currently, when CI runs the tests.yml workflow, the main jobs are all prefaced with `MRI:` or `NON-MRI:`. On smaller devices (tablets), this often truncates the job title, which contains the OS, Ruby version/platform, etc.

I don't think the `MRI:` or `NON-MRI:` text adds any helpful information, so let's remove them.

After this PR, I can now see the full job title when viewed on an iPad.

This PR only changes the workflow file.

Before PR: https://github.com/puma/puma/actions/runs/11508915225
After PR: https://github.com/puma/puma/actions/runs/11508748300

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
