### PR TITLE
client.rb - Skip reading zero bytes when request body is buffered

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -502,11 +502,8 @@ module Puma
 
       # don't bother with reading zero bytes
       unless remain.zero?
-
-        want = remain > CHUNK_SIZE ? CHUNK_SIZE : remain
-
         begin
-          chunk = @io.read_nonblock(want, @read_buffer)
+          chunk = @io.read_nonblock(remain.clamp(0, CHUNK_SIZE), @read_buffer)
         rescue IO::WaitReadable
           return false
         rescue SystemCallError, IOError


### PR DESCRIPTION
### Description

Current code in `Client` handles parsing a request's request line and headers (using `HttpParser`), along with reading the content/body if it exists.  Much of the body related code is in `Client#read_body`.  Some code is executed for every call, but the code can be skipped sometimes.

Code adds a conditional to skip the code.

The patch is best viewed with 'Hide whitespace', as several lines only have an indent added.

A larger refactor of this code could move the conditional 'higher', saving that for the future.  It also ties in with processing pipe-lined requests.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.

---
**Help Puma by sponsoring its maintainers**
* [dentarg](https://github.com/sponsors/dentarg)
* [MSP-Greg](https://github.com/sponsors/MSP-Greg)
* [schneems](https://github.com/sponsors/schneems)