### PR TITLE
ci: tests.yml - mac-13 -> macos-26, windows-2022 -> windows-2025

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,16 +39,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm,
-              macos-14, macos-15, macos-15-intel,
+              macos-14, macos-15, macos-15-intel, macos-26,
               windows-2022 ]
         ruby: [ '3.0', 3.1, 3.2, 3.3, 3.4, head ]
         no-ssl: ['']
         rack-v: ['']
         yjit: ['']
         include:
-          - { os: windows-2022    , ruby:  ucrt }
-          - { os: windows-2022    , ruby:  mswin }
-          - { os: windows-2022    , ruby: '3.0' , no-ssl: ' no SSL' }
+          - { os: windows-2025    , ruby:  ucrt }
+          - { os: windows-2025    , ruby:  mswin }
+          - { os: windows-2025    , ruby: '3.0' , no-ssl: ' no SSL' }
           - { os: windows-11-arm  , ruby:  3.4 }
           - { os: windows-11-arm  , ruby:  head }
           - { os: ubuntu-22.04    , ruby:  head , yjit: ' yjit'     }
@@ -59,9 +59,19 @@ jobs:
           - { os: ubuntu-24.04    , ruby: '3.0' }
           - { os: ubuntu-24.04-arm, ruby:  3.1  }
           - { os: ubuntu-24.04-arm, ruby:  3.3  }
-          - { os: macos-15     , ruby: '3.0' }
-          - { os: macos-15     , ruby:  3.2  }
-          - { os: windows-2022 , ruby: head  }
+          - { os: macos-14        , ruby: '3.0' }
+          - { os: macos-14        , ruby:  3.2  }
+          - { os: macos-14        , ruby:  3.4  }
+          - { os: macos-15        , ruby:  3.1  }
+          - { os: macos-15        , ruby:  3.3  }
+          - { os: macos-15        , ruby:  head }
+          - { os: macos-15-intel  , ruby: '3.0' }
+          - { os: macos-15-intel  , ruby:  3.2  }
+          - { os: macos-15-intel  , ruby:  3.4  }
+          - { os: macos-26        , ruby: '3.0' }
+          - { os: macos-26        , ruby:  3.2  }
+          - { os: macos-26        , ruby:  head }
+          - { os: windows-2025    , ruby:  head }
 
     steps:
       - name: repo checkout


### PR DESCRIPTION
### Description

The GHA `macos-13` image has been [deprecated](https://github.com/actions/runner-images/tree/dcf9c6937d64a3?tab=readme-ov-file#available-images).  The `macos-26` image is available (beta)

Remove `macos-13` and replace with `macos-26`, and replace `windows-2022` with `windows-2025`

From [actions/runner-images](https://github.com/actions/runner-images/issues/13046)

> Deprecation will begin on September 22nd, 2025 and the images will be fully unsupported by December 8th, 2025 for GitHub Actions and Azure DevOps.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
