### PR TITLE
CI: test/runner - add `-w` and `z` options for test file warnings

### DIFF
--- a/test/runner
+++ b/test/runner
@@ -11,6 +11,11 @@ The file extension is optional.
 If arguments are used that take values (eg seed), use the 'no space' version,
 like -s33388 or --seed=33388
 
+'-w' is an additional option, it will switch $VERBOSE to true before the
+test files are loaded.
+
+'-z' is an additional option, it will switch $VERBOSE to true and cancel the tests.
+
 Finally, to keep the code simple, if you pass an invalid argument for file
 filtering it will either error or run minitest with no tests loaded
 
@@ -27,6 +32,26 @@ test/runner -v 'test_integration_*.rb'
 =end
 
 require 'bundler/setup'
+require 'stringio'
+
+if ARGV.delete '-z'
+  show_warnings = true
+  no_tests = true
+elsif ARGV.delete '-w'
+  show_warnings = true
+elsif ARGV.delete('-wv') || ARGV.delete('-vw')
+  show_warnings = true
+  ARGV.unshift '-v'
+else
+  show_warnings = nil
+end
+
+if show_warnings
+  stderr, $stderr = STDERR, StringIO.new
+  $VERBOSE = true
+end
+
+STDOUT.syswrite "\n#{ARGV.join "\n"}\n\n"
 
 if ARGV.empty? || ARGV.last.start_with?('-')
   if RUBY_VERSION >= '2.5'
@@ -50,4 +75,18 @@ else
   end
 end
 
+if show_warnings
+  warnings = $stderr.string&.strip
+  $stderr = stderr
+  if warnings && !warnings.empty?
+    warnings = warnings.gsub("#{__dir__}/", '')
+      .split("\n")
+      .sort
+      .join("\n")
+    STDERR.syswrite "#{warnings}\n\n"
+  end
+end
+exit 1 if no_tests
+
 require 'minitest'
+STDOUT.syswrite "Minitest version: #{Minitest::VERSION}\n\n"


### PR DESCRIPTION
### Description

Allows test/runner to show warnings, with or without running tests.

This only works on the test files, a future PR may add a warnings check for both lib and test files.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
