### PR TITLE
Fixup use of Puma::Const::PipeRequest constants

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -456,7 +456,7 @@ module Puma
               req = read.read_nonblock(1)
               next unless req
 
-              if req == Puma::Const::PipeRequest::WAKEUP
+              if req == PIPE_WAKEUP
                 @next_check = Time.now
                 next
               end
@@ -464,7 +464,7 @@ module Puma
               result = read.gets
               pid = result.to_i
 
-              if req == Puma::Const::PipeRequest::BOOT || req == Puma::Const::PipeRequest::FORK
+              if req == PIPE_BOOT || req == PIPE_FORK
                 pid, idx = result.split(':').map(&:to_i)
                 w = worker_at idx
                 w.pid = pid if w.pid.nil?
@@ -472,17 +472,17 @@ module Puma
 
               if w = @workers.find { |x| x.pid == pid }
                 case req
-                when Puma::Const::PipeRequest::BOOT
+                when PIPE_BOOT
                   w.boot!
                   log "- Worker #{w.index} (PID: #{pid}) booted in #{w.uptime.round(2)}s, phase: #{w.phase}"
                   @next_check = Time.now
                   workers_not_booted -= 1
-                when Puma::Const::PipeRequest::EXTERNAL_TERM
+                when PIPE_EXTERNAL_TERM
                   # external term, see worker method, Signal.trap "SIGTERM"
                   w.term!
-                when Puma::Const::PipeRequest::TERM
+                when PIPE_TERM
                   w.term unless w.term?
-                when Puma::Const::PipeRequest::PING
+                when PIPE_PING
                   status = result.sub(/^\d+/,'').chomp
                   w.ping!(status)
                   @events.fire(:ping!, w)
@@ -497,7 +497,7 @@ module Puma
                     debug_loaded_extensions("Loaded Extensions - master:") if @log_writer.debug?
                     booted = true
                   end
-                when Puma::Const::PipeRequest::IDLE
+                when PIPE_IDLE
                   if idle_workers[pid]
                     idle_workers.delete pid
                   else

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -92,21 +92,21 @@ module Puma
                 restart_server << true << false
               else # fork worker
                 worker_pids << pid = spawn_worker(idx)
-                @worker_write << "#{Puma::Const::PipeRequest::FORK}#{pid}:#{idx}\n" rescue nil
+                @worker_write << "#{PIPE_FORK}#{pid}:#{idx}\n" rescue nil
               end
             end
           end
         end
 
         Signal.trap "SIGTERM" do
-          @worker_write << "#{Puma::Const::PipeRequest::EXTERNAL_TERM}#{Process.pid}\n" rescue nil
+          @worker_write << "#{PIPE_EXTERNAL_TERM}#{Process.pid}\n" rescue nil
           restart_server.clear
           server.stop
           restart_server << false
         end
 
         begin
-          @worker_write << "#{Puma::Const::PipeRequest::BOOT}#{Process.pid}:#{index}\n"
+          @worker_write << "#{PIPE_BOOT}#{Process.pid}:#{index}\n"
         rescue SystemCallError, IOError
           Puma::Util.purge_interrupt_queue
           STDERR.puts "Master seems to have exited, exiting."
@@ -148,7 +148,7 @@ module Puma
         # exiting until any background operations are completed
         @config.run_hooks(:before_worker_shutdown, index, @log_writer, @hook_data)
       ensure
-        @worker_write << "#{Puma::Const::PipeRequest::TERM}#{Process.pid}\n" rescue nil
+        @worker_write << "#{PIPE_TERM}#{Process.pid}\n" rescue nil
         @worker_write.close
       end
 

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -294,14 +294,15 @@ module Puma
 
     PROXY_PROTOCOL_V1_REGEX = /^PROXY (?:TCP4|TCP6|UNKNOWN) ([^\r]+)\r\n/.freeze
 
+    # All constants are prefixed with `PIPE_` to avoid name collisions.
     module PipeRequest
-      WAKEUP = "!"
-      BOOT = "b"
-      FORK = "f"
-      EXTERNAL_TERM = "e"
-      TERM = "t"
-      PING = "p"
-      IDLE = "i"
+      PIPE_WAKEUP = "!"
+      PIPE_BOOT = "b"
+      PIPE_FORK = "f"
+      PIPE_EXTERNAL_TERM = "e"
+      PIPE_TERM = "t"
+      PIPE_PING = "p"
+      PIPE_IDLE = "i"
     end
   end
 end

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -8,6 +8,9 @@ module Puma
   # serve requests. This class spawns a new instance of `Puma::Server` via
   # a call to `start_server`.
   class Runner
+
+    include ::Puma::Const::PipeRequest
+
     def initialize(launcher)
       @launcher = launcher
       @log_writer = launcher.log_writer
@@ -27,7 +30,7 @@ module Puma
     def wakeup!
       return unless @wakeup
 
-      @wakeup.write Puma::Const::PipeRequest::WAKEUP unless @wakeup.closed?
+      @wakeup.write PIPE_WAKEUP unless @wakeup.closed?
 
     rescue SystemCallError, IOError
       Puma::Util.purge_interrupt_queue

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -344,7 +344,7 @@ module Puma
                 @idle_timeout_reached = true
 
                 if @clustered
-                  @worker_write << "#{PipeRequest::IDLE}#{Process.pid}\n" rescue nil
+                  @worker_write << "#{PipeRequest::PIPE_IDLE}#{Process.pid}\n" rescue nil
                   next
                 else
                   @log_writer.log "- Idle timeout reached"
@@ -357,7 +357,7 @@ module Puma
 
             if @idle_timeout_reached && @clustered
               @idle_timeout_reached = false
-              @worker_write << "#{PipeRequest::IDLE}#{Process.pid}\n" rescue nil
+              @worker_write << "#{PipeRequest::PIPE_IDLE}#{Process.pid}\n" rescue nil
             end
 
             ios.first.each do |sock|


### PR DESCRIPTION
### Description

`Puma::Const::PipeRequest::` appears in code in quite a few places, and thought that including the class in `Runner` would be beneficial.  Prefixed all the constants in the class with `PIPE_` to avoid future collisions.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
