### PR TITLE
Gemfile - add fiddle for Windows Ruby >= 3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,10 @@ unless ENV['PUMA_NO_RUBOCOP'] || RUBY_PLATFORM.include?('mswin')
   gem 'rubocop-performance', require: false
 end
 
+if RUBY_VERSION >= '3.5' && ::Bundler::WINDOWS
+  gem "fiddle"
+end
+
 if RUBY_VERSION == '2.4.1'
   gem "stopgap_13632", "~> 1.0", :platforms => ["mri", "mingw", "x64_mingw"]
 elsif Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.5")


### PR DESCRIPTION
### Description

Currently, Windows Ruby head builds show the warning shown below, not sure what's loading `Win32::Registry`.

With Ruby 3.5 (head), `fiddle` has been changed to a bundled gem.  Previously, it was a default gem.

Update the Gemfile to remove the warning.

```text
▶ Run test/runner --verbose
D:/ruby-ucrt/lib/ruby/3.5.0+0/win32/registry.rb:2: warning: fiddle/import is found in fiddle, which is not part of the default gems since Ruby 3.5.0.
You can add fiddle to your Gemfile or gemspec to fix this error.

ruby 3.5.0dev (2025-03-27T07:57:10Z master df08cc629e) +PRISM [x64-mingw-ucrt]

▶ Run test/runner --verbose
D:/ruby-mswin/lib/ruby/3.5.0+0/win32/registry.rb:2: warning: fiddle/import is found in fiddle, which is not part of the default gems since Ruby 3.5.0.
You can add fiddle to your Gemfile or gemspec to fix this error.

ruby 3.5.0dev (2025-02-27T07:55:54Z master 2dff416ff2) +PRISM [x64-mswin64_140
```

### Your checklist for this pull request
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
