### PR TITLE
Fix race condition when deleting pidfile

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -140,7 +140,10 @@ module Puma
     # Delete the configured pidfile
     def delete_pidfile
       path = @options[:pidfile]
-      File.unlink(path) if path && File.exist?(path)
+      begin
+        File.unlink(path) if path
+      rescue Errno::ENOENT
+      end
     end
 
     # Begin async shutdown of the server


### PR DESCRIPTION
### Description

In a concurrent environment, a race condition can occur if the file is deleted between the call to `File.exist?` and the call to `File.unlink`. In this case, `File.unlink` will raise an `Errno::ENOENT` exception because the file no longer exists. This change removes the explicit `File.exist?` check and instead safely rescues `Errno::ENOENT`.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [X] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.