### PR TITLE
Add Ruby 3.4 to CI

### DIFF
--- a/.github/workflows/rack_conform.yml
+++ b/.github/workflows/rack_conform.yml
@@ -25,6 +25,7 @@ jobs:
           - { os: ubuntu-20.04 , ruby: '3.1' }
           - { os: ubuntu-20.04 , ruby: '3.2' }
           - { os: ubuntu-22.04 , ruby: '3.3' }
+          - { os: ubuntu-22.04 , ruby: '3.4' }
           - { os: ubuntu-22.04 , ruby: head  }
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15, windows-2022 ]
-        ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, head ]
+        ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4, head ]
         no-ssl: ['']
         rack-v: ['']
         yjit: ['']
@@ -75,6 +75,7 @@ jobs:
           - { os: macos-15     , ruby:  2.7  }
           - { os: macos-15     , ruby: '3.0' }
           - { os: macos-15     , ruby:  3.2  }
+          - { os: windows-2022 , ruby: '3.4' }
           - { os: windows-2022 , ruby: head  }
 
     steps:

--- a/.github/workflows/turbo-rails.yml
+++ b/.github/workflows/turbo-rails.yml
@@ -1,7 +1,7 @@
 name: turbo-rails
 
 # Note: turbo-rails often returns an ActionDispatch::Response::RackBody for the
-# body.  Also, Rack::BodyProxy or Sprockets::Asset
+# body. Also, Rack::BodyProxy or Sprockets::Asset.
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -25,13 +25,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-20.04 , ruby: '3.1', rails: '7.0' }
-          - { os: ubuntu-20.04 , ruby: '3.2', rails: '7.0' }
-          - { os: ubuntu-22.04 , ruby: '3.3', rails: '7.0' }
-          - { os: ubuntu-20.04 , ruby: '3.1', rails: '7.1' }
-          - { os: ubuntu-20.04 , ruby: '3.2', rails: '7.1' }
-          - { os: ubuntu-22.04 , ruby: '3.3', rails: '7.1' }
-          - { os: ubuntu-22.04 , ruby: head , rails: '7.1' }
+          # Run against the supported releases of Rails (https://rubyonrails.org/maintenance)
+          # and the corresponding supported Ruby versions.
+          - { os: ubuntu-20.04 , ruby: '3.1', rails: '7.2' }
+          - { os: ubuntu-20.04 , ruby: '3.2', rails: '7.2' }
+          - { os: ubuntu-22.04 , ruby: '3.3', rails: '7.2' }
+          - { os: ubuntu-22.04 , ruby: '3.4', rails: '7.2' }
+          - { os: ubuntu-20.04 , ruby: '3.2', rails: '8.0' }
+          - { os: ubuntu-22.04 , ruby: '3.3', rails: '8.0' }
+          - { os: ubuntu-22.04 , ruby: '3.4', rails: '8.0' }
+          - { os: ubuntu-22.04 , ruby: head , rails: '8.0' }
     env:
       CI: true
       FERRUM_PROCESS_TIMEOUT: 60
@@ -52,7 +55,7 @@ jobs:
           DST="gem 'puma', git: 'https://github.com/$GITHUB_REPOSITORY.git', ref: '$GITHUB_SHA'"
           sed -i "s#$SRC#$DST#" Gemfile
           SRC="gem ['\"]sqlite3['\"].*"
-          DST="gem 'sqlite3', '~> 1.4'"
+          DST="gem 'sqlite3', ENV['RAILS_VERSION'] == '8.0' ? '>= 2.1' : '~> 1.4'"
           sed -i "s#$SRC#$DST#" Gemfile
           #
           # allow using capybara from the repo, either a branch or a commit


### PR DESCRIPTION
Explicitly run CI against Ruby 3.4 now that it's out and [`setup-ruby` has been updated](https://github.com/ruby/setup-ruby/commit/bfefad842bb982ff05b233bcbc1571d97a87e69f).