### PR TITLE
OpenSSL: use native ruby OpenSSL instead of MiniSSL. Closes #2188.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "minitest-retry"
 gem "minitest-proveit"
 gem "minitest-stub-const"
 gem "concurrent-ruby", "~> 1.3"
+gem "debug"
 
 case ENV['PUMA_CI_RACK']&.strip
 when 'rack2'

--- a/ext/puma_http11/mini_ssl.c
+++ b/ext/puma_http11/mini_ssl.c
@@ -818,7 +818,7 @@ void Init_mini_ssl(VALUE puma) {
    * Returns `nil` when `MiniSSL::Context#verify_mode` is set to `VERIFY_NONE`.
    * @return [String, nil] DER encoded cert
    */
-  rb_define_method(eng, "peercert", engine_peercert, 0);
+  rb_define_method(eng, "peer_cert", engine_peercert, 0);
 
   rb_define_method(eng, "ssl_vers_st", engine_ssl_vers_st, 0);
 }

--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -24,11 +24,13 @@ module Puma
 
   # at present, MiniSSL::Engine is only defined in extension code (puma_http11),
   # not in minissl.rb
-  HAS_SSL = const_defined?(:MiniSSL, false) && MiniSSL.const_defined?(:Engine, false)
+  HAS_MINI_SSL = const_defined?(:MiniSSL, false) && MiniSSL.const_defined?(:Engine, false)
+  HAS_NATIVE_SSL = ENV["PUMA_NATIVE_SSL"]
+  HAS_SSL = HAS_MINI_SSL || HAS_NATIVE_SSL
 
   HAS_UNIX_SOCKET = Object.const_defined?(:UNIXSocket) && !IS_WINDOWS
 
-  if HAS_SSL
+  if HAS_MINI_SSL
     require_relative 'puma/minissl'
   else
     module MiniSSL

--- a/lib/puma/log_writer.rb
+++ b/lib/puma/log_writer.rb
@@ -124,8 +124,8 @@ module Puma
     # @param ssl_socket <Puma::MiniSSL::Socket>
     def ssl_error(error, ssl_socket)
       peeraddr = ssl_socket.peeraddr.last rescue "<unknown>"
-      peercert = ssl_socket.peercert
-      subject = peercert&.subject
+      peer_cert = ssl_socket.peer_cert
+      subject = peer_cert&.subject
       @error_logger.info(error: error, text: "SSL error, peer: #{peeraddr}, peer cert: #{subject}")
     end
 

--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -23,7 +23,7 @@ module Puma
       def initialize(socket, engine)
         @socket = socket
         @engine = engine
-        @peercert = nil
+        @peer_cert = nil
         @reuse = nil
       end
 
@@ -189,14 +189,14 @@ module Puma
       # When `VERIFY_NONE`, `MiniSSL::Engine#peercert` is nil, regardless of
       # whether the client sends a cert.
       # @return [OpenSSL::X509::Certificate, nil]
-      # @!attribute [r] peercert
-      def peercert
-        return @peercert if @peercert
+      # @!attribute [r] peer_cert
+      def peer_cert
+        return @peer_cert if @peer_cert
 
-        raw = @engine.peercert
+        raw = @engine.peer_cert
         return nil unless raw
 
-        @peercert = OpenSSL::X509::Certificate.new raw
+        @peer_cert = OpenSSL::X509::Certificate.new raw
       end
     end
 

--- a/lib/puma/minissl/context_builder.rb
+++ b/lib/puma/minissl/context_builder.rb
@@ -51,7 +51,7 @@ module Puma
             unless params['ca']
               log_writer.error "Please specify the SSL ca via 'ca='"
             end
-            # needed for Puma::MiniSSL::Socket#peercert, env['puma.peercert']
+            # needed for Puma::MiniSSL::Socket#peer_cert, env['puma.peer_cert']
             require 'openssl'
           end
 

--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -63,8 +63,8 @@ module Puma
 
       env[PUMA_SOCKET] = socket
 
-      if env[HTTPS_KEY] && socket.peercert
-        env[PUMA_PEERCERT] = socket.peercert
+      if env[HTTPS_KEY] && socket.peer_cert
+        env[PUMA_PEERCERT] = socket.peer_cert
       end
 
       env[HIJACK_P] = true

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -452,6 +452,13 @@ module Puma
 
       requests = 0
 
+      # Perform the SSL handshake.
+      #
+      # Note: I believe this is a blocking operation. A slow client would block this thread.
+      # However, at this stage it's executing in a client thread so it won't prevent other threads
+      # from handling requests. I don't know if that's acceptable or not for Puma.
+      client.io.accept if HAS_NATIVE_SSL && client.io.instance_of?(OpenSSL::SSL::SSLSocket)
+
       begin
         if @queue_requests &&
           !client.eagerly_finish

--- a/lib/puma/ssl/context_builder.rb
+++ b/lib/puma/ssl/context_builder.rb
@@ -1,0 +1,82 @@
+require 'openssl'
+
+module Puma
+  module SSL
+    class ContextBuilder
+      def initialize(params, log_writer)
+        @params = params
+        @log_writer = log_writer
+      end
+
+      def context
+        ctx = OpenSSL::SSL::SSLContext.new
+
+        if params['key'].nil? && params['key_pem'].nil?
+          log_writer.error "Please specify the SSL key via 'key=' or 'key_pem='"
+        end
+
+        #ctx.key = params['key'] if params['key']
+        #ctx.key_pem = params['key_pem'] if params['key_pem']
+        #ctx.key_password_command = params['key_password_command'] if params['key_password_command']
+
+        # TODO also handle params['key_pem']
+        key = OpenSSL::PKey.read(File.open(params['key']))
+
+        if params['cert'].nil? && params['cert_pem'].nil?
+          log_writer.error "Please specify the SSL cert via 'cert=' or 'cert_pem='"
+        end
+
+        # TODO handle also params['cert_pem']
+        cert = OpenSSL::X509::Certificate.new(File.binread(params['cert']))
+
+        #ctx.add_certificate(cert, key)
+        ctx.cert = cert
+        ctx.key = key
+
+        #if ['peer', 'force_peer'].include?(params['verify_mode'])
+          #unless params['ca']
+            #log_writer.error "Please specify the SSL ca via 'ca='"
+          #end
+          ## needed for Puma::MiniSSL::Socket#peercert, env['puma.peercert']
+          #require 'openssl'
+        #end
+
+        #ctx.ca = params['ca'] if params['ca']
+        #ctx.ssl_cipher_filter = params['ssl_cipher_filter'] if params['ssl_cipher_filter']
+        #ctx.ssl_ciphersuites = params['ssl_ciphersuites'] if params['ssl_ciphersuites'] && HAS_TLS1_3
+
+        #ctx.reuse = params['reuse'] if params['reuse']
+
+        #ctx.no_tlsv1   = params['no_tlsv1'] == 'true'
+        #ctx.no_tlsv1_1 = params['no_tlsv1_1'] == 'true'
+
+        ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE # TODO I believe this can be removed.
+        #if params['verify_mode']
+          #ctx.verify_mode = case params['verify_mode']
+                            #when "peer"
+                              #MiniSSL::VERIFY_PEER
+                            #when "force_peer"
+                              #MiniSSL::VERIFY_PEER | MiniSSL::VERIFY_FAIL_IF_NO_PEER_CERT
+                            #when "none"
+                              #MiniSSL::VERIFY_NONE
+                            #else
+                              #log_writer.error "Please specify a valid verify_mode="
+                              #MiniSSL::VERIFY_NONE
+                            #end
+        #end
+
+        #if params['verification_flags']
+          #ctx.verification_flags = params['verification_flags'].split(',').
+            #map { |flag| MiniSSL::VERIFICATION_FLAGS.fetch(flag) }.
+            #inject { |sum, flag| sum ? sum | flag : flag }
+        #end
+
+        ctx
+      end
+
+      private
+
+      attr_reader :params, :log_writer
+    end
+  end
+end

--- a/lib/puma/ssl/server.rb
+++ b/lib/puma/ssl/server.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Puma
+  module SSL
+    class Server
+      def initialize(svr, ctx)
+        @svr = svr
+        @ctx = ctx
+      end
+
+      def to_io
+        @svr
+      end
+
+      def accept_nonblock
+        socket = @svr.accept_nonblock
+        OpenSSL::SSL::SSLSocket.new(socket, @ctx)
+        # At this point the client has connected/accepted at the socket layer but hasn't finished
+        # the SSL handshake. We can't do a OpenSSL::SSL::SSLSocket#accept here because a slow client
+        # would block other clients from connecting.
+      end
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -51,7 +51,7 @@ if Puma::HAS_SSL
     def ssl_error(error, ssl_socket)
       self.error = error
       self.addr = ssl_socket.peeraddr.last rescue "<unknown>"
-      self.cert = ssl_socket.peercert
+      self.cert = ssl_socket.peer_cert
     end
   end
 end

--- a/test/test_log_writer.rb
+++ b/test/test_log_writer.rb
@@ -157,9 +157,9 @@ class TestLogWriter < PumaTest
       if subj
         cert = Object.new
         cert.define_singleton_method(:subject) { subj }
-        obj.define_singleton_method(:peercert) { cert }
+        obj.define_singleton_method(:peer_cert) { cert }
       else
-        obj.define_singleton_method(:peercert) { nil }
+        obj.define_singleton_method(:peer_cert) { nil }
       end
       obj
     }

--- a/test/test_minissl.rb
+++ b/test/test_minissl.rb
@@ -1,6 +1,6 @@
 require_relative "helper"
 
-require "puma/minissl" if ::Puma::HAS_SSL
+require "puma/minissl" if ::Puma::HAS_MINI_SSL
 
 class TestMiniSSL < PumaTest
 


### PR DESCRIPTION
### Description

This is a spike for using ruby's OpenSSL directly instead of via Minissl. Closes https://github.com/puma/puma/issues/2188.

This PR is still very much a work in progress so I've made it a draft. I've got it doing a basic hello world server using ssl and some of the context arguments, but there is still a lot more work to do. I figured as something is working it might be worth opening a PR for feedback.

Note, as part of this PR I renamed `Puma::MiniSSL::Socket#peercert` (no underscore) to `Puma::MiniSSL::Socket#peer_cert` (has an underscore) to make it consistent with [OpenSSL::SSL::SSLSocket ](https://ruby-doc.org/3.4.1/exts/openssl/OpenSSL/SSL/SSLSocket.html#method-i-peer_cert). This gives a consistent api for sockets ([example usage](https://github.com/puma/puma/blob/30e0d2254043f0ef8b586f23bc5f06a59a45c219/lib/puma/log_writer.rb#L127)).

The biggest challenge I encountered is that [`OpenSSL::SSL::SSLSocket`](https://ruby-doc.org/3.4.1/exts/openssl/OpenSSL/SSL/SSLServer.html) has an `#accept` method but not `#accept_nonblock`. Obviously we don't want slow clients preventing other requests from being processed. The current workaround I've used is to call `#accept_nonblock` on the underlying tcp socket to start work when a new client connects. The socket is passed to a worker thread which calls the blocking `#accept` method (this is the same way [Webrick handles it](https://github.com/ruby/webrick/blob/6c95f0c4b9ee559de02cd9435e33614d249456be/lib/webrick/server.rb#L262)).  I don't know if this is acceptable for Puma. Note, there is `[OpenSSL::SSL::SSLSocket#accept_nonblock](https://devdocs.io/ruby~3.4/openssl/ssl/sslsocket#method-i-accept_nonblock); however, I haven't looked far enough into it yet to see if we can use it.

At a minimum this PR is still missing:

- [ ]  Outstanding context flags
- [ ] Update `Puma::Binder#inherit_ssl_listener` to support Native SSL and MiniSSL.
- [ ] What about JRUBY? Will this just work :tm:?
- [ ] Tests
- [ ] Documentation

Any feedback is greatly appreciate.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.

