### PR TITLE
CI: fixup temp dir used in CI

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,6 +11,12 @@ if RUBY_VERSION == '2.4.1'
   end
 end
 
+# WIth GitHub Actions, OS's `/tmp` folder may be on a HDD, while
+# ENV['RUNNER_TEMP'] is an SSD.  Faster.
+if ENV['GITHUB_ACTIONS'] == 'true'
+  ENV['TMPDIR'] = ENV['RUNNER_TEMP']
+end
+
 require "securerandom"
 
 # needs to be loaded before minitest for Ruby 2.7 and earlier

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -102,7 +102,7 @@ class TestIntegration < Minitest::Test
       @config_file.syswrite config
       # not supported on some OS's, all GitHub Actions OS's support it
       @config_file.fsync rescue nil
-      @config_file.close
+      @ios_to_close << @config_file
       config = "-C #{@config_file.path}"
     end
 


### PR DESCRIPTION
### Description

Currently GitHub CI systems have both a HDD and a SSD.  The OS and related files are on the HDD, files installed for the CI jobs are on the SSD.

The HDD seems to be at least 5 times slower than the SSD, and may be more affected by 'noisy neighbors'.

Set `ENV['TMPDIR']` to point to a known SSD 'temp' folder on the GHA runners.  `ENV['TMPDIR']` is the first ENV value that Ruby checks to determine a temp dir location.

These changes only are used when `ENV['GITHUB_ACTIONS'] == 'true'`.

This may help with intermittent test failures/retries.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.