### PR TITLE
Reduce `TestIntegration#restart_does_not_drop_connections` restart frequency

### DIFF
--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -42,7 +42,7 @@ class TestIntegrationCluster < TestIntegration
 
   def test_phased_restart_does_not_drop_connections_threads_fork_worker
     restart_does_not_drop_connections num_threads: 10, total_requests: 3_000,
-      signal: :USR1 #, config: 'fork_worker', log: true
+      signal: :USR1, config: 'fork_worker'
   end
 
   def test_phased_restart_does_not_drop_connections_unix


### PR DESCRIPTION
### Description

Context:
- https://github.com/puma/puma/pull/3297#issuecomment-2509608503
- https://github.com/puma/puma/pull/3557#discussion_r1864735186

With `fork_worker` un-commented and the original `sleep` the test times out for me locally, but doesn't on this branch. We go from ~10 restarts to ~3 restarts in a non-`fork_worker` test like [this one](https://github.com/puma/puma/blob/52757c8bf96bdc07044b7243c0851a46c06c5fec/test/test_integration_cluster.rb#L23-L26), which I think is perfectly reasonable for what these tests are asserting.

Fixing this is necessary to unblock https://github.com/puma/puma/pull/3297.

cc/ @MSP-Greg 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
