### PR TITLE
[CI] test_launcher.rb - fixup

### DIFF
--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -4,8 +4,6 @@ require_relative "helpers/tmp_path"
 require "puma/configuration"
 require 'puma/log_writer'
 
-# Can't run parallel due to `ENV` use
-
 class TestLauncher < Minitest::Test
   include TmpPath
 
@@ -125,17 +123,15 @@ class TestLauncher < Minitest::Test
   end
 
   def test_log_config_enabled
-    ENV['PUMA_LOG_CONFIG'] = "1"
+    env = {'PUMA_LOG_CONFIG' => '1'}
 
-    launcher = create_launcher
+    launcher = create_launcher env: env
 
     assert_match(/Configuration:/, launcher.log_writer.stdout.string)
 
     launcher.config.final_options.each do |config_key, _value|
       assert_match(/#{config_key}/, launcher.log_writer.stdout.string)
     end
-  ensure
-    ENV.delete('PUMA_LOG_CONFIG')
   end
 
   def test_log_config_disabled
@@ -163,8 +159,8 @@ class TestLauncher < Minitest::Test
 
   private
 
-  def create_launcher(config = Puma::Configuration.new, lw = Puma::LogWriter.strings)
+  def create_launcher(config = Puma::Configuration.new, lw = Puma::LogWriter.strings, **kw)
     config.options[:binds] = ["tcp://127.0.0.1:#{UniquePort.call}"]
-    Puma::Launcher.new(config, log_writer: lw)
+    Puma::Launcher.new(config, log_writer: lw, **kw)
   end
 end


### PR DESCRIPTION
### Description

* `test_puma_stats_clustered` - recently there was one CI failure, logged as the below.  Fixup to (hopefully) consistently pass.

  ```text
    1) Error:
  TestLauncher#test_puma_stats_clustered:
  TimeoutEveryTestCase::TestTookTooLong: execution expired
      lib/puma/cluster.rb:242:in 'Process.waitall'
      lib/puma/cluster.rb:242:in 'Puma::Cluster#stop_blocked'
      lib/puma/launcher.rb:274:in 'Puma::Launcher#do_graceful_stop'
      lib/puma/launcher.rb:259:in 'Puma::Launcher#do_run_finished'
      lib/puma/launcher.rb:198:in 'Puma::Launcher#run'
      test/test_launcher.rb:116:in 'TestLauncher#test_puma_stats_clustered'
  ```

* `test_log_config_enabled` - current code only checked the config 'keys'.  Update code to check keys and values, and also an exact match of key/value pairs.  Remove use of `ENV`.


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
