### PR TITLE
add config command

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -29,6 +29,7 @@ module Puma
       @argv = argv.dup
       @log_writer = log_writer
       @events = events
+      @command = "run"
 
       @conf = nil
 
@@ -43,6 +44,10 @@ module Puma
         setup_options env
 
         if file = @argv.shift
+          if file == "config"
+            @command = "config"
+          end
+
           @conf.configure do |user_config, file_config|
             file_config.rackup file
           end
@@ -70,6 +75,10 @@ module Puma
     # for it to finish.
     #
     def run
+      if @command == "config"
+        @launcher.log_config
+        exit 0
+      end
       @launcher.run
     end
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -243,6 +243,15 @@ module Puma
       end
     end
 
+    def log_config
+      log "Configuration:"
+
+      @config.final_options
+        .each { |config_key, value| log "- #{config_key}: #{value}" }
+
+      log "\n"
+    end
+
     private
 
     def get_env
@@ -482,15 +491,6 @@ module Puma
         # Not going to log this one, as SIGINFO is *BSD only and would be pretty annoying
         # to see this constantly on Linux.
       end
-    end
-
-    def log_config
-      log "Configuration:"
-
-      @config.final_options
-        .each { |config_key, value| log "- #{config_key}: #{value}" }
-
-      log "\n"
     end
   end
 end


### PR DESCRIPTION
### Description
closes https://github.com/puma/puma/issues/3755

This Pr adds a config command that adds a more elegant way to get the puma config for debugging and or asking for validation from other people. This is still a draft so I'm still working on tests and will add the json flag as requested in the issue if you guys thinks this is a good solution to go forward.

