### PR TITLE
[CI] test.yml - allow non-MRI failure on compile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,8 +191,15 @@ jobs:
         run: echo 'PUMA_MAKE_WARNINGS_INTO_ERRORS=true' >> $GITHUB_ENV
 
       - name: compile
+        id: compile
+        continue-on-error: ${{ matrix.allow-failure || false }}
         if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
         run:  bundle exec rake compile
+
+      - name: >-
+          Compile outcome: ${{ steps.compile.outcome }}
+        # every step must define a `uses` or `run` key
+        run: echo NOOP
 
       - name: test
         id: test


### PR DESCRIPTION
### Description

See #3632

We currently allow non-MRI jobs to fail without causing a 'red X' CI status.  This is currently done on the 'test' step.  Since JRuby-head is not compiling, this PR adds the 'allow-failure' CI flag to also work with jobs that won't compile.

We can probably remove some of the current `allow-failure: true` settings, as (I think) many of the non-MRI are stable.  This PR leaves them unchanged.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
