### PR TITLE
Pass in server object before_thread_start event

### DIFF
--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -198,7 +198,7 @@ module Puma
 
       @before_thread_start.each do |b|
         begin
-          b[:block].call
+          b[:block].call(@server)
         rescue Exception => e
           STDERR.puts "WARNING before_thread_start hook failed with exception (#{e.class}) #{e.message}"
         end

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -155,6 +155,29 @@ class TestThreadPool < PumaTest
     assert_equal 1, started.length
   end
 
+  def test_thread_start_hook_with_server
+    dummy_server_obj = Object.new
+    started = Queue.new
+    options = {
+      min_threads: 0,
+      max_threads: 1,
+      before_thread_start: [
+        {
+          id: nil,
+          block: proc {|server| started << server },
+          cluster_only: false,
+        }
+      ]
+    }
+    block = proc { }
+    pool = MutexPool.new('tst', options, server: dummy_server_obj, &block)
+
+    pool << 1
+
+    assert_equal 1, pool.spawned
+    assert_same dummy_server_obj, started.pop
+  end
+
   def test_out_of_band_hook
     out_of_band_called = Queue.new
     options = {


### PR DESCRIPTION
### Description

I have the other pull request https://github.com/puma/puma/pull/3658 in order to add a way to change the # of threads at runtime. As suggested by https://github.com/puma/puma/pull/3658#discussion_r2436818878 (and after looking at https://github.com/puma/puma/pull/3774), the extra `Thread.current.puma_server = server` assignment looked unnecessary., so I removed a few lines that I thought was duplicate. This actually broke the build in one of the tests in our private repo - we basically lost access to the server object and now have to think about how we can grab it.

This PR updates the `before_thread_start` event call to take the `server` object. This way we will be able to grab the server object with:

```ruby
Puma::Plugin.create do
  def start(launcher)
    ...

    launcher.config.configure do |user_dsl, *|
      user_dsl.before_thread_start do |server|
        do_stuff_with_server(server)
      end
    end
  end
end
```

While there are still many questions such as:

1.  Why did we add a way to pass around the server object in the first place?
2. Why does it make sense that only the `before_thread_start` event hook takes an argument? (other events don't take arguments at all.)
3. Are there any other use cases than changing the thread number?

I'm not actually sure there are other ways to get access to the `server` object. I'd be open to suggestions as to what makes more sense here.

### Your checklist for this pull request

<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
