### PR TITLE
CI: test/test_puma_server.rb - fixup auto_trim tests

### DIFF
--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -2102,35 +2102,12 @@ class TestPumaServer < Minitest::Test
   end
 
   def test_auto_trim_with_variable_pool_size
-    auto_trim_time = 3
-    server_run(min_threads: 1, max_threads: 2, auto_trim_time: auto_trim_time)
-    sleep 1 # wait for possible initial trim on run
-    thread_pool_expect true, :trim, nil, after: auto_trim_time
+    server_run(min_threads: 1, max_threads: 2, auto_trim_time: 1)
+    assert @pool.instance_variable_get(:@auto_trim)
   end
 
   def test_auto_trim_with_fixed_pool_size
-    auto_trim_time = 3
-    server_run(min_threads: 2, max_threads: 2, auto_trim_time: auto_trim_time)
-    sleep 1 # wait for possible initial trim on run
-    thread_pool_expect false, :trim, nil, after: auto_trim_time
-  end
-
-  private
-
-  def thread_pool_expect(should_expect, expect_method, *expect_args, after: nil)
-    mock_pool = Minitest::Mock.new
-    mock_pool.expect(expect_method, *expect_args) if should_expect
-
-    @pool.singleton_class.class_eval do
-      define_method(expect_method) do |*args, **kwargs|
-        raise "unexpected #{expect_method} called on Puma::Threadpool" unless should_expect
-
-        mock_pool.public_send(expect_method, *args, **kwargs)
-      end
-    end
-
-    sleep after if after
-
-    assert mock_pool.verify # assert to satisfy proveit
+    server_run(min_threads: 2, max_threads: 2, auto_trim_time: 1)
+    refute @pool.instance_variable_get(:@auto_trim)
   end
 end


### PR DESCRIPTION
### Description

Fixup failing tests in test/test_puma_server.rb

@joshuay03 

Look ok to you?  If I revert the changes to `server.rb` in #3384, `test_auto_trim_with_fixed_pool_size` fails.  Also, one of the current tests raises in a thread, which stops CI...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
