### PR TITLE
Fix advertising of CLI config before config files are loaded

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -197,7 +197,7 @@ module Puma
       @clamped = false
     end
 
-    attr_reader :plugins, :events, :hooks
+    attr_reader :plugins, :events, :hooks, :_options
 
     def options
       raise NotClampedError, "ensure clamp is called before accessing options" unless @clamped

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -45,6 +45,8 @@ module Puma
       ## Minimal initialization for a potential early restart (e.g. when pruning bundle)
 
       @config = conf
+      # Advertise the CLI Configuration before config files are loaded
+      Puma.cli_config = @config if defined?(Puma.cli_config)
       @config.clamp
 
       @options = @config.options
@@ -70,8 +72,6 @@ module Puma
 
       env = launcher_args.delete(:env) || ENV
 
-      # Advertise the Configuration
-      Puma.cli_config = @config if defined?(Puma.cli_config)
       log_config if env['PUMA_LOG_CONFIG']
 
       @binder = Binder.new(@log_writer, @options)

--- a/test/config/cli_config.rb
+++ b/test/config/cli_config.rb
@@ -1,0 +1,3 @@
+if Puma.cli_config._options[:workers] == 2
+  Puma.cli_config._options[:workers] = 4
+end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -420,4 +420,12 @@ class TestCLI < PumaTest
 
     assert_equal true, config.options[:preload_app]
   end
+
+  def test_config_is_advertised_to_config_files
+    skip_unless :fork
+
+    Puma::CLI.new ['-w 2', '-C', File.expand_path('config/cli_config.rb', __dir__)]
+
+    assert_equal 4, Puma.cli_config._options[:workers]
+  end
 end


### PR DESCRIPTION
Closes #3801

#3616 introduced a breaking change where the CLI config was only advertised after `#clamp` (and therefore `#load`) [was called](https://github.com/puma/puma/pull/3616/files#diff-602f49141abce5814cc6115eb1c4e070adcd5bf7db662a97e0d6205b2ea5402dR54), meaning it wasn't available for use in the config files being loaded, which seems to have been [the original intent](https://github.com/puma/puma/commit/211aef15899a8e5b21174e74519193ead07768c9).

Here I've moved the setting of `Puma.cli_config` right before clamping to reintroduce that functionality, and added a regression test for it.

**Note:** Unlike the example in #3801, users will now have to access the options via `_options`, which imo is a good thing, as it makes it clear that the options are yet to be finalised and that they're only reading the values at that point.