### PR TITLE
ci: macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm,
-              macos-13, macos-14, macos-15,
+              macos-14, macos-15, macos-15-intel,
               windows-2022 ]
         ruby: [ '3.0', 3.1, 3.2, 3.3, 3.4, head ]
         no-ssl: ['']
@@ -141,16 +141,16 @@ jobs:
       matrix:
         include:
           # tto - test timeout
-          - { tto: 8 , os: ubuntu-22.04 , ruby: jruby }
-          - { tto: 8 , os: ubuntu-22.04 , ruby: jruby, no-ssl: ' no SSL' }
-          - { tto: 8 , os: ubuntu-22.04 , ruby: jruby-head, allow-failure: false }
-          - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby, allow-failure: false } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
-          - { tto: 8 , os: ubuntu-22.04 , ruby: truffleruby-head, allow-failure: false }
-          - { tto: 8 , os: ubuntu-24.04 , ruby: truffleruby, allow-failure: false } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
-          - { tto: 8 , os: ubuntu-24.04 , ruby: truffleruby-head, allow-failure: false }
-          - { tto: 8 , os: macos-13     , ruby: jruby }
-          - { tto: 8 , os: macos-14     , ruby: jruby }
-          - { tto: 8 , os: macos-15     , ruby: truffleruby, allow-failure: false }
+          - { tto: 8 , os: ubuntu-22.04  , ruby: jruby }
+          - { tto: 8 , os: ubuntu-22.04  , ruby: jruby, no-ssl: ' no SSL' }
+          - { tto: 8 , os: ubuntu-22.04  , ruby: jruby-head, allow-failure: false }
+          - { tto: 8 , os: ubuntu-22.04  , ruby: truffleruby, allow-failure: false } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
+          - { tto: 8 , os: ubuntu-22.04  , ruby: truffleruby-head, allow-failure: false }
+          - { tto: 8 , os: ubuntu-24.04  , ruby: truffleruby, allow-failure: false } # Until https://github.com/oracle/truffleruby/issues/2700 is solved
+          - { tto: 8 , os: ubuntu-24.04  , ruby: truffleruby-head, allow-failure: false }
+          - { tto: 8 , os: macos-14      , ruby: jruby }
+          - { tto: 8 , os: macos-15-intel, ruby: jruby }
+          - { tto: 8 , os: macos-15      , ruby: truffleruby, allow-failure: false }
 
     steps:
       - name: repo checkout


### PR DESCRIPTION
### Description

Having spent too much time paying attention to Actions CI logs, often the failures are on macos-13 (which is x86_64-darwin).

That runner is being deprecated, with removal on 04-Dec-2025.  It is being replaced by macos-15-intel.

PR switches all macos-13 jobs to macos-15-intel

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
