### PR TITLE
Add backward compatibility aliases for Events class methods

### DIFF
--- a/lib/puma/events.rb
+++ b/lib/puma/events.rb
@@ -42,6 +42,21 @@ module Puma
       register(:after_stopped, &block)
     end
 
+    def on_booted(&block)
+      Puma.deprecate_method_change :on_booted, __callee__, :after_booted
+      after_booted(&block)
+    end
+
+    def on_restart(&block)
+      Puma.deprecate_method_change :on_restart, __callee__, :before_restart
+      before_restart(&block)
+    end
+
+    def on_stopped(&block)
+      Puma.deprecate_method_change :on_stopped, __callee__, :after_stopped
+      after_stopped(&block)
+    end
+
     def fire_after_booted!
       fire(:after_booted)
     end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -919,4 +919,37 @@ class TestConfigFileWithFakeEnv < PumaTest
 
     assert_equal conf.options[:enable_keep_alives], false
   end
+
+  def test_on_booted_deprecated_alias_works
+    ran = false
+    conf = Puma::Configuration.new do |c|
+      c.on_booted { ran = true }
+    end
+    conf.clamp
+
+    conf.events.fire_after_booted!
+    assert ran, "on_booted callback should have run"
+  end
+
+  def test_on_restart_deprecated_alias_works
+    ran = false
+    conf = Puma::Configuration.new do |c|
+      c.on_restart { ran = true }
+    end
+    conf.clamp
+
+    conf.run_hooks(:before_restart, 'ARG', Puma::LogWriter.strings)
+    assert ran, "on_restart callback should have run"
+  end
+
+  def test_on_stopped_deprecated_alias_works
+    ran = false
+    conf = Puma::Configuration.new do |c|
+      c.on_stopped { ran = true }
+    end
+    conf.clamp
+
+    conf.events.fire_after_stopped!
+    assert ran, "on_stopped callback should have run"
+  end
 end

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -59,4 +59,70 @@ class TestEvents < PumaTest
 
     assert res
   end
+
+  def test_before_restart_callback
+    res = false
+
+    events = Puma::Events.new
+
+    events.before_restart { res = true }
+
+    events.fire_before_restart!
+
+    assert res
+  end
+
+  def test_after_stopped_callback
+    res = false
+
+    events = Puma::Events.new
+
+    events.after_stopped { res = true }
+
+    events.fire_after_stopped!
+
+    assert res
+  end
+
+  def test_on_booted_deprecated_with_warning
+    res = false
+    events = Puma::Events.new
+
+    _, err = capture_io do
+      events.on_booted { res = true }
+    end
+
+    events.fire_after_booted!
+
+    assert res
+    assert_match(/Use 'after_booted', 'on_booted' is deprecated and will be removed in v8/, err)
+  end
+
+  def test_on_restart_deprecated_with_warning
+    res = false
+    events = Puma::Events.new
+
+    _, err = capture_io do
+      events.on_restart { res = true }
+    end
+
+    events.fire_before_restart!
+
+    assert res
+    assert_match(/Use 'before_restart', 'on_restart' is deprecated and will be removed in v8/, err)
+  end
+
+  def test_on_stopped_deprecated_with_warning
+    res = false
+    events = Puma::Events.new
+
+    _, err = capture_io do
+      events.on_stopped { res = true }
+    end
+
+    events.fire_after_stopped!
+
+    assert res
+    assert_match(/Use 'after_stopped', 'on_stopped' is deprecated and will be removed in v8/, err)
+  end
 end


### PR DESCRIPTION
### Description
The PR #3438 renamed callback methods from on_* to before_*/after_* pattern but only added aliases in DSL, not in Events class. This broke applications that call these methods directly on Events instances (e.g., [SolidQueue](https://github.com/rails/solid_queue/pull/635)).

Added on_booted, on_restart, on_stopped aliases with deprecation warnings

Fixes compatibility issue reported in #3724


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
