### PR TITLE
Fix warnings in the test suite

### DIFF
--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -61,7 +61,7 @@ class TestBusyWorker < Minitest::Test
 
     sockets = send_http_array GET_10, n
 
-    responses = read_response_array(sockets)
+    read_response_array(sockets)
 
     assert_equal n, @requests_count, "number of requests needs to match"
     assert_equal 0, @requests_running, "none of requests needs to be running"
@@ -81,7 +81,7 @@ class TestBusyWorker < Minitest::Test
 
     sockets = send_http_array GET_10, n
 
-    responses = read_response_array(sockets)
+    read_response_array(sockets)
 
     assert_equal n, @requests_count, "number of requests needs to match"
     assert_equal 0, @requests_running, "none of requests needs to be running"

--- a/test/test_example_cert_expiration.rb
+++ b/test/test_example_cert_expiration.rb
@@ -28,7 +28,6 @@ class TestExampleCertExpiration < Minitest::Test
     expiration_data = TEST_FILES.map do |path|
       full_path  = File.join(EXAMPLES_DIR, path)
       not_after  = OpenSSL::X509::Certificate.new(File.read(full_path)).not_after
-      parent_dir = File.dirname(path)
       [not_after, path]
     end
 

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -226,7 +226,7 @@ class TestPersistent < Minitest::Test
   end
 
   def test_keepalive_doesnt_starve_clients
-    sz = @body[0].size.to_s
+    @body[0].size
 
     send_http @valid_request
 

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -120,7 +120,7 @@ class TestPumaServerSSL < Minitest::Test
 
   def rejection(server_ctx, min_max, ssl_version)
     if server_ctx
-      start_server &server_ctx
+      start_server(&server_ctx)
     else
       start_server
     end


### PR DESCRIPTION
```
test/test_busy_worker.rb:64: warning: assigned but unused variable - responses
test/test_busy_worker.rb:84: warning: assigned but unused variable - responses
test/test_example_cert_expiration.rb:31: warning: assigned but unused variable - parent_dir
test/test_persistent.rb:229: warning: assigned but unused variable - sz
test/test_puma_server_ssl.rb:123: warning: ambiguous `&` has been interpreted as an argument prefix
```
