### PR TITLE
CI: test_plugin_systemd.rb - fixups for intermittent retries

### DIFF
--- a/lib/puma/sd_notify.rb
+++ b/lib/puma/sd_notify.rb
@@ -137,10 +137,7 @@ module Puma
       ENV.delete("NOTIFY_SOCKET") if unset_env
 
       begin
-        Addrinfo.unix(sock, :DGRAM).connect do |s|
-          s.close_on_exec = true
-          s.write(state)
-        end
+        Addrinfo.unix(sock, :DGRAM).connect { |s| s.write state }
       rescue StandardError => e
         raise NotifyError, "#{e.class}: #{e.message}", e.backtrace
       end

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -4,7 +4,7 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestPluginSystemd < TestIntegration
-  parallelize_me! if ::Puma.mri?
+  parallelize_me! if ::Puma::IS_MRI
 
   THREAD_LOG = TRUFFLE ? "{ 0/16 threads, 16 available, 0 backlog }" :
     "{ 0/5 threads, 5 available, 0 backlog }"
@@ -17,7 +17,7 @@ class TestPluginSystemd < TestIntegration
 
     super
 
-    @sockaddr = tmp_path 'systemd'
+    @sockaddr = tmp_path '.systemd'
     @socket = Socket.new(:UNIX, :DGRAM, 0)
     socket_ai = Addrinfo.unix(@sockaddr)
     @socket.bind Addrinfo.unix(@sockaddr)
@@ -28,9 +28,8 @@ class TestPluginSystemd < TestIntegration
   def teardown
     return if skipped?
     @socket&.close
-    File.unlink(@sockaddr) if @sockaddr
     @socket = nil
-    @sockaddr = nil
+    super
   end
 
   def test_systemd_notify_usr1_phased_restart_cluster
@@ -106,14 +105,16 @@ class TestPluginSystemd < TestIntegration
 
   def assert_message(msg)
     @socket.wait_readable 1
-    read = @socket.sysread(msg.bytesize)
+    @message << @socket.sysread(msg.bytesize)
     # below is kind of hacky, but seems to work correctly when slow CI systems
     # write partial status messages
-    if read.start_with?('STATUS=') && !msg.start_with?('STATUS=')
-      read << @socket.sysread(512) while @socket.wait_readable(1) && !read.end_with?(msg)
-      assert_end_with read, msg
+    if @message.start_with?('STATUS=') && !msg.start_with?('STATUS=')
+      @message << @socket.sysread(512) while @socket.wait_readable(1) && !@message.include?(msg)
+      assert_includes @message, msg
+      @message = @message.split(msg, 2).last
     else
-      assert_equal msg, read
+      assert_equal msg, @message
+      @message = +''
     end
   end
 end

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -17,13 +17,12 @@ class TestPluginSystemd < TestIntegration
 
     super
 
-    ::Dir::Tmpname.create("puma_socket") do |sockaddr|
-      @sockaddr = sockaddr
-      @socket = Socket.new(:UNIX, :DGRAM, 0)
-      socket_ai = Addrinfo.unix(sockaddr)
-      @socket.bind(socket_ai)
-      @env = {"NOTIFY_SOCKET" => sockaddr }
-    end
+    @sockaddr = tmp_path 'systemd'
+    @socket = Socket.new(:UNIX, :DGRAM, 0)
+    socket_ai = Addrinfo.unix(@sockaddr)
+    @socket.bind Addrinfo.unix(@sockaddr)
+    @env = { "NOTIFY_SOCKET" => @sockaddr }
+    @message = +''
   end
 
   def teardown


### PR DESCRIPTION
### Description

The tests in this file fail and/or retry intermittently.  The changes involve code that parses the notify socket.  On GHA CI, there are status messages interlaced with other messages.  These are due to delays common on GHA, but not reproducible locally.

It seems to help...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
