### PR TITLE
Puma::ErrorLogger: missing "?" when logging requests with a query string 

### DIFF
--- a/lib/puma/error_logger.rb
+++ b/lib/puma/error_logger.rb
@@ -81,7 +81,7 @@ module Puma
       REQUEST_FORMAT % [
         env[REQUEST_METHOD],
         env[REQUEST_PATH] || env[PATH_INFO],
-        env[QUERY_STRING] || "",
+        format_query_string(env[QUERY_STRING]),
         env[HTTP_X_FORWARDED_FOR] || env[REMOTE_ADDR] || "-"
       ]
     end
@@ -109,5 +109,10 @@ module Puma
     rescue ThreadError
     end
     private :internal_write
+
+    def format_query_string(query_string)
+        query_string.nil? or query_string.empty?  ? "" : "?#{query_string}"  
+    end
+    private :format_query_string
   end
 end


### PR DESCRIPTION


- Are there related issues / prior discussions? [Issue](https://github.com/puma/puma/pull/3572)
- What alternatives have been tried? Does this supersede previous attempts?
- Why do you make the choices you did? What are the tradeoffs?

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
