### PR TITLE
CI: fix TestIntegration#server_gets - until, not unless

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -210,7 +210,7 @@ class TestIntegration < Minitest::Test
     error_retries = 0
     line = ''
 
-    sleep 0.05 unless @server.is_a?(IO) or Process.clock_gettime(Process::CLOCK_MONOTONIC) > time_timeout
+    sleep 0.05 until @server.is_a?(IO) || Process.clock_gettime(Process::CLOCK_MONOTONIC) > time_timeout
 
     raise Minitest::Assertion,  "@server is not an IO" unless @server.is_a?(IO)
     if Process.clock_gettime(Process::CLOCK_MONOTONIC) > time_timeout


### PR DESCRIPTION
### Description

I think this was an error I caused last year, where `unless` was used, but `until` was intended.

This may help with errors like:
```text
Error: Errno::EBADF: Waiting for server to log /(?:Master| ) PID: (\d+)$/
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
