### PR TITLE
Dry up deprecation warnings and fix deprecation warnings when running CI.

### DIFF
--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -75,4 +75,14 @@ module Puma
   def self.set_thread_name(name)
     Thread.current.name = "puma #{name}"
   end
+
+  # Shows deprecated warning for renamed methods.
+  # @example
+  #   Puma.deprecate_method_change :on_booted, __callee__, __method__
+  #
+  def self.deprecate_method_change(method_old, method_caller, method_new)
+    if method_old == method_caller
+      warn "Use '#{method_new}', '#{method_caller}' is deprecated and will be removed in v8"
+    end
+  end
 end

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -442,9 +442,7 @@ module Puma
     #   end
     #
     def before_restart(&block)
-      if __callee__ == :on_restart
-        warn "on_restart is deprecated, use before_restart instead"
-      end
+      Puma.deprecate_method_change :on_restart, __callee__, __method__
 
       process_hook :before_restart, nil, block, 'before_restart'
     end
@@ -752,9 +750,7 @@ module Puma
     #   end
     #
     def before_worker_boot(key = nil, &block)
-      if __callee__ == :on_worker_boot
-        warn "on_worker_boot is deprecated, use before_worker_boot instead"
-      end
+      Puma.deprecate_method_change :on_worker_boot, __callee__, __method__
 
       process_hook :before_worker_boot, key, block, 'before_worker_boot', cluster_only: true
     end
@@ -777,9 +773,7 @@ module Puma
     #   end
     #
     def before_worker_shutdown(key = nil, &block)
-      if __callee__ == :on_worker_shutdown
-        warn "on_worker_shutdown is deprecated, use before_worker_shutdown instead"
-      end
+      Puma.deprecate_method_change :on_worker_shutdown, __callee__, __method__
 
       process_hook :before_worker_shutdown, key, block, 'before_worker_shutdown', cluster_only: true
     end
@@ -799,9 +793,7 @@ module Puma
     #   end
     #
     def before_worker_fork(&block)
-      if __callee__ == :on_worker_fork
-        warn "on_worker_fork is deprecated, use before_worker_fork instead"
-      end
+      Puma.deprecate_method_change :on_worker_fork, __callee__, __method__
 
       process_hook :before_worker_fork, nil, block, 'before_worker_fork', cluster_only: true
     end
@@ -834,9 +826,7 @@ module Puma
     #   end
     #
     def after_booted(&block)
-      if __callee__ == :on_booted
-        warn "on_booted is deprecated, use after_booted instead"
-      end
+      Puma.deprecate_method_change :on_booted, __callee__, __method__
 
       @config.events.after_booted(&block)
     end
@@ -851,9 +841,7 @@ module Puma
     #   end
     #
     def after_stopped(&block)
-      if __callee__ == :on_stopped
-        warn "on_stopped is deprecated, use after_stopped instead"
-      end
+      Puma.deprecate_method_change :on_stopped, __callee__, __method__
 
       @config.events.after_stopped(&block)
     end
@@ -880,9 +868,7 @@ module Puma
     # @version 5.0.0
     #
     def before_refork(key = nil, &block)
-      if __callee__ == :on_refork
-        warn "on_refork is deprecated, use before_refork instead"
-      end
+      Puma.deprecate_method_change :on_refork, __callee__, __method__
 
       process_hook :before_refork, key, block, 'before_refork', cluster_only: true
     end
@@ -928,9 +914,7 @@ module Puma
     #   end
     #
     def before_thread_start(&block)
-      if __callee__ == :on_thread_start
-        warn "on_thread_start is deprecated, use before_thread_start instead"
-      end
+      Puma.deprecate_method_change :on_thread_start, __callee__, __method__
 
       process_hook :before_thread_start, nil, block, 'before_thread_start'
     end
@@ -958,9 +942,7 @@ module Puma
     #   end
     #
     def before_thread_exit(&block)
-      if __callee__ == :on_thread_exit
-        warn "on_thread_exit is deprecated, use before_thread_exit instead"
-      end
+      Puma.deprecate_method_change :on_thread_exit, __callee__, __method__
 
       process_hook :before_thread_exit, nil, block, 'before_thread_exit'
     end
@@ -1319,7 +1301,7 @@ module Puma
     # @deprecated Use {#max_keep_alive} instead.
     #
     def max_fast_inline(num_of_requests)
-      warn "[WARNING] `max_fast_inline` is deprecated use `max_keep_alive` instead"
+      Puma.deprecate_method_change :max_fast_inline, __method__, :max_keep_alive
       @options[:max_keep_alive] ||= Float(num_of_requests) unless num_of_requests.nil?
     end
 

--- a/test/config/max_fast_inline_infinity.rb
+++ b/test/config/max_fast_inline_infinity.rb
@@ -1,1 +1,1 @@
-max_fast_inline Float::INFINITY
+max_keep_alive Float::INFINITY

--- a/test/config/max_keep_alive_infinity.rb
+++ b/test/config/max_keep_alive_infinity.rb
@@ -1,1 +1,1 @@
-max_fast_inline Float::INFINITY
+max_keep_alive Float::INFINITY

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -397,7 +397,7 @@ class TestCLI < PumaTest
   def test_plugins
     assert_empty Puma::Plugins.instance_variable_get(:@plugins)
 
-    cli = Puma::CLI.new ['--plugin', 'tmp_restart', '--plugin', 'systemd']
+    Puma::CLI.new ['--plugin', 'tmp_restart', '--plugin', 'systemd']
 
     assert Puma::Plugins.find("tmp_restart")
     assert Puma::Plugins.find("systemd")
@@ -406,7 +406,7 @@ class TestCLI < PumaTest
   def test_config_does_not_preload_app_with_workers
     skip_unless :fork
 
-    cli = Puma::CLI.new ['-w 0']
+    Puma::CLI.new ['-w 0']
     config = Puma.cli_config
 
     assert_equal false, config.options[:preload_app]
@@ -415,7 +415,7 @@ class TestCLI < PumaTest
   def test_config_preloads_app_with_workers
     skip_unless :fork
 
-    cli = Puma::CLI.new ['-w 2']
+    Puma::CLI.new ['-w 2']
     config = Puma.cli_config
 
     assert_equal true, config.options[:preload_app]

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -744,7 +744,7 @@ class TestConfigFile < PumaTest
       conf.clamp
     end
 
-    assert_match /Warning: The code in the `#{hook_name}` block will not execute in the current Puma configuration/, out
+    assert_match(/Warning: The code in the `#{hook_name}` block will not execute in the current Puma configuration/, out)
   end
 end
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -442,8 +442,8 @@ class TestConfigFile < PumaTest
     assert_equal 150, conf.options[:worker_shutdown_timeout]
   end
 
-  def test_config_files_max_fast_inline_infinity
-    conf = Puma::Configuration.new(config_files: ['test/config/max_fast_inline_infinity.rb']) do
+  def test_config_files_max_keep_alive_infinity
+    conf = Puma::Configuration.new(config_files: ['test/config/max_keep_alive_infinity.rb']) do
     end
     conf.clamp
 
@@ -478,12 +478,12 @@ class TestConfigFile < PumaTest
 
   def test_run_hooks_before_restart_hook
     assert_run_hooks :before_restart
-    assert_run_hooks :before_restart, configured_with: :on_restart
+    assert_run_hooks :before_restart, configured_with: :before_restart
     assert_raise_on_hooks_without_block :before_restart
   end
 
   def test_run_hooks_before_worker_fork
-    assert_run_hooks :before_worker_fork, configured_with: :on_worker_fork
+    assert_run_hooks :before_worker_fork, configured_with: :before_worker_fork
 
     assert_raise_on_hooks_without_block :before_worker_fork
     assert_warning_for_hooks_defined_in_single_mode :before_worker_fork
@@ -498,7 +498,7 @@ class TestConfigFile < PumaTest
 
   def test_run_hooks_before_worker_boot
     assert_run_hooks :before_worker_boot
-    assert_run_hooks :before_worker_boot, configured_with: :on_worker_boot
+    assert_run_hooks :before_worker_boot, configured_with: :before_worker_boot
 
     assert_raise_on_hooks_without_block :before_worker_boot
     assert_warning_for_hooks_defined_in_single_mode :before_worker_boot
@@ -506,7 +506,7 @@ class TestConfigFile < PumaTest
 
   def test_run_hooks_before_worker_shutdown
     assert_run_hooks :before_worker_shutdown
-    assert_run_hooks :before_worker_shutdown, configured_with: :on_worker_shutdown
+    assert_run_hooks :before_worker_shutdown, configured_with: :before_worker_shutdown
 
     assert_raise_on_hooks_without_block :before_worker_shutdown
     assert_warning_for_hooks_defined_in_single_mode :before_worker_shutdown
@@ -521,7 +521,7 @@ class TestConfigFile < PumaTest
 
   def test_run_hooks_before_refork
     assert_run_hooks :before_refork
-    assert_run_hooks :before_refork, configured_with: :on_refork
+    assert_run_hooks :before_refork, configured_with: :before_refork
 
     assert_raise_on_hooks_without_block :before_refork
     assert_warning_for_hooks_defined_in_single_mode :before_refork
@@ -529,13 +529,13 @@ class TestConfigFile < PumaTest
 
   def test_run_hooks_before_thread_start
     assert_run_hooks :before_thread_start
-    assert_run_hooks :before_thread_start, configured_with: :on_thread_start
+    assert_run_hooks :before_thread_start, configured_with: :before_thread_start
     assert_raise_on_hooks_without_block :before_thread_start
   end
 
   def test_run_hooks_before_thread_exit
     assert_run_hooks :before_thread_exit
-    assert_run_hooks :before_thread_exit, configured_with: :on_thread_exit
+    assert_run_hooks :before_thread_exit, configured_with: :before_thread_exit
     assert_raise_on_hooks_without_block :before_thread_exit
   end
 

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1412,7 +1412,7 @@ class TestPumaServer < PumaTest
     req_count = 20
     requests = 0
 
-    server_run(max_fast_inline: 21) { |env|
+    server_run(max_keep_alive: 21) { |env|
       requests += 1
       env['rack.input'].read
       [200, {}, ["Request_#{requests}"]]


### PR DESCRIPTION
### Description
See title

Closes #3708.

Should we turn warnings on in CI?  Not included in this PR.

Also, the warnings for method name changes do not show a file/line number.  Should they?

- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
