### PR TITLE
CI: test/test_request_invalid.rb - fix macOS TruffleRuby failures

### DIFF
--- a/test/test_request_invalid.rb
+++ b/test/test_request_invalid.rb
@@ -61,6 +61,8 @@ class TestRequestInvalid < TimeoutTestCase
       else
         [EOFError]
       end
+    elsif Puma::IS_OSX && !Puma::IS_JRUBY # TruffleRuby
+      [Errno::ECONNRESET, EOFError]
     else
       [EOFError]
     end


### PR DESCRIPTION
### Description

Both OS's and Ruby type may affect what errors are raised by various socket conditions.

MacOS TruffleRuby is currently silently failing with
```text
652 runs, 1749 assertions, 16 failures, 0 errors, 42 skips
```

These failures are all due to one test file, which was using the wrong error for macOS TruffleRuby.  The current code set them correctly for macOS MRI, but not macOS TruffleRuby.

Fixed.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
