### PR TITLE
`Server#process_client` - add ka request to ThreadPool if readable & complete (prev sent to Reactor)

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -508,7 +508,7 @@ module Puma
           next_request_ready = if client.has_back_to_back_requests?
             with_force_shutdown(client) { client.process_back_to_back_requests }
           else
-            nil
+            with_force_shutdown(client) { client.eagerly_finish }
           end
 
           if next_request_ready


### PR DESCRIPTION
### Description

Puma 7 introduced new bahavior for keep-alive connections.  Some of the changes were in
`Server#process_client`.  After a response has been sent, below is the current behavior.

| Socket State                                                                | Puma Action       |
|:----------------------------------------------------------------------------|:------------------|
| 1. Socket has text in it's read buffer, and a full request is available     | add to ThreadPool |
| 2. Socket has text in it's read buffer, and a full request is not available | add to Reactor    |
| 3. Socket is readable and has a full request                                | add to Reactor    |
| 4. Socket is readable and does not have a full request                      | add to Reactor    |
| 5. Socket is not readable                                                   | add to Reactor    |

The third condition is not optimal, as a readable connection may contain a full request.  Also,
proxies or routers may create conditions like this with http2 translation.

This PR changes the behavior of the third condition to 'add to ThreadPool', as shown below:

| Socket State                                                                | Puma Action           |
|:----------------------------------------------------------------------------|:----------------------|
| 1. Socket has text in it's read buffer, and a full request is available     | add to ThreadPool     |
| 2. Socket has text in it's read buffer, and a full request is not available | add to Reactor        |
| **3. Socket is readable and has a full request**                            | **add to ThreadPool** |
| 4. Socket is readable and does not have a full request                      | add to Reactor        |
| 5. Socket is not readable                                                   | add to Reactor        |

Note that the first two conditions are often referred to as 'pipelined requests'.  Many servers
have issues with them, so proxies/routers may split them.


### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
