### PR TITLE
Update docs to show correct default value for worker_shutdown_timeout

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1107,7 +1107,7 @@ module Puma
 
     # Set the timeout for worker shutdown.
     #
-    # The default is 60 seconds.
+    # The default is 30 seconds.
     #
     # @note Cluster mode only.
     #


### PR DESCRIPTION
The documentation used to say 'The default is 60 seconds.' for
`worker_shutdown_timeout` but the actual default value is 30 as defined
in `lib/puma/configuration.rb` https://github.com/puma/puma/blob/bc648da28d4332276293b6ae21157c0b892ec392/lib/puma/configuration.rb#L170
