### PR TITLE
Fix the ability to focus individual tests

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -12,6 +12,7 @@ require_relative 'client'
 require_relative 'binder'
 require_relative 'util'
 require_relative 'request'
+require_relative 'configuration'
 
 require 'socket'
 require 'io/wait' unless Puma::HAS_NATIVE_IO_WAIT

--- a/test/test_log_writer.rb
+++ b/test/test_log_writer.rb
@@ -142,7 +142,7 @@ class TestLogWriter < PumaTest
     assert_match %r!\("GET #{path}" - \(-\)\)!, log_writer.stderr.string
   ensure
     sock.close if sock && !sock.closed?
-    server.stop true
+    server&.stop(true)
   end
 
   # test_puma_server_ssl.rb checks that ssl errors are raised correctly,


### PR DESCRIPTION
<details>
<summary>Script</summary>

This script runs all test files one by one and reports which cannot be run via being focused

```bash
#!/bin/bash
cd "$(dirname "$0")/.."
failed_tests=()
for test in test/test_*.rb; do
  if bundle exec m "$test" >/dev/null 2>&1; then
    echo "✓ $(basename "$test")"
  else
    echo "✗ $(basename "$test")"
    failed_tests+=("$test")
  fi
done

echo

if [ ${#failed_tests[@]} -eq 0 ]; then
  echo "All tests passed! ✨"
else
  echo "Failed tests:"
  printf '%s\n' "${failed_tests[@]}"
  echo
  echo "The above tests cannot be focused with 'bundle exec m <test-name>' fix them"
  exit 1
fi

```
</details>

I was trying to focus test a specific file for a PR and I couldn't due to errors. I wrote a script to print out all the files that couldn't be focused, turns out they were all due to one missing require.

Before:

```
Failed tests:
test/test_log_writer.rb
test/test_out_of_band_server.rb
test/test_persistent.rb
test/test_puma_localhost_authority.rb
test/test_puma_server_current.rb
test/test_puma_server_hijack.rb
test/test_puma_server_ssl.rb
test/test_puma_server.rb
test/test_rack_server.rb
test/test_request_invalid_multiple.rb
test/test_response_header.rb
test/test_unix_socket.rb
test/test_web_server.rb

The above tests cannot be focused with 'bundle exec m <test-name>' fix them
```

After:

```
All tests passed! ✨
```