### PR TITLE
Update 'clustered mode' references to 'cluster mode'

### DIFF
--- a/History.md
+++ b/History.md
@@ -163,7 +163,7 @@
 
 * Features
   * Ability to supply a custom logger ([#2770], [#2511])
-  * Warn when clustered-only hooks are defined in single mode ([#3089])
+  * Warn when cluster mode-only hooks are defined in single mode ([#3089])
   * Adds the on_booted event ([#2709])
 
 * Bugfixes
@@ -758,7 +758,7 @@ Each patchlevel release contains a separate security fix. We recommend simply up
   * Fix Java 8 support ([#1773])
   * Fix error `uninitialized constant Puma::Cluster` ([#1731])
   * Fix `not_token` being able to be set to true ([#1803])
-  * Fix "Hang on SIGTERM with ruby 2.6 in clustered mode" (PR [#1741], [#1674], [#1720], [#1730], [#1755])
+  * Fix "Hang on SIGTERM with ruby 2.6 in cluster mode" (PR [#1741], [#1674], [#1720], [#1730], [#1755])
 
 ## 3.12.1 / 2019-03-19
 
@@ -1169,7 +1169,7 @@ Each patchlevel release contains a separate security fix. We recommend simply up
 * 4 minor features:
 
   * Listen to unix socket with provided backlog if any
-  * Improves the clustered stats to report worker stats
+  * Improves the cluster mode stats to report worker stats
   * Pass the env to the lowlevel_error handler. Fixes [#854]
   * Treat path-like hosts as unix sockets. Fixes [#824]
 
@@ -1896,7 +1896,7 @@ The "clearly I don't have enough tests for the config" release.
 
 * 3 doc changes:
   * Add note about on_worker_boot hook
-  * Add some documentation for Clustered mode
+  * Add some documentation for Cluster mode
   * Added quotes to /etc/puma.conf
 
 ## 2.0.1 / 2013-04-30

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ Puma will automatically scale the number of threads, from the minimum until it c
 
 Be aware that additionally Puma creates threads on its own for internal purposes (e.g. handling slow clients). So, even if you specify -t 1:1, expect around 7 threads created in your application.
 
-### Clustered mode
+### Cluster mode
 
-Puma also offers "clustered mode". Clustered mode `fork`s workers from a master process. Each child process still has its own thread pool. You can tune the number of workers with the `-w` (or `--workers`) flag:
+Puma also offers "cluster mode". Cluster mode `fork`s workers from a master process. Each child process still has its own thread pool. You can tune the number of workers with the `-w` (or `--workers`) flag:
 
 ```
 $ puma -t 8:32 -w 3
@@ -116,13 +116,13 @@ Or with the `WEB_CONCURRENCY` environment variable:
 $ WEB_CONCURRENCY=3 puma -t 8:32
 ```
 
-Note that threads are still used in clustered mode, and the `-t` thread flag setting is per worker, so `-w 2 -t 16:16` will spawn 32 threads in total, with 16 in each worker process.
+Note that threads are still used in cluster mode, and the `-t` thread flag setting is per worker, so `-w 2 -t 16:16` will spawn 32 threads in total, with 16 in each worker process.
 
 If the `WEB_CONCURRENCY` environment variable is set to `"auto"` and the `concurrent-ruby` gem is available in your application, Puma will set the worker process count to the result of [available processors](https://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent.html#available_processor_count-class_method).
 
 For an in-depth discussion of the tradeoffs of thread and process count settings, [see our docs](https://github.com/puma/puma/blob/9282a8efa5a0c48e39c60d22ca70051a25df9f55/docs/kubernetes.md#workers-per-pod-and-other-config-issues).
 
-In clustered mode, Puma can "preload" your application. This loads all the application code *prior* to forking. Preloading reduces total memory usage of your application via an operating system feature called [copy-on-write](https://en.wikipedia.org/wiki/Copy-on-write).
+In cluster mode, Puma can "preload" your application. This loads all the application code *prior* to forking. Preloading reduces total memory usage of your application via an operating system feature called [copy-on-write](https://en.wikipedia.org/wiki/Copy-on-write).
 
 If the `WEB_CONCURRENCY` environment variable is set to a value > 1 (and `--prune-bundler` has not been specified), preloading will be enabled by default. Otherwise, you can use the `--preload` flag from the command line:
 
@@ -140,9 +140,9 @@ preload_app!
 
 Preloading can’t be used with phased restart, since phased restart kills and restarts workers one-by-one, and preloading copies the code of master into the workers.
 
-#### Clustered mode hooks
+#### Cluster mode hooks
 
-When using clustered mode, Puma's configuration DSL provides `before_fork` and `on_worker_boot`
+When using cluster mode, Puma's configuration DSL provides `before_fork` and `on_worker_boot`
 hooks to run code when the master process forks and child workers are booted respectively.
 
 It is recommended to use these hooks with `preload_app!`, otherwise constants loaded by your
@@ -176,7 +176,7 @@ after_refork do
 end
 ```
 
-Importantly, note the following considerations when Ruby forks a child process: 
+Importantly, note the following considerations when Ruby forks a child process:
 
 1. File descriptors such as network sockets **are** copied from the parent to the forked
    child process. Dual-use of the same sockets by parent and child will result in I/O conflicts

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -72,7 +72,7 @@ systemd and Puma also support socket activation, where systemd opens the
 listening socket(s) in advance and provides them to the Puma master process on
 startup. Among other advantages, this keeps listening sockets open across puma
 restarts and achieves graceful restarts, including when upgraded Puma, and is
-compatible with both clustered mode and application preload.
+compatible with both cluster mode and application preload.
 
 **Note:** Any wrapper scripts which `exec`, or other indirections in `ExecStart`
 may result in activated socket file descriptors being closed before reaching the

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -809,7 +809,7 @@ module Puma
 
     alias_method :after_worker_boot, :after_worker_fork
 
-    # Code to run after puma is booted (works for both: single and clustered)
+    # Code to run after puma is booted (works for both single and cluster modes).
     #
     # @example
     #   on_booted do
@@ -820,7 +820,7 @@ module Puma
       @config.options[:events].on_booted(&block)
     end
 
-    # Code to run after puma is stopped (works for both: single and clustered)
+    # Code to run after puma is stopped (works for both single and cluster modes).
     #
     # @example
     #   on_stopped do

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -33,7 +33,7 @@ require_relative "helpers/apps"
 Thread.abort_on_exception = true
 
 $debugging_info = []
-$debugging_hold = false   # needed for TestCLI#test_control_clustered
+$debugging_hold = false
 
 require "puma"
 require "puma/detect"
@@ -224,7 +224,6 @@ class Minitest::Test
 end
 
 Minitest.after_run do
-  # needed for TestCLI#test_control_clustered
   if !$debugging_hold && ENV['PUMA_TEST_DEBUG']
     $debugging_info.sort!
     out = $debugging_info.join.strip


### PR DESCRIPTION
### Description

A majority of user facing and internal documentation refer to the two modes puma functions in as 'single mode' and 'cluster mode'. However, there are some places where the term 'clustered mode' is used. For example, the README uses 'cluster mode' in [the configuration section](https://github.com/puma/puma?tab=readme-ov-file#configuration), but 'clustered mode' in [that respective section](https://github.com/puma/puma?tab=readme-ov-file#clustered-mode).

Here I've updated all such references to consistently use 'cluster mode'. 'clustered' is still used internally to name variables and predicates (e.g. `clustered?`) which makes sense, but not to refer to the mode itself.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.