### PR TITLE
Set `Thread.current.puma_server` in Thread init code, not every request

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -259,8 +259,7 @@ module Puma
 
       @status = :run
 
-      @options[:puma_server] = self
-      @thread_pool = ThreadPool.new(thread_name, options) { |client| process_client client }
+      @thread_pool = ThreadPool.new(thread_name, options, server: self) { |client| process_client client }
 
       if @queue_requests
         @reactor = Reactor.new(@io_selector_backend) { |c|

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -37,11 +37,8 @@ module Puma
     # The block passed is the work that will be performed in each
     # thread.
     #
-    def initialize(name, options = {}, &block)
-      # below is for CI
-      @server = options.respond_to?(:user_options) ?
-        options.user_options.delete(:puma_server) :
-        options.delete(:puma_server)
+    def initialize(name, options = {}, server: nil, &block)
+      @server = server
 
       @not_empty = ConditionVariable.new
       @not_full = ConditionVariable.new


### PR DESCRIPTION
### Description

Currently, the following is set in every call to `Server#process_request`:
```ruby
# Advertise this server into the thread
Thread.current.puma_server = self
```

PR moves code around to set it once in the `Thread.new` block.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
