### PR TITLE
Change `HttpParserError` to be subclass of `StandardError`

### DIFF
--- a/ext/puma_http11/org/jruby/puma/Http11.java
+++ b/ext/puma_http11/org/jruby/puma/Http11.java
@@ -77,7 +77,7 @@ public class Http11 extends RubyObject {
 
     public static void createHttp11(Ruby runtime) {
         RubyModule mPuma = runtime.defineModule("Puma");
-        mPuma.defineClassUnder("HttpParserError",runtime.getClass("IOError"),runtime.getClass("IOError").getAllocator());
+        mPuma.defineClassUnder("HttpParserError",runtime.getClass("StandardError"),runtime.getClass("StandardError").getAllocator());
 
         RubyClass cHttpParser = mPuma.defineClassUnder("HttpParser",runtime.getObject(),ALLOCATOR);
         cHttpParser.defineAnnotatedMethods(Http11.class);

--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -475,7 +475,7 @@ void Init_puma_http11(void)
   DEF_GLOBAL(server_protocol, "SERVER_PROTOCOL");
   DEF_GLOBAL(request_path, "REQUEST_PATH");
 
-  eHttpParserError = rb_define_class_under(mPuma, "HttpParserError", rb_eIOError);
+  eHttpParserError = rb_define_class_under(mPuma, "HttpParserError", rb_eStandardError);
   rb_global_variable(&eHttpParserError);
 
   rb_define_alloc_func(cHttpParser, HttpParser_alloc);


### PR DESCRIPTION
### Description

A long time ago (02-April-2006), `HttpParserError` was [added](https://github.com/puma/puma/commit/3c804d5e15f0), and it was a subclass of `IOError`.  Today, `IOError` is more associated with errors at the `IO` level.

Puma should differentiate between socket level errors and HTTP request validity errors.  Hence, change `HttpParserError` to be subclass of `StandardError`.  This change will stop `HttpParserError` from being 'swallowed' in:

https://github.com/puma/puma/blob/f5e4b77db927628e60dfb323d06a12c96883c462/lib/puma/client.rb#L184-L190

This PR also uncomments two tests in `test/test_request_invalid.rb`, which fail on master.

Note that `@to_io.wait_readable` may throw other socket related errors.  Something to keep an eye on...

Closes #3552

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
