### PR TITLE
puma_http11.c: pre-intern env keys

### DIFF
--- a/ext/puma_http11/puma_http11.c
+++ b/ext/puma_http11/puma_http11.c
@@ -133,10 +133,10 @@ static void init_common_fields(void)
   for(i = 0; i < ARRAY_SIZE(common_http_fields); cf++, i++) {
     rb_global_variable(&cf->value);
     if(cf->raw) {
-      cf->value = rb_str_new(cf->name, cf->len);
+      cf->value = rb_enc_interned_str(cf->name, cf->len, rb_utf8_encoding());
     } else {
       memcpy(tmp + HTTP_PREFIX_LEN, cf->name, cf->len + 1);
-      cf->value = rb_str_new(tmp, HTTP_PREFIX_LEN + cf->len);
+      cf->value = rb_enc_interned_str(tmp, HTTP_PREFIX_LEN + cf->len, rb_utf8_encoding());
     }
   }
 }
@@ -179,7 +179,7 @@ static void http_field(puma_parser* hp, const char *field, size_t flen,
     memcpy(hp->buf, HTTP_PREFIX, HTTP_PREFIX_LEN);
     memcpy(hp->buf + HTTP_PREFIX_LEN, field, flen);
 
-    f = rb_str_new(hp->buf, new_size);
+    f = rb_enc_interned_str(hp->buf, new_size, rb_utf8_encoding());
   }
 
   while (vlen > 0 && is_ows(value[vlen - 1])) vlen--;


### PR DESCRIPTION
As explained in https://byroot.github.io/ruby/json/2025/01/12/optimizing-ruby-json-part-6.html when inserting a string key in a hash, Ruby will try to lookup an equivalent string in the interned string table.

As such, in C extensions, it's generally advantageous to pre-intern that string, or at least to pre-freeze it.

~~The gain is minor, but measurable~~. The gain is ~17% once common fields are interned too.

```
ruby 3.4.6 (2025-09-16 revision dbd83256b1) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after    27.498k i/100ms
Calculating -------------------------------------
               after    272.866k (± 1.5%) i/s    (3.66 μs/i) -      1.375M in   5.039945s

Comparison:
              before:   265747.8 i/s
               after:   272866.0 i/s - 1.03x  faster
```

```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "benchmark-ips"
  gem "puma", path: "."
end

request = <<~HTTP.split("\n").join("\r\n").freeze
  GET /puma/puma HTTP/1.1
  Host: github.com
  User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:144.0) Gecko/20100101 Firefox/144.0
  Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
  Accept-Language: en-US,en;q=0.5
  Accept-Encoding: gzip, deflate, br, zstd
  Connection: keep-alive
  Cookie: user_session=Dsdfsdfdsfdsfdsfdsfdsfdfdfs; __Host-user_session_same_site=Zya7Q7Zndsfsdfdsfdsfdsfdsfdsf; logged_in=yes; dotcom_user=george; _octo=GH1.1.1796688136.1746271857; _device_id=dsfsdfsdfdsfdsfdsf1fb6c729; color_mode=%7B%22color_mode%22%3A%22auto%22%2C%22light_theme%22%3A%7B%22name%22%3A%22light%22%2C%22color_mode%22%3A%22light%22%7D%2C%22dark_theme%22%3A%7B%22name%22%3A%22dark%22%2C%22color_mode%22%3A%22dark%22%7D%7D; GHCC=Required:1-Analytics:0-SocialMedia:0-Advertising:0; cpu_bucket=lg; preferred_color_mode=dark; tz=Europe%2FDublin; _gh_sess=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
  Upgrade-Insecure-Requests: 1
  Sec-Fetch-Dest: document
  Sec-Fetch-Mode: navigate
  Sec-Fetch-Site: cross-site
  If-None-Match: W/"249a8aa7212f877b7ba603815b6f03d7"
  Priority: u=0, i
HTTP

def parse(request)
  http = Puma::HttpParser.new
  http.execute({}, request, 0)
  http.finished?
end

STAGE = ENV["STAGE"]
Benchmark.ips do |x|
  x.report(STAGE || "parse") do
    parse(request  + "\r\n\r\n")
  end
  if STAGE
    x.save!("/tmp/bench-puma-parser")
  end
  x.compare!(order: :baseline)
end
```
