### PR TITLE
Pin io-event to 1.14.0 in rack-conform CI to workaround compilation failure

### DIFF
--- a/.github/workflows/rack_conform.yml
+++ b/.github/workflows/rack_conform.yml
@@ -44,6 +44,8 @@ jobs:
           SRC="gem ['\"]puma['\"].*"
           DST="gem 'puma', git: 'https://github.com/$GITHUB_REPOSITORY.git', ref: '$GITHUB_SHA'"
           sed -i "s#$SRC#$DST#" gems/puma-head-rack-v3.rb
+          # pin io-event to 1.14.0 to workaround compilation issue in 1.14.1
+          echo "gem 'io-event', '1.14.0'" >> gems/puma-head-rack-v3.rb
 
       - name: load ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Summary

This PR pins `io-event` to version 1.14.0 in the rack-conform CI workflow to work around a compilation failure on Ruby head.

## Problem

The rack-conform CI is failing on Ruby head with compilation errors in `io-event` 1.14.1:

```
./io/event/worker_pool.c:224:1: error: stray '@' in program
224 | @@ -214,7 +227,7 @@ static int create_worker_thread(struct IO_Event_WorkerPool *pool) {
```

This is caused by git diff markers accidentally left in the C source code in io-event 1.14.1.

## Solution

Pin `io-event` to 1.14.0 in the rack-conform workflow until this is fixed upstream.

## Reference

- io-event commit with the issue: https://github.com/socketry/io-event/commit/903522e6c0484542cee3de06f5952c749dd213f6
- Failing CI run: https://github.com/puma/puma/actions/runs/19413345439/job/55537911174

cc @ioquatix - the io-event 1.14.1 gem appears to have corrupted C source files with git diff markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)