### PR TITLE
Set default keepalive connections to 999

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -147,7 +147,7 @@ module Puma
       # Limits how many requests a keep alive connection can make.
       # The connection will be closed after it reaches `max_keep_alive`
       # requests.
-      max_keep_alive: 25,
+      max_keep_alive: 999,
       max_threads: Puma.mri? ? 5 : 16,
       min_threads: 0,
       mode: :http,

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1309,7 +1309,7 @@ module Puma
     # Note that some applications (server to server) may benefit from a very high
     # number or Float::INFINITY.
     #
-    # The default is 25.
+    # The default is 999.
     #
     # @example
     #   max_keep_alive 20


### PR DESCRIPTION
When we initially merged #3678, we discussed the appropriate setting for this default `max_keep_alive` value and determined we didn't have a terribly good method for setting it. Therefore, we picked a magic number.

With #3715, I discovered that the setting `export RUBY_MN_THREADS=1` had disastrous effects on Puma 7.0.0.pre1 performance, but increasing this `max_keep_alive` value dramatically increased performance. The default value with nginx is 1000 http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests. Why not go full nginx and use 1000? Prudence is a virtue.

The test was modified to not require sending 1000 requests to observe the keepalive max behavior. This change effectively duplicated the behavior of `test_set_max_keep_alive`, so I removed the redundancy.