### PR TITLE
accept to_path to be nil on bodies

### DIFF
--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -191,7 +191,8 @@ module Puma
           elsif res_body.is_a?(File) && res_body.respond_to?(:size)
             body = res_body
             content_length = body.size
-          elsif res_body.respond_to?(:to_path) && File.readable?(fn = res_body.to_path)
+          elsif res_body.respond_to?(:to_path) && (fn = res_body.to_path) &&
+              File.readable?(fn)
             body = File.open fn, 'rb'
             content_length = body.size
             close_body = true
@@ -199,7 +200,7 @@ module Puma
             body = res_body
           end
         elsif !res_body.is_a?(::File) && res_body.respond_to?(:to_path) &&
-            File.readable?(fn = res_body.to_path)
+            (fn = res_body.to_path) && File.readable?(fn = res_body.to_path)
           body = File.open fn, 'rb'
           content_length = body.size
           close_body = true

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -159,6 +159,25 @@ class TestPumaServer < PumaTest
     tf&.close
   end
 
+  def test_pipe_body
+    random_bytes = SecureRandom.random_bytes(4096)
+
+    r, w = IO.pipe
+
+    w.write random_bytes
+    w.close
+
+    server_run { |env| [200, {}, r] }
+
+    body = send_http_read_resp_body "GET / HTTP/1.0\r\nConnection: close\r\n\r\n"
+
+    assert_equal random_bytes.bytesize, body.bytesize
+    assert_equal random_bytes, body
+  ensure
+    w&.close
+    r&.close
+  end
+
   def test_proper_stringio_body
     data = nil
 


### PR DESCRIPTION
### Description

The rack spec now supports bodies responding with `nil` for `to_path`.
This is the default behavior of IO objects made with `IO.pipe`.

This PR has a commit to prevent puma from crashing when `to_path` returns nil.
It also has a test for pipe response bodies which tests the presence of this bug.

https://github.com/puma/puma/issues/3634
https://github.com/rack/rack/pull/2318

Closes #3634

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
