### PR TITLE
ci: Fix Gemfiles for cgi removal in ruby head

### DIFF
--- a/.github/workflows/turbo-rails.yml
+++ b/.github/workflows/turbo-rails.yml
@@ -55,6 +55,11 @@ jobs:
           SRC="gem ['\"]puma['\"].*"
           DST="gem 'puma', git: 'https://github.com/$GITHUB_REPOSITORY.git', ref: '$GITHUB_SHA'"
           sed -i "s#$SRC#$DST#" Gemfile
+          # use rack main with ruby master
+          SRC="gem 'rack'"
+          DST="if RUBY_PATCHLEVEL == -1\n  gem 'rack', git: 'https://github.com/rack/rack', ref: 'main'\nelse\n  gem 'rack'\nend"
+          sed -i "s#$SRC#$DST#" Gemfile
+          #
           SRC="gem ['\"]sqlite3['\"].*"
           DST="gem 'sqlite3', ENV['RAILS_VERSION'] == '8.0' ? '>= 2.1' : '~> 1.4'"
           sed -i "s#$SRC#$DST#" Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,11 @@ when 'rack1'
   gem "rack"  , '~> 1.6'
 else
   gem "rackup", '>= 2.0'
-  gem "rack"  , '>= 2.2'
+  if RUBY_PATCHLEVEL == -1
+    gem "rack", git: "https://github.com/rack/rack", ref: "main"
+  else
+    gem "rack"  , '>= 2.2'
+  end
 end
 
 gem "jruby-openssl", :platform => "jruby"


### PR DESCRIPTION
### Description

Ruby master/head recently removed the cgi gem, and left `cgi/escape` in the std-lib.  This affected erb, rack, etc.  It also breaks Puma CI.

So, use the Rack main branch when running Ruby head jobs in CI.

See https://github.com/rack/rack/pull/2327

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
