### PR TITLE
Address some warnings in tests

### DIFF
--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -83,7 +83,7 @@ class TestBinderParallel < TestBinderBase
     mock = Minitest::Mock.new
     proc = -> { mock.call }
 
-    @binder.before_parse &proc
+    @binder.before_parse(&proc)
 
     mock.expect(:call, nil)
 

--- a/test/test_request_invalid.rb
+++ b/test/test_request_invalid.rb
@@ -269,7 +269,6 @@ class TestRequestInvalid < Minitest::Test
   # 200 kB body with Content-Length set to the same.
   # Verifies that the connection is closed properly.
   def __test_http_11_req_oversize_content_length
-    lleh_called = false
     lleh_err = nil
 
     lleh = -> (err) {
@@ -298,9 +297,7 @@ class TestRequestInvalid < Minitest::Test
   def __test_http_11_req_oversize_chunked
     chunk_length = 20_000
     chunk_part_qty = 10
-    req_body_length = chunk_length * chunk_part_qty
 
-    lleh_called = false
     lleh_err = nil
 
     lleh = -> (err) {
@@ -335,7 +332,6 @@ class TestRequestInvalid < Minitest::Test
   # 200 kB body with Content-Length set to the same.
   # Verifies that the connection is closed properly.
   def __test_http_11_req_oversize_no_content_length
-    lleh_called = false
     lleh_err = nil
 
     lleh = -> (err) {

--- a/test/test_web_concurrency_auto.rb
+++ b/test/test_web_concurrency_auto.rb
@@ -53,7 +53,7 @@ class TestWebConcurrencyAuto < TestIntegration
       # cannot find concurrent-ruby file?
     end
 
-    out, err = capture_io do
+    _, err = capture_io do
       assert_raises(LoadError) { Puma::Configuration.new({}, {}, ENV_WC_TEST) }
     end
     assert_includes err, 'Please add "concurrent-ruby" to your Gemfile'


### PR DESCRIPTION
Addresses these minor warnings:

```
/puma/test/test_binder.rb:86: warning: ambiguous `&` has been interpreted as an argument prefix
/puma/test/test_request_invalid.rb:272: warning: assigned but unused variable - lleh_called
/puma/test/test_request_invalid.rb:303: warning: assigned but unused variable - lleh_called
/puma/test/test_request_invalid.rb:301: warning: assigned but unused variable - req_body_length
/puma/test/test_request_invalid.rb:338: warning: assigned but unused variable - lleh_called
/puma/test/test_web_concurrency_auto.rb:56: warning: assigned but unused variable - out
```