### PR TITLE
Don't set `env['HTTP_VERSION']` for Rack > 3.1

### DIFF
--- a/lib/puma/commonlogger.rb
+++ b/lib/puma/commonlogger.rb
@@ -29,13 +29,13 @@ module Puma
 
     CONTENT_LENGTH       = 'Content-Length' # should be lower case from app,
                                             # Util::HeaderHash allows mixed
-    HTTP_VERSION         = Const::HTTP_VERSION
     HTTP_X_FORWARDED_FOR = Const::HTTP_X_FORWARDED_FOR
     PATH_INFO            = Const::PATH_INFO
     QUERY_STRING         = Const::QUERY_STRING
     REMOTE_ADDR          = Const::REMOTE_ADDR
     REMOTE_USER          = 'REMOTE_USER'
     REQUEST_METHOD       = Const::REQUEST_METHOD
+    SERVER_PROTOCOL      = Const::SERVER_PROTOCOL
 
     def initialize(app, logger=nil)
       @app = app
@@ -70,7 +70,7 @@ module Puma
         env[REQUEST_METHOD],
         env[PATH_INFO],
         env[QUERY_STRING].empty? ? "" : "?#{env[QUERY_STRING]}",
-        env[HTTP_VERSION],
+        env[SERVER_PROTOCOL],
         now - began_at ]
 
       write(msg)
@@ -87,7 +87,7 @@ module Puma
         env[REQUEST_METHOD],
         env[PATH_INFO],
         env[QUERY_STRING].empty? ? "" : "?#{env[QUERY_STRING]}",
-        env[HTTP_VERSION],
+        env[SERVER_PROTOCOL],
         status.to_s[0..3],
         length,
         now - began_at ]

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -481,7 +481,7 @@ module Puma
 
       # The legacy HTTP_VERSION header can be sent as a client header.
       # Rack v4 may remove using HTTP_VERSION.  If so, remove this line.
-      env[HTTP_VERSION] = env[SERVER_PROTOCOL]
+      env[HTTP_VERSION] = env[SERVER_PROTOCOL] if @env_set_http_version
     end
     private :normalize_env
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -327,6 +327,9 @@ module Puma
     end
 
     def handle_servers
+      @env_set_http_version = Object.const_defined?(:Rack) && ::Rack.respond_to?(:release) &&
+        Gem::Version.new(::Rack.release) < Gem::Version.new('3.1.0')
+
       begin
         check = @check
         sockets = [check] + @binder.ios


### PR DESCRIPTION
### Description

See #3706.  This PR Is very similar, but it sets an ivar (`@env_set_http_version`) in `Server#handle_servers` to determine whether to overwrite `env['HTTP_VERSION']` with the value of `env['SERVER_PROTOCOL']`.

Adds a test to `test_rack_server.rb`

Closes #3576

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
