### PR TITLE
ci: test_thread_pool.rb - only run parallel on MRI

### DIFF
--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -6,7 +6,8 @@ require "puma/thread_pool"
 
 class TestThreadPool < PumaTest
 
-  parallelize_me!
+  # intermittent failures on non MRI Rubies
+  parallelize_me! if Puma::IS_MRI
 
   def teardown
     @pool.shutdown(1) if defined?(@pool)


### PR DESCRIPTION
### Description

Several recent CI runs of the tests.yml workflow have passed.  Recently, in one run, test_thread_pool.rb failed on a JRuby job and a TruffleRuby job.

Currently the file is run parallel for all jobs.  PR updates it to only run parallel on MRI Rubies.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
