### PR TITLE
Replace` sleep 0.001 while out_of_band_running` with condition variable

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -382,7 +382,7 @@ module Puma
               else
                 # if ThreadPool out_of_band code is running, we don't want to add
                 # clients until the code is finished.
-                sleep 0.001 while pool.out_of_band_running
+                pool.wait_while_out_of_band_running
 
                 # only use delay when clustered and busy
                 if pool.busy_threads >= @max_threads


### PR DESCRIPTION
### Description

This refactors a bit of code mentioned in https://github.com/puma/puma/pull/3678/files#r2310028332

This replaces a sleep loop with a condition variable. Theoretically this should be better, but it doesn't seem like this behavior is tested  with the `test_out_of_band_server.rb`. 

Better because:
- The `sleep 0.001 while ...` will cause threads to be awakened unnecessarily while OOB is running

Worse, maybe, because:
- After the OOB runs, all of the Server threads will have to pass through the same mutex to continue

Also, this is written with a condition variable, but in the current implementation it will never by waited upon by the calling code because the mutex will always be locked already while OOB is running--it's actually the mutex that will hold the thread in Server. I did though want to do it _correctly_ with a condition variable in case that method is reused elsewhere, specifically within the `ThreadPool` where the condvar would be expected to be functional.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
