### PR TITLE
ci: turbo-rails.yml - update for 'minitest-mock'

### DIFF
--- a/.github/workflows/turbo-rails.yml
+++ b/.github/workflows/turbo-rails.yml
@@ -70,6 +70,11 @@ jobs:
           # DST="kw =\n    if RUBY_VERSION.start_with? '3'\n      {git: 'https://github.com/teamcapybara/capybara.git', ref: '43e32a8495'}\n    else\n      {}\n    end\n  gem 'capybara', **kw"
           # sed -i "s#$SRC#$DST#" Gemfile
           #
+          # use `minitest-mock`
+          SRC="gem ['\"]rexml['\"]"
+          DST="gem 'rexml'\n  gem 'minitest-mock'"
+          sed -i "s#$SRC#$DST#" Gemfile
+          #
           # use `stdio` for log_writer, always have one thread existing
           SRC="Silent: true"
           DST="Silent: false, Threads: '1:4'"
@@ -90,4 +95,4 @@ jobs:
 
       - name: turbo-rails test
         id: test
-        run: bin/test test/**/*_test.rb -vd
+        run: bin/test test/**/*_test.rb -v


### PR DESCRIPTION
### Description

This PR adds 'minitest-mock' to the Turbo-Rails Gemfile, as it was recently removed from 'Minitest' to make updates easier.  The PR may be able to be removed when/if 'minitest-mock' is added to the Turbo-Rails Gemfile.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
