### PR TITLE
Add test/rackup/sleep_fibonacci.ru, update benchmark hey files

### DIFF
--- a/benchmarks/local/bench_base.rb
+++ b/benchmarks/local/bench_base.rb
@@ -181,7 +181,7 @@ module TestPuma
     # @return [Hash] The hey data
     #
     def run_hey_parse(cmd, mult, log: false)
-      STDOUT.syswrite cmd
+      STDOUT.syswrite format('%4.2f %s', mult, cmd)
 
       hey_output = %x[#{cmd}].strip.gsub(' secs', '')
 
@@ -211,12 +211,12 @@ module TestPuma
         end
         temp[100] = hey_output[/^\s+Slowest\:\s+([\d.]+)/, 1].to_f
       end
-      STDOUT.syswrite format("   RPS %6d   50%% %7.4f   99%% %7.4f\n", job[:rps].to_i, job[:latency][50], job[:latency][99]) unless log
+      STDOUT.syswrite format(" %6d  %7.4f  %7.4f\n", job[:rps].to_i, job[:latency][50], job[:latency][99]) unless log
       job
     end
 
     # Runs wrk and returns data from its output.
-    # @param cmd [String] The wrk command string, with arguments
+    # @param cmd [String] The wrk command string, with arguments
     # @return [Hash] The wrk data
     #
     def run_wrk_parse(cmd, log: false)

--- a/benchmarks/local/bench_base.sh
+++ b/benchmarks/local/bench_base.sh
@@ -176,8 +176,7 @@ StartPuma()
   if [ -n "$1" ]; then
     rackup_file=$1
   fi
-
-  echo "Branch: $(git branch --show-current)"
+  export PUMA_RU_FILE=$rackup_file
 
   printf "\nbundle exec puma -q -b $bind $puma_args --control-url=tcp://$PUMA_CTRL --control-token=test $rackup_file\n\n"
   bundle exec puma -q -b $bind $puma_args --control-url=tcp://$PUMA_CTRL --control-token=test $rackup_file &

--- a/test/rackup/sleep_fibonacci.ru
+++ b/test/rackup/sleep_fibonacci.ru
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+=begin
+This runs loops of fibonacci code to use some CPU resources, then sleeps for the
+balance of time that's sent in the request.  The body returned is a text string
+that includes the percent of time spent in the fibonacci code.
+
+Call with "GET /sleep<d> HTTP/1.1\r\n\r\n", where <d> is the number of
+seconds to sleep, normally a float.
+
+This may fail with an error if the fibonacci code takes longer than the delay
+amount.  If so, increase the number in line 19 or lower the number in line 20
+
+Can be tested with curl.
+=end
+
+regex_delay = /\A\/sleep(\d+(?:\.\d+)?)/
+
+fibonacci = ->(n) { n <= 1 ? n : fibonacci.call(n - 1) + fibonacci.call(n - 2) }
+
+run lambda { |env|
+  delay = (env['REQUEST_PATH'][regex_delay,1] || '0').to_f
+  t_st = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  loops = (delay/0.0015).to_i
+  loops = 1 if loops.zero?
+  loops.times { fibonacci.call 20 }
+  t_end = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  sleep(delay + t_st - t_end)
+  percent = 100 * (t_end - t_st)/delay
+  [200, {"Content-Type" => "text/plain"}, [format("%6.3f Delay   %4.1f%% CPU   %3d Loops\n", delay, percent, loops)]]
+}


### PR DESCRIPTION
### Description

Two commits, neither change any 'lib' code.

#### 1. Create test/rackup/sleep_fibonacci.ru
Currently, the benchmark tests default to using `test/rackup/sleep.ru`.  This looks at the request's path and sleeps for a given amount of time.  The sleep uses virtually no CPU.  Add another file `test/rackup/sleep_fibonacci.ru` which runs a few loops of some fibonacci code, the sleeps for the balance.  Every PC is different, so the code may need changes to run on different systems.  If the 'fibonacci' code runs longer than the expected request delay time, it will error in Puma.  See comments in the file to adjust.


#### 2. benchmarks/local updates
Formatting changes to the hey benchmarking code.  Example output below:
```
Branch: 00-bench-hey-update
  Puma: -w4  -t3:3  dly 0.005  sleep.ru                                  RPS      50%       99%
6.00 hey -c  72 -n  7200 -cpus 8  http://127.0.0.1:40001/sleep0.005     2238    0.0313    0.0448
4.00 hey -c  48 -n  4800 -cpus 8  http://127.0.0.1:40001/sleep0.005     2257    0.0209    0.0257
3.00 hey -c  36 -n  3600 -cpus 8  http://127.0.0.1:40001/sleep0.005     2278    0.0157    0.0165
2.00 hey -c  24 -n  2400 -cpus 8  http://127.0.0.1:40001/sleep0.005     2166    0.0104    0.0150
1.50 hey -c  18 -n  1800 -cpus 8  http://127.0.0.1:40001/sleep0.005     2184    0.0073    0.0108
1.00 hey -c  12 -n  1200 -cpus 8  http://127.0.0.1:40001/sleep0.005     2170    0.0054    0.0059
0.50 hey -c   6 -n   600 -cpus 8  http://127.0.0.1:40001/sleep0.005      988    0.0058    0.0082


Branch: 00-bench-hey-update
  Puma: -w4  -t3:3  dly 0.005  sleep.ru
                                ───────────────────── Hey Latency ───────────────────── Long Tail
Mult/Conn  requests   rps %     10%    25%    50%    75%    90%    95%    99%    100%   100% / 10%
6.00  72     7200      93.3     0.93   1.00   1.04   1.08   1.21   1.22   1.49   2.39      2.57
4.00  48     4800      94.1     0.88   1.04   1.04   1.06   1.14   1.24   1.28   1.64      1.85
3.00  36     3600      94.9     1.04   1.04   1.05   1.05   1.07   1.07   1.10   1.17      1.12
2.00  24     2400      90.3     0.84   1.03   1.04   1.07   1.20   1.40   1.50   1.67      1.99
1.50  18     1800      91.0     0.73   0.75   0.97   1.33   1.36   1.37   1.44   1.52      2.07
1.00  12     1200      90.4     1.06   1.08   1.08   1.10   1.12   1.14   1.18   1.34      1.26
0.50   6      600      41.2     1.10   1.12   1.16   1.24   1.42   1.50   1.64   1.76      1.60

Branch: 00-bench-hey-update
  Puma: -w4  -t3:3  dly 0.005  sleep.ru                  ───── Worker Request Info ─────
                         ── Reactor ──   ── Backlog ──    Std           % deviation
Mult/Conn  requests       Min     Max     Min     Max     Dev           from 25.00%
6.00  72     7200         18      22      18      21      0.35    -0.3  -0.3   0.1   0.6
4.00  48     4800         11      13       9      11      0.51    -0.7  -0.2   0.1   0.8
3.00  36     3600          9       9       7       7      0.08    -0.1   0.0   0.0   0.1
2.00  24     2400          5       7       2       4      2.73    -2.8  -1.0  -0.7   4.5
1.50  18     1800          4       5       2       3      2.50    -4.0   0.4   0.7   2.9
1.00  12     1200          3       3       2       2      0.41    -0.7   0.0   0.3   0.3
0.50   6      600          1       2       1       2     33.33   -33.3 -33.3  33.3  33.3
```

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
