### PR TITLE
CI: test/helper.rb - place timeout checks inside Minitest capture_exceptions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 require:
   - rubocop-performance
-  - ./cops/tests_must_timeout.rb
+  - ./cops/tests_puma.rb
 
 AllCops:
   DisabledByDefault: true
@@ -84,5 +84,5 @@ Style/TrailingCommaInArguments:
 Style/WhileUntilModifier:
   Enabled: true
 
-Puma/TestsMustTimeout:
+TestsMustUsePumaTest:
   Enabled: true

--- a/cops/tests_puma.rb
+++ b/cops/tests_puma.rb
@@ -3,10 +3,10 @@ require 'rubocop'
 module RuboCop
   module Cop
     module Puma
-      class TestsMustTimeout < Base
+      class TestsMustUsePumaTest < Base
         extend AutoCorrector
 
-        MSG = 'Inherit from TimeoutTestCase instead of Minitest::Test'
+        MSG = 'Inherit from PumaTest instead of Minitest::Test'
 
         def_node_matcher :inherits_from_minitest_test?, <<~PATTERN
           (class _ (const (const nil? :Minitest) :Test) ...)
@@ -16,7 +16,7 @@ module RuboCop
           return unless inherits_from_minitest_test?(node)
 
           add_offense(node.children[1]) do |corrector|
-            corrector.replace(node.children[1], 'TimeoutTestCase')
+            corrector.replace(node.children[1], 'PumaTest')
           end
         end
       end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -102,7 +102,7 @@ end
 
 Minitest::Test.prepend TimeoutPrepend
 
-class TimeoutTestCase < Minitest::Test # rubocop:disable Puma/TestsMustTimeout
+class PumaTest < Minitest::Test # rubocop:disable Puma/TestsMustTimeout
   def teardown
     clean_tmp_paths if respond_to? :clean_tmp_paths
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -102,7 +102,7 @@ end
 
 Minitest::Test.prepend TimeoutPrepend
 
-class PumaTest < Minitest::Test # rubocop:disable Puma/TestsMustTimeout
+class PumaTest < Minitest::Test # rubocop:disable Puma/TestsMustUsePumaTest
   def teardown
     clean_tmp_paths if respond_to? :clean_tmp_paths
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -34,9 +34,6 @@ Thread.abort_on_exception = true
 
 $debugging_info = []
 $debugging_hold = false   # needed for TestCLI#test_control_clustered
-$test_case_timeout = ENV.fetch("TEST_CASE_TIMEOUT") do
-  RUBY_ENGINE == "ruby" ? 45 : 60
-end.to_i
 
 require "puma"
 require "puma/detect"
@@ -87,19 +84,26 @@ end
 
 require "timeout"
 
-class TimeoutTestCase < Minitest::Test # rubocop:disable Puma/TestsMustTimeout
+module TimeoutPrepend
+  TEST_CASE_TIMEOUT = ENV.fetch("TEST_CASE_TIMEOUT") do
+    RUBY_ENGINE == "ruby" ? 45 : 60
+  end.to_i
+
   # our own subclass so we never confuse different timeouts
   class TestTookTooLong < Timeout::Error
   end
 
-  def self.run_one_method(klass, method_name, reporter)
-    ::Timeout.timeout($test_case_timeout, TestTookTooLong) do
-      super
+  def capture_exceptions
+    super do
+      ::Timeout.timeout(TEST_CASE_TIMEOUT, TestTookTooLong) { yield }
     end
   end
+end
 
+Minitest::Test.prepend TimeoutPrepend
+
+class TimeoutTestCase < Minitest::Test # rubocop:disable Puma/TestsMustTimeout
   def teardown
-    super
     clean_tmp_paths if respond_to? :clean_tmp_paths
   end
 end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -7,7 +7,7 @@ require_relative 'tmp_path'
 
 # Only single mode tests go here. Cluster and pumactl tests
 # have their own files, use those instead
-class TestIntegration < TimeoutTestCase
+class TestIntegration < PumaTest
   include TmpPath
   HOST  = "127.0.0.1"
   TOKEN = "xxyyzz"

--- a/test/test_app_status.rb
+++ b/test/test_app_status.rb
@@ -5,7 +5,7 @@ require_relative "helper"
 require "puma/app/status"
 require "rack"
 
-class TestAppStatus < TimeoutTestCase
+class TestAppStatus < PumaTest
   class FakeServer
     def initialize
       @status = :running

--- a/test/test_binder.rb
+++ b/test/test_binder.rb
@@ -8,7 +8,7 @@ require "puma/binder"
 require "puma/events"
 require "puma/configuration"
 
-class TestBinderBase < TimeoutTestCase
+class TestBinderBase < PumaTest
   include SSLHelper if ::Puma::HAS_SSL
   include TmpPath
 

--- a/test/test_bundle_pruner.rb
+++ b/test/test_bundle_pruner.rb
@@ -2,7 +2,7 @@ require_relative 'helper'
 
 require 'puma/events'
 
-class TestBundlePruner < TimeoutTestCase
+class TestBundlePruner < PumaTest
 
   PUMA_VERS = "puma-#{Puma::Const::PUMA_VERSION}"
 

--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -1,7 +1,7 @@
 require_relative "helper"
 require_relative "helpers/test_puma/puma_socket"
 
-class TestBusyWorker < TimeoutTestCase
+class TestBusyWorker < PumaTest
   include ::TestPuma::PumaSocket
 
   def setup

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -7,7 +7,7 @@ require "puma/cli"
 require "json"
 require "psych"
 
-class TestCLI < TimeoutTestCase
+class TestCLI < PumaTest
   include SSLHelper if ::Puma::HAS_SSL
   include TmpPath
   include TestPuma::PumaSocket

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -6,7 +6,7 @@ require "puma/configuration"
 require 'puma/log_writer'
 require 'rack'
 
-class TestConfigFile < TimeoutTestCase
+class TestConfigFile < PumaTest
   parallelize_me!
 
   def test_default_max_threads
@@ -633,7 +633,7 @@ class TestConfigFile < TimeoutTestCase
 end
 
 # contains tests that cannot run parallel
-class TestConfigFileSingle < TimeoutTestCase
+class TestConfigFileSingle < PumaTest
   def test_custom_logger_from_DSL
     conf = Puma::Configuration.new { |c| c.load 'test/config/custom_logger.rb' }
 
@@ -645,7 +645,7 @@ class TestConfigFileSingle < TimeoutTestCase
 end
 
 # Thread unsafe modification of ENV
-class TestEnvModifificationConfig < TimeoutTestCase
+class TestEnvModifificationConfig < PumaTest
   def test_double_bind_port
     port = (rand(10_000) + 30_000).to_s
     env = { "PORT" => port }
@@ -659,7 +659,7 @@ class TestEnvModifificationConfig < TimeoutTestCase
   end
 end
 
-class TestConfigEnvVariables < TimeoutTestCase
+class TestConfigEnvVariables < PumaTest
   def test_config_loads_correct_min_threads
     assert_equal 0, Puma::Configuration.new.options.default_options[:min_threads]
 
@@ -719,7 +719,7 @@ class TestConfigEnvVariables < TimeoutTestCase
   end
 end
 
-class TestConfigFileWithFakeEnv < TimeoutTestCase
+class TestConfigFileWithFakeEnv < PumaTest
   def setup
     FileUtils.mkpath("config/puma")
     File.write("config/puma/fake-env.rb", "")

--- a/test/test_error_logger.rb
+++ b/test/test_error_logger.rb
@@ -1,7 +1,7 @@
 require 'puma/error_logger'
 require_relative "helper"
 
-class TestErrorLogger < TimeoutTestCase
+class TestErrorLogger < PumaTest
   Req = Struct.new(:env, :body)
 
   def test_stdio

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -1,7 +1,7 @@
 require 'puma/events'
 require_relative "helper"
 
-class TestEvents < TimeoutTestCase
+class TestEvents < PumaTest
   def test_register_callback_with_block
     res = false
 

--- a/test/test_example_cert_expiration.rb
+++ b/test/test_example_cert_expiration.rb
@@ -7,7 +7,7 @@ require 'openssl'
 #
 # These tests will start to fail 1 month before the certs expire
 #
-class TestExampleCertExpiration < TimeoutTestCase
+class TestExampleCertExpiration < PumaTest
   EXAMPLES_DIR = File.expand_path '../examples/puma', __dir__
   EXPIRE_THRESHOLD = Time.now.utc - (60 * 60 * 24 * 30) # 30 days
 

--- a/test/test_http10.rb
+++ b/test/test_http10.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 
 require "puma/puma_http11"
 
-class Http10ParserTest < TimeoutTestCase
+class Http10ParserTest < PumaTest
   def test_parse_simple
     parser = Puma::HttpParser.new
     req = {}

--- a/test/test_iobuffer.rb
+++ b/test/test_iobuffer.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 
 require "puma/io_buffer"
 
-class TestIOBuffer < TimeoutTestCase
+class TestIOBuffer < PumaTest
   attr_accessor :iobuf
   def setup
     self.iobuf = Puma::IOBuffer.new

--- a/test/test_json_serialization.rb
+++ b/test/test_json_serialization.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 require "json"
 require "puma/json_serialization"
 
-class TestJSONSerialization < TimeoutTestCase
+class TestJSONSerialization < PumaTest
   parallelize_me! unless JRUBY_HEAD
 
   def test_json_generates_string_for_hash_with_string_keys

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -5,7 +5,7 @@ require "puma/configuration"
 require 'puma/log_writer'
 
 # Intermittent failures & errors when run parallel in GHA, local use may run fine.
-class TestLauncher < TimeoutTestCase
+class TestLauncher < PumaTest
   include TmpPath
 
   def test_prints_thread_traces

--- a/test/test_log_writer.rb
+++ b/test/test_log_writer.rb
@@ -2,7 +2,7 @@ require 'puma/detect'
 require 'puma/log_writer'
 require_relative "helper"
 
-class TestLogWriter < TimeoutTestCase
+class TestLogWriter < PumaTest
   def test_null
     log_writer = Puma::LogWriter.null
 

--- a/test/test_minissl.rb
+++ b/test/test_minissl.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 
 require "puma/minissl" if ::Puma::HAS_SSL
 
-class TestMiniSSL < TimeoutTestCase
+class TestMiniSSL < PumaTest
 
   if Puma.jruby?
     def test_raises_with_invalid_keystore_file

--- a/test/test_normalize.rb
+++ b/test/test_normalize.rb
@@ -4,7 +4,7 @@ require_relative "helper"
 
 require "puma/request"
 
-class TestNormalize < TimeoutTestCase
+class TestNormalize < PumaTest
   parallelize_me!
 
   include Puma::Request

--- a/test/test_null_io.rb
+++ b/test/test_null_io.rb
@@ -4,7 +4,7 @@ require_relative "helper"
 
 require "puma/null_io"
 
-class TestNullIO < TimeoutTestCase
+class TestNullIO < PumaTest
   parallelize_me!
 
   attr_accessor :nio

--- a/test/test_out_of_band_server.rb
+++ b/test/test_out_of_band_server.rb
@@ -1,6 +1,6 @@
 require_relative "helper"
 
-class TestOutOfBandServer < TimeoutTestCase
+class TestOutOfBandServer < PumaTest
   parallelize_me!
 
   def setup

--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -3,7 +3,7 @@
 require_relative "helper"
 require_relative "helpers/test_puma/puma_socket"
 
-class TestPersistent < TimeoutTestCase
+class TestPersistent < PumaTest
   parallelize_me!
 
   include ::TestPuma::PumaSocket

--- a/test/test_puma_localhost_authority.rb
+++ b/test/test_puma_localhost_authority.rb
@@ -11,7 +11,7 @@ if ::Puma::HAS_SSL && !Puma::IS_JRUBY
   require "openssl" unless Object.const_defined? :OpenSSL
 end
 
-class TestPumaLocalhostAuthority < TimeoutTestCase
+class TestPumaLocalhostAuthority < PumaTest
   include TestPuma
   include TestPuma::PumaSocket
 
@@ -45,7 +45,7 @@ class TestPumaLocalhostAuthority < TimeoutTestCase
 
 end if ::Puma::HAS_SSL && !Puma::IS_JRUBY
 
-class TestPumaSSLLocalhostAuthority < TimeoutTestCase
+class TestPumaSSLLocalhostAuthority < PumaTest
   include TestPuma
   include TestPuma::PumaSocket
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -10,7 +10,7 @@ class WithoutBacktraceError < StandardError
   def message; "no backtrace error"; end
 end
 
-class TestPumaServer < TimeoutTestCase
+class TestPumaServer < PumaTest
   parallelize_me!
 
   include TestPuma

--- a/test/test_puma_server_current.rb
+++ b/test/test_puma_server_current.rb
@@ -13,7 +13,7 @@ class PumaServerCurrentApplication
   end
 end
 
-class PumaServerCurrentTest < TimeoutTestCase
+class PumaServerCurrentTest < PumaTest
   parallelize_me!
 
   def setup

--- a/test/test_puma_server_hijack.rb
+++ b/test/test_puma_server_hijack.rb
@@ -14,7 +14,7 @@ require "rack/body_proxy"
 # The sleep statements may not be needed for local CI, but are needed
 # for use with GitHub Actions...
 
-class TestPumaServerHijack < TimeoutTestCase
+class TestPumaServerHijack < PumaTest
   parallelize_me!
 
   def setup

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -24,7 +24,7 @@ if ::Puma::HAS_SSL
   end
 end
 
-class TestPumaServerSSL < TimeoutTestCase
+class TestPumaServerSSL < PumaTest
   parallelize_me!
 
   include TestPuma
@@ -270,7 +270,7 @@ class TestPumaServerSSL < TimeoutTestCase
 end if ::Puma::HAS_SSL
 
 # client-side TLS authentication tests
-class TestPumaServerSSLClient < TimeoutTestCase
+class TestPumaServerSSLClient < PumaTest
   parallelize_me! unless ::Puma.jruby?
 
   include TestPuma
@@ -489,7 +489,7 @@ class TestPumaServerSSLClient < TimeoutTestCase
 
 end if ::Puma::HAS_SSL
 
-class TestPumaServerSSLWithCertPemAndKeyPem < TimeoutTestCase
+class TestPumaServerSSLWithCertPemAndKeyPem < PumaTest
   include TestPuma
   include TestPuma::PumaSocket
 
@@ -531,7 +531,7 @@ end if ::Puma::HAS_SSL && !Puma::IS_JRUBY
 #
 #   bundle exec ruby ../examples/puma/chain_cert/generate_chain_test.rb
 #
-class TestPumaSSLCertChain < TimeoutTestCase
+class TestPumaSSLCertChain < PumaTest
   include TestPuma
   include TestPuma::PumaSocket
 

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -4,7 +4,7 @@ require_relative "helpers/ssl"
 require 'pathname'
 require 'puma/control_cli'
 
-class TestPumaControlCli < TimeoutTestCase
+class TestPumaControlCli < PumaTest
   include SSLHelper
 
   def setup

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -11,7 +11,7 @@ module TestRackUp
   rescue LoadError
   end
 
-  class TestOnBootedHandler < TimeoutTestCase
+  class TestOnBootedHandler < PumaTest
     def app
       Proc.new {|env| @input = env; [200, {}, ["hello world"]]}
     end
@@ -45,7 +45,7 @@ module TestRackUp
     end
   end
 
-  class TestPathHandler < TimeoutTestCase
+  class TestPathHandler < PumaTest
     def app
       Proc.new {|env| @input = env; [200, {}, ["hello world"]]}
     end
@@ -88,7 +88,7 @@ module TestRackUp
     end
   end
 
-  class TestUserSuppliedOptionsPortIsSet < TimeoutTestCase
+  class TestUserSuppliedOptionsPortIsSet < PumaTest
     def setup
       @options = {}
       @options[:user_supplied_options] = [:Port]
@@ -113,7 +113,7 @@ module TestRackUp
     end
   end
 
-  class TestUserSuppliedOptionsHostIsSet < TimeoutTestCase
+  class TestUserSuppliedOptionsHostIsSet < PumaTest
     def setup
       @options = {}
       @options[:user_supplied_options] = [:Host]
@@ -172,7 +172,7 @@ module TestRackUp
     end
   end
 
-  class TestUserSuppliedOptionsIsEmpty < TimeoutTestCase
+  class TestUserSuppliedOptionsIsEmpty < PumaTest
     def setup
       @options = {}
       @options[:user_supplied_options] = []
@@ -235,7 +235,7 @@ module TestRackUp
     end
   end
 
-  class TestUserSuppliedOptionsIsNotPresent < TimeoutTestCase
+  class TestUserSuppliedOptionsIsNotPresent < PumaTest
     def setup
       @options = {}
     end
@@ -336,7 +336,7 @@ module TestRackUp
   end
 
   # Run using IO.popen so we don't load Rack and/or Rackup in the main process
-  class RackUp < TimeoutTestCase
+  class RackUp < PumaTest
     def setup
       FileUtils.copy_file 'test/rackup/hello.ru', 'config.ru'
     end

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -18,7 +18,7 @@ require "rack/chunked" if Rack.release.start_with? '3.0'
 
 require "nio"
 
-class TestRackServer < TimeoutTestCase
+class TestRackServer < PumaTest
   parallelize_me!
 
   HOST = '127.0.0.1'

--- a/test/test_request_invalid.rb
+++ b/test/test_request_invalid.rb
@@ -11,7 +11,7 @@ require_relative "helpers/test_puma/puma_socket"
 # https://httpwg.org/specs/rfc9112.html#field.transfer-encoding Transfer-Encoding
 # https://httpwg.org/specs/rfc9112.html#chunked.encoding        Chunked Transfer Coding
 #
-class TestRequestInvalid < TimeoutTestCase
+class TestRequestInvalid < PumaTest
   # running parallel seems to take longer...
   # parallelize_me! unless JRUBY_HEAD
 

--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -3,7 +3,7 @@ require "puma/events"
 require "net/http"
 require "nio"
 
-class TestResponseHeader < TimeoutTestCase
+class TestResponseHeader < PumaTest
   parallelize_me!
 
   # this file has limited response length, so 10kB works.

--- a/test/test_state_file.rb
+++ b/test/test_state_file.rb
@@ -3,7 +3,7 @@ require_relative "helpers/tmp_path"
 
 require 'puma/state_file'
 
-class TestStateFile < TimeoutTestCase
+class TestStateFile < PumaTest
   include TmpPath
 
   def test_load_empty_value_as_nil

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 
 require "puma/thread_pool"
 
-class TestThreadPool < TimeoutTestCase
+class TestThreadPool < PumaTest
 
   def teardown
     @pool.shutdown(1) if defined?(@pool)

--- a/test/test_unix_socket.rb
+++ b/test/test_unix_socket.rb
@@ -3,7 +3,7 @@
 require_relative "helper"
 require_relative "helpers/tmp_path"
 
-class TestPumaUnixSocket < TimeoutTestCase
+class TestPumaUnixSocket < PumaTest
   include TmpPath
 
   App = lambda { |env| [200, {}, ["Works"]] }

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -16,7 +16,7 @@ class TestHandler
   end
 end
 
-class WebServerTest < TimeoutTestCase
+class WebServerTest < PumaTest
   parallelize_me!
 
   VALID_REQUEST = "GET / HTTP/1.1\r\nHost: www.zedshaw.com\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n"


### PR DESCRIPTION
### Description

Previously, the Puma test framework prepended the `run` method in `Minitest::Test`:

https://github.com/puma/puma/blob/979cc374fc525f1730736bba28ea4495544c0727/test/helper.rb#L121-L147

The above placed the `Timeout.timeout` blocks within the `capture_exception` blocks.  Recently that was changed, and the timeout errors are not working correctly, resulting in more frequent test runs that freeze and timeout via the GHA step timeout.

Code in this PR simplifies the above code by adding the `Timeout.timeout` blocks to `capture_exception`.

ping @zenspider

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
