### PR TITLE
Revert "Add @joshuay03 to the maintainer list [ci skip]"

### DIFF
--- a/.github/workflows/pr-label-status.yml
+++ b/.github/workflows/pr-label-status.yml
@@ -29,7 +29,6 @@ jobs:
               'dentarg',
               'schneems',
               'nateberkopec',
-              'joshuay03'
             ];
 
             const LABELS = {


### PR DESCRIPTION
## Summary
- Reverts commit b37e9490 which added @joshuay03 to the maintainer list

## Details
This PR reverts the addition of @joshuay03 to the MAINTAINERS_LIST in the pr-label-status.yml workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)