### PR TITLE
Fix handling of invalid Transfer-Encoding header errors

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -414,14 +414,15 @@ module Puma
           te_ary = te_lwr.split(',').each { |te| te.gsub!(STRIP_OWS, "") }
           te_count = te_ary.count CHUNKED
           te_valid = te_ary[0..-2].all? { |e| ALLOWED_TRANSFER_ENCODING.include? e }
-          if te_ary.last == CHUNKED && te_count == 1 && te_valid
-            @env.delete TRANSFER_ENCODING2
-            return setup_chunked_body body
-          elsif te_count > 1
+          if te_count > 1
             raise HttpParserError   , "#{TE_ERR_MSG}, multiple chunked: '#{te}'"
+          elsif te_ary.last != CHUNKED
+            raise HttpParserError   , "#{TE_ERR_MSG}, last value must be chunked: '#{te}'"
           elsif !te_valid
             raise HttpParserError501, "#{TE_ERR_MSG}, unknown value: '#{te}'"
           end
+          @env.delete TRANSFER_ENCODING2
+          return setup_chunked_body body
         elsif te_lwr == CHUNKED
           @env.delete TRANSFER_ENCODING2
           return setup_chunked_body body

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -56,6 +56,11 @@ module Puma
 
     TE_ERR_MSG = 'Invalid Transfer-Encoding'
 
+    # See:
+    # https://httpwg.org/specs/rfc9110.html#rfc.section.5.6.1.1
+    # https://httpwg.org/specs/rfc9112.html#rfc.section.6.1
+    STRIP_OWS = /\A[ \t]+|[ \t]+\z/
+
     # The object used for a request with no body. All requests with
     # no body share this one object since it has no state.
     EmptyBody = NullIO.new
@@ -406,8 +411,7 @@ module Puma
       if te
         te_lwr = te.downcase
         if te.include? ','
-          te_ary = te_lwr.split ','
-          te_ary.each(&:strip!)
+          te_ary = te_lwr.split(',').each { |te| te.gsub!(STRIP_OWS, "") }
           te_count = te_ary.count CHUNKED
           te_valid = te_ary[0..-2].all? { |e| ALLOWED_TRANSFER_ENCODING.include? e }
           if te_ary.last == CHUNKED && te_count == 1 && te_valid

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -407,12 +407,13 @@ module Puma
         te_lwr = te.downcase
         if te.include? ','
           te_ary = te_lwr.split ','
+          te_ary.each(&:strip!)
           te_count = te_ary.count CHUNKED
           te_valid = te_ary[0..-2].all? { |e| ALLOWED_TRANSFER_ENCODING.include? e }
           if te_ary.last == CHUNKED && te_count == 1 && te_valid
             @env.delete TRANSFER_ENCODING2
             return setup_chunked_body body
-          elsif te_count >= 1
+          elsif te_count > 1
             raise HttpParserError   , "#{TE_ERR_MSG}, multiple chunked: '#{te}'"
           elsif !te_valid
             raise HttpParserError501, "#{TE_ERR_MSG}, unknown value: '#{te}'"

--- a/test/test_request_single.rb
+++ b/test/test_request_single.rb
@@ -406,8 +406,7 @@ class TestTransferEncodingInvalid < TestRequestBase
     ].join "\r\n"
 
     assert_invalid "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}",
-      "Invalid Transfer-Encoding, unknown value: 'chunked, gzip'",
-      Puma::HttpParserError501
+      "Invalid Transfer-Encoding, last value must be chunked: 'chunked, gzip'"
   end
 
   def test_chunked_multiple

--- a/test/test_request_single.rb
+++ b/test/test_request_single.rb
@@ -132,6 +132,27 @@ class TestRequestValid < TestRequestBase
       fail
     end
   end
+
+  def test_gzip_chunked
+    te = "gzip \t , \t chunked"
+    request = <<~REQ.gsub("\n", "\r\n").rstrip
+      GET / HTTP/1.1
+      Transfer_Encoding: #{te}
+      Content_Length: 11
+
+      Hello World
+    REQ
+
+    create_client request
+
+    if @parser.finished?
+      assert_equal '11', @client.env['HTTP_CONTENT,LENGTH']
+      assert_equal te, @client.env['HTTP_TRANSFER,ENCODING']
+      assert_instance_of Puma::NullIO, @client.body
+    else
+      fail
+    end
+  end
 end
 
 # Tests request start line, which sets `env` values for:

--- a/test/test_request_single.rb
+++ b/test/test_request_single.rb
@@ -385,7 +385,8 @@ class TestTransferEncodingInvalid < TestRequestBase
     ].join "\r\n"
 
     assert_invalid "#{GET_PREFIX}#{te}\r\n\r\n#{CHUNKED}",
-      "Invalid Transfer-Encoding, multiple chunked: 'chunked, gzip'"
+      "Invalid Transfer-Encoding, unknown value: 'chunked, gzip'",
+      Puma::HttpParserError501
   end
 
   def test_chunked_multiple


### PR DESCRIPTION
- `chunked,gzip` case was handled incorrectly. It should be reported as an unknown (unsupported) value.
- spaces were not stripped so something like `chunked, gzip, chunked` also was handled incorrectly.

