### PR TITLE
Simplify `Puma::DSL#process_hook` logic

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -430,15 +430,16 @@ module Puma
       return if options[:workers] > 0
       return if options[:silence_fork_callback_warning]
 
-      @hooks.each do |key, method|
-        options.all_of(key).each do |hook_options|
+      log_writer = LogWriter.stdio
+      @hooks.each_key do |hook|
+        options.all_of(hook).each do |hook_options|
           next unless hook_options[:cluster_only]
 
-          LogWriter.stdio.log(<<~MSG.tr("\n", " "))
-            Warning: The code in the `#{method}` block will not execute
-            in the current Puma configuration. The `#{method}` block only
+          log_writer.log(<<~MSG.tr("\n", " "))
+            Warning: The code in the `#{hook}` block will not execute
+            in the current Puma configuration. The `#{hook}` block only
             executes in Puma's cluster mode. To fix this, either remove the
-            `#{method}` call or increase Puma's worker count above zero.
+            `#{hook}` call or increase Puma's worker count above zero.
           MSG
         end
       end

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -446,7 +446,7 @@ module Puma
         warn "on_restart is deprecated, use before_restart instead"
       end
 
-      process_hook :before_restart, nil, block, 'before_restart'
+      process_hook :before_restart, nil, block
     end
 
     alias_method :on_restart, :before_restart
@@ -736,7 +736,7 @@ module Puma
     #   end
     #
     def before_fork(&block)
-      process_hook :before_fork, nil, block, 'before_fork', cluster_only: true
+      process_hook :before_fork, nil, block, cluster_only: true
     end
 
     # Code to run in a worker when it boots to setup
@@ -756,7 +756,7 @@ module Puma
         warn "on_worker_boot is deprecated, use before_worker_boot instead"
       end
 
-      process_hook :before_worker_boot, key, block, 'before_worker_boot', cluster_only: true
+      process_hook :before_worker_boot, key, block, cluster_only: true
     end
 
     alias_method :on_worker_boot, :before_worker_boot
@@ -781,7 +781,7 @@ module Puma
         warn "on_worker_shutdown is deprecated, use before_worker_shutdown instead"
       end
 
-      process_hook :before_worker_shutdown, key, block, 'before_worker_shutdown', cluster_only: true
+      process_hook :before_worker_shutdown, key, block, cluster_only: true
     end
 
     alias_method :on_worker_shutdown, :before_worker_shutdown
@@ -803,7 +803,7 @@ module Puma
         warn "on_worker_fork is deprecated, use before_worker_fork instead"
       end
 
-      process_hook :before_worker_fork, nil, block, 'before_worker_fork', cluster_only: true
+      process_hook :before_worker_fork, nil, block, cluster_only: true
     end
 
     alias_method :on_worker_fork, :before_worker_fork
@@ -821,7 +821,7 @@ module Puma
     #   end
     #
     def after_worker_fork(&block)
-      process_hook :after_worker_fork, nil, block, 'after_worker_fork', cluster_only: true
+      process_hook :after_worker_fork, nil, block, cluster_only: true
     end
 
     alias_method :after_worker_boot, :after_worker_fork
@@ -884,7 +884,7 @@ module Puma
         warn "on_refork is deprecated, use before_refork instead"
       end
 
-      process_hook :before_refork, key, block, 'before_refork', cluster_only: true
+      process_hook :before_refork, key, block, cluster_only: true
     end
 
     alias_method :on_refork, :before_refork
@@ -907,7 +907,7 @@ module Puma
     #   end
     #
     def after_refork(key = nil, &block)
-      process_hook :after_refork, key, block, 'after_refork'
+      process_hook :after_refork, key, block
     end
 
     # Provide a block to be executed just before a thread is added to the thread
@@ -932,7 +932,7 @@ module Puma
         warn "on_thread_start is deprecated, use before_thread_start instead"
       end
 
-      process_hook :before_thread_start, nil, block, 'before_thread_start'
+      process_hook :before_thread_start, nil, block
     end
 
     alias_method :on_thread_start, :before_thread_start
@@ -962,7 +962,7 @@ module Puma
         warn "on_thread_exit is deprecated, use before_thread_exit instead"
       end
 
-      process_hook :before_thread_exit, nil, block, 'before_thread_exit'
+      process_hook :before_thread_exit, nil, block
     end
 
     alias_method :on_thread_exit, :before_thread_exit
@@ -978,7 +978,7 @@ module Puma
     # This can be called multiple times to add several hooks.
     #
     def out_of_band(&block)
-      process_hook :out_of_band, nil, block, 'out_of_band'
+      process_hook :out_of_band, nil, block
     end
 
     # The directory to operate out of.
@@ -1463,19 +1463,19 @@ module Puma
       end
     end
 
-    def process_hook(options_key, key, block, method, cluster_only: false)
-      raise ArgumentError, "expected #{method} to be given a block" unless block
+    def process_hook(options_key, key, block, cluster_only: false)
+      raise ArgumentError, "expected #{options_key} to be given a block" unless block
 
-      @config.hooks[options_key] = method
+      @config.hooks[options_key] = true
 
       @options[options_key] ||= []
       hook_options = { block: block, cluster_only: cluster_only }
-      hook_options[:id] = if ON_WORKER_KEY.include? key.class
+      hook_options[:id] = if ON_WORKER_KEY.include?(key.class)
         key.to_sym
       elsif key.nil?
         nil
       else
-        raise "'#{method}' key must be String or Symbol"
+        raise "'#{options_key}' key must be String or Symbol"
       end
       @options[options_key] << hook_options
     end


### PR DESCRIPTION
### Description

Follow-up to https://github.com/puma/puma/pull/3438 and https://github.com/puma/puma/pull/3616.

In #3438, hooks were renamed and aliases were added for their deprecated names. The `process_hook` calls were also updated to pass the new method names as the fourth positional argument. Looking back, that PR probably should have passed `__callee__`/`__method__` instead, so that cluster-only hook warnings in single mode would use the correct method name. However, I think it's acceptable that only the new method name is shown, since users will see a deprecation warning with the old name before they encounter the single mode warnings, so they won't be entirely confused about what's being referenced.

In #3616, I refactored the warning logic. This PR follows up on that work because the key used to store these hooks in the options hash now matches the new method name, making it unnecessary to pass both values. I've maintained the approach of not referencing the old name and have removed the fourth argument entirely, which allows us to simplify `process_hook` a bit. See the comments for additional details.

**Note:** All these changes have comprehensive coverage in https://github.com/puma/puma/blob/master/test/test_config.rb.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.