### PR TITLE
Remove DSL version comments, note fork_worker as experimental

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -654,8 +654,6 @@ module Puma
     # @example
     #   state_permission 0600
     #
-    # @version 5.0.0
-    #
     def state_permission(permission)
       @options[:state_permission] = permission
     end
@@ -850,8 +848,6 @@ module Puma
     #   on_refork do
     #     3.times {GC.start}
     #   end
-    #
-    # @version 5.0.0
     #
     def on_refork(key = nil, &block)
       warn_if_in_single_mode('on_refork')
@@ -1194,8 +1190,6 @@ module Puma
     # @see Puma::Server#handle_servers
     # @see Puma::ThreadPool#wait_for_less_busy_worker
     #
-    # @version 5.0.0
-    #
     def wait_for_less_busy_worker(val=0.005)
       @options[:wait_for_less_busy_worker] = val.to_f
     end
@@ -1269,9 +1263,8 @@ module Puma
     # A refork will automatically trigger once after the specified number of requests
     # (default 1000), or pass 0 to disable auto refork.
     #
+    # @note This is experimental.
     # @note Cluster mode only.
-    #
-    # @version 5.0.0
     #
     def fork_worker(after_requests=1000)
       @options[:fork_worker] = Integer(after_requests)


### PR DESCRIPTION
### Description

Closes https://github.com/puma/puma/issues/3431

It seems the only version comments are from v5 i.e. they haven't been used before v5 and haven't been kept up in v6. IMO the mention of new features in the changelog/upgrade guide is sufficient to know when they were introduced. Even without these, I would expect that users are reading the DSL at a specific tag if they are in the process of upgrading. Also, options may be added in minor versions (e.g. [this](https://github.com/puma/puma/pull/3496)), I don't think we have to tag every single one as such.

This PR removes the handful of existing version comment notes, and mentions in a comment note that fork_worker is experimental.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.