### PR TITLE
Fix formatting for each signal description in signals.md [ci skip]

### DIFF
--- a/docs/signals.md
+++ b/docs/signals.md
@@ -42,7 +42,7 @@ Puma cluster responds to these signals:
 - `INT`:  Equivalent of sending Ctrl-C to cluster. Puma will attempt to finish then exit.
 - `CHLD`: Reap zombie child processes and wake event loop in `fork_worker` mode.
 - `URG`:  Refork workers in phases from worker 0 if `fork_worker` option is enabled.
-- `INFO`: Print backtraces of all puma threads.
+- `INFO`: Print backtraces of all Puma threads.
 
 ## Callbacks order in case of different signals
 


### PR DESCRIPTION
### Description

This PR just makes a minor fixes about formatting for each signal in the signals.md document:

- Trimming extra whitespaces
- Adding missing periods
- Adding `:` to clearly separate each signal and its description

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
