### PR TITLE
Option to turn off SIGUSR2 trapping

### DIFF
--- a/docs/java_options.md
+++ b/docs/java_options.md
@@ -12,6 +12,7 @@ Moreover, default values may be used in case of invalid inputs.
 | PUMA_QUERY_STRING_MAX_LENGTH |   1024 * 10   | Positive natural number  |
 | PUMA_REQUEST_PATH_MAX_LENGTH |     8192      | Positive natural number  |
 | PUMA_REQUEST_URI_MAX_LENGTH  |   1024 * 12   | Positive natural number  |
+| PUMA_SKIP_SIGUSR2            |   nil         | n/a                      |
 
 ## Examples
 
@@ -46,3 +47,8 @@ foo@bar:~ curl "http://localhost:9292${path}"
 Hello World
 ```
 
+### Java Flight Recorder Compatibility
+
+Unfortunately Java Flight Recorder uses `SIGUSR2` internally. If you wish to 
+use JFR, turn off Puma's trapping of `SIGUSR2` by setting the environment variable
+`PUMA_SKIP_SIGUSR2` to any value.

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -419,12 +419,14 @@ module Puma
     end
 
     def setup_signals
-      begin
-        Signal.trap "SIGUSR2" do
-          restart
+      unless ENV["PUMA_SKIP_SIGUSR2"]
+        begin
+          Signal.trap "SIGUSR2" do
+            restart
+          end
+        rescue Exception
+          log "*** SIGUSR2 not implemented, signal based restart unavailable!"
         end
-      rescue Exception
-        log "*** SIGUSR2 not implemented, signal based restart unavailable!"
       end
 
       unless Puma.jruby?

--- a/test/test_skip_sigusr2.rb
+++ b/test/test_skip_sigusr2.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+require_relative "helpers/integration"
+
+require "puma/plugin"
+
+class TestSkipSigusr2 < TestIntegration
+
+  def setup
+    skip_unless_signal_exist? :TERM
+    skip_unless_signal_exist? :USR2
+
+    super
+  end
+
+  def teardown
+    super unless skipped?
+  end
+
+  def test_sigusr2_handler_not_installed
+    cli_server "test/rackup/hello.ru",
+               env: { 'PUMA_SKIP_SIGUSR2' => 'true' }, config: <<~CONFIG
+      app do |_|
+        [200, {}, [Signal.trap('SIGUSR2', 'IGNORE').to_s]]
+      end
+    CONFIG
+
+    assert_equal 'DEFAULT', read_body(connect)
+
+    stop_server
+  end
+end


### PR DESCRIPTION
This option is necessary for compatibility with Java Flight Recorder, a performance monitoring and diagnostic tool used with JRuby and TruffleRuby

Closes https://github.com/puma/puma/issues/3567

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.