### PR TITLE
Fix flappy `test/test_thread_pool.rb` tests 

### DIFF
--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -195,10 +195,10 @@ class TestThreadPool < PumaTest
 
     assert_equal 2, pool.spawned
 
-    pool.trim
+    pool.trim(wait: true)
     assert_equal 1, pool.spawned
 
-    pool.trim
+    pool.trim(wait: true)
     assert_equal 1, pool.spawned
   end
 

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -61,8 +61,8 @@ class TestThreadPool < PumaTest
         # Lock for race safety
         with_mutex do
           return if @trim_requested == 0
-          Thread.pass
         end
+        Thread.pass
       end
     end
   end

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -59,7 +59,7 @@ class TestThreadPool < PumaTest
         # While we wait until @trim_requested is 0, the test might inspect other values
         # such as @spawned which may be modified after this variable is modified in the loop
         # Lock for race safety
-        @mutex.synchronize do
+        with_mutex do
           return if @trim_requested == 0
           Thread.pass
         end


### PR DESCRIPTION
You can validate this by running this command in a loop with jruby

```
$ chruby jruby 10.0.2.0                                                             
$ while be m test/test_thread_pool.rb; do echo "Test passed, running again..."; done
```

If it exits, we missed a flappy test.

Close #3771

