### PR TITLE
ci: test_integration_pumactl.rb - fix control_gc_stats for TruffleRuby head

### DIFF
--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -279,7 +279,7 @@ class TestIntegrationPumactl < TestIntegration
   def control_gc_stats(unix: false)
     cli_server "-t1:1 -q test/rackup/hello.ru #{set_pumactl_args unix: unix} -S #{@state_path}"
 
-    key = Puma::IS_MRI || TRUFFLE_HEAD ? "count" : "used"
+    key = Puma::IS_MRI ? "count" : "used"
 
     resp_io = cli_pumactl "gc-stats", unix: unix
     before = JSON.parse resp_io.read.split("\n", 2).last


### PR DESCRIPTION
### Description

Currently, TruffleRuby head (not release TruffleRuby) is silently failing on two tests shown below.  Fix the tests.

```
TestIntegrationPumactl#test_control_gc_stats_tcp
Failure: [test/test_integration_pumactl.rb:300]:

make sure a gc has happened.
Expected 0 to be < 0.

TestIntegrationPumactl#test_control_gc_stats_unix
Failure: [test/test_integration_pumactl.rb:300]:

make sure a gc has happened.
Expected 0 to be < 0.
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
