### PR TITLE
CI: tests.yml - try MT_CPU: 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,6 +130,8 @@ jobs:
         if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
         timeout-minutes: 10
         run: test/runner --verbose
+        env:
+          MT_CPU: 2
 
   test_non_mri:
     name: >-
@@ -202,6 +204,8 @@ jobs:
           success() &&
           (needs.skip_duplicate_runs.outputs.should_skip != 'true')
         run: test/runner --verbose
+        env:
+          MT_CPU: 2
 
       - name: >-
           Test outcome: ${{ steps.test.outcome }}


### PR DESCRIPTION
### Description

Many of the CI runs have intermittent failures and/or intermittent retries.  These often happen when tests involving clustered servers are running parallel.  Currently, Windows & Ubuntu CI runs on x86-64 systems with two h/t cores.  macOS 13 runs on the same.  macOS 14 and 15 run on three arm cores.

This PR limits the number of Minitest threads running parallel testing to two (MT_CPU = 2).  It will probably slow testing down, but we should have fewer failures and fewer test retries, which saves time.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
