### PR TITLE
Fix Ctrl-C, set `force_shutdown_after` and `worker_shutdown_timeout` to small values

### DIFF
--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -441,6 +441,13 @@ module Puma
       spawn_workers
 
       Signal.trap "SIGINT" do
+        # setting the below to allow Ctrl-C to shutdown Puma, especially with
+        # hijacked responses.  See https://github.com/puma/puma/issues/3569
+        @options[:worker_shutdown_timeout] = 2
+        if @options.fetch(:force_shutdown_after, -1) < 0
+          @options[:force_shutdown_after]    = 0.5
+          log "- Setting 'force_shutdown_after' to 0.5"
+        end
         stop
       end
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -451,6 +451,12 @@ module Puma
 
       begin
         Signal.trap "SIGINT" do
+          # setting the below to allow Ctrl-C to shutdown Puma, especially with
+          # hijacked responses.  See https://github.com/puma/puma/issues/3569
+          if @options.fetch(:force_shutdown_after, -1) < 0
+            @options[:force_shutdown_after] = 0.5
+            log "- Setting 'force_shutdown_after' to 0.5"
+          end
           stop
         end
       rescue Exception


### PR DESCRIPTION
### Description

Depending on the configuration and response types, using Ctrl-C to shutdown Puma may either not work or take a long time.

When `SIGINT` is received, set `force_shutdown_after` to 0.5 if it has not been set to a positive number.  When running clustered, set `worker_shutdown_timeout` to 2.

Note that `Puma::ControlCLI` (`pumactl`) does not use `SIGINT`, and most external control apps would use `SIGTERM` to shutdown Puma.

Closes #3569

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.