### PR TITLE
Remove redundant signal exists guards in tests

### DIFF
--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -111,18 +111,14 @@ class TestIntegrationCluster < TestIntegration
   # No more than 10 should throw Errno::ECONNRESET.
 
   def test_term_closes_listeners_tcp
-    skip_unless_signal_exist? :TERM
     term_closes_listeners unix: false
   end
 
   def test_term_closes_listeners_unix
-    skip_unless_signal_exist? :TERM
     term_closes_listeners unix: true
   end
 
   def test_term_exit_code
-    skip_unless_signal_exist? :TERM
-
     cli_server "-w #{workers} test/rackup/hello.ru"
     _, status = stop_server
 
@@ -130,8 +126,6 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_term_suppress
-    skip_unless_signal_exist? :TERM
-
     cli_server "-w #{workers} -C test/config/suppress_exception.rb test/rackup/hello.ru"
 
     _, status = stop_server
@@ -140,7 +134,6 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_on_booted_and_on_stopped
-    skip_unless_signal_exist? :TERM
     cli_server "-w #{workers} test/rackup/hello.ru", config: <<~CONFIG
       on_booted  { STDOUT.syswrite "on_booted called\n"  }
       on_stopped { STDOUT.syswrite "on_stopped called\n" }
@@ -157,11 +150,9 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_on_booted_with_fork_worker_refork
-    skip_unless_signal_exist? :TERM
-
     cli_server "-w #{workers} test/rackup/hello.ru", config: <<~CONFIG
       fork_worker
-      on_booted  { STDOUT.syswrite "on_booted called\n"  }
+      on_booted { STDOUT.syswrite "on_booted called\n" }
     CONFIG
 
     assert wait_for_server_to_include("on_booted called")
@@ -172,7 +163,6 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_term_worker_clean_exit
-    skip_unless_signal_exist? :TERM
     cli_server "-w #{workers} test/rackup/hello.ru"
 
     # Get the PIDs of the child workers.
@@ -189,8 +179,6 @@ class TestIntegrationCluster < TestIntegration
 
   # mimicking stuck workers, test respawn with external TERM
   def test_stuck_external_term_spawn
-    skip_unless_signal_exist? :TERM
-
     worker_respawn(0) do |phase0_worker_pids|
       last = phase0_worker_pids.last
       # test is tricky if only one worker is TERM'd, so kill all but
@@ -208,8 +196,6 @@ class TestIntegrationCluster < TestIntegration
   # `Process.wait2(<child pid>)` still works properly. This bug has
   # been fixed in Ruby 3.3.
   def test_workers_respawn_with_process_detach
-    skip_unless_signal_exist? :KILL
-
     config = 'test/config/process_detach_before_fork.rb'
 
     worker_respawn(0, workers, config) do |phase0_worker_pids|
@@ -232,7 +218,6 @@ class TestIntegrationCluster < TestIntegration
 
   # mimicking stuck workers, test restart
   def test_stuck_phased_restart
-    skip_unless_signal_exist? :USR1
     worker_respawn { |phase0_worker_pids| Process.kill :USR1, @pid }
   end
 
@@ -295,8 +280,6 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_worker_index_is_with_in_options_limit
-    skip_unless_signal_exist? :TERM
-
     cli_server "-C test/config/t3_conf.rb test/rackup/hello.ru"
 
     get_worker_pids(0, 3) # this will wait till all the processes are up
@@ -564,8 +547,6 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_hook_data
-    skip_unless_signal_exist? :TERM
-
     cli_server "-C test/config/hook_data.rb test/rackup/hello.ru"
     get_worker_pids 0, 2 # make sure workers are booted
     stop_server
@@ -639,8 +620,6 @@ class TestIntegrationCluster < TestIntegration
   # Send requests 10 per second.  Send 10, then :TERM server, then send another 30.
   # No more than 10 should throw Errno::ECONNRESET.
   def term_closes_listeners(unix: false)
-    skip_unless_signal_exist? :TERM
-
     cli_server "-w #{workers} -t 0:6 -q test/rackup/sleep_step.ru", unix: unix
     threads = []
     replies = []

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -11,8 +11,6 @@ class TestPluginSystemd < TestIntegration
 
   def setup
     skip_unless :linux
-    skip_unless :unix
-    skip_unless_signal_exist? :TERM
     skip_if :jruby
 
     super

--- a/test/test_plugin_systemd_jruby.rb
+++ b/test/test_plugin_systemd_jruby.rb
@@ -9,8 +9,6 @@ class TestPluginSystemdJruby < TestIntegration
 
   def setup
     skip_unless :linux
-    skip_unless :unix
-    skip_unless_signal_exist? :TERM
     skip_unless :jruby
 
     super

--- a/test/test_preserve_bundler_env.rb
+++ b/test/test_preserve_bundler_env.rb
@@ -15,8 +15,6 @@ class TestPreserveBundlerEnv < TestIntegration
 
   # It does not wipe out BUNDLE_GEMFILE et al
   def test_usr2_restart_preserves_bundler_environment
-    skip_unless_signal_exist? :USR2
-
     env = {
       # Intentionally set this to something we wish to keep intact on restarts
       "BUNDLE_GEMFILE" => "Gemfile.bundle_env_preservation_test",
@@ -37,8 +35,6 @@ class TestPreserveBundlerEnv < TestIntegration
   end
 
   def test_worker_forking_preserves_bundler_config_path
-    skip_unless_signal_exist? :TERM
-
     @tcp_port = UniquePort.call
     env = {
       # Disable the .bundle/config file in the bundle_app_config_test directory
@@ -57,8 +53,6 @@ class TestPreserveBundlerEnv < TestIntegration
   end
 
   def test_phased_restart_preserves_unspecified_bundle_gemfile
-    skip_unless_signal_exist? :USR1
-
     @tcp_port = UniquePort.call
     env = {
       "BUNDLE_GEMFILE" => nil,

--- a/test/test_skip_systemd.rb
+++ b/test/test_skip_systemd.rb
@@ -9,8 +9,6 @@ class TestSkipSystemd < TestIntegration
 
   def setup
     skip_unless :linux
-    skip_unless :unix
-    skip_unless_signal_exist? :TERM
     skip_if :jruby
 
     super

--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -92,8 +92,6 @@ class TestWorkerGemIndependence < TestIntegration
                                                new_version:,
                                                server_opts: '',
                                                before_restart: nil)
-    skip_unless_signal_exist? :USR1
-
     set_release_symlink File.expand_path(old_app_dir, __dir__)
 
     Dir.chdir(current_release_symlink) do


### PR DESCRIPTION
### Description

My original intent was to correct an incorrect guard I added [here](https://github.com/puma/puma/pull/3601/files#diff-355b57e321e1a1fb604586cd830ccb12f20f8198e2e4b3c191b8cfb7fa6ef902R160) (should check for URG).

However, seeing as CI was green, I realised that all except one (for INFO) of these guards is redundant in that suite as it [only runs on fork-compatible OSs](https://github.com/puma/puma/blob/801d292e174d1b32b7b95bafef498ea44c8f2a83/test/test_integration_cluster.rb#L14).

This motivated me to find similar redundant guards in other suites and remove them, which I've done here.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.