### PR TITLE
ci: test_http11.rb - don't run parallel on macos intel JRuby

### DIFF
--- a/test/test_http11.rb
+++ b/test/test_http11.rb
@@ -11,7 +11,7 @@ require "puma/puma_http11"
 
 class Http11ParserTest < TestIntegration
 
-  parallelize_me!
+  parallelize_me! unless ::Puma::IS_JRUBY && RUBY_DESCRIPTION.include?('x86_64-darwin')
 
   def test_parse_simple
     parser = Puma::HttpParser.new
@@ -156,7 +156,8 @@ class Http11ParserTest < TestIntegration
              { envs: %w[-4000 0 3000.45], exp: default_exp, error_indexes: [0, 1, 2] }]
     cli_config = <<~CONFIG
         app do |_|
-          [200, {}, [JSONSerialization.generate({ MAX_REQUEST_URI_LENGTH:      org.jruby.puma.Http11::MAX_REQUEST_URI_LENGTH,
+          [200, {}, [JSONSerialization.generate({
+                       MAX_REQUEST_URI_LENGTH:      org.jruby.puma.Http11::MAX_REQUEST_URI_LENGTH,
                        MAX_REQUEST_PATH_LENGTH:     org.jruby.puma.Http11::MAX_REQUEST_PATH_LENGTH,
                        MAX_QUERY_STRING_LENGTH:     org.jruby.puma.Http11::MAX_QUERY_STRING_LENGTH,
                        MAX_REQUEST_URI_LENGTH_ERR:  org.jruby.puma.Http11::MAX_REQUEST_URI_LENGTH_ERR,
@@ -171,6 +172,7 @@ class Http11ParserTest < TestIntegration
         merge_err: true,
         config: cli_config
 
+      sleep 0.25
       result = JSON.parse read_body(connect)
 
       assert_equal conf[:exp][0], result['MAX_REQUEST_URI_LENGTH']


### PR DESCRIPTION
### Description

Frequently one job has often failed in CI.  Previously, it was the macos-13 JRuby job.  Now, the macos-15-intel job is doing the same.  The failure is on `Http11ParserTest#test_get_const_length`, which never completes, and hangs the CI, so the test step times out.

The `Http11ParserTest` file (`test_http11.rb`) currently runs parallel, and contains one 'integration' test, which is `test_get_const_length`.  This test is an 'integration' test because it tests setting ENV values that are picked up by the java http parser.  It only runs on JRuby.

Because we run some tests parallel, and also have 'retry', one really can't change the environment in tests, unless it's done by passing an `ENV` to `IO.popen`.

So, the test is currently run parallel, this PR runs it parallel for all jobs **except JRuby on macos-15-intel**.  It may not fix the intermittent, but it's worth a try...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
