### PR TITLE
Only ping worker 0 during phased restart if using fork worker

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -491,7 +491,7 @@ module Puma
                   w.ping!(status)
                   @events.fire(:ping!, w)
 
-                  if in_phased_restart && workers_not_booted.positive? && w0 = worker_at(0)
+                  if in_phased_restart && @options[:fork_worker] && workers_not_booted.positive? && w0 = worker_at(0)
                     w0.ping!(status)
                     @events.fire(:ping!, w0)
                   end


### PR DESCRIPTION
### Description

The ping added in https://github.com/puma/puma/pull/3225 is only needed when forking workers from worker 0 during a phased restart (i.e., fork worker is enabled); however, it is currently called during an ordinary phased restart as well.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.