### PR TITLE
[Experiment] Pure ruby parser

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,23 @@ file 'ext/puma_http11/org/jruby/puma/Http11Parser.java' => ['ext/puma_http11/htt
 end
 task :ragel => ['ext/puma_http11/org/jruby/puma/Http11Parser.java']
 
-if !Puma.jruby?
+if ENV["PUMA_PURE_RUBY_PARSER"]
+  task :compile => ['ext/puma_http11/puma_http11.rb'] do
+    src = 'ext/puma_http11/puma_http11.rb'
+    dest = 'lib/puma/puma_http11.rb'
+    if File.exist?(dest)
+      if File.symlink?(dest)
+        puts "Using ruby parser (already symlinked)"
+      else
+        puts "Refusing to symlink ruby parser. Did you forget to run `rake clean`?"
+      end
+    else
+      puts "Symlinking ruby parser"
+      FileUtils.symlink(src, dest, relative: true)
+    end
+  end
+  CLEAN.include "lib/puma/puma_http11.rb"
+elsif !Puma.jruby?
   # compile extensions using rake-compiler
   # C (MRI, Rubinius)
   Rake::ExtensionTask.new("puma_http11", gemspec) do |ext|

--- a/benchmarks/wrk/hello.sh
+++ b/benchmarks/wrk/hello.sh
@@ -1,8 +1,32 @@
 # You are encouraged to use @ioquatix's wrk fork, located here: https://github.com/ioquatix/wrk
 
-bundle exec bin/puma -t 4 test/rackup/hello.ru &
-PID1=$!
-sleep 5
-wrk -c 4 -d 30 --latency http://localhost:9292
+benchmark() {
+  bundle exec bin/puma -t 4 test/rackup/hello.ru &
+  PID1=$!
+  sleep 5
+  echo "Warming up YJIT"
+  wrk -c 4 -d 30 --latency http://localhost:9292 > /dev/null
+  echo "Running"
+  wrk -c 16 -t 8 -d 30 --latency http://localhost:9292
+  kill $PID1
+}
 
-kill $PID1
+export RUBY_YJIT_ENABLE=1
+
+echo "===================================="
+echo "C parser"
+echo "===================================="
+
+unset PUMA_PURE_RUBY_PARSER
+rake clean
+rake compile
+benchmark
+
+echo "===================================="
+echo "Ruby parser"
+echo "===================================="
+
+rake clean
+export PUMA_PURE_RUBY_PARSER=1
+rake compile
+benchmark

--- a/ext/puma_http11/puma_http11.rb
+++ b/ext/puma_http11/puma_http11.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require "strscan"
+require_relative "../../lib/puma/const"
+require_relative "../../lib/puma/client"
+
+module Puma
+  RUBY_PARSER = true
+
+  class HttpParserError < IOError
+  end
+
+  # Hand written HTTP 1.1 parser written in Ruby. Similar to the Ragel approach this parser uses a
+  # state machine. However, while Ragel state machine works one character at a time, this parser
+  # works in chunks: http_method, target, version, headers, and body.
+  #
+  # Given this request:
+  #
+  #  POST /example-page HTTP/1.1
+  #  Host: www.example.com
+  #  User-Agent: Mozilla/5.0
+  #
+  #  Hello World
+  #
+  # Each step of the parser does the following:
+  #
+  # http_method: "POST"
+  # target: "/example-page"
+  # version: "HTTP/1.1"
+  # headers: "Host: www.example.com", "User-Agent: Mozilla/5.0", "\r\n"
+  # body: "Hello World"
+  class HttpParser
+    include Puma::Const
+
+    STEPS = [
+      :http_method,
+      :target,
+      :version,
+      :headers,
+      :body
+    ]
+
+    # Step delimeters
+    SPACE = /\s/
+    RETURN_OR_NEWLINE = /[\r\n]/
+
+    SSL = "Invalid HTTP format, parsing fails. Are you trying to open an SSL connection to a non-SSL Puma?"
+
+    METHODS = %r{#{SUPPORTED_HTTP_METHODS.join("|")}\b}
+    WS = /\s+/
+    def http_method(req)
+      req["REQUEST_METHOD"] = (@scanner.scan(METHODS) || raise_error!("Invalid HTTP format, parsing fails. Are you trying to open an SSL connection to a non-SSL Puma?")).strip
+      @scanner.skip(WS)
+      @step += 1
+    end
+
+    # URL components
+    URI = /[^\s#]+/ # Match everything up until whitespace or a hash
+    SCHEME = %r{\Ahttps?://}
+    PARTS = /\A(?<path>[^?#]*)(\?(?<params>[^#]*))?/
+    NWS = /\S*/ # not white space
+    FRAGMENT_DELIMETER = /#/
+    UNPRINTABLE_CHARACTERS = %r{[^ -~]} # find a character that's not between " " (space) and "~" (tilde)
+    def target(req)
+      uri = @scanner.scan(URI)
+      req["REQUEST_URI"] = uri
+      raise_error!("HTTP element REQUEST_URI is longer than the (1024 * 12) allowed length (was #{uri.length})") if uri.length > 1024 * 12
+      unless uri.match? SCHEME
+        parts = PARTS
+          .match(uri)
+          .named_captures
+        path = parts["path"]
+        if path.match? UNPRINTABLE_CHARACTERS
+          raise_error!(SSL)
+        else
+          req["REQUEST_PATH"] = path
+          raise_error!("HTTP element REQUEST_PATH is longer than the (8192) allowed length (was #{path.length})") if path.length > 8192
+        end
+        params = parts["params"] || ""
+        if params.match? UNPRINTABLE_CHARACTERS
+          raise_error!(SSL)
+        else
+          req["QUERY_STRING"] = params
+          raise_error!("HTTP element QUERY_STRING is longer than the (1024 * 10) allowed length (was #{params.length})") if params.length > 1024 * 10
+        end
+        if @scanner.skip(FRAGMENT_DELIMETER)
+          req["FRAGMENT"] = @scanner.scan(NWS)
+          raise_error!("HTTP element FRAGMENT is longer than the 1024 allowed length (was #{req["FRAGMENT"].length})") if req["FRAGMENT"].length > 1024
+        end
+      end
+      @scanner.scan(WS)
+      @step += 1
+    end
+
+    HTTP_VERSION = %r{(HTTP/1\.[01])}
+    RETURN_NEWLINE = %r{\r\n}
+    NEWLINE = %r{\n}
+    def version(req)
+      req["SERVER_PROTOCOL"] = @scanner.scan(HTTP_VERSION) || raise_error!(SSL)
+      @scanner.skip(RETURN_NEWLINE) || raise_error!
+      @delimeter = RETURN_OR_NEWLINE
+      @step += 1
+    end
+
+    HEADER = %r{[^\r\n]+\r\n}
+    HEADER_FORMAT = /\A([^:]+):\s*([^\r\n]+)/
+    DIGITS = /\A\d+\z/
+    TRAILING_WS = /\s*$/
+    def headers(req)
+      while header = @scanner.scan(HEADER)
+        @headers_count += 1
+        raise_error! if @headers_count > 1024 # TODO Use a  better number
+        @headers_total_length += header.length
+        raise_error!("HTTP element HEADER is longer than the (1024 * (80 + 32)) allowed length (was 114930)") if @headers_total_length > 1024 * (80 + 32) # TODO Need to figure out how to calculate 114930 better.
+        raise_error! unless HEADER_FORMAT.match(header)
+        key = $1
+        value = $2
+        raise_error!("HTTP element FIELD_NAME is longer than the 256 allowed length (was #{key.length})") if key.length > 256
+        raise_error!("HTTP element FIELD_VALUE is longer than the 80 * 1024 allowed length (was #{value.length})") if value.length > 80 * 1024
+        raise_error! if value.match?(NEWLINE)
+        key = key.upcase.tr("_-", ",_")
+        key = "HTTP_#{key}" unless ["CONTENT_LENGTH", "CONTENT_TYPE"].include?(key)
+        value = value.rstrip
+        if req.has_key?(key)
+          req[key] << ", #{value}"
+        else
+          req[key] = value
+        end
+      end
+      if @scanner.skip(RETURN_NEWLINE)
+        @step += 1
+        @finished = true
+      end
+      raise_error!(SSL) if @scanner.exist?(/[^\r]\n/) # catch bad headers that are missing a return.
+      raise_error!(SSL) if @scanner.exist?(/\r[^\n]/) # catch bad headers that are missing a newline.
+    end
+
+    def execute(req, data, start)
+      unless @scanner
+        reset
+        @scanner = StringScanner.new(data)
+      end
+
+      send(STEPS[@step], req) while !@finished && @scanner.exist?(@delimeter)
+
+      if @step == 0
+        raise_error!("Invalid HTTP format, parsing fails. Are you trying to open an SSL connection to a non-SSL Puma?")
+      end
+
+      nread
+    end
+
+    def body
+      @body ||= @scanner.rest.tap { @scanner.terminate } # Using terminate feels hacky to me. Is there something better?
+    end
+
+    def nread
+      @scanner&.pos || 0
+    end
+
+    def reset
+      @step = 0
+      @finished = false
+      @delimeter = SPACE
+      @error = false
+      @scanner = nil
+      @body = nil
+      @headers_count = 0
+      @headers_total_length = 0
+    end
+
+    def finished?
+      @finished
+    end
+
+    def raise_error!(message = nil)
+      @error = true
+      raise HttpParserError.new(message)
+    end
+
+    def error?
+      @error
+    end
+  end
+end

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -10,6 +10,7 @@ end
 
 require_relative 'detect'
 require_relative 'io_buffer'
+require_relative 'null_io'
 require 'tempfile'
 
 if Puma::IS_JRUBY

--- a/lib/puma/detect.rb
+++ b/lib/puma/detect.rb
@@ -42,4 +42,8 @@ module Puma
   def self.forkable?
     HAS_FORK
   end
+
+  def self.ruby_parser?
+    defined?(RUBY_PARSER)
+  end
 end

--- a/test/test_request_single.rb
+++ b/test/test_request_single.rb
@@ -256,7 +256,7 @@ class TestRequestHeadersInvalid < TestRequestBase
   def test_malformed_headers_no_return
     request = "GET / HTTP/1.1\r\nno-return: 10\nContent-Length: 11\r\n\r\nHello World"
 
-    msg = Puma::IS_JRUBY ?
+    msg = Puma::IS_JRUBY || Puma.ruby_parser? ?
       "Invalid HTTP format, parsing fails. Bad headers\nno-return: 10\\nContent-Length: 11" :
       "Invalid HTTP format, parsing fails. Bad headers\nNO_RETURN: 10\\nContent-Length: 11"
 
@@ -266,7 +266,7 @@ class TestRequestHeadersInvalid < TestRequestBase
   def test_malformed_headers_no_newline
     request = "GET / HTTP/1.1\r\nno-newline: 10\rContent-Length: 11\r\n\r\nHello World"
 
-    msg = Puma::IS_JRUBY ?
+    msg = Puma::IS_JRUBY || Puma.ruby_parser? ?
       "Invalid HTTP format, parsing fails. Bad headers\nno-newline: 10\rContent-Length: 11" :
       "Invalid HTTP format, parsing fails. Bad headers\nNO_NEWLINE: 10\rContent-Length: 11"
 


### PR DESCRIPTION
### Description

As an experiment/learning exercise I decided to try implementing a HTTP parser in pure ruby. See https://github.com/puma/puma/issues/1889.  I did this purely as an exercise and not in an attempt to get it merged. I'm posting in the hope it might provide an interesting data point when comparing the C parser vs a pure ruby one.

I took inspiration from [Tenderlove's blog post](https://tenderlovemaking.com/2023/09/02/fast-tokenizers-with-stringscanner/) and used StringScanner.

# FAQ

* Why didn't you use `protocol-http`?

Somehow when I was reading through [the issue](https://github.com/puma/puma/issues/1889) initially I missed those comments. That would have been a good idea. Then again, building it from scratch was part of the fun of learning about http parsers.

* Is this a valid HTTP parser?

Probably not. I wrote it to pass the test suite and only briefly referred to the RFCs. No doubt there are bugs & security issues. Note that while it passes most of the test suite, there are still about 6 failing tests.

* Why did you change the number of connections & threads used by `wrk` in the `hello.sh` benchmark?

For reasons I don't understand if I ran `wrk` with 4 connections and 4 threads against my ruby parser it would only do 4096 requests (1024 per thread). The latency statistics would still be very low so I'm not sure what was causing the delay.

* Why do you warm up the YJIT?

In practice the pure ruby parser will be significantly slower for the first request than the C extension due to the time taken to compile the ruby into VM instructions. As Puma processes are typically long lived I felt like including the YJIT compilation step would be an unfair comparison.

* Is this a fair comparison?

I don't know ¯_(ツ)_/¯ The `hello.sh` benchmark feels interesting but also artificial to me. I don't think it's representative of a production workload, and that could skew the usefulness of these results.

I did a little performance optimisation of the ruby parser but I'm not expert in that area. It feels a little unfair to compare the optimised C parser against a poorly optimised ruby parser; but then, performance is a big part of the question around it a ruby parser so the comparison is kind of the point.

# STOP WRITING CAVEATS AND GET TO THE RESULTS!

On my x86 laptop running Linux I get:

```
====================================
C parser
====================================
Warming up YJIT
Running 30s test @ http://localhost:9292
  8 threads and 16 connections
  860021 requests in 30.01s, 63.87MB read
Requests/sec:  28654.45
Transfer/sec:      2.13MB

Thread Stats         Avg       Stdev         Min         Max    +/- Stdev
     Latency:       1.33ms      1.59ms     41.00us     11.64ms   79.23%
     Req/sec:       3.60k     169.12        2.43k       3.96k    85.71%

Latency Distribution
     50%  171.00us
     75%    2.59ms
     90%    3.96ms
     99%    5.12ms

Request Stats        Avg       Stdev         Min         Max    +/- Stdev
    Req/conn:      53.75k      96.45       53.63k      53.97k    68.75%
====================================
Ruby parser
====================================
Warming up YJIT
Running 30s test @ http://localhost:9292
  8 threads and 16 connections
  685083 requests in 30.01s, 50.88MB read
Requests/sec:  22826.75
Transfer/sec:      1.70MB

Thread Stats         Avg       Stdev         Min         Max    +/- Stdev
     Latency:       1.67ms      2.00ms     49.00us     12.94ms   79.05%
     Req/sec:       2.87k     147.58        1.80k       3.19k    88.42%

Latency Distribution
     50%  219.00us
     75%    3.24ms
     90%    4.98ms
     99%    6.43ms

Request Stats        Avg       Stdev         Min         Max    +/- Stdev
    Req/conn:      42.82k      60.09       42.71k      42.94k    75.00%
- Gracefully stopping, waiting for requests to finish
```

The C parser is definitely faster; but the ruby results look pretty good to me.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
