### PR TITLE
Add suport for rack.response_finished

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -230,6 +230,7 @@ module Puma
     RACK_INPUT = "rack.input"
     RACK_URL_SCHEME = "rack.url_scheme"
     RACK_AFTER_REPLY = "rack.after_reply"
+    RACK_RESPONSE_FINISHED = "rack.response_finished"
     PUMA_SOCKET = "puma.socket"
     PUMA_CONFIG = "puma.config"
     PUMA_PEERCERT = "puma.peercert"

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -91,7 +91,7 @@ module Puma
       # A rack extension. If the app writes #call'ables to this
       # array, we will invoke them when the request is done.
       #
-      env[RACK_AFTER_REPLY] ||= []
+      env[RACK_RESPONSE_FINISHED] = env[RACK_AFTER_REPLY] ||= []
 
       begin
         if @supported_http_methods == :any || @supported_http_methods.key?(env[REQUEST_METHOD])

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -90,7 +90,10 @@ module Puma
 
       # A rack extension. If the app writes #call'ables to this
       # array, we will invoke them when the request is done.
-      #
+      # 
+      # Note: The `RACK_RESPONSE_FINISHED` and `RACK_AFTER_REPLY` keys intentionally
+      # share the same array to avoid duplicating behavior. This ensures that any
+      # callable added to either key will be executed when the request is finished.
       env[RACK_RESPONSE_FINISHED] = env[RACK_AFTER_REPLY] ||= []
 
       begin


### PR DESCRIPTION
### Description

Looking to add support for racks response finished hooks.

> #### rack.response_finished
>An array of callables run by the server after the response has been processed. This would typically be invoked after sending the response to the client, but it could also be invoked if an error occurs while generating the response or sending the response; in that case, the error argument will be a subclass of Exception. The callables are invoked with +env, status, headers, error+ arguments and should not raise any exceptions. They should be invoked in reverse order of registration.

It is my understanding that the expected use of `rack.after_reply` and `rack.response_finished` are the same, so for this PR I opted to have them share the callable array instead of duplicating the `after_reply` behaviour just for `response_finished`.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
