### PR TITLE
ci: setup-ruby - add a 'cache-version' so Bundler caches aren't mixed up

### DIFF
--- a/.github/workflows/rack_conform.yml
+++ b/.github/workflows/rack_conform.yml
@@ -51,6 +51,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           rubygems: latest
           bundler-cache: true
+          cache-version: rack-conform
         timeout-minutes: 10
 
       - name: cat gems/puma-head-rack-v3.rb.lock

--- a/.github/workflows/ragel.yml
+++ b/.github/workflows/ragel.yml
@@ -55,6 +55,7 @@ jobs:
           apt-get: ragel
           brew: ragel
           bundler-cache: true
+          cache-version: ragel
         timeout-minutes: 10
 
       - name: check ragel generation

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,7 @@ jobs:
           rubygems: default
           bundler: default
           bundler-cache: true
+          cache-version: tests
         timeout-minutes: 10
 
       - name: Repo & Commit Info

--- a/.github/workflows/turbo-rails.yml
+++ b/.github/workflows/turbo-rails.yml
@@ -82,6 +82,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           rubygems: latest
           bundler-cache: true
+          cache-version: "turbo-rails-${{ matrix.rails }}"
         timeout-minutes: 10
 
       - name: turbo-rails Gemfile.lock


### PR DESCRIPTION
### Description

Recently I saw a workflow job in tests.yml while it was in the setup-ruby step.  It had a bundler cache 'miss', so it was running `bundle install`, but at the end it logged removing several Rails gems (see post below).

Added `cache-version:` values to setup-ruby that are unique to the workflows.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
