### PR TITLE
Fix Puma not booting if queue_requests disabled

### DIFF
--- a/lib/puma/cluster/worker_handle.rb
+++ b/lib/puma/cluster/worker_handle.rb
@@ -73,6 +73,8 @@ module Puma
         # check stat max values, we can't signal workers to reset the max values,
         # so we do so here
         WORKER_MAX_KEYS.each_with_index do |key, idx|
+          next unless hsh[key]
+
           if hsh[key] < @worker_max[idx]
             hsh[key] = @worker_max[idx]
           else

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -685,13 +685,13 @@ module Puma
       stats = @thread_pool&.stats || {}
       stats[:max_threads]    = @max_threads
       stats[:requests_count] = @requests_count
-      stats[:reactor_max] = @reactor.reactor_max
+      stats[:reactor_max] = @reactor.reactor_max if @reactor
       reset_max
       stats
     end
 
     def reset_max
-      @reactor.reactor_max = 0
+      @reactor.reactor_max = 0 if @reactor
       @thread_pool.reset_max
     end
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -283,6 +283,14 @@ class TestIntegrationCluster < TestIntegration
     end
   end
 
+  def test_queue_results_disabled
+    cli_server "-w #{workers} test/rackup/hello.ru", config: "queue_requests false"
+
+    get_worker_pids # wait for workers to boot
+
+    fast_connect
+  end
+
   def test_worker_index_is_with_in_options_limit
     cli_server "-C test/config/t3_conf.rb test/rackup/hello.ru"
 


### PR DESCRIPTION
Previously if queue_requests were disabled, Puma would crash at startup:

```
puma-7.0.1/lib/puma/server.rb:688:in `stats': undefined method `reactor_max' for nil (NoMethodError)

      stats[:reactor_max] = @reactor.reactor_max
                                    ^^^^^^^^^^^^
```

Fix this by checking the presence of `@reactor`.

### Description
Thank you for contributing! You're the best.

We can read your code, so consider leaving some comments here that are more about your motivations and decision making. Some things that may be helpful to address in your description:

- What original problem led to this PR?
- Are there related issues / prior discussions?
- What alternatives have been tried? Does this supersede previous attempts?
- Why do you make the choices you did? What are the tradeoffs?

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [X ] All new and existing tests passed, including Rubocop.
