### PR TITLE
ci: rack_conform.yml - Ruby 3.1 no longer supported

### DIFF
--- a/.github/workflows/rack_conform.yml
+++ b/.github/workflows/rack_conform.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-22.04 , ruby: '3.1' }
           - { os: ubuntu-22.04 , ruby: '3.2' }
           - { os: ubuntu-22.04 , ruby: '3.3' }
           - { os: ubuntu-22.04 , ruby: '3.4' }


### PR DESCRIPTION
### Description

See https://github.com/puma/puma/pull/3416#issuecomment-3166068205

@ioquatix Thanks for the notification.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
