### PR TITLE
ci: tests.yml - set 'allow-failure' to false for non MRI jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,14 +158,14 @@ jobs:
           # tto - test timeout
           - { tto: 8 , os: ubuntu-22.04 , ruby: jruby }
           - { tto: 8 , os: ubuntu-22.04 , ruby: jruby, no-ssl: ' no SSL' }
-          - { tto: 8 , os: ubuntu-22.04 , ruby: jruby-head, allow-failure: true }
-          - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby, allow-failure: true } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
-          - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby-head, allow-failure: true }
-          - { tto: 8 , os: ubuntu-24.04 , ruby: truffleruby, allow-failure: true } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
-          - { tto: 8 , os: ubuntu-24.04 , ruby: truffleruby-head, allow-failure: true }
+          - { tto: 8 , os: ubuntu-22.04 , ruby: jruby-head, allow-failure: false }
+          - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby, allow-failure: false } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
+          - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby-head, allow-failure: false }
+          - { tto: 8 , os: ubuntu-24.04 , ruby: truffleruby, allow-failure: false } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
+          - { tto: 8 , os: ubuntu-24.04 , ruby: truffleruby-head, allow-failure: false }
           - { tto: 8 , os: macos-13     , ruby: jruby }
           - { tto: 8 , os: macos-14     , ruby: jruby }
-          - { tto: 8 , os: macos-13     , ruby: truffleruby, allow-failure: true }
+          - { tto: 8 , os: macos-13     , ruby: truffleruby, allow-failure: false }
 
     steps:
       - name: repo checkout


### PR DESCRIPTION
### Description

Having recently jumped back into Puma, I've noticed that non-MRI jobs (JRuby & TruffleRuby) seem to be stable, so I think it's time to remove the 'allow-failure' that happens with many non-MRI jobs.

The PR changes the setting from `true` to `false`, rather than removing the key value.

Additionally, people involved with both JRuby & TruffleRuby have contributed to Puma, so it seems appropriate to support both platforms, especially their head builds.

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
