### PR TITLE
s/assert/assert_equal in tests

### DIFF
--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -435,7 +435,7 @@ class TestIntegrationCluster < TestIntegration
     cli_server "-C test/config/prune_bundler_with_multiple_workers.rb"
     reply = read_body(connect)
 
-    assert reply, "embedded app"
+    assert_equal reply, "embedded app"
   end
 
   def test_load_path_includes_extra_deps
@@ -575,8 +575,8 @@ class TestIntegrationCluster < TestIntegration
       wait_for_server_to_match(/(index \d data \d)/, 1)
     end.sort
 
-    assert 'index 0 data 0', ary[0]
-    assert 'index 1 data 1', ary[1]
+    assert_equal 'index 0 data 0', ary[0]
+    assert_equal 'index 1 data 1', ary[1]
   end
 
   def test_after_worker_shutdown_hook


### PR DESCRIPTION
### Description
Fix `assert`s that should have been `assert_equal` in tests. Found as part of feedback on https://github.com/puma/puma/pull/3707

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.