### PR TITLE
Remove unused global $debugging_hold in test helper

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -33,7 +33,6 @@ require_relative "helpers/apps"
 Thread.abort_on_exception = true
 
 $debugging_info = []
-$debugging_hold = false
 
 require "puma"
 require "puma/detect"
@@ -224,7 +223,7 @@ class Minitest::Test
 end
 
 Minitest.after_run do
-  if !$debugging_hold && ENV['PUMA_TEST_DEBUG']
+  if ENV['PUMA_TEST_DEBUG']
     $debugging_info.sort!
     out = $debugging_info.join.strip
     unless out.empty?


### PR DESCRIPTION
### Description

Addresses https://github.com/puma/puma/pull/3613/files#r1940084990

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
