### PR TITLE
[ci skip] Remove check and merge metadata together

### DIFF
--- a/puma.gemspec
+++ b/puma.gemspec
@@ -15,20 +15,18 @@ Gem::Specification.new do |s|
   s.executables = ["puma", "pumactl"]
   s.extensions = ["ext/puma_http11/extconf.rb"]
   s.add_runtime_dependency "nio4r", "~> 2.0"
-  s.metadata["msys2_mingw_dependencies"] = "openssl"
   s.files = `git ls-files -- bin docs ext lib tools`.split("\n") +
             %w[History.md LICENSE README.md]
   s.homepage = "https://puma.io"
 
-  if s.respond_to?(:metadata=)
-    s.metadata = {
-      "bug_tracker_uri" => "https://github.com/puma/puma/issues",
-      "changelog_uri" => "https://github.com/puma/puma/blob/master/History.md",
-      "homepage_uri" => "https://puma.io",
-      "source_code_uri" => "https://github.com/puma/puma",
-      "rubygems_mfa_required" => "true"
-    }
-  end
+  s.metadata = {
+    "bug_tracker_uri" => "https://github.com/puma/puma/issues",
+    "changelog_uri" => "https://github.com/puma/puma/blob/master/History.md",
+    "homepage_uri" => "https://puma.io",
+    "source_code_uri" => "https://github.com/puma/puma",
+    "rubygems_mfa_required" => "true",
+    "msys2_mingw_dependencies" => "openssl"
+  }
 
   s.license = "BSD-3-Clause"
   s.required_ruby_version = Gem::Requirement.new(">= 3.0")


### PR DESCRIPTION
### Description
The check for existence has been removed, as this has already been the case since RubyGems 2.0, and we are now at RubyGems 3.7.

The motivation was that the Renovate Bot cannot display any information about Puma due to this check.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
