### PR TITLE
ci: test_puma_server_hijack.rb - use puma_socket.rb, fixups

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -460,7 +460,7 @@ class TestIntegration < PumaTest
             else
               mutex.synchronize { replies[:unexpected_response] += 1 }
             end
-          rescue Errno::ECONNRESET, Errno::EBADF, Errno::ENOTCONN
+          rescue Errno::ECONNRESET, Errno::EBADF, Errno::ENOTCONN, Errno::ENOTSOCK
             # connection was accepted but then closed
             # client would see an empty response
             # Errno::EBADF Windows may not be able to make a connection

--- a/test/helpers/test_puma/puma_socket.rb
+++ b/test/helpers/test_puma/puma_socket.rb
@@ -235,7 +235,7 @@ module TestPuma
             times << (Process.clock_gettime(Process::CLOCK_MONOTONIC) - time_read).round(4)
             status ||= part[/\AHTTP\/1\.[01] (\d{3})/, 1]
             if status
-              no_body ||= NO_ENTITY_BODY.key? status.to_i || status.to_i < 200
+              no_body ||= NO_ENTITY_BODY.key?(status.to_i) || status.to_i < 200
             end
             if no_body && part.end_with?(RESP_SPLIT)
               response.times = times

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -436,7 +436,8 @@ class TestPumaServer < PumaTest
      [200, { "X-Hello" => "World" }, ["Hello world!"]]
     end
 
-    response = send_http_read_response "HEAD / HTTP/1.0\r\n\r\n"
+    # two requests must be read
+    response = send_http_read_all "HEAD / HTTP/1.0\r\n\r\n"
 
     expected_resp = <<~EOF.gsub("\n", "\r\n") + "\r\n"
       HTTP/1.1 103 Early Hints
@@ -979,7 +980,8 @@ class TestPumaServer < PumaTest
   def test_Expect_100
     server_run { [200, {}, [""]] }
 
-    response = send_http_read_response "GET / HTTP/1.1\r\nConnection: close\r\nExpect: 100-continue\r\n\r\n"
+    # two requests must be read
+    response = send_http_read_all "GET / HTTP/1.1\r\nConnection: close\r\nExpect: 100-continue\r\n\r\n"
 
     assert_equal "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", response
   end

--- a/test/test_puma_server_hijack.rb
+++ b/test/test_puma_server_hijack.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "helper"
+require_relative "helpers/test_puma/puma_socket"
 require "puma/events"
 require "puma/server"
 require "net/http"
@@ -19,8 +20,13 @@ require "rack/body_proxy"
 class TestPumaServerHijack < PumaTest
   parallelize_me!
 
+  include TestPuma
+  include TestPuma::PumaSocket
+
+  HOST = HOST4
+
   def setup
-    @host = "127.0.0.1"
+    @host = HOST
 
     @ios = []
 
@@ -35,44 +41,14 @@ class TestPumaServerHijack < PumaTest
     @server.stop(true)
     assert_empty @log_writer.stdout.string
     assert_empty @log_writer.stderr.string
-
-    # Errno::EBADF raised on macOS
-    @ios.each do |io|
-      begin
-        io.close if io.respond_to?(:close) && !io.closed?
-        File.unlink io.path if io.is_a? File
-      rescue Errno::EBADF
-      ensure
-        io = nil
-      end
-    end
   end
 
   def server_run(**options, &block)
     options[:log_writer]  ||= @log_writer
     options[:min_threads] ||= 1
     @server = Puma::Server.new block || @app, @events, options
-    @port = (@server.add_tcp_listener @host, 0).addr[1]
+    @bind_port = (@server.add_tcp_listener @host, 0).addr[1]
     @server.run
-  end
-
-  # only for shorter bodies!
-  def send_http_and_sysread(req)
-    send_http(req).sysread 2_048
-  end
-
-  def send_http_and_read(req)
-    send_http(req).read
-  end
-
-  def send_http(req)
-    t = new_connection
-    t.syswrite req
-    t
-  end
-
-  def new_connection
-    TCPSocket.new(@host, @port).tap {|sock| @ios << sock}
   end
 
   # Full hijack does not return headers
@@ -120,11 +96,12 @@ class TestPumaServerHijack < PumaTest
     end
 
     sock = send_http "GET / HTTP/1.1\r\n\r\n"
-    resp = sock.sysread 1_024
+    response = sock.read_response
     echo_msg = "This should echo..."
     sock.syswrite echo_msg
 
-    assert_includes resp, 'Connection: Upgrade'
+    assert_includes response, 'Connection: Upgrade'
+    sock.wait_readable 0.2 # for TruffleRuby Errno::EAGAIN
     assert_equal echo_msg, sock.sysread(256)
   end
 
@@ -148,11 +125,12 @@ class TestPumaServerHijack < PumaTest
     end
 
     sock = send_http "GET / HTTP/1.1\r\n\r\n"
-    resp = sock.sysread 1_024
+    response = sock.read_response
     echo_msg = "This should echo..."
     sock.syswrite echo_msg
 
-    assert_includes resp, 'Connection: Upgrade'
+    assert_includes response, 'Connection: Upgrade'
+    sock.wait_readable 0.2 # for TruffleRuby Errno::EAGAIN
     assert_equal echo_msg, sock.sysread(256)
   end
 
@@ -169,9 +147,9 @@ class TestPumaServerHijack < PumaTest
     end
 
     # using sysread may only receive part of the response
-    data = send_http_and_read "GET / HTTP/1.0\r\nConnection: close\r\n\r\n"
+    response = send_http_read_response "GET / HTTP/1.0\r\nConnection: close\r\n\r\n"
 
-    assert_equal "HTTP/1.0 200 OK\r\nContent-Length: 5\r\n\r\nabcde", data
+    assert_equal "HTTP/1.0 200 OK\r\nContent-Length: 5\r\n\r\nabcde", response
   end
 
   def test_partial_hijack_body_closes_body
@@ -211,15 +189,15 @@ class TestPumaServerHijack < PumaTest
 
     sock1 = send_http "GET / HTTP/1.1\r\n\r\n"
     sleep (Puma::IS_WINDOWS || !Puma::IS_MRI ? 0.3 : 0.1)
-    resp1 = sock1.sysread 1_024
+    response1 = sock1.read_response
 
     sleep 0.01 # time for close block to be called ?
 
     sock2 = send_http "GET / HTTP/1.1\r\n\r\n"
     sleep (Puma::IS_WINDOWS || !Puma::IS_MRI ? 0.3 : 0.1)
-    resp2 = sock2.sysread 1_024
+    response2 = sock2.read_response
 
-    assert_operator resp1, :end_with?, 'hijacked'
-    assert_operator resp2, :end_with?, 'hijacked'
+    assert_operator response1, :end_with?, 'hijacked'
+    assert_operator response2, :end_with?, 'hijacked'
   end
 end


### PR DESCRIPTION
### Description

While working on other PR's, I noticed that all TruffleRuby jobs were silently failing.  Some of the failures were in `test_puma_server_hijack.rb`.  This also required small changes in two other files.

After this PR, TruffleRuby jobs are passing, TruffleRuby-head jobs are failing on two gc related tests.  More work later.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
