### PR TITLE
puma_http11.c: Use interned UTF-8 strings for hash keys

### DIFF
--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -48,7 +48,7 @@ static VALUE global_request_path;
 #define VALIDATE_MAX_LENGTH(len, N) if(len > MAX_##N##_LENGTH) { rb_raise(eHttpParserError, MAX_##N##_LENGTH_ERR, len); }
 
 /** Defines global strings in the init method. */
-#define DEF_GLOBAL(N, val)   global_##N = rb_str_new2(val); rb_global_variable(&global_##N)
+#define DEF_GLOBAL(N, val)  rb_global_variable(&global_##N); global_##N = rb_str_new2(val)
 
 
 /* Defines the maximum allowed lengths for various input elements.*/
@@ -134,13 +134,13 @@ static void init_common_fields(void)
   memcpy(tmp, HTTP_PREFIX, HTTP_PREFIX_LEN);
 
   for(i = 0; i < ARRAY_SIZE(common_http_fields); cf++, i++) {
+    rb_global_variable(&cf->value);
     if(cf->raw) {
       cf->value = rb_str_new(cf->name, cf->len);
     } else {
       memcpy(tmp + HTTP_PREFIX_LEN, cf->name, cf->len + 1);
       cf->value = rb_str_new(tmp, HTTP_PREFIX_LEN + cf->len);
     }
-    rb_global_variable(&cf->value);
   }
 }
 
@@ -475,8 +475,8 @@ void Init_puma_http11(void)
   DEF_GLOBAL(server_protocol, "SERVER_PROTOCOL");
   DEF_GLOBAL(request_path, "REQUEST_PATH");
 
-  eHttpParserError = rb_define_class_under(mPuma, "HttpParserError", rb_eStandardError);
   rb_global_variable(&eHttpParserError);
+  eHttpParserError = rb_define_class_under(mPuma, "HttpParserError", rb_eStandardError);
 
   rb_define_alloc_func(cHttpParser, HttpParser_alloc);
   rb_define_method(cHttpParser, "initialize", HttpParser_init, 0);

--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -7,6 +7,7 @@
 #define RSTRING_NOT_MODIFIED 1
 
 #include "ruby.h"
+#include "ruby/encoding.h"
 #include "ext_help.h"
 #include <assert.h>
 #include <string.h>
@@ -48,8 +49,11 @@ static VALUE global_request_path;
 #define VALIDATE_MAX_LENGTH(len, N) if(len > MAX_##N##_LENGTH) { rb_raise(eHttpParserError, MAX_##N##_LENGTH_ERR, len); }
 
 /** Defines global strings in the init method. */
-#define DEF_GLOBAL(N, val)  rb_global_variable(&global_##N); global_##N = rb_str_new2(val)
-
+static inline void DEF_GLOBAL(VALUE *var, const char *cstr)
+{
+    rb_global_variable(var);
+    *var = rb_enc_interned_str_cstr(cstr, rb_utf8_encoding());
+}
 
 /* Defines the maximum allowed lengths for various input elements.*/
 #ifndef PUMA_REQUEST_URI_MAX_LENGTH
@@ -468,12 +472,12 @@ void Init_puma_http11(void)
   VALUE mPuma = rb_define_module("Puma");
   VALUE cHttpParser = rb_define_class_under(mPuma, "HttpParser", rb_cObject);
 
-  DEF_GLOBAL(request_method, "REQUEST_METHOD");
-  DEF_GLOBAL(request_uri, "REQUEST_URI");
-  DEF_GLOBAL(fragment, "FRAGMENT");
-  DEF_GLOBAL(query_string, "QUERY_STRING");
-  DEF_GLOBAL(server_protocol, "SERVER_PROTOCOL");
-  DEF_GLOBAL(request_path, "REQUEST_PATH");
+  DEF_GLOBAL(&global_request_method, "REQUEST_METHOD");
+  DEF_GLOBAL(&global_request_uri, "REQUEST_URI");
+  DEF_GLOBAL(&global_fragment, "FRAGMENT");
+  DEF_GLOBAL(&global_query_string, "QUERY_STRING");
+  DEF_GLOBAL(&global_server_protocol, "SERVER_PROTOCOL");
+  DEF_GLOBAL(&global_request_path, "REQUEST_PATH");
 
   rb_global_variable(&eHttpParserError);
   eHttpParserError = rb_define_class_under(mPuma, "HttpParserError", rb_eStandardError);


### PR DESCRIPTION
`rb_str_new2` creates a mutable, ASCII-8BIT (binary) strings.
    
Hence, when used with `rb_hash_aset`, ruby always has to lookup the equivalent string in the fstring table, likely fail to find it, then dup and free the given string, and use that as the hash key.
    
By keeping interned strings in these global variables, we can save Ruby quite a bit of work. It's not a whole lot in the grand scheme of things, but still welcome.

There is also a preliminary commit to fix `rb_global_variable` usage.