### PR TITLE
server.rb - initialize ivars `@reactor` and `@env_set_http_version`

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -85,6 +85,9 @@ module Puma
 
       @thread = nil
       @thread_pool = nil
+      @reactor = nil
+
+      @env_set_http_version = nil
 
       @options = if options.is_a?(UserFileDefaultOptions)
         options


### PR DESCRIPTION
### Description

See [comment](https://github.com/puma/puma/pull/3711#issuecomment-3235392044), or

> Also the order that ivars are set can affect JIT caching. If we are going to set an ivar outside of initialize, we should define it as nil inside of initialize so the order of ivars is the same for every instance.

The above comment was directed at adding `@env_set_http_version` without initializing it.

I tried to audit whether any other ivars needed the same, and only noticed `@reactor`.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
