### PR TITLE
CI: test_launcher.rb - move `test_puma_stats_clustered` to test_integration_clustered.rb

### DIFF
--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -221,6 +221,25 @@ class TestIntegrationCluster < TestIntegration
     worker_respawn { |phase0_worker_pids| Process.kill :USR1, @pid }
   end
 
+  def test_puma_stats_clustered
+    worker_check_interval = 2
+
+    cli_server "-w 1 -t 1:1 #{set_pumactl_args unix: true} test/rackup/hello.ru",
+      config: "worker_check_interval #{worker_check_interval}"
+
+    sleep worker_check_interval + 1
+
+    stats = get_stats
+
+    assert_instance_of Hash, stats
+
+    last_status = stats['worker_status'].first['last_status']
+
+    Puma::Server::STAT_METHODS.each do |stat|
+      assert_includes last_status, stat.to_s
+    end
+  end
+
   def test_worker_check_interval
     # iso8601 2022-12-14T00:05:49Z
     re_8601 = /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\z/
@@ -611,7 +630,7 @@ class TestIntegrationCluster < TestIntegration
     pids = []
     re = /Terminating timed out worker \(Worker \d+ #{details}\): (\d+)/
 
-    Timeout.timeout(iterations * (timeout + 1)) do
+    Timeout.timeout(iterations * (timeout + 1.5)) do
       while (pids.size < workers * iterations)
         idx = wait_for_server_to_match(re, 1).to_i
         pids << idx


### PR DESCRIPTION
### Description

`Puma::Cluster` calls `Process.waitall` when shutting down.  The tests in `test_launcher.rb` are not run in a sub-process, so `Process.waitall` may affect other tests now or in the future.

Move the test to `test_integration_clustered.rb`, which runs Puma in a sub-process.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
