### PR TITLE
Handle blank environment variables when loading config

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -235,9 +235,9 @@ module Puma
       end
 
       {
-        min_threads: min && Integer(min),
-        max_threads: max && Integer(max),
-        workers: workers && Integer(workers),
+        min_threads: min && min != "" && Integer(min),
+        max_threads: max && max != "" && Integer(max),
+        workers: workers && workers != "" && Integer(workers),
         environment: env['APP_ENV'] || env['RACK_ENV'] || env['RAILS_ENV'],
       }
     end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -660,6 +660,10 @@ class TestConfigEnvVariables < Minitest::Test
     env = { "PUMA_MIN_THREADS" => "8" }
     conf = Puma::Configuration.new({}, {}, env)
     assert_equal 8, conf.options.default_options[:min_threads]
+
+    env = { "PUMA_MIN_THREADS" => "" }
+    conf = Puma::Configuration.new({}, {}, env)
+    assert_equal 0, conf.options.default_options[:min_threads]
   end
 
   def test_config_loads_correct_max_threads
@@ -673,12 +677,22 @@ class TestConfigEnvVariables < Minitest::Test
     env = { "PUMA_MAX_THREADS" => "8" }
     conf = Puma::Configuration.new({}, {}, env)
     assert_equal 8, conf.options.default_options[:max_threads]
+
+    env = { "PUMA_MAX_THREADS" => "" }
+    conf = Puma::Configuration.new({}, {}, env)
+    assert_equal default_max_threads, conf.options.default_options[:max_threads]
   end
 
   def test_config_loads_workers_from_env
     env = { "WEB_CONCURRENCY" => "9" }
     conf = Puma::Configuration.new({}, {}, env)
     assert_equal 9, conf.options.default_options[:workers]
+  end
+
+  def test_config_ignores_blank_workers_from_env
+    env = { "WEB_CONCURRENCY" => "" }
+    conf = Puma::Configuration.new({}, {}, env)
+    assert_equal 0, conf.options.default_options[:workers]
   end
 
   def test_config_does_not_preload_app_if_not_using_workers

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -663,7 +663,8 @@ class TestConfigEnvVariables < Minitest::Test
   end
 
   def test_config_loads_correct_max_threads
-    conf = Puma::Configuration.new
+    default_max_threads = Puma.mri? ? 5 : 16
+    assert_equal default_max_threads, Puma::Configuration.new.options.default_options[:max_threads]
 
     env = { "MAX_THREADS" => "7" }
     conf = Puma::Configuration.new({}, {}, env)


### PR DESCRIPTION
### Description

Sometimes (usually for overriding values temporarily) shells can unset environment variables by setting them to a blank value, ruby interprets this as an empty string. Doing so with Puma's default environment parsing would previously blow up because `Integer("")` is not valid.

    $ WEB_CONCURRENCY= bundle exec puma
    bundler: failed to load command: puma (/Users/caius/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/bin/puma)
    <internal:kernel>:307:in `Integer': invalid value for Integer(): "" (ArgumentError)

- [x] Add tests for `WEB_CONCURRENCY`, `PUMA_MIN_THREADS` and `PUMA_MAX_THREADS` being `""`
- [x] Check in code we're not trying to parse empty strings before parsing values
- [x] Update existing test for `PUMA_MAX_THREADS` to match `PUMA_MIN_THREADS` test

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
