### PR TITLE
add `after_worker_shutdown` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ Preloading can’t be used with phased restart, since phased restart kills and r
 
 #### Cluster mode hooks
 
-When using clustered mode, Puma's configuration DSL provides `before_fork` and `before_worker_boot`
-hooks to run code when the master process forks and child workers are booted respectively.
+When using clustered mode, Puma's configuration DSL provides `before_fork`, `before_worker_boot`, and `after_worker_shutdown`
+hooks to run code when the master process forks, the child workers are booted, and after each child worker exits respectively.
 
 It is recommended to use these hooks with `preload_app!`, otherwise constants loaded by your
 application (such as `Rails`) will not be available inside the hooks.
@@ -156,6 +156,11 @@ end
 
 before_worker_boot do
   # Add code to run inside the Puma worker process after forking.
+end
+
+after_worker_shutdown do |worker_handle|
+  # Add code to run inside the Puma master process after a worker exits. `worker.process_status` can be used to get the
+  # `Process::Status` of the exited worker.
 end
 ```
 

--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -28,10 +28,10 @@ module Puma
         @worker_max = Array.new WORKER_MAX_KEYS.length, 0
       end
 
-      attr_reader :index, :pid, :phase, :signal, :last_checkin, :last_status, :started_at
+      attr_reader :index, :pid, :phase, :signal, :last_checkin, :last_status, :started_at, :process_status
 
       # @version 5.0.0
-      attr_writer :pid, :phase
+      attr_writer :pid, :phase, :process_status
 
       def booted?
         @stage == :booted

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -818,6 +818,20 @@ module Puma
 
     alias_method :after_worker_boot, :after_worker_fork
 
+    # Code to run in the master right after a worker has stopped. The worker's
+    # index and Process::Status are passed as arguments.
+    #
+    # @note Cluster mode only.
+    #
+    # @example
+    #   after_worker_shutdown do |worker_handle|
+    #     puts 'Worker crashed' unless worker_handle.process_status.success?
+    #   end
+    #
+    def after_worker_shutdown(&block)
+      process_hook :after_worker_shutdown, nil, block, cluster_only: true
+    end
+
     # Code to run after puma is booted (works for both single and cluster modes).
     #
     # @example

--- a/test/config/after_shutdown_hook.rb
+++ b/test/config/after_shutdown_hook.rb
@@ -1,0 +1,5 @@
+workers 2
+
+after_worker_shutdown do |worker|
+  STDOUT.syswrite "\nafter_worker_shutdown worker=#{worker.index} status=#{worker.process_status.to_i}"
+end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -579,6 +579,19 @@ class TestIntegrationCluster < TestIntegration
     assert 'index 1 data 1', ary[1]
   end
 
+  def test_after_worker_shutdown_hook
+    cli_server "-C test/config/after_shutdown_hook.rb test/rackup/hello.ru"
+    get_worker_pids 0, 2 # make sure workers are booted
+    stop_server
+
+    ary = Array.new(2) do |_index|
+      wait_for_server_to_match(/(after_worker_shutdown worker=\d status=\d+)/, 1)
+    end.sort
+
+    assert_equal 'after_worker_shutdown worker=0 status=0', ary[0]
+    assert_equal 'after_worker_shutdown worker=1 status=0', ary[1]
+  end
+
   def test_worker_hook_warning_cli
     cli_server "-w2 test/rackup/hello.ru", config: <<~CONFIG
       before_worker_boot(:test) do |index, data|


### PR DESCRIPTION
### Description
Add a new worker lifecycle hook `after_worker_shutdown` that runs in the parent process. This can be used to e.g., send a notification when a worker process crashes.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.