### PR TITLE
Remove HTTP_VERSION use SERVER_PROTOCOL instead

### DIFF
--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -479,9 +479,13 @@ module Puma
         env[REMOTE_ADDR] = addr
       end
 
-      # The legacy HTTP_VERSION header can be sent as a client header.
-      # Rack v4 may remove using HTTP_VERSION.  If so, remove this line.
-      env[HTTP_VERSION] = env[SERVER_PROTOCOL]
+      # This assignment of HTTP_VERSION can be removed once Rack 2 is no longer supported
+      #
+      # - It is used in recently released software (Sinatra 3.2.0)
+      #   https://github.com/sinatra/sinatra/blob/4e8fdb5172a81c1c237388f264e5684a4a15ed4f/lib/sinatra/base.rb#L303-L315
+       if Object.const_defined?(:Rack) && Rack.release < "3.1.0"
+        env[HTTP_VERSION] = env[SERVER_PROTOCOL]
+       end
     end
     private :normalize_env
 


### PR DESCRIPTION
Going back to 2010 the rack spec (https://github.com/rack/rack/commit/859ab9f1455d42a7e5879024ea9505ac810b1726) states:

```
<tt>HTTP_</tt> Variables:: Variables corresponding to the
                           client-supplied HTTP request
                           headers (i.e., variables whose
                           names begin with <tt>HTTP_</tt>). The
                           presence or absence of these
                           variables should correspond with
                           the presence or absence of the
                           appropriate HTTP header in the
                           request.
```

Puma used HTTP_VERSION to return the server protocol information i.e. HTTP/1.0 or HTTP/1.1 to the rack app. However we can see this violated the rack spec since it does not correspond to an HTTP_ key in a header provided by a client.

Rack added SERVER_PROTOCOL as an interface in Rack 3.0 and Puma adopted this in 2022 https://github.com/puma/puma/pull/2871 but aliased HTTP_VERSION to SERVER_PROTOCOL. This removes the alias and brings Puma closer to the spec for Rack 3.1+.

Still supporting the variable as recent software (Sinatra 3.2.0) still relies on it https://github.com/sinatra/sinatra/blob/4e8fdb5172a81c1c237388f264e5684a4a15ed4f/lib/sinatra/base.rb#L303-L315 and we want them to be able to use Puma 7.

close #3576

