### PR TITLE
Send watchdog to systemd when puma is ready

### DIFF
--- a/lib/puma/sd_notify.rb
+++ b/lib/puma/sd_notify.rb
@@ -51,6 +51,7 @@ module Puma
 
     def self.ready(unset_env=false)
       notify(READY, unset_env)
+      watchdog(unset_env) if watchdog?
     end
 
     def self.reloading(unset_env=false)

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -54,6 +54,14 @@ class TestPluginSystemd < TestIntegration
     assert_message "STOPPING=1"
   end
 
+  def test_systemd_watchdog_on_ready
+    wd_env = @env.merge({"WATCHDOG_USEC" => "10_000_000"})
+    cli_server "test/rackup/hello.ru", env: wd_env
+    assert_message "READY=1"
+    assert_message "WATCHDOG=1", wait: false
+    stop_server
+  end
+
   def test_systemd_notify
     cli_server "test/rackup/hello.ru", env: @env
     assert_message "READY=1"
@@ -100,12 +108,12 @@ class TestPluginSystemd < TestIntegration
     assert_message 'STOPPING=1'
   end
 
-  def assert_message(msg)
+  def assert_message(msg, wait: true)
     @socket.wait_readable 1
     @message << @socket.sysread(msg.bytesize)
     # below is kind of hacky, but seems to work correctly when slow CI systems
     # write partial status messages
-    if @message.start_with?('STATUS=') && !msg.start_with?('STATUS=')
+    if wait && @message.start_with?('STATUS=') && !msg.start_with?('STATUS=')
       @message << @socket.sysread(512) while @socket.wait_readable(1) && !@message.include?(msg)
       assert_includes @message, msg
       @message = @message.split(msg, 2).last


### PR DESCRIPTION
Fixes #3675 

We send an watchdog notification via SD notify immediately once we are ready. This avoids systemd restarting puma immediately after a long restart has just completed.

I needed to add a ```wait``` option to assert_message in test/test_plugin_systemd.rb to ensure the test doesn't wait and receive the later (periodic) watchdog notification causing test success when it should fail.
