### PR TITLE
Fix single runner stats before the server start

### DIFF
--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -17,7 +17,7 @@ module Puma
     def stats
       {
         started_at: utc_iso8601(@started_at)
-      }.merge(@server.stats).merge(super)
+      }.merge(@server&.stats || {}).merge(super)
     end
 
     def restart

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -85,6 +85,7 @@ class TestLauncher < PumaTest
       sleep 1.1 unless Puma.mri?
       launcher.stop
     }
+    launcher.stats # Ensure `stats` method return without errors before run
     launcher.run
     sleep 1 unless Puma.mri?
     Puma::Server::STAT_METHODS.each do |stat|


### PR DESCRIPTION
It might happen the luncher stats are called before the server even starts resulting in NoMethodError (e.g. metrics plugin). This change prevents the exception and returns default stats only.

### Description

The metrics plugin might call `stats` on the launcher before the server is instantiated resulting in `NoMethodError`. 

https://github.com/harmjanblok/puma-metrics/issues/49

It seems like the plugin is not actively maintained since [the PR](https://github.com/harmjanblok/puma-metrics/pull/68) has not been responded to in a few months.

I see that `server` is already treated like `Maybe` type, so the change only aligns this one call with the reset of the class.


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
