### PR TITLE
replace fork_pipe with more robust implementation

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -5,6 +5,7 @@ require_relative 'util'
 require_relative 'plugin'
 require_relative 'cluster/worker_handle'
 require_relative 'cluster/worker'
+require_relative 'cluster/fork_pipe'
 
 module Puma
   # This class is instantiated by the `Puma::Launcher` and used
@@ -73,14 +74,14 @@ module Puma
 
       master = Process.pid
       if @options[:fork_worker]
-        @fork_writer << "-1\n"
+        @fork_writer.start_refork
       end
 
       diff.times do
         idx = next_worker_index
 
         if @options[:fork_worker] && idx != 0
-          @fork_writer << "#{idx}\n"
+          @fork_writer.refork_workers(idx)
           pid = nil
         else
           pid = spawn_worker(idx, master)
@@ -91,11 +92,8 @@ module Puma
       end
 
       if @options[:fork_worker] && all_workers_in_phase?
-        @fork_writer << "0\n"
-
-        if worker_at(0).phase > 0
-          @fork_writer << "-2\n"
-        end
+        @fork_writer.after_refork if worker_at(0).phase > 0
+        @fork_writer.restart_server
       end
     end
 
@@ -419,7 +417,8 @@ module Puma
 
       # Separate pipe used by worker 0 to receive commands to
       # fork new worker processes.
-      @fork_pipe, @fork_writer = Puma::Util.pipe
+      @fork_pipe, fork_writer_pipe = Puma::Util.pipe
+      @fork_writer = ForkPipeWriter.new(fork_writer_pipe)
 
       log "Use Ctrl-C to stop"
 


### PR DESCRIPTION
Trying out _just_ this as the safest change outlined in https://github.com/puma/puma/issues/3596; molding worker zero is proving hard to test safely. This will ensure that only one payload at a time is read off the fork_pipe by introducing a standard packet length, using pack and unpack1 and integers to avoid allocating any new objects during the loop, but more importantly it does _not_ eagerly read off the pipe so if anything happens to worker 0 we can only lose 1 worker at most permanently.