### PR TITLE
CI: test/test_request_invalid.rb - use TestPuma::PumaSocket, RFC 9112

### DIFF
--- a/test/test_request_invalid.rb
+++ b/test/test_request_invalid.rb
@@ -1,27 +1,37 @@
 require_relative "helper"
+require_relative "helpers/test_puma/puma_socket"
 
 # These tests check for invalid request headers and metadata.
 # Content-Length, Transfer-Encoding, and chunked body size
 # values are checked for validity
 #
-# See https://datatracker.ietf.org/doc/html/rfc7230
+# See https://httpwg.org/specs/rfc9112.html
 #
-# https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2 Content-Length
-# https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.1 Transfer-Encoding
-# https://datatracker.ietf.org/doc/html/rfc7230#section-4.1   chunked body size
+# https://httpwg.org/specs/rfc9112.html#body.content-length     Content-Length
+# https://httpwg.org/specs/rfc9112.html#field.transfer-encoding Transfer-Encoding
+# https://httpwg.org/specs/rfc9112.html#chunked.encoding        Chunked Transfer Coding
 #
 class TestRequestInvalid < Minitest::Test
   # running parallel seems to take longer...
   # parallelize_me! unless JRUBY_HEAD
 
+  include TestPuma
+  include TestPuma::PumaSocket
+
   GET_PREFIX = "GET / HTTP/1.1\r\nConnection: close\r\n"
   CHUNKED = "1\r\nH\r\n4\r\nello\r\n5\r\nWorld\r\n0\r\n\r\n"
 
+  HOST = HOST4
+
+  STATUS_CODES = ::Puma::HTTP_STATUS_CODES
+
+  HEADERS_413 = [
+    "Connection: close",
+    "Content-Length: #{STATUS_CODES[413].bytesize}"
+  ]
+
   def setup
-    @host = '127.0.0.1'
-
-    @ios = []
-
+    @host = HOST
     # this app should never be called, used for debugging
     app = ->(env) {
       body = +''
@@ -35,31 +45,55 @@ class TestRequestInvalid < Minitest::Test
     }
 
     @log_writer = Puma::LogWriter.strings
-    @server = Puma::Server.new app, nil, {log_writer: @log_writer}
-    @port = (@server.add_tcp_listener @host, 0).addr[1]
+    options = {}
+    options[:log_writer]  = @log_writer
+    options[:min_threads] = 1
+    @server = Puma::Server.new app, nil, options
+    @bind_port = (@server.add_tcp_listener @host, 0).addr[1]
     @server.run
     sleep 0.15 if Puma.jruby?
   end
 
   def teardown
     @server.stop(true)
-    @ios.each { |io| io.close if io && !io.closed? }
   end
 
-  def send_http_and_read(req)
-    send_http(req).read
+  def server_run(**options, &block)
+    options[:log_writer]  ||= @log_writer
+    options[:min_threads] ||= 1
+    @server = Puma::Server.new block || @app, nil, options
+    @bind_port = (@server.add_tcp_listener @host, 0).addr[1]
+    @server.run
   end
 
-  def send_http(req)
-    new_connection << req
+  def assert_status(request, status = 400, socket: nil)
+    response = if socket
+      socket.req_write(request).read_response
+    else
+      send_http_read_response request
+    end
+
+    re = /\AHTTP\/1\.[01] #{status}/
+
+    assert_match re, response, "'#{response[/[^\r]+/]}' should be #{status}"
   end
 
-  def new_connection
-    TCPSocket.new(@host, @port).tap {|sock| @ios << sock}
+  # ──────────────────────────────────── below are oversize path length
+
+  def test_oversize_path
+    path = "/#{'a' * 8_500}"
+
+    assert_status  "GET #{path} HTTP/1.1\r\n\r\n"
   end
 
-  def assert_status(str, status = 400)
-    assert str.start_with?("HTTP/1.1 #{status}"), "'#{str[/[^\r]+/]}' should be #{status}"
+  def __test_oversize_path_keep_alive
+    path = "/#{'a' * 8_500}"
+
+    socket = new_socket
+
+    assert_status  "GET / HTTP/1.1\r\n\r\n", 200, socket: socket
+
+    assert_status  "GET #{path} HTTP/1.1\r\n\r\n", socket: socket
   end
 
   # ──────────────────────────────────── below are invalid Content-Length
@@ -70,33 +104,35 @@ class TestRequestInvalid < Minitest::Test
       'Content-Length: 5'
     ].join "\r\n"
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
-
-    assert_status data
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
   end
 
   def test_content_length_bad_characters_1
     te = 'Content-Length: 5.01'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
-
-    assert_status data
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
   end
 
   def test_content_length_bad_characters_2
     te = 'Content-Length: +5'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
-
-    assert_status data
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
   end
 
   def test_content_length_bad_characters_3
     te = 'Content-Length: 5 test'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\nHello\r\n\r\n"
+  end
 
-    assert_status data
+  def __test_content_length_bad_characters_1_keep_alive
+    socket = new_socket
+
+    assert_status "GET / HTTP/1.1\r\n\r\n", 200, socket: socket
+
+    cl = 'Content-Length: 5.01'
+
+    assert_status "#{GET_PREFIX}#{cl}\r\n\r\nHello\r\n\r\n", socket: socket
   end
 
   # ──────────────────────────────────── below are invalid Transfer-Encoding
@@ -107,9 +143,7 @@ class TestRequestInvalid < Minitest::Test
       'Transfer-Encoding: gzip'
     ].join "\r\n"
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
-
-    assert_status data
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
   end
 
   def test_transfer_encoding_chunked_multiple
@@ -119,17 +153,13 @@ class TestRequestInvalid < Minitest::Test
       'Transfer-Encoding: chunked'
     ].join "\r\n"
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
-
-    assert_status data
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
   end
 
   def test_transfer_encoding_invalid_single
     te = 'Transfer-Encoding: xchunked'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
-
-    assert_status data, 501
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}", 501
   end
 
   def test_transfer_encoding_invalid_multiple
@@ -139,17 +169,13 @@ class TestRequestInvalid < Minitest::Test
       'Transfer-Encoding: chunked'
     ].join "\r\n"
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
-
-    assert_status data, 501
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}", 501
   end
 
   def test_transfer_encoding_single_not_chunked
     te = 'Transfer-Encoding: gzip'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
-
-    assert_status data
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}"
   end
 
   # ──────────────────────────────────── below are invalid chunked size
@@ -158,62 +184,54 @@ class TestRequestInvalid < Minitest::Test
     te = 'Transfer-Encoding: chunked'
     chunked ='5.01'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
-
-    assert_status data
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\n" \
+      "1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
   end
 
   def test_chunked_size_bad_characters_2
     te = 'Transfer-Encoding: chunked'
     chunked ='+5'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
-
-    assert_status data
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\n" \
+      "1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
   end
 
   def test_chunked_size_bad_characters_3
     te = 'Transfer-Encoding: chunked'
     chunked ='5 bad'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
-
-    assert_status data
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\n" \
+      "1\r\nh\r\n#{chunked}\r\nHello\r\n0\r\n\r\n"
   end
 
   def test_chunked_size_bad_characters_4
     te = 'Transfer-Encoding: chunked'
     chunked ='0xA'
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n1\r\nh\r\n#{chunked}\r\nHelloHello\r\n0\r\n\r\n"
-
-    assert_status data
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\n" \
+      "1\r\nh\r\n#{chunked}\r\nHelloHello\r\n0\r\n\r\n"
   end
 
-  # size is less than bytesize
+  # size is less than bytesize, 4 < 'world'.bytesize
   def test_chunked_size_mismatch_1
     te = 'Transfer-Encoding: chunked'
     chunked =
       "5\r\nHello\r\n" \
       "4\r\nWorld\r\n" \
-      "0"
+      "0\r\n\r\n"
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n#{chunked}\r\n\r\n"
-
-    assert_status data
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\n#{chunked}"
   end
 
-  # size is greater than bytesize
+  # size is greater than bytesize, 6 > 'world'.bytesize
   def test_chunked_size_mismatch_2
     te = 'Transfer-Encoding: chunked'
     chunked =
       "5\r\nHello\r\n" \
       "6\r\nWorld\r\n" \
-      "0"
+      "0\r\n\r\n"
 
-    data = send_http_and_read "#{GET_PREFIX}#{te}\r\n\r\n#{chunked}\r\n\r\n"
-
-    assert_status data
+    assert_status "#{GET_PREFIX}#{te}\r\n\r\n#{chunked}"
   end
 
   def test_underscore_header_1
@@ -224,7 +242,7 @@ class TestRequestInvalid < Minitest::Test
       "Content-Length: 5",
     ].join "\r\n"
 
-    response = send_http_and_read "#{GET_PREFIX}#{hdrs}\r\n\r\nHello\r\n\r\n"
+    response = send_http_read_response "#{GET_PREFIX}#{hdrs}\r\n\r\nHello\r\n\r\n"
 
     assert_includes response, "HTTP_X_FORWARDED_FOR = 1.1.1.1, 2.2.2.2"
     refute_includes response, "3.3.3.3"
@@ -238,9 +256,106 @@ class TestRequestInvalid < Minitest::Test
       "Content-Length: 5",
     ].join "\r\n"
 
-    response = send_http_and_read "#{GET_PREFIX}#{hdrs}\r\n\r\nHello\r\n\r\n"
+    response = send_http_read_response "#{GET_PREFIX}#{hdrs}\r\n\r\nHello\r\n\r\n"
 
     assert_includes response, "HTTP_X_FORWARDED_FOR = 2.2.2.2, 1.1.1.1"
     refute_includes response, "3.3.3.3"
+  end
+
+
+  # ──────────────────────────────────── below have http_content_length_limit set
+
+  # Sets the server to have a http_content_length_limit of 190 kB, then sends a
+  # 200 kB body with Content-Length set to the same.
+  # Verifies that the connection is closed properly.
+  def __test_http_11_req_oversize_content_length
+    lleh_called = false
+    lleh_err = nil
+
+    lleh = -> (err) {
+      lleh_err = err
+      [500, {'Content-Type' => 'text/plain'}, ['error']]
+    }
+    long_string = 'a' * 200_000
+    server_run(http_content_length_limit: 190_000, lowlevel_error_handler: lleh) { [200, {}, ['Hello World']] }
+
+    socket = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nContent-Length: 200000\r\n\r\n" \
+      "#{long_string}"
+
+    response = socket.read_response
+
+    # Content Too Large
+    assert_equal "HTTP/1.1 413 #{STATUS_CODES[413]}", response.status
+    assert_equal HEADERS_413, response.headers
+
+    sleep 0.5
+    refute lleh_err
+    assert_raises(Errno::ECONNRESET) { socket << GET_11 }
+  end
+
+  # Sets the server to have a http_content_length_limit of 100 kB, then sends a
+  # 200 kB chunked body.  Verifies that the connection is closed properly.
+  def __test_http_11_req_oversize_chunked
+    chunk_length = 20_000
+    chunk_part_qty = 10
+    req_body_length = chunk_length * chunk_part_qty
+
+    lleh_called = false
+    lleh_err = nil
+
+    lleh = -> (err) {
+      lleh_err = err
+      [500, {'Content-Type' => 'text/plain'}, ['error']]
+    }
+    long_string = 'a' * chunk_length
+    long_string_part = "#{long_string.bytesize.to_s 16}\r\n#{long_string}\r\n"
+    long_chunked = "#{long_string_part * chunk_part_qty}0\r\n\r\n"
+
+    server_run(
+      http_content_length_limit: 100_000,
+      lowlevel_error_handler: lleh
+    ) { [200, {}, ['Hello World']] }
+
+    socket = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\n" \
+      "Transfer-Encoding: chunked\r\n\r\n#{long_chunked}"
+
+    response = socket.read_response
+
+    # Content Too Large
+    assert_equal "HTTP/1.1 413 #{STATUS_CODES[413]}", response.status
+    assert_equal HEADERS_413, response.headers
+
+    sleep 0.5
+    refute lleh_err
+
+    assert_raises(Errno::ECONNRESET) { socket << GET_11 }
+  end
+
+  # Sets the server to have a http_content_length_limit of 190 kB, then sends a
+  # 200 kB body with Content-Length set to the same.
+  # Verifies that the connection is closed properly.
+  def __test_http_11_req_oversize_no_content_length
+    lleh_called = false
+    lleh_err = nil
+
+    lleh = -> (err) {
+      lleh_err = err
+      [500, {'Content-Type' => 'text/plain'}, ['error']]
+    }
+    long_string = 'a' * 200_000
+    server_run(http_content_length_limit: 190_000, lowlevel_error_handler: lleh) { [200, {}, ['Hello World']] }
+
+    socket = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\n\r\n" \
+      "#{long_string}"
+
+    response = socket.read_response
+
+    # Content Too Large
+    assert_equal "HTTP/1.1 413 #{STATUS_CODES[413]}", response.status
+    assert_equal HEADERS_413, response.headers
+
+    sleep 0.5
+    refute lleh_err
+    assert_raises(Errno::ECONNRESET) { socket << GET_11 }
   end
 end


### PR DESCRIPTION
### Description

Update for use with `TestPuma::PumaSocket`, update comments to refer to RFC 9112, the current document.

Add several commented out tests, these deal with "oversize path length" and "have http_content_length_limit set" issues. These involve future PR's addressing #3540 and #3552.  These will fail on master.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
