### PR TITLE
server.rb - improve delay conditional when workers < 2

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -384,15 +384,10 @@ module Puma
                 # clients until the code is finished.
                 sleep 0.001 while pool.out_of_band_running
 
-                # only use delay when clustered and busy
-                if pool.busy_threads >= @max_threads
-                  if @clustered
-                    delay = 0.0001 * ((@reactor&.reactor_size || 0) + pool.busy_threads * 1.5)/max_flt
-                    sleep delay
-                  else
-                    # use small sleep for busy single worker
-                    sleep 0.0001
-                  end
+                # only use delay when clustered (more than one worker) and busy
+                if @options[:workers] > 1 && (pbr = pool.busy_threads) >= 1.5 * @max_threads
+                  delay = 0.0001 * ((@reactor&.reactor_size || 0) + pbr * 1.5)/max_flt
+                  sleep delay
                 end
 
                 io = begin


### PR DESCRIPTION
### Description

When workers are either 0 or 1, a delay isn't needed, which is used to send connections to the least busy worker.  Also, the current code causes slowdowns with very fast responses (e.g. 'Hello World').

Seems to help with both keep-alive requests and non-keep-alive requests.

@dentarg - have time to check this with your various tests?  I've tried several...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
