### PR TITLE
integration.rb - fix up writing config file

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -97,7 +97,9 @@ class TestIntegration < Minitest::Test
 
     if config
       @config_file = Tempfile.create(%w(config .rb))
-      @config_file.write config
+      @config_file.syswrite config
+      # not supported on some OS's, all GitHub Actions OS's support it
+      @config_file.fsync rescue nil
       @config_file.close
       config = "-C #{@config_file.path}"
     end


### PR DESCRIPTION
### Description

`cli_server` is used to start a Puma instance in a sub process using `IO.popen`.  It has a keyword parameter `config:` that sets the contents of a Puma config file.  This is often used for short config files, as it allows the test code to contain the config file code.

PR #3545 fixed a test that was consistently failing, and I ran the PR thru GHA (GitHub Actions) several times in my fork.  No failures.

After it was merged, I was working on another PR, and the test stopped the CI job in my fork, as in `did not finish`, with no summary, error of failure, etc.

These are difficult to determine the cause, possibly a 'noisy neighbors' issue.

This PR changes writing and closing the config file when the config string is specified.  Hopefully more robust...

As mentioned previously, these also never fail locally, so it's difficult to determine the cause.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
