### PR TITLE
Monomorphize `handle_request` return (refactor)

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -501,10 +501,10 @@ module Puma
           can_loop = false
           @requests_count += 1
           case handle_request(client, requests + 1)
-          when false
+          when :close
           when :async
             close_socket = false
-          when true
+          when :keep_alive
             requests += 1
 
             client.reset


### PR DESCRIPTION
Before `handle_request` returns either a boolean (true/false), or a symbol `:async`. Now it returns one of three symbols `:close`, `:keep_alive`, or `:async`.

This improves the readability of the case statement in the server that utilizes the output of this response.

### Description
Thank you for contributing! You're the best.

We can read your code, so consider leaving some comments here that are more about your motivations and decision making. Some things that may be helpful to address in your description:

- What original problem led to this PR?
- Are there related issues / prior discussions?
- What alternatives have been tried? Does this supersede previous attempts?
- Why do you make the choices you did? What are the tradeoffs?

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
