### PR TITLE
Optimize Puma::Request#default_server_port

### DIFF
--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -273,11 +273,17 @@ module Puma
       !shutting_down? && keep_alive
     end
 
+    HTTP_ON_VALUES = { "on" => true, HTTPS => true }
+    private_constant :HTTP_ON_VALUES
+
     # @param env [Hash] see Puma::Client#env, from request
     # @return [Puma::Const::PORT_443,Puma::Const::PORT_80]
     #
     def default_server_port(env)
-      if ['on', HTTPS].include?(env[HTTPS_KEY]) || env[HTTP_X_FORWARDED_PROTO].to_s[0...5] == HTTPS || env[HTTP_X_FORWARDED_SCHEME] == HTTPS || env[HTTP_X_FORWARDED_SSL] == "on"
+      if HTTP_ON_VALUES[env[HTTPS_KEY]] ||
+          env[HTTP_X_FORWARDED_PROTO]&.to_s&.[](0...5) == HTTPS ||
+          env[HTTP_X_FORWARDED_SCHEME] == HTTPS ||
+          env[HTTP_X_FORWARDED_SSL] == "on"
         PORT_443
       else
         PORT_80

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -281,7 +281,7 @@ module Puma
     #
     def default_server_port(env)
       if HTTP_ON_VALUES[env[HTTPS_KEY]] ||
-          env[HTTP_X_FORWARDED_PROTO]&.to_s&.[](0...5) == HTTPS ||
+          env[HTTP_X_FORWARDED_PROTO]&.start_with?(HTTPS) ||
           env[HTTP_X_FORWARDED_SCHEME] == HTTPS ||
           env[HTTP_X_FORWARDED_SSL] == "on"
         PORT_443


### PR DESCRIPTION
For the case when https is not being used, this reduces the amount of time it takes to run this method.

## Ruby prof

From ruby-prof while executing wrk for 15s:

Before

```
1.35% 0.60% 0.21  0.09  0.00  0.12  76881 Puma::Request#default_server_port 267
    0.04  0.02  0.00  0.02  76881/76881 Array#include?  268
    0.03  0.03  0.00  0.00  307524/1082376  Hash#[] 268
    0.02  0.02  0.00  0.00  76881/76883 String#[] 268
    0.01  0.01  0.00  0.00  153762/155270 BasicObject#==  268
    0.01  0.01  0.00  0.00  76881/76881 NilClass#to_s 268
    0.01  0.01  0.00  0.00  76881/384407  String#== 268
```

After: 

```
0.89% 0.49% 0.14  0.08  0.00  0.06  78559 Puma::Request#default_server_port 268
    0.03  0.03  0.00  0.00  314236/1106188  Hash#[] 269
    0.02  0.02  0.00  0.00  235677/237265 BasicObject#==  269
    0.01  0.01  0.00  0.00  78559/78559 Hash#include?
```

I didn't do rigourous statistical analysis but it seems to reduce time to serve the "hello world" request by ~0.5% (a very low number but it's measurable so 🤷.

## Benchmark IPS

```
require 'benchmark/ips'

HTTPS = "https".freeze
HTTPS_KEY = "HTTPS".freeze
HTTP_X_FORWARDED_FOR = "HTTP_X_FORWARDED_FOR".freeze
HTTP_X_FORWARDED_SSL = "HTTP_X_FORWARDED_SSL".freeze
HTTP_X_FORWARDED_SCHEME = "HTTP_X_FORWARDED_SCHEME".freeze
HTTP_X_FORWARDED_PROTO = "HTTP_X_FORWARDED_PROTO".freeze

HTTP_ON_VALUES = { "on".freeze => true, HTTPS => true }

env = {}

Benchmark.ips do |x|
  x.report("before") do
    ['on', HTTPS].include?(env[HTTPS_KEY]) || env[HTTP_X_FORWARDED_PROTO].to_s[0...5] == HTTPS || env[HTTP_X_FORWARDED_SCHEME] == HTTPS || env[HTTP_X_FORWARDED_SSL] == "on"
  end
  x.report("after") do
    HTTP_ON_VALUES[env[HTTPS_KEY]] ||
        env[HTTP_X_FORWARDED_PROTO]&.to_s&.[](0...5) == HTTPS ||
        env[HTTP_X_FORWARDED_SCHEME] == HTTPS ||
        env[HTTP_X_FORWARDED_SSL] == "on"
  end
  x.compare!
end
```

```
Warming up --------------------------------------
              before   274.136k i/100ms
               after   714.055k i/100ms
Calculating -------------------------------------
              before      2.743M (± 7.6%) i/s  (364.56 ns/i) -     13.707M in   5.041631s
               after      7.091M (± 1.6%) i/s  (141.03 ns/i) -     35.703M in   5.036471s

Comparison:
               after:  7090750.3 i/s
              before:  2743021.2 i/s - 2.59x  slower
```

## Methodology

I found the string allocation via memory_profiler

```
Allocated String Report
-----------------------------------
    769009  ""
    499337  /Users/rschneeman/Documents/projects/puma/lib/puma/request.rb:268
```

Optimized that away, then removed the array allocation.
