### PR TITLE
client.rb - rename local variable `body` to `parser_body`

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -406,7 +406,7 @@ module Puma
 
       @read_header = false
 
-      body = @parser.body
+      parser_body = @parser.body
 
       te = @env[TRANSFER_ENCODING2]
       if te
@@ -417,7 +417,7 @@ module Puma
           te_valid = te_ary[0..-2].all? { |e| ALLOWED_TRANSFER_ENCODING.include? e }
           if te_ary.last == CHUNKED && te_count == 1 && te_valid
             @env.delete TRANSFER_ENCODING2
-            return setup_chunked_body body
+            return setup_chunked_body parser_body
           elsif te_count >= 1
             raise HttpParserError   , "#{TE_ERR_MSG}, multiple chunked: '#{te}'"
           elsif !te_valid
@@ -425,7 +425,7 @@ module Puma
           end
         elsif te_lwr == CHUNKED
           @env.delete TRANSFER_ENCODING2
-          return setup_chunked_body body
+          return setup_chunked_body parser_body
         elsif ALLOWED_TRANSFER_ENCODING.include? te_lwr
           raise HttpParserError     , "#{TE_ERR_MSG}, single value must be chunked: '#{te}'"
         else
@@ -443,7 +443,7 @@ module Puma
           raise HttpParserError, "Invalid Content-Length: #{cl.inspect}"
         end
       else
-        @buffer = body.empty? ? nil : body
+        @buffer = parser_body.empty? ? nil : parser_body
         @body = EmptyBody
         set_ready
         return true
@@ -451,23 +451,23 @@ module Puma
 
       content_length = cl.to_i
 
-      remain = content_length - body.bytesize
+      remain = content_length - parser_body.bytesize
 
       if remain <= 0
-        # Part of the body is a pipelined request OR garbage. We'll deal with that later.
+        # Part of the parser_body is a pipelined request OR garbage. We'll deal with that later.
         if content_length == 0
           @body = EmptyBody
-          if body.empty?
+          if parser_body.empty?
             @buffer = nil
           else
-            @buffer = body
+            @buffer = parser_body
           end
         elsif remain == 0
-          @body = StringIO.new body
+          @body = StringIO.new parser_body
           @buffer = nil
         else
-          @body = StringIO.new(body[0,content_length])
-          @buffer = body[content_length..-1]
+          @body = StringIO.new(parser_body[0,content_length])
+          @buffer = parser_body[content_length..-1]
         end
         set_ready
         return true
@@ -479,12 +479,12 @@ module Puma
         @body.binmode
         @tempfile = @body
       else
-        # The body[0,0] trick is to get an empty string in the same
-        # encoding as body.
-        @body = StringIO.new body[0,0]
+        # The parser_body[0,0] trick is to get an empty string in the same
+        # encoding as parser_body.
+        @body = StringIO.new parser_body[0,0]
       end
 
-      @body.write body
+      @body.write parser_body
 
       @body_remain = remain
 


### PR DESCRIPTION
### Description

The `Client#setup_body` method is about 100 lines.  While checking an issue where a request was processed correctly but was added to the reactor when it shouldn't be, I noticed the following code:
https://github.com/puma/puma/blob/ca201ef69757f8830b636251b0af7a51270eb68a/lib/puma/client.rb#L459-L464

`Client` has a readable attribute `body`, an instance variable `@body`, and the method has a local variable `body`, which is set to `@parser.body`.

This PR renames the local variable to `parser_body`, which may help with clarity.  It obviously currently works, but I prefer code that doesn't have name collisions between method local variables and class/module variables...

Note that JRuby head is failing in CI...  See #3632.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
