### PR TITLE
Fixes for `warning: literal string will be frozen`

### DIFF
--- a/test/helpers/apps.rb
+++ b/test/helpers/apps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TestApps
 
   # call with "GET /sleep<d> HTTP/1.1\r\n\r\n", where is the number of

--- a/test/helpers/ssl.rb
+++ b/test/helpers/ssl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SSLHelper
   def ssl_query
     @ssl_query ||= if Puma.jruby?

--- a/test/helpers/test_puma/response.rb
+++ b/test/helpers/test_puma/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TestPuma
 
   # A subclass of String, allows processing the response returned by

--- a/test/test_bundle_pruner.rb
+++ b/test/test_bundle_pruner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
 
 require 'puma/events'

--- a/test/test_busy_worker.rb
+++ b/test/test_busy_worker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/test_puma/puma_socket"
 

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/ssl" if ::Puma::HAS_SSL
 require_relative "helpers/tmp_path"

--- a/test/test_error_logger.rb
+++ b/test/test_error_logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puma/error_logger'
 require_relative "helper"
 

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puma/events'
 require_relative "helper"
 

--- a/test/test_example_cert_expiration.rb
+++ b/test/test_example_cert_expiration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
 require 'openssl'
 

--- a/test/test_http10.rb
+++ b/test/test_http10.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 
 require "puma/puma_http11"

--- a/test/test_http11.rb
+++ b/test/test_http11.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2011 Evan Phoenix
 # Copyright (c) 2005 Zed A. Shaw
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/integration"
 

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/integration"
 

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/integration"
 

--- a/test/test_integration_ssl.rb
+++ b/test/test_integration_ssl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
 require_relative "helpers/integration"
 

--- a/test/test_iobuffer.rb
+++ b/test/test_iobuffer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 
 require "puma/io_buffer"

--- a/test/test_json_serialization.rb
+++ b/test/test_json_serialization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require "json"
 require "puma/json_serialization"

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/tmp_path"
 

--- a/test/test_out_of_band_server.rb
+++ b/test/test_out_of_band_server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 
 class TestOutOfBandServer < PumaTest

--- a/test/test_plugin.rb
+++ b/test/test_plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/integration"
 

--- a/test/test_preserve_bundler_env.rb
+++ b/test/test_preserve_bundler_env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/integration"
 

--- a/test/test_puma_localhost_authority.rb
+++ b/test/test_puma_localhost_authority.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Nothing in this file runs if Puma isn't compiled with ssl support
 #
 # helper is required first since it loads Puma, which needs to be

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/test_puma/puma_socket"
 require "puma/events"

--- a/test/test_puma_server_hijack.rb
+++ b/test/test_puma_server_hijack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require "puma/events"
 require "puma/server"

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Nothing in this file runs if Puma isn't compiled with ssl support
 #
 # helper is required first since it loads Puma, which needs to be
@@ -82,7 +84,7 @@ class TestPumaServerSSL < PumaTest
     ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
     @bind_port = @server.connected_ports[0]
 
-    socket = send_http "HEAD",  ctx: new_ctx
+    socket = send_http "HEAD", ctx: new_ctx
     sleep 0.1
 
     # Capture the amount of threads being used after connecting and being idle

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/ssl"
 

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 
 # Most tests check that ::Rack::Handler::Puma works by itself

--- a/test/test_request_invalid_multiple.rb
+++ b/test/test_request_invalid_multiple.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/test_puma/puma_socket"
 

--- a/test/test_request_single.rb
+++ b/test/test_request_single.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 
 require 'puma/client'

--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require "puma/events"
 require "net/http"

--- a/test/test_state_file.rb
+++ b/test/test_state_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/tmp_path"
 

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 
 require "puma/thread_pool"

--- a/test/test_url_map.rb
+++ b/test/test_url_map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/integration"
 

--- a/test/test_web_concurrency_auto.rb
+++ b/test/test_web_concurrency_auto.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/integration"
 require_relative "helpers/test_puma/puma_socket"

--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "helper"
 require_relative "helpers/integration"
 


### PR DESCRIPTION
### Description

Add `# frozen_string_literal: true` to all test files (no lib files in this PR),  fixes `warning: literal string will be frozen in the future`

Example from CI run in current master:
```
/home/runner/work/puma/puma/test/helpers/test_puma/puma_socket.rb:183:
warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
