### PR TITLE
Rescue and validate lowlevel_error_handler

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -584,7 +584,9 @@ module Puma
                      end
 
           # Validate that the handler returned a proper Rack response
-          if response.is_a?(Array) && response.length == 3
+          if response.is_a?(Array) && response.length == 3 &&
+            response[0].is_a?(Integer) && response[1].is_a?(Hash) &&
+            (response[2].respond_to?(:each) || response[2].respond_to?(:call))
             return response
           else
             @log_writer.unknown_error StandardError.new("lowlevel_error_handler returned invalid response: #{response.inspect}"), nil, "lowlevel_error_handler validation"


### PR DESCRIPTION
# The change

In this PR, I'm adding some safety around the `lowlevel_error_handler`. Today, it's not rescued and it can be devastating for the server.

# What original problem led to this PR?

We had a small bug in our `lowlevel_error_handler`, where we used a method that doesn't exist.
```rb
lowlevel_error_handler do |err, env, status|
  Sentry.configure_scope do |scope|
    scope.set_transaction("Puma") # <- This should be set_transaction_name
    scope.set_contexts(puma: env)
  end
  Sentry.capture_exception(err)

  [status, {}, ["Puma caught this error: #{err.message} (#{err.class})\n#{err.backtrace.join("\n")}"]]
end
```

Upon receiving of some invalid requests, this proc was, rightfully so, executed. Unfortunately, there's a `NoMethodError` in there, because Sentry has `set_transaction_name` method, not `set_transaction`. What happened next? This error got propagated. The error was then logged like this:
```
Error in reactor loop escaped: undefined method `set_transaction' for an instance of Sentry::Scope (NoMethodError)
```
And if we follow that up, we see that the selector won't be closed.

https://github.com/puma/puma/blob/ef2c6aae78a5df5ceb6126045768e474fe2b51be/lib/puma/reactor.rb#L102-L118

It seems that when the selector is not closed, the reactor ends up being in an invalid state. What we experienced, is that the server was accepting but not processing requests (well, to be precise probably a worker was not processing, because some requests were handled properly, or a thread, I'm not entirely sure here about the puma architecture).
The symptoms that we've seen is that requests made to our app were timing out, but we didn't see any metrics on our server to be wrong.

# What alternatives have been tried? Does this supersede previous attempts?

To be fair, we simply used the correct method so we don't raise anymore. But since this was so hard to debug and so destructive, I figured it might be a good idea to prevent others from making the same mistake.

I've contemplated modifying the rescue in the `Reactor` to avoid rescuing `NoMethodError`, or having some kind of behavior of self-healing of the `Reactor`. But I don't have enough knowledge around the Puma internals to feel comfortable exploring these.

For context, with the help of AI, I've built this reproduction script. Commenting out `undefined_method_that_causes_nomethoderror` makes the difference in the output.

<details><summary>Reproduction script</summary>

```rb
#!/usr/bin/env ruby
# Demonstration script for Puma reactor "black hole" bug
#
# This script reproduces the exact issue you described:
# 1. A faulty lowlevel_error_handler that raises NoMethodError
# 2. This corrupts the reactor's selector (close_selector = false in reactor.rb:110)
# 3. TCP connections succeed but HTTP requests are silently lost
# 4. Clients timeout without server-side errors

require 'puma'
require 'puma/server'
require 'puma/events'
require 'socket'
require 'timeout'

class BlackHoleDemo
  def initialize
    @log_writer = Puma::LogWriter.new($stdout, $stderr)
    @events = Puma::Events.new

    # App that always raises to trigger lowlevel_error_handler
    @app = ->(env) { raise StandardError, "App error to trigger handler" }

    @handler_calls = 0

    # The faulty lowlevel_error_handler that causes the problem
    @faulty_handler = ->(err, env, status) do
      @handler_calls += 1
      puts "Handler called #{@handler_calls} times"

      # This NoMethodError will be caught in reactor.rb:102-114
      # Setting close_selector = false and corrupting the reactor
      undefined_method_that_causes_nomethoderror

      [500, {}, ["message"]]
    end

    @server = nil
    @port = nil
  end

  def start_server
    puts "🚀 Starting Puma server with faulty lowlevel_error_handler..."

    @server = Puma::Server.new(@app, @events, {
      log_writer: @log_writer,
      min_threads: 1,
      max_threads: 1,
      lowlevel_error_handler: @faulty_handler
    })

    @port = @server.add_tcp_listener("127.0.0.1", 0).addr[1]
    @server.run

    puts "Server listening on port #{@port}"
    sleep 0.2  # Let server start
  end

  def trigger_corruption
    puts "\n💥 Triggering reactor corruption..."

    socket = TCPSocket.new("127.0.0.1", @port)
    socket.write("GET /trigger-corruption HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")

    # Give time for the corruption to occur
    sleep 0.3
    socket.close rescue nil

    puts "Faulty handler called #{@handler_calls} times (should be > 0)"
  end

  def demonstrate_blackhole
    puts "\n🕳️  Demonstrating 'black hole' behavior..."
    puts "TCP connections will succeed, but HTTP requests will be silently lost"

    successful_connections = 0
    successful_responses = 0
    timeouts = 0

    5.times do |i|
      print "Request #{i+1}: "

      begin
        # TCP connection should succeed
        socket = TCPSocket.new("127.0.0.1", @port)
        successful_connections += 1

        # Send HTTP request
        socket.write("GET /test-#{i} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")

        # Try to read response (this will timeout due to corruption)
        response = nil
        Timeout.timeout(2) do
          response = socket.read(1024)
        end

        p "Response: #{response}"
        if response && !response.empty?
          successful_responses += 1
          print "✅ Response received"
        else
          print "❌ Empty response"
        end

        socket.close
      rescue Timeout::Error
        timeouts += 1
        print "⏰ Timeout (no response)"
      rescue => e
        print "💥 Error: #{e.class}"
      ensure
        socket&.close rescue nil
      end

      puts
      sleep 0.1
    end

    puts "\n📊 Results:"
    puts "  - TCP connections established: #{successful_connections}/5"
    puts "  - HTTP responses received: #{successful_responses}/5"
    puts "  - Timeouts: #{timeouts}/5"
    puts "  - Handler calls: #{@handler_calls}"

    if successful_connections > 0 && successful_responses == 0
      puts "\n✅ BLACK HOLE REPRODUCED!"
      puts "  - TCP connections work (#{successful_connections}/5)"
      puts "  - But HTTP requests are silently lost (0 responses)"
      puts "  - This matches your production issue exactly"
    else
      puts "\n❓ Results unclear - may need to run again"
    end
  end

  def check_server_logs
    puts "\n📝 Server-side logging analysis:"
    puts "In production, you'd see minimal server errors despite client timeouts"
    puts "This is because the reactor is corrupted but not completely dead"
  end

  def cleanup
    puts "\n🧹 Cleaning up..."
    @server&.stop(true) rescue nil
  end

  def run
    start_server
    trigger_corruption
    demonstrate_blackhole
    check_server_logs
    cleanup

    puts "\n" + "="*60
    puts "SUMMARY: Puma Reactor 'Black Hole' Bug Reproduction"
    puts "="*60
    puts "1. ✅ Faulty lowlevel_error_handler raises NoMethodError"
    puts "2. ✅ Reactor catches error, sets close_selector=false (reactor.rb:110)"
    puts "3. ✅ TCP connections establish normally (no socket-level issues)"
    puts "4. ✅ HTTP requests are silently dropped (reactor corruption)"
    puts "5. ✅ Clients timeout without meaningful server-side errors"
    puts ""
    puts "This exactly matches your production 'black hole' behavior where:"
    puts "- Clients can establish TCP connections"
    puts "- HTTP requests disappear without a trace"
    puts "- Server appears healthy but doesn't process requests"
    puts "- Socket backlog and TCP metrics appear normal"
  end
end

if __FILE__ == $0
  demo = BlackHoleDemo.new

  begin
    demo.run
  rescue Interrupt
    puts "\n\n⏹️  Demo interrupted"
    demo.cleanup
  end
end
```

</details> 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
