### PR TITLE
Move sleep cluster logic to its own class

### DIFF
--- a/lib/puma/cluster_accept_loop_delay.rb
+++ b/lib/puma/cluster_accept_loop_delay.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Puma
+  # Calculate a delay value for sleeping when running in clustered mode
+  #
+  # The main reason this is a class is so it can be unit tested independently.
+  # This makes modification easier in the future if we can encode properties of the
+  # delay into a test instead of relying on end-to-end testing only.
+  #
+  # This is an imprecise mechanism to address specific goals:
+  #
+  # - Evenly distribute requests across all workers at start
+  # - Evenly distribute CPU resources across all workers
+  #
+  # ## Goal: Distribute requests across workers at start
+  #
+  # There was a perf bug in Puma where one worker would wake up slightly before the rest and accept
+  # all the requests on the socket even though it didn't have enough resources to process all of them.
+  # This was originally fixed by never calling accept when a worker had more requests than threads
+  # already https://github.com/puma/puma/pull/3678/files/2736ebddb3fc8528e5150b5913fba251c37a8bf7#diff-a95f46e7ce116caddc9b9a9aa81004246d5210d5da5f4df90a818c780630166bL251-L291
+  #
+  # With the introduction of true keepalive support, there are two ways a request can come in:
+  # - A new request from a new client comes into the socket and it must be "accept"-d
+  # - A keepalive request is served and the connection is retained. Another request is then accepted
+  #
+  # Ideally the server handles requests in the order they come in, and ideally it doesn't accept more requests than it can handle.
+  # These goals are contradictory, because when the server is at maximum capacity due to keepalive connections, it could mean we
+  # block all new requests, even if those came in before the new request on the older keepalive connection.
+  #
+  # ## Distribute CPU resources across all workers
+  #
+  # - This issue was opened https://github.com/puma/puma/issues/2078
+  #
+  # There are several entangled issues and it's not exactly clear the root cause, but the observable outcome
+  # was that performance was better with a small sleep, and that eventually became the default.
+  #
+  # An attempt to describe why this works is here: https://github.com/puma/puma/issues/2078#issuecomment-3287032470.
+  #
+  # Summarizing: The delay is for tuning the rate at which "accept" is called on the socket.
+  # Puma works by calling "accept" nonblock on the socket in a loop. When there are multiple workers,
+  # (processes) then they will "race" to accept a request at roughly the same rate. However if one
+  # worker has all threads busy processing requests, then accepting a new request might "steal" it from
+  # a less busy worker. If a worker has no work to do, it should loop as fast as possible.
+  #
+  # ## Solution(s): Distribute requests across workers at start
+  #
+  # For now, both goals are framed as "load balancing" across workers (processes) and achieved through
+  # the same mechanism of sleeping longer to delay busier workers. Rather than the prior Puma 6.x
+  # and earlier behavior of using a binary on/off sleep value, we increase it an amound proportional
+  # to the load the server is under. Capping the maximum delay to the scenario where all threads are busy.
+  #
+  # Private: API may change unexpectedly
+  class ClusterAcceptLoopDelay
+    attr_reader :max_threads, :max_threads_flt, :max_delay, :min_delay, :divisor
+
+    # Initialize happens once, `call` happens often. Push global calculations here
+    def initialize(
+        # Maximum number of configured threads in the pool. There are situations where the actual number of threads spawned
+        # is greater than this number. Although Puma will eventually "trim" excess threads, you cannot rely on this being a true maximum.
+        max_threads:,
+        # Maximum delay in seconds i.e. 0.005 is 5 microseconds
+        max_delay: # In seconds i.e. 0.005 is 5 microseconds
+      )
+      @max_threads = Integer(max_threads)
+      @max_threads_flt = max_threads.to_f
+      @max_delay = max_delay.to_f
+      # Same divisor as percent_busy
+      @min_delay = max_delay / @max_threads
+    end
+
+    # We want the extreme values of this delay to be known (minimum and maximum) as well as
+    # a predictable curve between the two. i.e. no step functions or hard cliffs.
+    #
+    # Return value is always numeric. Returns 0 if there should be no delay
+    def calculate(
+      # Number of threads working right now
+      busy_threads:
+    )
+      return 0 if max_delay == 0
+
+      percent_busy = busy_threads / max_threads_flt
+      if percent_busy > 0
+        return (max_delay * percent_busy).clamp(min_delay, max_delay)
+      else
+        return 0
+      end
+    end
+  end
+end

--- a/lib/puma/cluster_accept_loop_delay.rb
+++ b/lib/puma/cluster_accept_loop_delay.rb
@@ -47,7 +47,8 @@ module Puma
   # For now, both goals are framed as "load balancing" across workers (processes) and achieved through
   # the same mechanism of sleeping longer to delay busier workers. Rather than the prior Puma 6.x
   # and earlier behavior of using a binary on/off sleep value, we increase it an amound proportional
-  # to the load the server is under. Capping the maximum delay to the scenario where all threads are busy.
+  # to the load the server is under. Capping the maximum delay to the scenario where all threads are busy
+  # and the todo list has reached a multiplier of the maximum number of threads.
   #
   # Private: API may change unexpectedly
   class ClusterAcceptLoopDelay

--- a/lib/puma/cluster_accept_loop_delay.rb
+++ b/lib/puma/cluster_accept_loop_delay.rb
@@ -80,8 +80,8 @@ module Puma
     )
       return 0 if max_delay == 0
 
-      percent_busy = busy_threads_plus_todo.clamp(0, @max_threads_with_overload) / @max_threads_with_overload
-      if percent_busy > 0
+      if busy_threads_plus_todo > 0
+        percent_busy = busy_threads_plus_todo.clamp(0, @max_threads_with_overload) / @max_threads_with_overload
         return (max_delay * percent_busy).clamp(min_delay, max_delay)
       else
         return 0

--- a/lib/puma/cluster_accept_loop_delay.rb
+++ b/lib/puma/cluster_accept_loop_delay.rb
@@ -56,10 +56,13 @@ module Puma
 
     # Initialize happens once, `call` happens often. Push global calculations here
     def initialize(
+        # Number of workers in the cluster
+        workers: ,
         # Maximum delay in seconds i.e. 0.005 is 5 microseconds
         max_delay: # In seconds i.e. 0.005 is 5 microseconds
+
       )
-      @on = max_delay > 0
+      @on = max_delay > 0 && workers >= 2
       @max_delay = max_delay.to_f
 
       # Reach maximum delay when `max_threads * overload_multiplier` is reached in the system

--- a/lib/puma/cluster_accept_loop_delay.rb
+++ b/lib/puma/cluster_accept_loop_delay.rb
@@ -80,13 +80,9 @@ module Puma
       # if the pool needs to be reaped. The busy thread plus todo count may go over this value by a large amount
       max_threads:
     )
-      if busy_threads_plus_todo > 0
-        max_value = @overload_multiplier * max_threads
-        # Approaches max delay when `busy_threads_plus_todo` approaches `max_value`
-        return max_delay * busy_threads_plus_todo.clamp(0, max_value) / max_value
-      else
-        return 0
-      end
+      max_value = @overload_multiplier * max_threads
+      # Approaches max delay when `busy_threads_plus_todo` approaches `max_value`
+      return max_delay * busy_threads_plus_todo.clamp(0, max_value) / max_value
     end
   end
 end

--- a/lib/puma/cluster_accept_loop_delay.rb
+++ b/lib/puma/cluster_accept_loop_delay.rb
@@ -58,10 +58,15 @@ module Puma
         # Maximum delay in seconds i.e. 0.005 is 5 microseconds
         max_delay: # In seconds i.e. 0.005 is 5 microseconds
       )
+      @on = max_delay > 0
       @max_delay = max_delay.to_f
 
       # Reach maximum delay when `max_threads * overload_multiplier` is reached in the system
       @overload_multiplier = 25.0
+    end
+
+    def on?
+      @on
     end
 
     # We want the extreme values of this delay to be known (minimum and maximum) as well as
@@ -75,8 +80,6 @@ module Puma
       # if the pool needs to be reaped. The busy thread plus todo count may go over this value by a large amount
       max_threads:
     )
-      return 0 if max_delay == 0
-
       if busy_threads_plus_todo > 0
         max_value = @overload_multiplier * max_threads
         # Approaches max delay when `busy_threads_plus_todo` approaches `max_value`

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -111,7 +111,6 @@ module Puma
       @io_selector_backend       = @options[:io_selector_backend]
       @http_content_length_limit = @options[:http_content_length_limit]
       @cluster_accept_loop_delay = ClusterAcceptLoopDelay.new(
-        max_threads: @max_threads,
         max_delay: @options[:wait_for_less_busy_worker] || 0 # Real default is in Configuration::DEFAULTS, this is for unit testing
       )
 
@@ -392,6 +391,7 @@ module Puma
                 # A well rested herd (cluster) runs faster
                 if @options[:workers] > 2
                   delay = @cluster_accept_loop_delay.calculate(
+                    max_threads: @max_threads,
                     busy_threads_plus_todo: pool.busy_threads
                   )
                   sleep(delay) if delay > 0

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -390,12 +390,12 @@ module Puma
                 pool.wait_while_out_of_band_running
 
                 # A well rested herd (cluster) runs faster
-                if @cluster_accept_loop_delay.on?
+                if @cluster_accept_loop_delay.on? && (busy_threads_plus_todo = pool.busy_threads) > 0
                   delay = @cluster_accept_loop_delay.calculate(
                     max_threads: @max_threads,
-                    busy_threads_plus_todo: pool.busy_threads
+                    busy_threads_plus_todo: busy_threads_plus_todo
                   )
-                  sleep(delay) if delay > 0
+                  sleep(delay)
                 end
 
                 io = begin

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -249,11 +249,6 @@ module Puma
       @thread_pool&.pool_capacity
     end
 
-    # @!attribute [r] busy_threads
-    def busy_threads
-      @thread_pool&.busy_threads
-    end
-
     # Runs the server.
     #
     # If +background+ is true (the default) then a thread is spun

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -59,7 +59,6 @@ module Puma
     attr_accessor :app
     attr_accessor :binder
 
-
     # Create a server for the rack app +app+.
     #
     # +log_writer+ is a Puma::LogWriter object used to log info and error messages.

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -392,7 +392,7 @@ module Puma
                 # A well rested herd (cluster) runs faster
                 if @options[:workers] > 2
                   delay = @cluster_accept_loop_delay.calculate(
-                    busy_threads: pool.busy_threads
+                    busy_threads_plus_todo: pool.busy_threads
                   )
                   sleep(delay) if delay > 0
                 end

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -389,7 +389,7 @@ module Puma
                 pool.wait_while_out_of_band_running
 
                 # A well rested herd (cluster) runs faster
-                if @options[:workers] > 2
+                if @options[:workers] > 2 && @cluster_accept_loop_delay.on?
                   delay = @cluster_accept_loop_delay.calculate(
                     max_threads: @max_threads,
                     busy_threads_plus_todo: pool.busy_threads

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -111,6 +111,7 @@ module Puma
       @io_selector_backend       = @options[:io_selector_backend]
       @http_content_length_limit = @options[:http_content_length_limit]
       @cluster_accept_loop_delay = ClusterAcceptLoopDelay.new(
+        workers: @options[:workers],
         max_delay: @options[:wait_for_less_busy_worker] || 0 # Real default is in Configuration::DEFAULTS, this is for unit testing
       )
 
@@ -389,7 +390,7 @@ module Puma
                 pool.wait_while_out_of_band_running
 
                 # A well rested herd (cluster) runs faster
-                if @options[:workers] > 2 && @cluster_accept_loop_delay.on?
+                if @cluster_accept_loop_delay.on?
                   delay = @cluster_accept_loop_delay.calculate(
                     max_threads: @max_threads,
                     busy_threads_plus_todo: pool.busy_threads

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -112,7 +112,7 @@ module Puma
       @http_content_length_limit = @options[:http_content_length_limit]
       @cluster_accept_loop_delay = ClusterAcceptLoopDelay.new(
         max_threads: @max_threads,
-        max_delay: @options[:cluster_accept_loop_delay_max_delay] || 0 # Real default is in Configuration::DEFAULTS, this is for unit testing
+        max_delay: @options[:wait_for_less_busy_worker] || 0 # Real default is in Configuration::DEFAULTS, this is for unit testing
       )
 
       if @options[:fiber_per_request]

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -118,10 +118,14 @@ module Puma
       waiting + (@max - spawned)
     end
 
+    # Busy state of the thread pool
+    #
+    # Different from `busy_threads` stat in that it's clamped to `max_threads` already
+    #
     # @!attribute [r] busy_threads
     # @version 5.0.0
     def busy_threads
-      with_mutex { @spawned - @waiting + @todo.size }
+      with_mutex { @spawned - @waiting + @todo.size }.clamp(0, @max)
     end
 
     # :nodoc:

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -118,14 +118,10 @@ module Puma
       waiting + (@max - spawned)
     end
 
-    # Busy state of the thread pool
-    #
-    # Different from `busy_threads` stat in that it's clamped to `max_threads` already
-    #
     # @!attribute [r] busy_threads
     # @version 5.0.0
     def busy_threads
-      with_mutex { @spawned - @waiting + @todo.size }.clamp(0, @max)
+      with_mutex { @spawned - @waiting + @todo.size }
     end
 
     # :nodoc:

--- a/test/test_cluster_accept_loop_delay.rb
+++ b/test/test_cluster_accept_loop_delay.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+require "puma/cluster_accept_loop_delay"
+
+class TestClusterAcceptLoopDelay < PumaTest
+  parallelize_me!
+
+  def test_zero_max_delay_always_returns_zero
+    cal_delay = Puma::ClusterAcceptLoopDelay.new(
+      max_threads: 16,
+      max_delay: 0
+    )
+    assert_equal 0, cal_delay.calculate(busy_threads: 0)
+    assert_equal 0, cal_delay.calculate(busy_threads: 42)
+    assert_equal 0, cal_delay.calculate(busy_threads: 42 * 42)
+  end
+
+
+  def test_zero_busy_threads_always_returns_zero
+    cal_delay = Puma::ClusterAcceptLoopDelay.new(
+      max_threads: 10,
+      max_delay: 0.005
+    )
+
+    assert_equal 0, cal_delay.calculate(busy_threads: 0)
+  end
+
+  def test_linear_increase_with_busy_threads
+    cal_delay = Puma::ClusterAcceptLoopDelay.new(
+      max_threads: 5,
+      max_delay: 0.05
+    )
+
+    assert_in_delta 0, cal_delay.calculate(busy_threads: 0), 0.001
+    assert_in_delta 0.01, cal_delay.calculate(busy_threads: 1), 0.001
+    assert_in_delta 0.02, cal_delay.calculate(busy_threads: 2), 0.001
+    assert_in_delta 0.03, cal_delay.calculate(busy_threads: 3), 0.001
+    assert_in_delta 0.04, cal_delay.calculate(busy_threads: 4), 0.001
+    assert_in_delta 0.05, cal_delay.calculate(busy_threads: 5), 0.001
+  end
+
+  def test_always_return_float_when_non_zero
+    # Dividing integers accidentally returns 0 so want to make sure we are correctly converting to float before division
+    cal_delay = Puma::ClusterAcceptLoopDelay.new(
+      max_threads: Integer(5),
+      max_delay: Integer(5)
+    )
+
+    assert_in_delta 0, cal_delay.calculate(busy_threads: 0.to_f), 0.001
+    assert_equal Float, cal_delay.calculate(busy_threads: Integer(1)).class
+    assert_in_delta 1, cal_delay.calculate(busy_threads: 1), 0.001
+    assert_equal Float, cal_delay.calculate(busy_threads: Integer(2)).class
+    assert_in_delta 2, cal_delay.calculate(busy_threads: 2.to_f), 0.001
+  end
+
+  def test_extreme_busy_values_produce_sensible_delays
+    cal_delay = Puma::ClusterAcceptLoopDelay.new(
+      max_threads: 5,
+      max_delay: 0.05
+    )
+
+    assert_in_delta 0, cal_delay.calculate(busy_threads: -10), 0.001
+    assert_in_delta 0.05, cal_delay.calculate(busy_threads: Float::INFINITY), 0.001
+  end
+end

--- a/test/test_cluster_accept_loop_delay.rb
+++ b/test/test_cluster_accept_loop_delay.rb
@@ -8,55 +8,50 @@ class TestClusterAcceptLoopDelay < PumaTest
 
   def test_zero_max_delay_always_returns_zero
     cal_delay = Puma::ClusterAcceptLoopDelay.new(
-      max_threads: 16,
       max_delay: 0
     )
-    assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 0)
-    assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 42)
-    assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 42 * 42)
+    assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 0, max_threads: 16)
+    assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 42, max_threads: 16)
+    assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 42 * 42, max_threads: 16)
   end
 
 
   def test_zero_busy_threads_plus_todo_always_returns_zero
     cal_delay = Puma::ClusterAcceptLoopDelay.new(
-      max_threads: 10,
       max_delay: 0.005
     )
 
-    assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 0)
+    assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 0, max_threads: 10)
   end
 
   def test_linear_increase_with_busy_threads_plus_todo
     cal_delay = Puma::ClusterAcceptLoopDelay.new(
-      max_threads: 1,
       max_delay: 0.05
     )
 
-    assert_in_delta 0, cal_delay.calculate(busy_threads_plus_todo: 0), 0.001
-    assert_in_delta 0.002, cal_delay.calculate(busy_threads_plus_todo: 1), 0.001
-    assert_in_delta 0.05, cal_delay.calculate(busy_threads_plus_todo: 25), 0.001
-    assert_in_delta 0.05, cal_delay.calculate(busy_threads_plus_todo: 26), 0.001
+    assert_in_delta 0, cal_delay.calculate(busy_threads_plus_todo: 0, max_threads: 1), 0.001
+    assert_in_delta 0.002, cal_delay.calculate(busy_threads_plus_todo: 1, max_threads: 1), 0.001
+    assert_in_delta 0.05, cal_delay.calculate(busy_threads_plus_todo: 25, max_threads: 1), 0.001
+    assert_in_delta 0.05, cal_delay.calculate(busy_threads_plus_todo: 26, max_threads: 1), 0.001
   end
 
   def test_always_return_float_when_non_zero
     # Dividing integers accidentally returns 0 so want to make sure we are correctly converting to float before division
     cal_delay = Puma::ClusterAcceptLoopDelay.new(
-      max_threads: Integer(1),
       max_delay: Integer(5)
     )
 
-    assert_in_delta 0, cal_delay.calculate(busy_threads_plus_todo: 0.to_f), 0.001
-    assert_equal Float, cal_delay.calculate(busy_threads_plus_todo: Integer(25)).class
-    assert_in_delta 5, cal_delay.calculate(busy_threads_plus_todo: 25), 0.001
+    assert_in_delta 0, cal_delay.calculate(busy_threads_plus_todo: 0.to_f, max_threads: Integer(1)), 0.001
+    assert_equal Float, cal_delay.calculate(busy_threads_plus_todo: Integer(25), max_threads: Integer(1)).class
+    assert_in_delta 5, cal_delay.calculate(busy_threads_plus_todo: 25, max_threads: Integer(1)), 0.001
   end
 
   def test_extreme_busy_values_produce_sensible_delays
     cal_delay = Puma::ClusterAcceptLoopDelay.new(
-      max_threads: 5,
       max_delay: 0.05
     )
 
-    assert_in_delta 0, cal_delay.calculate(busy_threads_plus_todo: -10), 0.001
-    assert_in_delta 0.05, cal_delay.calculate(busy_threads_plus_todo: Float::INFINITY), 0.001
+    assert_in_delta 0, cal_delay.calculate(busy_threads_plus_todo: -10, max_threads: 5), 0.001
+    assert_in_delta 0.05, cal_delay.calculate(busy_threads_plus_todo: Float::INFINITY, max_threads: 5), 0.001
   end
 end

--- a/test/test_cluster_accept_loop_delay.rb
+++ b/test/test_cluster_accept_loop_delay.rb
@@ -11,47 +11,43 @@ class TestClusterAcceptLoopDelay < PumaTest
       max_threads: 16,
       max_delay: 0
     )
-    assert_equal 0, cal_delay.calculate(busy_threads: 0)
-    assert_equal 0, cal_delay.calculate(busy_threads: 42)
-    assert_equal 0, cal_delay.calculate(busy_threads: 42 * 42)
+    assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 0)
+    assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 42)
+    assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 42 * 42)
   end
 
 
-  def test_zero_busy_threads_always_returns_zero
+  def test_zero_busy_threads_plus_todo_always_returns_zero
     cal_delay = Puma::ClusterAcceptLoopDelay.new(
       max_threads: 10,
       max_delay: 0.005
     )
 
-    assert_equal 0, cal_delay.calculate(busy_threads: 0)
+    assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 0)
   end
 
-  def test_linear_increase_with_busy_threads
+  def test_linear_increase_with_busy_threads_plus_todo
     cal_delay = Puma::ClusterAcceptLoopDelay.new(
-      max_threads: 5,
+      max_threads: 1,
       max_delay: 0.05
     )
 
-    assert_in_delta 0, cal_delay.calculate(busy_threads: 0), 0.001
-    assert_in_delta 0.01, cal_delay.calculate(busy_threads: 1), 0.001
-    assert_in_delta 0.02, cal_delay.calculate(busy_threads: 2), 0.001
-    assert_in_delta 0.03, cal_delay.calculate(busy_threads: 3), 0.001
-    assert_in_delta 0.04, cal_delay.calculate(busy_threads: 4), 0.001
-    assert_in_delta 0.05, cal_delay.calculate(busy_threads: 5), 0.001
+    assert_in_delta 0, cal_delay.calculate(busy_threads_plus_todo: 0), 0.001
+    assert_in_delta 0.002, cal_delay.calculate(busy_threads_plus_todo: 1), 0.001
+    assert_in_delta 0.05, cal_delay.calculate(busy_threads_plus_todo: 25), 0.001
+    assert_in_delta 0.05, cal_delay.calculate(busy_threads_plus_todo: 26), 0.001
   end
 
   def test_always_return_float_when_non_zero
     # Dividing integers accidentally returns 0 so want to make sure we are correctly converting to float before division
     cal_delay = Puma::ClusterAcceptLoopDelay.new(
-      max_threads: Integer(5),
+      max_threads: Integer(1),
       max_delay: Integer(5)
     )
 
-    assert_in_delta 0, cal_delay.calculate(busy_threads: 0.to_f), 0.001
-    assert_equal Float, cal_delay.calculate(busy_threads: Integer(1)).class
-    assert_in_delta 1, cal_delay.calculate(busy_threads: 1), 0.001
-    assert_equal Float, cal_delay.calculate(busy_threads: Integer(2)).class
-    assert_in_delta 2, cal_delay.calculate(busy_threads: 2.to_f), 0.001
+    assert_in_delta 0, cal_delay.calculate(busy_threads_plus_todo: 0.to_f), 0.001
+    assert_equal Float, cal_delay.calculate(busy_threads_plus_todo: Integer(25)).class
+    assert_in_delta 5, cal_delay.calculate(busy_threads_plus_todo: 25), 0.001
   end
 
   def test_extreme_busy_values_produce_sensible_delays
@@ -60,7 +56,7 @@ class TestClusterAcceptLoopDelay < PumaTest
       max_delay: 0.05
     )
 
-    assert_in_delta 0, cal_delay.calculate(busy_threads: -10), 0.001
-    assert_in_delta 0.05, cal_delay.calculate(busy_threads: Float::INFINITY), 0.001
+    assert_in_delta 0, cal_delay.calculate(busy_threads_plus_todo: -10), 0.001
+    assert_in_delta 0.05, cal_delay.calculate(busy_threads_plus_todo: Float::INFINITY), 0.001
   end
 end

--- a/test/test_cluster_accept_loop_delay.rb
+++ b/test/test_cluster_accept_loop_delay.rb
@@ -10,11 +10,11 @@ class TestClusterAcceptLoopDelay < PumaTest
     cal_delay = Puma::ClusterAcceptLoopDelay.new(
       max_delay: 0
     )
+    assert_equal false, cal_delay.on?
     assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 0, max_threads: 16)
     assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 42, max_threads: 16)
     assert_equal 0, cal_delay.calculate(busy_threads_plus_todo: 42 * 42, max_threads: 16)
   end
-
 
   def test_zero_busy_threads_plus_todo_always_returns_zero
     cal_delay = Puma::ClusterAcceptLoopDelay.new(

--- a/test/test_cluster_accept_loop_delay.rb
+++ b/test/test_cluster_accept_loop_delay.rb
@@ -6,8 +6,23 @@ require "puma/cluster_accept_loop_delay"
 class TestClusterAcceptLoopDelay < PumaTest
   parallelize_me!
 
+  def test_off_when_fewer_than_two_workers
+    cal_delay = Puma::ClusterAcceptLoopDelay.new(
+      workers: 2,
+      max_delay: 1
+    )
+    assert_equal true, cal_delay.on?
+
+    cal_delay = Puma::ClusterAcceptLoopDelay.new(
+      workers: 1,
+      max_delay: 1
+    )
+    assert_equal false, cal_delay.on?
+  end
+
   def test_zero_max_delay_always_returns_zero
     cal_delay = Puma::ClusterAcceptLoopDelay.new(
+      workers: 2,
       max_delay: 0
     )
     assert_equal false, cal_delay.on?
@@ -18,6 +33,7 @@ class TestClusterAcceptLoopDelay < PumaTest
 
   def test_zero_busy_threads_plus_todo_always_returns_zero
     cal_delay = Puma::ClusterAcceptLoopDelay.new(
+      workers: 2,
       max_delay: 0.005
     )
 
@@ -26,6 +42,7 @@ class TestClusterAcceptLoopDelay < PumaTest
 
   def test_linear_increase_with_busy_threads_plus_todo
     cal_delay = Puma::ClusterAcceptLoopDelay.new(
+      workers: 2,
       max_delay: 0.05
     )
 
@@ -38,6 +55,7 @@ class TestClusterAcceptLoopDelay < PumaTest
   def test_always_return_float_when_non_zero
     # Dividing integers accidentally returns 0 so want to make sure we are correctly converting to float before division
     cal_delay = Puma::ClusterAcceptLoopDelay.new(
+      workers: 2,
       max_delay: Integer(5)
     )
 
@@ -48,6 +66,7 @@ class TestClusterAcceptLoopDelay < PumaTest
 
   def test_extreme_busy_values_produce_sensible_delays
     cal_delay = Puma::ClusterAcceptLoopDelay.new(
+      workers: 2,
       max_delay: 0.05
     )
 


### PR DESCRIPTION
### Description

Thank you for contributing! You're the best.

Aww stop, no YOU're the best.

## Details

Simplify the calculations: Puma 6.6.1 behavior documented here https://gist.github.com/schneems/cef38e9448dfb72943d13050a7da0869

This changes the puma 7 behavior to:

- Starts sleeping the event loop before being overloaded (the prior `pool.busy_threads` included in the ready @todo queue) and would only fire. This is closer to puma 6.6.1 behavior
- Sleeps a consistent proportional amount, closer to puma 7 behavior, versus puma 6 used a static value.
- Sleeping behavior is restricted to 2 or more workers, verus puma 7 was accidentally enabled for clusters with only 1 worker (This is an alternative to #3723.)
- Modifies the `busy_threads` method from the thread pool to be clamped between 0 and max_threads. 

Fixes #3740. This `wait_for_less_busy_worker` value is now treated as a maximum value for the sleep calculation. It also now respects a value of 0 to mean "don't sleep at all" which was the prior behavior of that value.

Details in individual commits