### PR TITLE
Warn when RUBY_MN_THREADS env var is set

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -421,6 +421,7 @@ module Puma
 
       log "Use Ctrl-C to stop"
 
+      warn_ruby_mn_threads
       single_worker_warning
 
       redirect_io

--- a/lib/puma/runner.rb
+++ b/lib/puma/runner.rb
@@ -111,6 +111,14 @@ module Puma
       end
     end
 
+    def warn_ruby_mn_threads
+      return if !ENV.key?('RUBY_MN_THREADS')
+
+      log "! WARNING: Detected `RUBY_MN_THREADS=#{ENV['RUBY_MN_THREADS']}`"
+      log "! This setting is known to cause performance regressions with Puma."
+      log "! Consider disabling this environment variable: https://github.com/puma/puma/issues/3720"
+    end
+
     def redirected_io?
       @options[:redirect_stdout] || @options[:redirect_stderr]
     end

--- a/lib/puma/single.rb
+++ b/lib/puma/single.rb
@@ -53,6 +53,9 @@ module Puma
       server_thread = server.run
 
       log "Use Ctrl-C to stop"
+
+      warn_ruby_mn_threads
+
       redirect_io
 
       @events.fire_after_booted!

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -483,6 +483,13 @@ class TestIntegrationCluster < TestIntegration
     assert_match(/WARNING: Detected running cluster mode with 1 worker/, @server_log)
   end
 
+  def test_warning_message_outputted_when_ruby_mn_threads_is_set
+    cli_server "-w 1 test/rackup/hello.ru", env: { 'RUBY_MN_THREADS' => '1' }
+
+    assert wait_for_server_to_include('Worker 0 (PID')
+    assert_match(/WARNING: Detected `RUBY_MN_THREADS/, @server_log)
+  end
+
   def test_warning_message_not_outputted_when_single_worker_silenced
     cli_server "-w 1 test/rackup/hello.ru", config: "silence_single_worker_warning"
 


### PR DESCRIPTION
This setting causes massive performance degradation with Puma 7+.

Warning suggested in https://github.com/puma/puma/issues/3715#issuecomment-3247388449. Tracking issue https://github.com/puma/puma/issues/3720.
