### PR TITLE
Fixes a bug where triggering hooks in the ThreadPool fails

### DIFF
--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -188,7 +188,7 @@ module Puma
 
       @before_thread_start.each do |b|
         begin
-          b.call
+          b[:block].call
         rescue Exception => e
           STDERR.puts "WARNING before_thread_start hook failed with exception (#{e.class}) #{e.message}"
         end
@@ -203,7 +203,7 @@ module Puma
 
       @before_thread_exit.each do |b|
         begin
-          b.call
+          b[:block].call
         rescue Exception => e
           STDERR.puts "WARNING before_thread_exit hook failed with exception (#{e.class}) #{e.message}"
         end
@@ -220,7 +220,7 @@ module Puma
       # we execute on idle hook when all threads are free
       return false unless @spawned == @waiting
       @out_of_band_running = true
-      @out_of_band.each(&:call)
+      @out_of_band.each { |b| b[:block].call }
       true
     rescue Exception => e
       STDERR.puts "Exception calling out_of_band_hook: #{e.message} (#{e.class})"


### PR DESCRIPTION
### Description

https://github.com/puma/puma/pull/3616 has introduced some internal changes to the hooks object, which used to be arrays of callable objects. Now it's arrays of hashes that contain these three keys: `:id`, `:block`, and `:cluster_only`. The methods that call these hooks in the `ThreadPool` class have not been updated as part of that PR, so they started failing as it attempts to call the `#call` method on the Hash object.

cc @joshuay03

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
