### PR TITLE
Fix reactor initialization calling wrong JRuby Selector initialization

### DIFF
--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -24,8 +24,12 @@ module Puma
       unless valid_backends.include?(backend)
         raise ArgumentError.new("unsupported IO selector backend: #{backend} (available backends: #{valid_backends.join(', ')})")
       end
-
-      @selector = ::NIO::Selector.new(NIO::Selector.backends.delete(backend))
+      delete_output = NIO::Selector.backends.delete(backend)
+      if delete_output.nil?
+        @selector = ::NIO::Selector.new
+      else
+        @selector = ::NIO::Selector.new(delete_output)
+      end
       @input = Queue.new
       @timeouts = []
       @block = block

--- a/lib/puma/reactor.rb
+++ b/lib/puma/reactor.rb
@@ -24,12 +24,8 @@ module Puma
       unless valid_backends.include?(backend)
         raise ArgumentError.new("unsupported IO selector backend: #{backend} (available backends: #{valid_backends.join(', ')})")
       end
-      delete_output = NIO::Selector.backends.delete(backend)
-      if delete_output.nil?
-        @selector = ::NIO::Selector.new
-      else
-        @selector = ::NIO::Selector.new(delete_output)
-      end
+
+      @selector = ::NIO::Selector.new(NIO::Selector.backends.delete(backend))
       @input = Queue.new
       @timeouts = []
       @block = block

--- a/puma.gemspec
+++ b/puma.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.email = ["evan@phx.io"]
   s.executables = ["puma", "pumactl"]
   s.extensions = ["ext/puma_http11/extconf.rb"]
-  s.add_runtime_dependency "nio4r", "~> 2.0"
+  s.add_runtime_dependency "nio4r", "~> 2.5.5"
   if RbConfig::CONFIG['ruby_version'] >= '2.5'
     s.metadata["msys2_mingw_dependencies"] = "openssl"
   end

--- a/test/test_reactor.rb
+++ b/test/test_reactor.rb
@@ -1,7 +1,7 @@
 require 'puma/reactor'
 require_relative "helper"
 
-class TestReactor < Minitest::Test
+class TestReactor < TimeoutTestCase
   def test_initialization_on_jruby
     skip_unless :jruby
     @reactor = Puma::Reactor.new(:auto) { |c| reactor_wakeup c }

--- a/test/test_reactor.rb
+++ b/test/test_reactor.rb
@@ -1,0 +1,10 @@
+require 'puma/reactor'
+require_relative "helper"
+
+class TestReactor < Minitest::Test
+  def test_initialization_on_jruby
+    skip_unless :jruby
+    @reactor = Puma::Reactor.new(:auto) { |c| reactor_wakeup c }
+    assert_instance_of Puma::Reactor, @reactor
+  end
+end


### PR DESCRIPTION
https://github.com/puma/puma/pull/3151 broke JRuby selector initialization via the following:

```
NIO::Selector.backends.delete(backend) => nil
```

What results is that `::NIO::Selector.new(nil)` is not the same as `::NIO::Selector.new`.

The former invokes
https://github.com/socketry/nio4r/blob/v2.5.2/ext/nio4r/org/nio4r/Selector.java#L47, which results in an exception being thrown.

This PR will restore the reactor initialization to call the intended https://github.com/socketry/nio4r/blob/v2.5.2/ext/nio4r/org/nio4r/Selector.java#L41

### Description
Please describe your pull request. Thank you for contributing! You're the best.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
