### PR TITLE
`client.rb` - `read_body` - cleanup last lines of method

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -525,12 +525,11 @@ module Puma
         @body.rewind
         @buffer = nil
         set_ready
-        return true
+        true
+      else
+        @body_remain = remain
+        false
       end
-
-      @body_remain = remain
-
-      false
     end
 
     def read_chunked_body


### PR DESCRIPTION
### Description

Small refactor that should have been included in PR #3795.  A `return` statement ends an if/end block, followed by two lines of code ending the method.  Removed the `return` and ended the method with an if/else/end block.  See patch...  

Or, I really dislike return statements near the end of a method.  Better to use an implicit return.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
