### PR TITLE
Implement `env["puma.mark_as_io_bound"]`

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -150,6 +150,7 @@ module Puma
       max_keep_alive: 999,
       max_threads: Puma.mri? ? 5 : 16,
       min_threads: 0,
+      max_io_threads: 0,
       mode: :http,
       mutate_stdout_and_stderr_to_sync_on_write: true,
       out_of_band: [],

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -595,6 +595,29 @@ module Puma
       @options[:max_threads] = max
     end
 
+    # Configure the max number of IO threads.
+    #
+    # When request handlers know the current requests will no longer use a significant amount
+    # of CPU, they can mark the current request as IO bound using <tt>env["puma.mark_as_io_bound"]</tt>.
+    #
+    # Threads marked as IO bound are allowed to go over the max thread limit.
+    #
+    # @example
+    #   threads 5
+    #   max_io_threads 5
+    #
+    # The above example allows for 5 regular threads and 5 IO threads to process requests concurrently.
+    # Any IO thread over the limit is counted as a regular thread, hence the above configuration also
+    # allows for 3 regular threads and 7 IO threads for example.
+    def max_io_threads(max)
+      max = Integer(max)
+      if max < 0
+        raise "The maximum number of IO threads (#{max}) must be a positive number"
+      end
+
+      @options[:max_io_threads] = max
+    end
+
     # Instead of using +bind+ and manually constructing a URI like:
     #
     #    bind 'ssl://127.0.0.1:9292?key=key_path&cert=cert_path'

--- a/lib/puma/response.rb
+++ b/lib/puma/response.rb
@@ -46,10 +46,11 @@ module Puma
     # elsewhere, i.e. the connection has been hijacked by the Rack application.
     #
     # Finally, it'll return +true+ on keep-alive connections.
+    # @param processor [Puma::ThreadPool::ProcessorThread]
     # @param client [Puma::Client]
     # @param requests [Integer]
     # @return [:close, :keep_alive, :async]
-    def handle_request(client, requests)
+    def handle_request(processor, client, requests)
       env = client.env
       io_buffer = client.io_buffer
       socket  = client.io   # io may be a MiniSSL::Socket
@@ -70,6 +71,8 @@ module Puma
           end
         }
       end
+
+      env["puma.mark_as_io_bound"] = -> { processor.mark_as_io_thread! }
 
       begin
         status, headers, app_body = @thread_pool.with_force_shutdown do

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -31,7 +31,7 @@ module Puma
   # Each `Puma::Server` will have one reactor and one thread pool.
   class Server
     module FiberPerRequest
-      def handle_request(client, requests)
+      def handle_request(processor, client, requests)
         Fiber.new do
           super
         end.resume
@@ -259,7 +259,9 @@ module Puma
 
       @status = :run
 
-      @thread_pool = ThreadPool.new(thread_name, options, server: self) { |client| process_client client }
+      @thread_pool = ThreadPool.new(thread_name, options, server: self) do |processor, client|
+        process_client(processor, client)
+      end
 
       if @queue_requests
         @reactor = Reactor.new(@io_selector_backend) { |c|
@@ -304,7 +306,7 @@ module Puma
     # The method checks to see if it has the full header and body with
     # the `Puma::Client#try_to_finish` method. If the full request has been sent,
     # then the request is passed to the ThreadPool (`@thread_pool << client`)
-    # so that a "worker thread" can pick up the request and begin to execute application logic.
+    # so that a "processor thread" can pick up the request and begin to execute application logic.
     # The Client is then removed from the reactor (return `true`).
     #
     # If a client object times out, a 408 response is written, its connection is closed,
@@ -473,14 +475,14 @@ module Puma
     # Given a connection on +client+, handle the incoming requests,
     # or queue the connection in the Reactor if no request is available.
     #
-    # This method is called from a ThreadPool worker thread.
+    # This method is called from a ThreadPool processor thread.
     #
     # This method supports HTTP Keep-Alive so it may, depending on if the client
     # indicates that it supports keep alive, wait for another request before
     # returning.
     #
     # Return true if one or more requests were processed.
-    def process_client(client)
+    def process_client(processor, client)
       close_socket = true
 
       requests = 0
@@ -503,7 +505,7 @@ module Puma
         while can_loop
           can_loop = false
           @requests_count += 1
-          case handle_request(client, requests + 1)
+          case handle_request(processor, client, requests + 1)
           when :close
           when :async
             close_socket = false
@@ -671,7 +673,7 @@ module Puma
     end
     private :notify_safely
 
-    # Stops the acceptor thread and then causes the worker threads to finish
+    # Stops the acceptor thread and then causes the processor threads to finish
     # off the request queue before finally exiting.
 
     def stop(sync=false)

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -25,6 +25,51 @@ module Puma
     class ForceShutdown < RuntimeError
     end
 
+    class ProcessorThread
+      attr_accessor :thread
+      attr_writer :marked_as_io_thread
+
+      def initialize(pool)
+        @pool = pool
+        @thread = nil
+        @marked_as_io_thread = false
+      end
+
+      def mark_as_io_thread!
+        unless @marked_as_io_thread
+          @marked_as_io_thread = true
+
+          # Immediately signal the pool that it can spawn a new thread
+          # if there's some work in the queue.
+          @pool.spawn_thread_if_needed
+        end
+      end
+
+      def marked_as_io_thread?
+        @marked_as_io_thread
+      end
+
+      def alive?
+        @thread&.alive?
+      end
+
+      def join(...)
+        @thread.join(...)
+      end
+
+      def kill(...)
+        @thread.kill(...)
+      end
+
+      def [](key)
+        @thread[key]
+      end
+
+      def raise(...)
+        @thread.raise(...)
+      end
+    end
+
     # How long, after raising the ForceShutdown of a thread during
     # forced shutdown mode, to wait for the thread to try and finish
     # up its work before leaving the thread to die on the vine.
@@ -53,6 +98,8 @@ module Puma
       @name = name
       @min = Integer(options[:min_threads])
       @max = Integer(options[:max_threads])
+      @max_io_threads = Integer(options[:max_io_threads] || 0)
+
       # Not an 'exposed' option, options[:pool_shutdown_grace_time] is used in CI
       # to shorten @shutdown_grace_time from SHUTDOWN_GRACE_TIME. Parallel CI
       # makes stubbing constants difficult.
@@ -71,7 +118,7 @@ module Puma
       @trim_requested = 0
       @out_of_band_pending = false
 
-      @workers = []
+      @processors = []
 
       @auto_trim = nil
       @reaper = nil
@@ -100,6 +147,7 @@ module Puma
           running: @spawned,
           pool_capacity: pool_capacity,
           busy_threads: @spawned - @waiting + @todo.size,
+          io_threads: @processors.count(&:marked_as_io_thread?),
           backlog_max: temp
         }
       end
@@ -140,7 +188,8 @@ module Puma
       @spawned += 1
 
       trigger_before_thread_start_hooks
-      th = Thread.new(@spawned) do |spawned|
+      processor = ProcessorThread.new(self)
+      processor.thread = Thread.new(processor, @spawned) do |processor, spawned|
         Puma.set_thread_name '%s tp %03i' % [@name, spawned]
         # Advertise server into the thread
         Thread.current.puma_server = @server
@@ -155,11 +204,23 @@ module Puma
           work = nil
 
           mutex.synchronize do
+            if processor.marked_as_io_thread?
+              if @processors.count { |t| !t.marked_as_io_thread? } < @max
+                # We're not at max processor threads, so the io thread can rejoin the normal population.
+                processor.marked_as_io_thread = false
+              else
+                # We're already at max threads, so we exit the extra io thread.
+                @processors.delete(processor)
+                trigger_before_thread_exit_hooks
+                Thread.exit
+              end
+            end
+
             while todo.empty?
               if @trim_requested > 0
                 @trim_requested -= 1
                 @spawned -= 1
-                @workers.delete th
+                @processors.delete(processor)
                 not_full.signal
                 trigger_before_thread_exit_hooks
                 Thread.exit
@@ -181,16 +242,16 @@ module Puma
           end
 
           begin
-            @out_of_band_pending = true if block.call(work)
+            @out_of_band_pending = true if block.call(processor, work)
           rescue Exception => e
             STDERR.puts "Error reached top of thread-pool: #{e.message} (#{e.class})"
           end
         end
       end
 
-      @workers << th
+      @processors << processor
 
-      th
+      processor
     end
 
     private :spawn_thread
@@ -259,6 +320,16 @@ module Puma
         @mutex.synchronize(&block)
     end
 
+    # :nodoc:
+    #
+    # Must be called with @mutex held!
+    #
+    def can_spawn_processor?
+      io_processors_count = @processors.count(&:marked_as_io_thread?)
+      extra_io_processors_count = io_processors_count > @max_io_threads ? io_processors_count - @max_io_threads : 0
+      (@spawned - io_processors_count) < (@max - extra_io_processors_count)
+    end
+
     # Add +work+ to the todo list for a Thread to pickup and process.
     def <<(work)
       with_mutex do
@@ -270,11 +341,20 @@ module Puma
         t = @todo.size
         @backlog_max = t if t > @backlog_max
 
-        if @waiting < @todo.size and @spawned < @max
+        if @waiting < @todo.size and can_spawn_processor?
           spawn_thread
         end
 
         @not_empty.signal
+      end
+      self
+    end
+
+    def spawn_thread_if_needed # :nodoc:
+      with_mutex do
+        if @waiting < @todo.size and can_spawn_processor?
+          spawn_thread
+        end
       end
     end
 
@@ -296,15 +376,11 @@ module Puma
     # spawned counter so that new healthy threads could be created again.
     def reap
       with_mutex do
-        dead_workers = @workers.reject(&:alive?)
+        @processors, dead_processors = @processors.partition(&:alive?)
 
-        dead_workers.each do |worker|
-          worker.kill
+        dead_processors.each do |processor|
+          processor.kill
           @spawned -= 1
-        end
-
-        @workers.delete_if do |w|
-          dead_workers.include?(w)
         end
       end
     end
@@ -373,8 +449,8 @@ module Puma
 
         @auto_trim&.stop
         @reaper&.stop
-        # dup workers so that we join them all safely
-        @workers.dup
+        # dup processors so that we join them all safely
+        @processors.dup
       end
 
       if timeout == -1
@@ -407,7 +483,7 @@ module Puma
       end
 
       @spawned = 0
-      @workers = []
+      @processors = []
     end
   end
 end

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -248,6 +248,26 @@ class TestRackServer < PumaTest
     assert_equal [1], calls
   end
 
+  def test_puma_mark_as_io_bound
+    called = false
+
+    @server.app = lambda do |env|
+      env['puma.mark_as_io_bound'].call
+      called = true
+      [200, { "X-Header" => "Works" }, ["OK"]]
+    rescue => e
+      called = e
+    end
+
+    @server.run
+
+    hit(["#{@tcp}/test"])
+
+    stop
+
+    assert_equal true, called
+  end
+
   def test_rack_body_proxy
     closed = false
     body = Rack::BodyProxy.new(["Hello"]) { closed = true }

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -12,11 +12,12 @@ class TestThreadPool < PumaTest
     @pool.shutdown(1) if defined?(@pool)
   end
 
-  def new_pool(min, max, pool_shutdown_grace_time: nil, &block)
+  def new_pool(min, max, pool_shutdown_grace_time: nil, max_io_threads: 0, &block)
     block = proc { } unless block
     options = {
       min_threads: min,
       max_threads: max,
+      max_io_threads: max_io_threads,
       pool_shutdown_grace_time: pool_shutdown_grace_time,
     }
     @pool = Puma::ThreadPool.new('tst', options, &block)
@@ -69,7 +70,7 @@ class TestThreadPool < PumaTest
 
   def test_append_spawns
     saw = []
-    pool = mutex_pool(0, 1) do |work|
+    pool = mutex_pool(0, 1) do |_processor, work|
       saw << work
     end
 
@@ -404,8 +405,8 @@ class TestThreadPool < PumaTest
     pool = new_pool(1, 1) { |_| }
     sleep 1
 
-    # simulate our waiting worker thread getting killed for whatever reason
-    pool.instance_eval { @workers[0].kill }
+    # simulate our waiting processor thread getting killed for whatever reason
+    pool.instance_eval { @processors[0].kill }
     sleep 1
     pool.reap
     sleep 1
@@ -434,5 +435,53 @@ class TestThreadPool < PumaTest
     pool.max = 1
 
     assert_equal 0, pool.pool_capacity
+  end
+
+  def test_io_threads_allowed_over_the_limit
+    mutex = Mutex.new
+    mutex.lock
+    queue = Queue.new
+    concurrent_threads = []
+    pool = new_pool(0, 4, max_io_threads: 4) do |processor, io_bound_thread|
+      if io_bound_thread
+        processor.mark_as_io_thread!
+      end
+      queue << Thread.current
+      mutex.synchronize { }
+    end
+
+    8.times do
+      pool << true
+      concurrent_threads << queue.pop
+    end
+    assert_equal 8, concurrent_threads.size
+    refute_predicate pool, :can_spawn_processor?
+  ensure
+    mutex.unlock
+    pool.shutdown
+  end
+
+  def test_io_threads_over_the_limit_count_as_normal_threads
+    mutex = Mutex.new
+    mutex.lock
+    queue = Queue.new
+    concurrent_threads = []
+    pool = new_pool(0, 2, max_io_threads: 2) do |processor, io_bound_thread|
+      if io_bound_thread
+        processor.mark_as_io_thread!
+      end
+      queue << Thread.current
+      mutex.synchronize { }
+    end
+
+    [true, true, true, false].each do |io_bound_thread|
+      pool << io_bound_thread
+      concurrent_threads << queue.pop
+    end
+    assert_equal 4, concurrent_threads.size
+    refute_predicate pool, :can_spawn_processor?
+  ensure
+    mutex.unlock
+    pool.shutdown
   end
 end


### PR DESCRIPTION
Fix: https://github.com/puma/puma/issues/3777

Workers can now be marked as "IO bound". This state last until the end of the current request.

At the end of the request, the pool decide whether the "IO bound" thread rejoin the normal population, or is abandonned.

Generally speaking, an "IO bound" thread no longer counts towards the `max_threads` configuration. However, there is a `max_io_threads` configuration, and any "IO bound" thread above that limit automatically counts as a "normal" thread.

For example, imagine a config of `max_threads: 5, max_io_threads: 10`:

If there is 3 normal threads and 12 io threads, then puma won't spawn any new thread, but the next deferred thread that complete will become "normal" again so that we now have 4 normal threads and 11 deferred threads.

Now if there is 5 normal threads and 2 IO threads, then when the next IO threads complete, it will exit.