### PR TITLE
server.rb - fixup `closed_socket?` in case `state` is `nil`

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -217,6 +217,7 @@ module Puma
           false
         else
           state = tcp_info.unpack(UNPACK_TCP_STATE_FROM_TCP_INFO)[0]
+          return false unless state
           # TIME_WAIT: 6, CLOSE: 7, CLOSE_WAIT: 8, LAST_ACK: 9, CLOSING: 11
           (state >= 6 && state <= 9) || state == 11
         end


### PR DESCRIPTION
### Description

Currently, Puma has the following code to check if `BasicSocket#getsockoptgetsockopt` can determine whether a socket is closed.  For most platforms & OS's, this works.  #3766 shows that the check may not always work.

PR adds one line to verify the return of `BasicSocket#getsockoptgetsockopt`.

https://github.com/puma/puma/blob/474f4ac87b3a49884080f6611636eff2e6e61cee/lib/puma/server.rb#L168-L170

Closes #3766

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
