### PR TITLE
runner.rb - remove `ruby_engine` method, deprecated Nov-2024

### DIFF
--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -92,22 +92,6 @@ module Puma
       @control.binder.close_listeners if @control
     end
 
-    # @!attribute [r] ruby_engine
-    # @deprecated Use `RUBY_DESCRIPTION` instead
-    def ruby_engine
-      warn "Puma::Runner#ruby_engine is deprecated; use RUBY_DESCRIPTION instead. It will be removed in puma v7."
-
-      if !defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby"
-        "ruby #{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
-      else
-        if defined?(RUBY_ENGINE_VERSION)
-          "#{RUBY_ENGINE} #{RUBY_ENGINE_VERSION} - ruby #{RUBY_VERSION}"
-        else
-          "#{RUBY_ENGINE} #{RUBY_VERSION}"
-        end
-      end
-    end
-
     def output_header(mode)
       min_t = @options[:min_threads]
       max_t = @options[:max_threads]


### PR DESCRIPTION
### Description

Remove deprecated method from runner.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
