### PR TITLE
ci: test_puma_server_ssl.rb - catch error in thread

### DIFF
--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -200,7 +200,11 @@ class TestPumaServerSSL < PumaTest
     end
 
     ssl = Thread.new do
-      body_https = send_http_read_resp_body ctx: new_ctx
+      begin
+        body_https = send_http_read_resp_body ctx: new_ctx
+      rescue => e
+        body_https = "test_http_rejection error in SSL #{e.class}\n#{e.message}\n"
+      end
     end
 
     tcp.join


### PR DESCRIPTION
### Description

Errors raised in threads are not retried and will abort CI.  A recent failure
```
#<Thread:0x00000001273d3588 /Users/runner/work/puma/puma/test/test_puma_server_ssl.rb:202 run> terminated with exception (report_on_exception is true):
# ...
	from /Users/runner/work/puma/puma/test/test_puma_server_ssl.rb:203:in 'block in TestPumaServerSSL#test_http_rejection'
```

Add a begin/rescue block so the error is caught, allowing retry.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
