### PR TITLE
CI: test_integration_single.rb - fixup exit status tests when using JRuby

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -155,6 +155,7 @@ class TestIntegration < Minitest::Test
     return unless pid
     begin
       _, status = Process.wait2 pid
+      status = status.exitstatus % 128 if ::Puma::IS_JRUBY
       assert_equal exit_code, status
     rescue Errno::ECHILD # raised on Windows ?
     end


### PR DESCRIPTION
### Description

JRuby returns a `Process::Status` that is different than the object returned by other Ruby platforms.   If one uses the below, the 'exit code' is the same.

```ruby
status = status.exitstatus % 128
```
Fixup tests to account for this...


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
