### PR TITLE
ci: Add Ubuntu and Windows arm jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,29 +38,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15, windows-2022 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm,
+              macos-13, macos-14, macos-15,
+              windows-2022 ]
         ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4, head ]
         no-ssl: ['']
         rack-v: ['']
         yjit: ['']
         include:
-          - { os: windows-2022 , ruby: ucrt }
-          - { os: windows-2022 , ruby: mswin }
-          - { os: windows-2022 , ruby: 2.7  , no-ssl: ' no SSL' }
-          - { os: windows-11-arm, ruby: 3.4 }
-          - { os: windows-11-arm, ruby: head }
-          - { os: ubuntu-22.04 , ruby: head , yjit: ' yjit'     }
-          - { os: ubuntu-22.04 , ruby: 2.4  , rack-v: ' rack2'  }
-          - { os: ubuntu-22.04 , ruby: 2.7  , no-ssl: ' no SSL' }
-          - { os: ubuntu-22.04 , ruby: 3.2  , rack-v: ' rack2'  }
-          - { os: ubuntu-22.04 , ruby: 2.4  , rack-v: ' rack1'  }
+          - { os: windows-2022    , ruby:  ucrt }
+          - { os: windows-2022    , ruby:  mswin }
+          - { os: windows-2022    , ruby:  2.7  , no-ssl: ' no SSL' }
+          - { os: windows-11-arm  , ruby:  3.4 }
+          - { os: windows-11-arm  , ruby:  head }
+          - { os: ubuntu-22.04    , ruby:  head , yjit: ' yjit'     }
+          - { os: ubuntu-22.04    , ruby:  2.4  , rack-v: ' rack2'  }
+          - { os: ubuntu-22.04    , ruby:  2.7  , no-ssl: ' no SSL' }
+          - { os: ubuntu-22.04    , ruby:  3.2  , rack-v: ' rack2'  }
+          - { os: ubuntu-22.04    , ruby:  2.4  , rack-v: ' rack1'  }
 
         exclude:
-          - { os: ubuntu-24.04 , ruby:  2.4  }
-          - { os: ubuntu-24.04 , ruby:  2.5  }
-          - { os: ubuntu-24.04 , ruby:  2.6  }
-          - { os: ubuntu-24.04 , ruby:  2.7  }
-          - { os: ubuntu-24.04 , ruby: '3.0' }
+          - { os: ubuntu-24.04    , ruby:  2.4  }
+          - { os: ubuntu-24.04    , ruby:  2.5  }
+          - { os: ubuntu-24.04    , ruby:  2.6  }
+          - { os: ubuntu-24.04    , ruby:  2.7  }
+          - { os: ubuntu-24.04    , ruby: '3.0' }
+          - { os: ubuntu-24.04-arm, ruby:  2.5  }
+          - { os: ubuntu-24.04-arm, ruby:  2.6  }
+          - { os: ubuntu-24.04-arm, ruby:  3.1  }
+          - { os: ubuntu-24.04-arm, ruby:  3.3  }
           - { os: macos-14     , ruby:  2.4  }
           - { os: macos-14     , ruby:  2.5  }
           - { os: macos-14     , ruby:  2.6  }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,9 @@ jobs:
         run: ruby .github/workflows/github_actions_info.rb
 
       - name: set WERRORFLAG
-        if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
+        if: |
+          (needs.skip_duplicate_runs.outputs.should_skip != 'true') &&
+          !(contains(matrix.os, 'ubuntu') && contains(matrix.os, 'arm'))
         shell: bash
         run: echo 'PUMA_MAKE_WARNINGS_INTO_ERRORS=true' >> $GITHUB_ENV
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,8 @@ jobs:
           - { os: windows-2022 , ruby: ucrt }
           - { os: windows-2022 , ruby: mswin }
           - { os: windows-2022 , ruby: 2.7  , no-ssl: ' no SSL' }
+          - { os: windows-11-arm, ruby: 3.4 }
+          - { os: windows-11-arm, ruby: head }
           - { os: ubuntu-22.04 , ruby: head , yjit: ' yjit'     }
           - { os: ubuntu-22.04 , ruby: 2.4  , rack-v: ' rack2'  }
           - { os: ubuntu-22.04 , ruby: 2.7  , no-ssl: ' no SSL' }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: repo checkout
-        if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
+        if: needs.skip_duplicate_runs.outputs.should_skip != 'true'
         uses: actions/checkout@v4
 
       - name: Compile Puma without SSL support
@@ -96,7 +96,7 @@ jobs:
         run: echo 'PUMA_CI_RACK=${{ matrix.rack-v }}' >> $GITHUB_ENV
 
       - name: load ruby
-        if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
+        if: needs.skip_duplicate_runs.outputs.should_skip != 'true'
         uses: ruby/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -109,7 +109,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Repo & Commit Info
-        if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
+        if: needs.skip_duplicate_runs.outputs.should_skip != 'true'
         run: ruby .github/workflows/github_actions_info.rb
 
       - name: set WERRORFLAG
@@ -120,7 +120,7 @@ jobs:
         run: echo 'PUMA_MAKE_WARNINGS_INTO_ERRORS=true' >> $GITHUB_ENV
 
       - name: compile
-        if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
+        if: needs.skip_duplicate_runs.outputs.should_skip != 'true'
         run:  bundle exec rake compile
 
       - name: Use yjit
@@ -131,7 +131,7 @@ jobs:
         run: echo 'RUBYOPT=--yjit' >> $GITHUB_ENV
 
       - name: test
-        if: ${{ needs.skip_duplicate_runs.outputs.should_skip != 'true' }}
+        if: needs.skip_duplicate_runs.outputs.should_skip != 'true'
         timeout-minutes: 10
         run: test/runner --verbose
         env:

--- a/lib/puma/detect.rb
+++ b/lib/puma/detect.rb
@@ -18,6 +18,8 @@ module Puma
 
   IS_LINUX = !(IS_OSX || IS_WINDOWS)
 
+  IS_ARM = RUBY_PLATFORM.include? 'aarch64'
+
   # @version 5.2.0
   IS_MRI = RUBY_ENGINE == 'ruby'
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1842,6 +1842,7 @@ class TestPumaServer < PumaTest
   # System-resource errors such as EMFILE should not be silently swallowed by accept loop.
   def test_accept_emfile
     stub_accept_nonblock Errno::EMFILE.new('accept(2)')
+    sleep 0.1 if Puma::IS_WINDOWS && Puma::IS_ARM
     refute_empty @log_writer.stderr.string, "Expected EMFILE error not logged"
   end
 


### PR DESCRIPTION
### Description
GHA now supports arm64 runners on Ubuntu & Windows.

Added jobs for both.

Note that the Ubuntu jobs are affected by an unsigned vs signed char bug, probably in ragel, as the failures related to the c source code generated by it. I tried a few things, and got Ruby 2.7 passing, but the other versions failed. Gave up.

Disabled the 'PUMA_MAKE_WARNINGS_INTO_ERRORS=true' workflow step in the Ubuntu arm64 jobs, and the jobs passed...

Windows arm had issues with `TestPumaServertest_accept_emfile` (retries & intermittent failures), added a `Puma::IS_ARM` constant, add used it to add a small sleep for the test.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
