### PR TITLE
feat: add requests_wait_time metric

### DIFF
--- a/docs/stats.md
+++ b/docs/stats.md
@@ -61,6 +61,7 @@ When Puma runs in single mode, these stats are available at the top level. When 
 * pool_capacity: the number of requests that the server is capable of taking right now. For example, if the number is 5, then it means there are 5 threads sitting idle ready to take a request. If one request comes in, then the value would be 4 until it finishes processing. If the minimum threads allowed is zero, this number will still have a maximum value of the maximum threads allowed.
 * max_threads: the maximum number of threads Puma is configured to spool per worker
 * requests_count: the number of requests this worker has served since starting
+* requests_wait_time: the total time of all requests are waiting to be processed (milliseconds)
 
 
 ### cluster mode
@@ -94,7 +95,8 @@ Here are two example stats hashes produced by `Puma.stats`:
   "running": 5,
   "pool_capacity": 5,
   "max_threads": 5,
-  "requests_count": 3
+  "requests_count": 3,
+  "requests_wait_time": 2340
 }
 ```
 
@@ -120,7 +122,8 @@ Here are two example stats hashes produced by `Puma.stats`:
         "running": 5,
         "pool_capacity": 5,
         "max_threads": 5,
-        "requests_count": 2
+        "requests_count": 2,
+        "requests_wait_time": 2340
       }
     },
     {
@@ -135,7 +138,8 @@ Here are two example stats hashes produced by `Puma.stats`:
         "running": 5,
         "pool_capacity": 5,
         "max_threads": 5,
-        "requests_count": 1
+        "requests_count": 1,
+        "requests_wait_time": 2340
       }
     }
   ]

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -149,6 +149,10 @@ module Puma
       @timeout_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) + val
     end
 
+    def set_accept_time(accept_time)
+      @accept_time = accept_time
+    end
+
     # Number of seconds until the timeout elapses.
     def timeout
       [@timeout_at - Process.clock_gettime(Process::CLOCK_MONOTONIC), 0].max

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -111,7 +111,8 @@ module Puma
     end
 
     attr_reader :env, :to_io, :body, :io, :timeout_at, :ready, :hijacked,
-                :tempfile, :io_buffer, :http_content_length_limit_exceeded
+                :tempfile, :io_buffer, :http_content_length_limit_exceeded,
+                :wait_time_starts_at
 
     attr_writer :peerip, :http_content_length_limit
 
@@ -149,8 +150,8 @@ module Puma
       @timeout_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) + val
     end
 
-    def set_accept_time(accept_time)
-      @accept_time = accept_time
+    def set_wait_time_starts_at(wait_time_starts_at)
+      @wait_time_starts_at = wait_time_starts_at
     end
 
     # Number of seconds until the timeout elapses.

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -131,7 +131,8 @@ module Puma
                 t = server.pool_capacity || 0
                 m = server.max_threads || 0
                 rc = server.requests_count || 0
-                payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r}, "pool_capacity":#{t}, "max_threads":#{m}, "requests_count":#{rc} }\n!
+                rwt = server.requests_wait_time || 0
+                payload = %Q!#{base_payload}{ "backlog":#{b}, "running":#{r}, "pool_capacity":#{t}, "max_threads":#{m}, "requests_count":#{rc}, "requests_wait_time":#{rwt} }\n!
                 io << payload
               rescue IOError
                 Puma::Util.purge_interrupt_queue

--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -51,7 +51,7 @@ module Puma
         @term
       end
 
-      STATUS_PATTERN = /{ "backlog":(?<backlog>\d*), "running":(?<running>\d*), "pool_capacity":(?<pool_capacity>\d*), "max_threads":(?<max_threads>\d*), "requests_count":(?<requests_count>\d*) }/
+      STATUS_PATTERN = /{ "backlog":(?<backlog>\d*), "running":(?<running>\d*), "pool_capacity":(?<pool_capacity>\d*), "max_threads":(?<max_threads>\d*), "requests_count":(?<requests_count>\d*), "requests_wait_time":(?<requests_wait_time>\d*) }/
       private_constant :STATUS_PATTERN
 
       def ping!(status)

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -41,7 +41,7 @@ module Puma
     attr_reader :events
     attr_reader :min_threads, :max_threads  # for #stats
     attr_reader :requests_count             # @version 5.0.0
-    attr_reader :preprocess_time
+    attr_reader :requests_wait_time
 
     # @todo the following may be deprecated in the future
     attr_reader :auto_trim_time, :early_hints, :first_data_timeout,
@@ -124,7 +124,7 @@ module Puma
       @precheck_closing = true
 
       @requests_count = 0
-      @preprocess_time = 0
+      @requests_wait_time = 0
 
       @idle_timeout_reached = false
     end
@@ -359,7 +359,7 @@ module Puma
             end
 
             ios.first.each do |sock|
-              accept_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+              wait_time_starts_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
               if sock == check
                 break if handle_check
@@ -377,7 +377,7 @@ module Puma
                   c.listener = sock
                   c.http_content_length_limit = @http_content_length_limit
                   c.send(addr_send_name, addr_value) if addr_value
-                  c.set_accept_time(accept_time)
+                  c.set_wait_time_starts_at(wait_time_starts_at)
                 }
               end
             end
@@ -470,8 +470,7 @@ module Puma
 
         while true
           @requests_count += 1
-          @preprocess_time += ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - client.accept_time) * 1000).round if client.accept_time != nil
-          client.time_since_created_at
+          @requests_wait_time += ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - client.wait_time_starts_at) * 1000).round
           case handle_request(client, requests + 1)
           when false
             break
@@ -653,7 +652,7 @@ module Puma
 
     # List of methods invoked by #stats.
     # @version 5.0.0
-    STAT_METHODS = [:backlog, :running, :pool_capacity, :max_threads, :requests_count, :preprocess_time].freeze
+    STAT_METHODS = [:backlog, :running, :pool_capacity, :max_threads, :requests_count, :requests_wait_time].freeze
 
     # Returns a hash of stats about the running server for reporting purposes.
     # @version 5.0.0
@@ -663,7 +662,7 @@ module Puma
       stats = @thread_pool&.stats || {}
       stats[:max_threads]    = @max_threads
       stats[:requests_count] = @requests_count
-      stats[:preprocess_time] = @preprocess_time
+      stats[:requests_wait_time] = @requests_wait_time
       stats
     end
 

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -64,7 +64,7 @@ class TestCLI < Minitest::Test
     assert_equal Puma.stats_hash, JSON.parse(Puma.stats, symbolize_names: true)
 
     dmt = Puma::Configuration::DEFAULTS[:max_threads]
-    expected_stats = /\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
+    expected_stats = /\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"requests_wait_time":\d+,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
     assert_match(expected_stats, body)
   ensure
     cli.launcher.stop
@@ -117,7 +117,7 @@ class TestCLI < Minitest::Test
     body = send_http_read_resp_body "GET /stats HTTP/1.0\r\n\r\n", path: @tmp_path
 
     dmt = Puma::Configuration::DEFAULTS[:max_threads]
-    expected_stats = /{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
+    expected_stats = /{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","backlog":0,"running":0,"pool_capacity":#{dmt},"max_threads":#{dmt},"requests_count":0,"requests_wait_time":\d+,"versions":\{"puma":"#{@puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
     assert_match(expected_stats, body)
   ensure
     if UNIX_SKT_EXIST

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -215,7 +215,7 @@ class TestIntegrationPumactl < TestIntegration
 
     body = resp_io.read.split("\n", 2).last
 
-    expected_stats = /\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","workers":2,"phase":0,"booted_workers":2,"old_workers":0,"worker_status":\[\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":0,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\},\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":1,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\}\}\],"versions":\{"puma":"#{puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
+    expected_stats = /\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","workers":2,"phase":0,"booted_workers":2,"old_workers":0,"worker_status":\[\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":0,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0,"requests_wait_time":\d+\}\},\{"started_at":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z","pid":\d+,"index":1,"phase":0,"booted":true,"last_checkin":"[^"]+","last_status":\{"backlog":0,"running":2,"pool_capacity":2,"max_threads":2,"requests_count":0\,"requests_wait_time":\d+\}\}\],"versions":\{"puma":"#{puma_version_pattern}","ruby":\{"engine":"\w+","version":"\d+.\d+.\d+","patchlevel":-?\d+\}\}\}/
 
     assert_match(expected_stats, body)
   end


### PR DESCRIPTION
### Description
Introduce new metric `requests_wait_time`, describing how many time requests are waiting to be processed (wait time to get to backlog [here](https://github.com/puma/puma/blob/master/lib/puma/server.rb#L363C1-L364C98).
```ruby
                pool.wait_until_not_full
                pool.wait_for_less_busy_worker(options[:wait_for_less_busy_worker]) if @clustered
```
and wait time in backlog.

In that way backlog value is not full representable to determine the lack of capacity (f.e. to use as a scaling factor for Horizontal Pod Autoscaler) . Because backlog might be equal to zero, but the wait time could be non-zero.

Here i've created some kind of stress-tests environment in yabeda-puma-plugin gem https://github.com/yabeda-rb/yabeda-puma-plugin/pull/33 representing such case (see image below)

<img width="1420" alt="puma-request_wait_time" src="https://github.com/user-attachments/assets/eedf454a-d0e6-483b-858d-a5ca2de0a26d">

This new metric also helps to tune up `wait_for_less_busy_worker` time by measuring and comparing "request reprocessing time" before and after config change (introduced here https://github.com/puma/puma/pull/2079)


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
