### PR TITLE
Request body - increase read size to 64 kB

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -501,7 +501,7 @@ module Puma
     def read_chunked_body
       while true
         begin
-          chunk = @io.read_nonblock(4096, @read_buffer)
+          chunk = @io.read_nonblock(CHUNK_SIZE, @read_buffer)
         rescue IO::WaitReadable
           return false
         rescue SystemCallError, IOError

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -137,7 +137,7 @@ module Puma
     }.freeze
 
     # The basic max request size we'll try to read.
-    CHUNK_SIZE = 16 * 1024
+    CHUNK_SIZE = 64 * 1024
 
     # This is the maximum header that is allowed before a client is booted.  The parser detects
     # this, but we'd also like to do this as well.


### PR DESCRIPTION
### Description

While looking into #3540, I noticed that the `read_nonblock` calls used for requests were either 4k or 16k.  For large request bodies, this causes a large number of loops to read them.

Using curl, I increased the value to 128k, and checked the bytes read.  They were 64k for both `content-length` and chunked bodies.

Also, the 16k value in `Puma::Const` dates back to at least 2007, and networks are much different now.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
