### PR TITLE
Link to official Ruby documentation

### DIFF
--- a/docs/signals.md
+++ b/docs/signals.md
@@ -17,13 +17,13 @@ $ ps aux | grep tail
 schneems        87152   0.0  0.0  2432772    492 s032  S+   12:46PM   0:00.00 tail -f my.log
 ```
 
-You can send a signal in Ruby using the [Process module](https://ruby-doc.org/3.2.2/Process.html#method-c-kill):
+You can send a signal in Ruby using the [Process module](https://docs.ruby-lang.org/en/master/Process.html#method-c-kill):
 
 ```
 $ irb
 > puts pid
 => 87152
-Process.detach(pid) # https://ruby-doc.org/3.2.2/Process.html#method-c-detach
+Process.detach(pid) # https://docs.ruby-lang.org/en/master/Process.html#method-c-detach
 Process.kill("TERM", pid)
 ```
 


### PR DESCRIPTION
ruby-doc.org is not official documentation.
By using master, we always link to the latest version.

### Your checklist for this pull request
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
