### PR TITLE
Fix SSL_shutdown error handling

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -309,7 +309,7 @@ module Puma
       end
     rescue StandardError => e
       client_error(e, client)
-      client.close
+      close_client_safely(client)
       true
     end
 
@@ -382,11 +382,9 @@ module Puma
                   next
                 end
                 drain += 1 if shutting_down?
-                pool << Client.new(io, @binder.env(sock)).tap { |c|
-                  c.listener = sock
-                  c.http_content_length_limit = @http_content_length_limit
-                  c.send(addr_send_name, addr_value) if addr_value
-                }
+                client = new_client(io, sock)
+                client.send(addr_send_name, addr_value) if addr_value
+                pool << client
               end
             end
           rescue IOError, Errno::EBADF
@@ -421,6 +419,14 @@ module Puma
       end
 
       @events.fire :state, :done
+    end
+
+    # :nodoc:
+    def new_client(io, sock)
+      client = Client.new(io, @binder.env(sock))
+      client.listener = sock
+      client.http_content_length_limit = @http_content_length_limit
+      client
     end
 
     # :nodoc:
@@ -513,14 +519,19 @@ module Puma
       ensure
         client.io_buffer.reset
 
-        begin
-          client.close if close_socket
-        rescue IOError, SystemCallError
-          # Already closed
-        rescue StandardError => e
-          @log_writer.unknown_error e, nil, "Client"
-        end
+        close_client_safely(client) if close_socket
       end
+    end
+
+    # :nodoc:
+    def close_client_safely(client)
+      client.close
+    rescue IOError, SystemCallError
+      # Already closed
+    rescue MiniSSL::SSLError => e
+      @log_writer.ssl_error e, client.io
+    rescue StandardError => e
+      @log_writer.unknown_error e, nil, "Client"
     end
 
     # Triggers a client timeout if the thread-pool shuts down

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -37,10 +37,15 @@ end
 if Puma::HAS_SSL
   require 'puma/log_writer'
   class SSLLogWriterHelper < ::Puma::LogWriter
-    attr_accessor :addr, :cert, :error
+    attr_accessor :addr, :cert
+    attr_reader :errors
+
+    def error
+      @errors&.last
+    end
 
     def ssl_error(error, ssl_socket)
-      self.error = error
+      (@errors ||= []) << error
       self.addr = ssl_socket.peeraddr.last rescue "<unknown>"
       self.cert = ssl_socket.peercert
     end

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -216,6 +216,25 @@ class TestPumaServerSSL < PumaTest
     assert busy_threads.zero?, "Our connection wasn't dropped"
   end
 
+  def test_http_10_close_no_errors
+    start_server
+
+    assert_equal 'https', send_http_read_response(GET_10, ctx: new_ctx).body
+
+    assert_empty @log_stderr.string
+  end
+
+  def test_http_11_close_no_errors
+    start_server
+
+    skt = send_http ctx: new_ctx
+
+    assert_equal 'https', skt.read_response.body
+    skt.close
+
+    assert_empty @log_stderr.string
+  end
+
   unless Puma.jruby?
     def test_invalid_cert
       assert_raises(Puma::MiniSSL::SSLError) do


### PR DESCRIPTION
`SSL_shutdown()` call may result in error and in OpenSSL every error should be consumed by the valler via `SSL_get_error()` or a similar func.

`MiniSSL` implementation was breaking this convention so it resulted in cryptic bugs like SSL clients (not related to Puma in any way) return errors with text like `"SSL_read: shutdown while in init"` that is initially generated by the Puma reactor but not consumed by it.

Such bugs are really hard to debug...

### Description
Thank you for contributing! You're the best.

We can read your code, so consider leaving some comments here that are more about your motivations and decision making. Some things that may be helpful to address in your description:

- What original problem led to this PR?
- Are there related issues / prior discussions?
- What alternatives have been tried? Does this supersede previous attempts?
- Why do you make the choices you did? What are the tradeoffs?

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
