### PR TITLE
Add a new API to update the min & max thread count dynamically

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -680,6 +680,11 @@ module Puma
       @binder.add_unix_listener path, umask, mode, backlog
     end
 
+    def update_worker_count(min: @thread_pool.min, max: @thread_pool.max)
+      @thread_pool.min, @thread_pool.max = min, max
+      @min_threads, @max_threads = min, max
+    end
+
     # @!attribute [r] connected_ports
     def connected_ports
       @binder.connected_ports

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -78,6 +78,7 @@ module Puma
     end
 
     attr_reader :spawned, :trim_requested, :waiting
+    attr_accessor :min, :max
 
     def self.clean_thread_locals
       Thread.current.keys.each do |key| # rubocop: disable Style/HashEachMethods

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -2156,4 +2156,21 @@ class TestPumaServer < PumaTest
     server_run(min_threads: 2, max_threads: 2, auto_trim_time: 1)
     refute @pool.instance_variable_get(:@auto_trim)
   end
+
+  def test_update_worker_count
+    server_run(min_threads: 1, max_threads: 1, auto_trim_time: 1)
+
+    assert_equal 1, @server.stats[:running]
+
+    @server.update_worker_count(min: 3, max: 3)
+
+    # By making multiple requests, we can ensure that the pool is filled up to the max.
+    10.times { send_http_read_response(GET_11) }
+
+    assert_equal 3, @pool.max
+    assert_equal 3, @pool.min
+    assert_equal 3, @server.max_threads
+    assert_equal 3, @server.min_threads
+    assert_equal 3, @server.stats[:running]
+  end
 end


### PR DESCRIPTION
### Description

@nateberkopec and I are working on something that automatically identifies the optional worker count on the fly and updates the thread count accordingly and dynamically. The algorithm we are actively working on will be proprietary, but we think that it makes sense to add an API to dynamically change the thread count could be part of the open source Puma, hence the PR here.

I have looked into Puma's source code, and noticed that this isn't extremely complicated, as Puma's thread pool already looks at the `min` and `max` to not allocate too many threads or trim unused threads dynamically. What this means is that in order to achieve what we want to do, we can simply set a new number to `min` or/and `max`.

This PR includes a simple change where `#update_worker_count` was added to do that. The accessors for `min` and `max` have also been added to the `ThreadPool`. I know this may seem a bit scary, but that's basically what dynamic update means so I thought it might be fine.

Please let me know what you all think.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
