### PR TITLE
CI: integration.rb - catch Errno::EBADF in restart thread

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -515,6 +515,8 @@ class TestIntegration < PumaTest
             sleep 0.15 * (2 ** restart_count)
           rescue Minitest::Assertion # Timeout
             run = false
+          rescue Errno::EBADF # bad restart?
+            run = false
           end
         else
           sleep 0.1


### PR DESCRIPTION
### Description

Recently, two jobs (both using old Rack versions), froze when `Errno::EBADF` was raised in the restart thread of `restart_does_not_drop_connections`.  Odd failure.

This PR catches the error in the thread.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
