### PR TITLE
CI: test_puma_server_ssl.rb -fix for  `set_minmax_proto_version` removal

### DIFF
--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -31,7 +31,7 @@ class TestPumaServerSSL < PumaTest
   include TestPuma::PumaSocket
 
   PROTOCOL_USE_MIN_MAX =
-    OpenSSL::SSL::SSLContext.private_instance_methods(false).include?(:set_minmax_proto_version)
+    OpenSSL::SSL::SSLContext.public_instance_methods(false).include?(:min_version=)
 
   OPENSSL_3 = OpenSSL::OPENSSL_LIBRARY_VERSION.match?(/OpenSSL 3\.\d\.\d/)
 


### PR DESCRIPTION
### Description

`OpenSSL::SSL::SSLContext#set_minmax_proto_version` was removed in Ruby head/3.5.

See:
https://github.com/ruby/openssl/pull/849
https://github.com/ruby/ruby/commit/5a14f536958d20e98c58606bd44bd2c0bed6da4b

Currently, Windows head builds are failing.  But, the Windows ucrt & mswin builds are built three times a day, the Ubuntu & macOS builds are done once a day.

Hence, this affects all OS's.  The removed method was a Ruby method, so the extension code is ok, as it doesn't use any Ruby OpenSSL methods...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
