### PR TITLE
Strip whitespace from the beginnings of header values

### DIFF
--- a/ext/puma_http11/org/jruby/puma/Http11.java
+++ b/ext/puma_http11/org/jruby/puma/Http11.java
@@ -109,6 +109,10 @@ public class Http11 extends RubyObject {
         return (RubyClass)runtime.getModule("Puma").getConstant("HttpParserError");
     }
 
+    private static boolean is_ows(int c) {
+        return c == ' ' || c == '\t';
+    }
+
     public static void http_field(Ruby runtime, RubyHash req, ByteList buffer, int field, int flen, int value, int vlen) {
         RubyString f;
         IRubyObject v;
@@ -127,7 +131,11 @@ public class Http11 extends RubyObject {
             }
         }
 
-        while (vlen > 0 && Character.isWhitespace(buffer.get(value + vlen - 1))) vlen--;
+        while (vlen > 0 && is_ows(buffer.get(value + vlen - 1))) vlen--;
+        while (vlen > 0 && is_ows(buffer.get(value))) {
+            vlen--;
+            value++;
+        }
 
         if (b.equals(CONTENT_LENGTH_BYTELIST) || b.equals(CONTENT_TYPE_BYTELIST)) {
           f = RubyString.newString(runtime, b);

--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -155,6 +155,10 @@ static VALUE find_common_field_value(const char *field, size_t flen)
   return Qnil;
 }
 
+static int is_ows(const char c) {
+    return c == ' ' || c == '\t';
+}
+
 void http_field(puma_parser* hp, const char *field, size_t flen,
                                  const char *value, size_t vlen)
 {
@@ -181,7 +185,11 @@ void http_field(puma_parser* hp, const char *field, size_t flen,
     f = rb_str_new(hp->buf, new_size);
   }
 
-  while (vlen > 0 && isspace(value[vlen - 1])) vlen--;
+  while (vlen > 0 && is_ows(value[vlen - 1])) vlen--;
+  while (vlen > 0 && is_ows(value[0])) {
+      vlen--;
+      value++;
+  }
 
   /* check for duplicate header */
   v = rb_hash_aref(hp->request, f);

--- a/test/test_http11.rb
+++ b/test/test_http11.rb
@@ -248,7 +248,7 @@ class Http11ParserTest < TestIntegration
   def test_trims_whitespace_from_headers
     parser = Puma::HttpParser.new
     req = {}
-    http = "GET / HTTP/1.1\r\nX-Strip-Me: Strip This       \r\n\r\n"
+    http = "GET / HTTP/1.1\r\nX-Strip-Me: \t Strip This \t      \r\n\r\n"
 
     parser.execute(req, http, 0)
 


### PR DESCRIPTION
### Description

When Puma receives a header with tabs before the value, it doesn't strip them.

For example, when Puma receives the following request:
```
GET / HTTP/1.1\r\n
Host: whatever\r\n
Test: \t\t whatever\r\n
\r\n
```
...it sees the `Test` header as having value `\t\t whatever`. This is incorrect according to spec, because the OWS preceding a header value should consume the `\t` characters, leaving a value of just `whatever`.

Puma is (to my knowledge) the only web server that doesn't strip the tabs appropriately. I've tested the full list [here](https://github.com/narfindustries/http-garden?tab=readme-ov-file#targets).

This PR basically makes 2 changes:
1. Checks for leading whitespace and skips past it during header value parsing.
2. Updates the way that trailing whitespace is skipped to avoid using `isspace` (in C) and `Character.isWhitespace` (in Java) because those functions accept more characters than just space and tab, which is all we should care about according to the RFCs.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [X] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
