### PR TITLE
Mold worker zero at refork

### DIFF
--- a/.github/workflows/turbo-rails.yml
+++ b/.github/workflows/turbo-rails.yml
@@ -3,7 +3,7 @@ name: turbo-rails
 # Note: turbo-rails often returns an ActionDispatch::Response::RackBody for the
 # body. Also, Rack::BodyProxy or Sprockets::Asset.
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, review_requested, ready_for_review, workflow_dispatch]
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/lib/puma/cluster/fork_pipe.rb
+++ b/lib/puma/cluster/fork_pipe.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "io/wait"
+
+module Puma
+  class Cluster
+    class ForkPipeReader
+      PAYLOAD_STRING = "q" # going with bigint out of learned fear of overflow
+      PAYLOAD_SIZE = 4 # # of bytes in a q payload
+
+      RESTART_SERVER = 0
+      START_REFORK = -1
+      AFTER_REFORK = -2
+
+      # avoids allocation of objects while reading
+      # only reads 1 payload at a time (minimize data loss if process exits unexpectedly)
+      # NOT thread-safe, but concurrent access not required anywhere currently
+      def initialize(pipe)
+        @pipe = pipe
+        @buffer = +""
+        @payload = +""
+      end
+
+      def read
+        @buffer.clear
+        @payload.clear
+        remaining = PAYLOAD_SIZE
+        while remaining > 0
+          case @pipe.read_nonblock(remaining, @buffer, exception: false)
+          when :wait_readable
+            @pipe.wait_readable
+          when :wait_writable
+            @pipe.wait_writable
+          else
+            @payload << @buffer
+            remaining -= @buffer.bytesize
+          end
+        end
+        @payload.unpack1(PAYLOAD_STRING)
+      end
+
+      def close
+        @pipe.close
+      end
+    end
+
+    class ForkPipeWriter < DelegateClass(IO)
+      # not thread safe, no concurrency expected
+      # minimize object allocation per loop
+      def initialize(pipe)
+        @pipe = pipe
+        @payloads = []
+        @buffer = +""
+      end
+
+      def <<(payload)
+        @buffer.clear
+        @payloads << payload
+        @payloads.pack(ForkPipeReader::PAYLOAD_STRING, buffer: @buffer)
+        @payloads.clear
+        until @buffer.empty?
+          case (written = @pipe.write_nonblock(@buffer, exception: false))
+          when :wait_writable
+            @pipe.wait_writable
+          when :wait_readable
+            @pipe.wait_readable
+          when Integer
+            @buffer = @buffer[written, ForkPipeReader::PAYLOAD_SIZE]
+          end
+        end
+      end
+
+      def start_refork
+        self << ForkPipeReader::START_REFORK
+      end
+
+      def after_refork
+        self << ForkPipeReader::AFTER_REFORK
+      end
+
+      def refork_workers(*indices)
+        indices.each do |idx|
+          self << idx
+        end
+      end
+
+      def restart_server
+        self << ForkPipeReader::RESTART_SERVER
+      end
+
+      def close
+        @pipe.close
+      end
+    end
+  end
+end

--- a/lib/puma/cluster/fork_pipe.rb
+++ b/lib/puma/cluster/fork_pipe.rb
@@ -42,9 +42,13 @@ module Puma
       def close
         @pipe.close
       end
+
+      def wait_readable
+        @pipe.wait_readable
+      end
     end
 
-    class ForkPipeWriter < DelegateClass(IO)
+    class ForkPipeWriter
       # not thread safe, no concurrency expected
       # minimize object allocation per loop
       def initialize(pipe)

--- a/lib/puma/cluster/fork_pipe.rb
+++ b/lib/puma/cluster/fork_pipe.rb
@@ -6,7 +6,7 @@ module Puma
   class Cluster
     class ForkPipeReader
       PAYLOAD_STRING = "q" # going with bigint out of learned fear of overflow
-      PAYLOAD_SIZE = 4 # # of bytes in a q payload
+      PAYLOAD_SIZE = 8 # # of bytes in a q payload
 
       RESTART_SERVER = 0
       START_REFORK = -1

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -21,7 +21,7 @@ module Puma
         @master = master
         @check_pipe = pipes[:check_pipe]
         @worker_write = pipes[:worker_write]
-        @fork_pipe = pipes[:fork_pipe]
+        @fork_pipe = ForkPipeReader.new(pipes[:fork_pipe])
         @wakeup = pipes[:wakeup]
         @server = server
         @hook_data = {}
@@ -80,17 +80,16 @@ module Puma
 
           Thread.new do
             Puma.set_thread_name "wrkr fork"
-            while (idx = @fork_pipe.gets)
-              idx = idx.to_i
-              if idx == -1 # stop server
+            while (idx = @fork_pipe.read)
+              if idx == ForkPipeReader::START_REFORK # stop server
                 if restart_server.length > 0
                   restart_server.clear
                   server.begin_restart(true)
                   @config.run_hooks(:before_refork, nil, @log_writer, @hook_data)
                 end
-              elsif idx == -2 # refork cycle is done
+              elsif idx == ForkPipeReader::AFTER_REFORK # refork cycle is done
                 @config.run_hooks(:after_refork, nil, @log_writer, @hook_data)
-              elsif idx == 0 # restart server
+              elsif idx == ForkPipeReader::RESTART_SERVER # restart server
                 restart_server << true << false
               else # fork worker
                 worker_pids << pid = spawn_worker(idx)

--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -23,6 +23,7 @@ module Puma
         @last_checkin = Time.now
         @last_status = {}
         @term = false
+        @mold = false
       end
 
       attr_reader :index, :pid, :phase, :signal, :last_checkin, :last_status, :started_at
@@ -45,6 +46,14 @@ module Puma
 
       def term!
         @term = true
+      end
+
+      def mold?
+        @mold
+      end
+
+      def mold!
+        @mold = true if @index.zero?
       end
 
       def term?


### PR DESCRIPTION
### Description
Per discussion in https://github.com/puma/puma/issues/3596, this is an attempt to make worker-0 an idle "mold" process whenever it has to refork, to reduce the complexity of the fork_worker functionality and eliminate a class of bugs coming from the current behavior which switches Thread.main to the "puma wrkr fork" thread, effectively deleting what many Ruby gems/apps treat as global state.

This also pulled in changes to fork_pipe message handling; the current implementation pulls eagerly from the pipe into a local buffer which risks permanent data loss, so I've changed it from newline-delimited strings to a standard packed bigint payload that can be read individually. Implemented using read_/write_nonblock as I think we can improve on its performance and simplify the protocol later (if we don't have to worry about pausing a server, we can let worker zero determine when to run hooks based on when it's read everything it can) but happy to convert to a blocking read/write implementation for simplicity for now, or leave those changes out altogether.

I also made this behavior the default and only fork_worker behavior; in its most general function it will remain the same (it spawns a new worker to replace the now-idle worker 0) but there may be a _lot_ of implementations out there that have implicit or explicit expectations that the specific process will be handling requests so I may also convert it to an additional config.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
