### PR TITLE
[CI] GHA workflows - remove Ubuntu 20.04

### DIFF
--- a/.github/workflows/rack_conform.yml
+++ b/.github/workflows/rack_conform.yml
@@ -22,11 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-20.04 , ruby: '3.1' }
-          - { os: ubuntu-20.04 , ruby: '3.2' }
+          - { os: ubuntu-22.04 , ruby: '3.1' }
+          - { os: ubuntu-22.04 , ruby: '3.2' }
           - { os: ubuntu-22.04 , ruby: '3.3' }
           - { os: ubuntu-22.04 , ruby: '3.4' }
-          - { os: ubuntu-22.04 , ruby: head  }
+          - { os: ubuntu-24.04 , ruby: head  }
 
     env:
       BUNDLE_GEMFILE: gems/puma-head-rack-v3.rb

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15, windows-2022 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15, windows-2022 ]
         ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4, head ]
         no-ssl: ['']
         rack-v: ['']
@@ -47,18 +47,13 @@ jobs:
           - { os: windows-2022 , ruby: ucrt }
           - { os: windows-2022 , ruby: mswin }
           - { os: windows-2022 , ruby: 2.7  , no-ssl: ' no SSL' }
-          - { os: ubuntu-20.04 , ruby: 2.7  , no-ssl: ' no SSL' }
-          - { os: ubuntu-22.04 , ruby: head , yjit: ' yjit' }
-          - { os: ubuntu-22.04 , ruby: 2.4  , rack-v: ' rack2' }
-          - { os: ubuntu-22.04 , ruby: 3.2  , rack-v: ' rack2' }
-          - { os: ubuntu-22.04 , ruby: 2.4  , rack-v: ' rack1' }
+          - { os: ubuntu-22.04 , ruby: head , yjit: ' yjit'     }
+          - { os: ubuntu-22.04 , ruby: 2.4  , rack-v: ' rack2'  }
+          - { os: ubuntu-22.04 , ruby: 2.7  , no-ssl: ' no SSL' }
+          - { os: ubuntu-22.04 , ruby: 3.2  , rack-v: ' rack2'  }
+          - { os: ubuntu-22.04 , ruby: 2.4  , rack-v: ' rack1'  }
 
         exclude:
-          - { os: ubuntu-22.04 , ruby:  2.4  }
-          - { os: ubuntu-22.04 , ruby:  2.5  }
-          - { os: ubuntu-22.04 , ruby:  2.6  }
-          - { os: ubuntu-22.04 , ruby:  2.7  }
-          - { os: ubuntu-22.04 , ruby: '3.0' }
           - { os: ubuntu-24.04 , ruby:  2.4  }
           - { os: ubuntu-24.04 , ruby:  2.5  }
           - { os: ubuntu-24.04 , ruby:  2.6  }
@@ -154,10 +149,10 @@ jobs:
           - { tto: 8 , os: ubuntu-22.04 , ruby: jruby }
           - { tto: 8 , os: ubuntu-22.04 , ruby: jruby, no-ssl: ' no SSL' }
           - { tto: 8 , os: ubuntu-22.04 , ruby: jruby-head, allow-failure: true }
-          - { tto: 8 , os: ubuntu-20.04 , ruby: truffleruby, allow-failure: true } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
-          - { tto: 8 , os: ubuntu-20.04 , ruby: truffleruby-head, allow-failure: true }
           - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby, allow-failure: true } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
           - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby-head, allow-failure: true }
+          - { tto: 8 , os: ubuntu-24.04 , ruby: truffleruby, allow-failure: true } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
+          - { tto: 8 , os: ubuntu-24.04 , ruby: truffleruby-head, allow-failure: true }
           - { tto: 8 , os: macos-13     , ruby: jruby }
           - { tto: 8 , os: macos-14     , ruby: jruby }
           - { tto: 8 , os: macos-13     , ruby: truffleruby, allow-failure: true }

--- a/.github/workflows/turbo-rails.yml
+++ b/.github/workflows/turbo-rails.yml
@@ -27,14 +27,15 @@ jobs:
         include:
           # Run against the supported releases of Rails (https://rubyonrails.org/maintenance)
           # and the corresponding supported Ruby versions.
-          - { os: ubuntu-20.04 , ruby: '3.1', rails: '7.2' }
-          - { os: ubuntu-20.04 , ruby: '3.2', rails: '7.2' }
+          - { os: ubuntu-22.04 , ruby: '3.1', rails: '7.2' }
+          - { os: ubuntu-22.04 , ruby: '3.2', rails: '7.2' }
           - { os: ubuntu-22.04 , ruby: '3.3', rails: '7.2' }
           - { os: ubuntu-22.04 , ruby: '3.4', rails: '7.2' }
-          - { os: ubuntu-20.04 , ruby: '3.2', rails: '8.0' }
+          - { os: ubuntu-22.04 , ruby: '3.2', rails: '8.0' }
           - { os: ubuntu-22.04 , ruby: '3.3', rails: '8.0' }
           - { os: ubuntu-22.04 , ruby: '3.4', rails: '8.0' }
           - { os: ubuntu-22.04 , ruby: head , rails: '8.0' }
+          - { os: ubuntu-24.04 , ruby: head , rails: '8.0' }
     env:
       CI: true
       FERRUM_PROCESS_TIMEOUT: 60


### PR DESCRIPTION
### Description

Ubuntu-20.04 has been removed from GHA. 

See Issue ["The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-15"](https://github.com/actions/runner-images/issues/11101).

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
