### PR TITLE
Fix incomplete worker boot state on refork

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -228,7 +228,7 @@ module Puma
     def phased_restart(refork = false)
       return false if @options[:preload_app] && !refork
 
-      @phased_restart = true
+      @phased_restart = refork ? :refork : true
       wakeup!
 
       true
@@ -449,9 +449,13 @@ module Puma
 
             if @phased_restart
               start_phased_restart
+
+              in_phased_restart = @phased_restart
               @phased_restart = false
-              in_phased_restart = true
+
               workers_not_booted = @options[:workers]
+              # worker 0 is not restarted on refork
+              workers_not_booted -= 1 if in_phased_restart == :refork
             end
 
             check_workers

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -156,6 +156,21 @@ class TestIntegrationCluster < TestIntegration
     wait_server 15
   end
 
+  def test_on_booted_with_fork_worker_refork
+    skip_unless_signal_exist? :TERM
+
+    cli_server "-w #{workers} test/rackup/hello.ru", config: <<~CONFIG
+      fork_worker
+      on_booted  { STDOUT.syswrite "on_booted called\n"  }
+    CONFIG
+
+    assert wait_for_server_to_include("on_booted called")
+
+    Process.kill :SIGURG, @pid
+
+    assert wait_for_server_to_include("on_booted called")
+  end
+
   def test_term_worker_clean_exit
     skip_unless_signal_exist? :TERM
     cli_server "-w #{workers} test/rackup/hello.ru"


### PR DESCRIPTION
### Description

Not the root cause, but a contributing factor to https://github.com/puma/puma/issues/3599

When a refork happens, worker 0 is untouched and all other workers are terminated and forked from it. Since the fork worker logic piggy backs off phased restart, `workers_not_booted` is used by the master to determine if the refork cycle has been completed. However, [the initial value for this is always set to the configured worker count](https://github.com/puma/puma/blob/edd2a1728e39d055545fd12ffdfa42d5d4ccbc58/lib/puma/cluster.rb#L454), which is incorrect for refork as worker 0 doesn't need to be booted up. This means that on every refork, [`in_phased_restart` is never set to `false`](https://github.com/puma/puma/blob/edd2a1728e39d055545fd12ffdfa42d5d4ccbc58/lib/puma/cluster.rb#L519), as `workers_not_booted` will at least be `1`.

This has two consequences:
1. The logic for pinging worker 0 during a phased restart or refork when `fork_worker` is enabled continues to be executed after all the necessary workers have been booted up, which also means worker 0's ping events (one of which is [the refork request count check](https://github.com/puma/puma/blob/edd2a1728e39d055545fd12ffdfa42d5d4ccbc58/lib/puma/cluster.rb#L309-L313)) continue to fire, which is incorrect: https://github.com/puma/puma/blob/edd2a1728e39d055545fd12ffdfa42d5d4ccbc58/lib/puma/cluster.rb#L494-L497
2. `on_booted` events are never fired and loaded extension debug logs are never logged after all the necessary workers have been booted up: https://github.com/puma/puma/blob/edd2a1728e39d055545fd12ffdfa42d5d4ccbc58/lib/puma/cluster.rb#L516-L520

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.