### PR TITLE
CI: Bump OS versions used for ragel jobs

### DIFF
--- a/.github/workflows/ragel.yml
+++ b/.github/workflows/ragel.yml
@@ -27,8 +27,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-20.04 , ruby: head }
-          - { os: macos-12     , ruby: head }
+          - { os: ubuntu-22.04 , ruby: head }
+          - { os: macos-13     , ruby: head }
           # Dec-2023 - incorrect line directives with Windows
           # occurs with both MSYS2 and MSFT/vpkg versions of ragel
           # - { os: windows-2022 , ruby: ucrt } 


### PR DESCRIPTION
The macos-12 job is going away, currently brownouts are happening: https://github.com/actions/runner-images/issues/10721

Ubuntu 20.04 will go away at some point soon too (next year?), so let's up that too while at it.
