### PR TITLE
Use IPv6 (`::`) default for production

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -148,7 +148,7 @@ module Puma
 
           o.on "-p", "--port PORT", "Define the TCP port to bind to",
             "Use -b for more advanced options" do |arg|
-            user_config.bind "tcp://#{Configuration::DEFAULTS[:tcp_host]}:#{arg}"
+            user_config.port arg, Configuration.default_tcp_host
           end
 
           o.on "--pidfile PATH", "Use PATH as a pidfile" do |arg|

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'socket'
+require 'uri'
+
 require_relative 'plugin'
 require_relative 'const'
 require_relative 'dsl'
@@ -232,6 +235,8 @@ module Puma
 
     def puma_default_options(env = ENV)
       defaults = DEFAULTS.dup
+      defaults[:tcp_host] = self.class.default_tcp_host
+      defaults[:binds] = [self.class.default_tcp_bind]
       puma_options_from_env(env).each { |k,v| defaults[k] = v if v }
       defaults
     end
@@ -282,6 +287,7 @@ module Puma
       run_mode_hooks
       set_conditional_default_options
       @_options.finalize_values
+      rewrite_unavailable_ipv6_binds!
       @clamped = true
       warn_hooks
       options
@@ -360,6 +366,23 @@ module Puma
       options.final_options
     end
 
+    def self.default_tcp_host
+      ipv6_interface_available? ? Const::UNSPECIFIED_IPV6 : Const::UNSPECIFIED_IPV4
+    end
+
+    def self.default_tcp_bind(port = DEFAULTS[:tcp_port])
+      URI::Generic.build(scheme: 'tcp', host: default_tcp_host, port: Integer(port)).to_s
+    end
+
+    def self.ipv6_interface_available?
+      Socket.getifaddrs.any? do |ifaddr|
+        addr = ifaddr.addr
+        addr&.ipv6? && !addr&.ipv6_loopback?
+      end
+    rescue StandardError
+      false
+    end
+
     def self.temp_path
       require 'tmpdir'
 
@@ -374,6 +397,31 @@ module Puma
     end
 
     private
+
+    def rewrite_unavailable_ipv6_binds!
+      return if self.class.ipv6_interface_available?
+
+      tried_ipv6_bind = false
+      bind_schemes = ['tcp', 'ssl']
+
+      @_options[:binds] = Array(@_options[:binds]).map do |bind|
+        uri = URI.parse(bind)
+        next bind unless bind_schemes.include?(uri.scheme)
+
+        host = uri.host&.delete_prefix('[')&.delete_suffix(']')
+        next bind unless host&.include?(':')
+
+        tried_ipv6_bind = true
+        next bind unless host == Const::UNSPECIFIED_IPV6
+
+        uri.host = Const::UNSPECIFIED_IPV4
+        uri.to_s
+      rescue URI::InvalidURIError
+        bind
+      end
+
+      warn "WARNING: IPv6 bind requested but no non-loopback IPv6 interface was detected" if tried_ipv6_bind
+    end
 
     def require_processor_counter
       require 'concurrent/utility/processor_counter'

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -131,7 +131,7 @@ module Puma
 
     DEFAULTS = {
       auto_trim_time: 30,
-      binds: ['tcp://0.0.0.0:9292'.freeze],
+      binds: ['tcp://[::]:9292'.freeze],
       debug: false,
       early_hints: nil,
       enable_keep_alives: true,
@@ -167,7 +167,7 @@ module Puma
       silence_fork_callback_warning: false,
       silence_single_worker_warning: false,
       tag: File.basename(Dir.getwd),
-      tcp_host: '0.0.0.0'.freeze,
+      tcp_host: '::'.freeze,
       tcp_port: 9292,
       wait_for_less_busy_worker: 0.005,
       worker_boot_timeout: 60,

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -260,7 +260,7 @@ module Puma
     # accepted protocols. Multiple urls can be bound to, calling +bind+ does
     # not overwrite previous bindings.
     #
-    # The default is "tcp://0.0.0.0:9292".
+    # The default is "tcp://[::]:9292".
     #
     # You can use query parameters within the url to specify options:
     #
@@ -279,7 +279,7 @@ module Puma
     # @example SSL cert for mutual TLS (mTLS)
     #   bind 'ssl://127.0.0.1:9292?key=key.key&cert=cert.pem&ca=ca.pem&verify_mode=force_peer'
     # @example Disable optimization for low latency
-    #   bind 'tcp://0.0.0.0:9292?low_latency=false'
+    #   bind 'tcp://[::]:9292?low_latency=false'
     # @example Socket permissions
     #   bind 'unix:///var/run/puma.sock?umask=0111'
     #

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -155,7 +155,7 @@ module Puma
     end
 
     def default_host
-      @options[:default_host] || Configuration::DEFAULTS[:tcp_host]
+      @options[:default_host] || Configuration.default_tcp_host
     end
 
     def inject(&blk)
@@ -260,7 +260,8 @@ module Puma
     # accepted protocols. Multiple urls can be bound to, calling +bind+ does
     # not overwrite previous bindings.
     #
-    # The default is "tcp://[::]:9292".
+    # The default is "tcp://[::]:9292" when IPv6 interfaces are available,
+    # otherwise "tcp://0.0.0.0:9292".
     #
     # You can use query parameters within the url to specify options:
     #

--- a/lib/rack/handler/puma.rb
+++ b/lib/rack/handler/puma.rb
@@ -109,7 +109,7 @@ module Puma
         end
 
         if port
-          host ||= ::Puma::Configuration::DEFAULTS[:tcp_host]
+          host ||= ::Puma::Configuration.default_tcp_host
           config.port port, host
         end
       end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -20,7 +20,7 @@ class TestConfigFile < PumaTest
   def test_app_from_rackup
     if Rack.release >= '3'
       fn = "test/rackup/hello-bind_rack3.ru"
-      bind = "tcp://0.0.0.0:9292"
+      bind = "tcp://[::]:9292"
     else
       fn = "test/rackup/hello-bind.ru"
       bind = "tcp://127.0.0.1:9292"
@@ -877,12 +877,12 @@ class TestEnvModifificationConfig < PumaTest
     port = (rand(10_000) + 30_000).to_s
     env = { "PORT" => port }
     conf = Puma::Configuration.new({}, {}, env)  do |user_config, file_config, default_config|
-      user_config.bind "tcp://#{Puma::Configuration::DEFAULTS[:tcp_host]}:#{port}"
+      user_config.bind "tcp://[#{Puma::Configuration::DEFAULTS[:tcp_host]}]:#{port}"
       file_config.load "test/config/app.rb"
     end
     conf.clamp
 
-    assert_equal ["tcp://0.0.0.0:#{port}"], conf.options[:binds]
+    assert_equal ["tcp://[::]:#{port}"], conf.options[:binds]
   end
 end
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -20,7 +20,7 @@ class TestConfigFile < PumaTest
   def test_app_from_rackup
     if Rack.release >= '3'
       fn = "test/rackup/hello-bind_rack3.ru"
-      bind = "tcp://[::]:9292"
+      bind = Puma::Configuration.default_tcp_bind
     else
       fn = "test/rackup/hello-bind.ru"
       bind = "tcp://127.0.0.1:9292"
@@ -869,20 +869,64 @@ class TestConfigFileSingle < PumaTest
 
     assert_equal "Custom logging: test\n", out
   end
+
+  def test_defaults_to_ipv4_when_non_loopback_ipv6_is_unavailable
+    Socket.stub(:getifaddrs, []) do
+      conf = Puma::Configuration.new
+      conf.clamp
+
+      assert_equal '0.0.0.0', conf.options.default_options[:tcp_host]
+      assert_equal ['tcp://0.0.0.0:9292'], conf.options[:binds]
+    end
+  end
+
+  def test_defaults_to_ipv6_when_non_loopback_ipv6_is_available
+    ipv6_addr = Object.new
+    ipv6_addr.define_singleton_method(:ipv6?) { true }
+    ipv6_addr.define_singleton_method(:ipv6_loopback?) { false }
+
+    ifaddr = Struct.new(:addr).new(ipv6_addr)
+
+    Socket.stub(:getifaddrs, [ifaddr]) do
+      conf = Puma::Configuration.new
+      conf.clamp
+
+      assert_equal '::', conf.options.default_options[:tcp_host]
+      assert_equal ['tcp://[::]:9292'], conf.options[:binds]
+    end
+  end
+
+  def test_rewrites_unspecified_ipv6_bind_to_ipv4_and_logs_warning_when_ipv6_is_unavailable
+    Socket.stub(:getifaddrs, []) do
+      conf = Puma::Configuration.new do |config|
+        config.bind 'tcp://[::]:9292'
+      end
+
+      _out, err = capture_io do
+        conf.clamp
+      end
+
+      assert_equal ['tcp://0.0.0.0:9292'], conf.options[:binds]
+      assert_match(/WARNING: IPv6 bind requested/, err)
+    end
+  end
 end
 
 # Thread unsafe modification of ENV
 class TestEnvModifificationConfig < PumaTest
   def test_double_bind_port
     port = (rand(10_000) + 30_000).to_s
+    host = Puma::Configuration.default_tcp_host
+    host_uri = host.include?(':') ? "[#{host}]" : host
     env = { "PORT" => port }
-    conf = Puma::Configuration.new({}, {}, env)  do |user_config, file_config, default_config|
-      user_config.bind "tcp://[#{Puma::Configuration::DEFAULTS[:tcp_host]}]:#{port}"
+
+    conf = Puma::Configuration.new({}, {}, env) do |user_config, file_config, default_config|
+      user_config.bind "tcp://#{host_uri}:#{port}"
       file_config.load "test/config/app.rb"
     end
     conf.clamp
 
-    assert_equal ["tcp://[::]:#{port}"], conf.options[:binds]
+    assert_equal ["tcp://#{host_uri}:#{port}"], conf.options[:binds]
   end
 end
 

--- a/test/test_pumactl.rb
+++ b/test/test_pumactl.rb
@@ -161,7 +161,7 @@ class TestPumaControlCli < PumaTest
   end
 
   def test_control_url_and_status
-    host = "127.0.0.1"
+    host = "localhost"
     port = UniquePort.call
     url = "tcp://#{host}:#{port}/"
 

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -109,7 +109,7 @@ module TestRackUp
           conf = ::Rack::Handler::Puma.config(->{}, @options)
           conf.clamp
 
-          assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+          assert_equal ["tcp://[::]:#{user_port}"], conf.options[:binds]
         end
       end
     end
@@ -193,7 +193,7 @@ module TestRackUp
           conf = ::Rack::Handler::Puma.config(->{}, @options)
           conf.clamp
 
-          assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
+          assert_equal ["tcp://[::]:#{file_port}"], conf.options[:binds]
         end
       end
     end
@@ -246,7 +246,7 @@ module TestRackUp
       conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.clamp
 
-      assert_equal ["tcp://0.0.0.0:9292"], conf.options[:binds]
+      assert_equal ["tcp://[::]:9292"], conf.options[:binds]
     end
 
     def test_config_wins_over_default
@@ -260,7 +260,7 @@ module TestRackUp
           conf = ::Rack::Handler::Puma.config(->{}, @options)
           conf.clamp
 
-          assert_equal ["tcp://0.0.0.0:#{file_port}"], conf.options[:binds]
+          assert_equal ["tcp://[::]:#{file_port}"], conf.options[:binds]
         end
       end
     end
@@ -272,7 +272,7 @@ module TestRackUp
       conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.clamp
 
-      assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+      assert_equal ["tcp://[::]:#{user_port}"], conf.options[:binds]
     end
 
     def test_user_port_wins_over_default
@@ -281,7 +281,7 @@ module TestRackUp
       conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.clamp
 
-      assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+      assert_equal ["tcp://[::]:#{user_port}"], conf.options[:binds]
     end
 
     def test_user_port_wins_over_config
@@ -297,7 +297,7 @@ module TestRackUp
           conf = ::Rack::Handler::Puma.config(->{}, @options)
           conf.clamp
 
-          assert_equal ["tcp://0.0.0.0:#{user_port}"], conf.options[:binds]
+          assert_equal ["tcp://[::]:#{user_port}"], conf.options[:binds]
         end
       end
     end

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -8,6 +8,7 @@ module TestRackUp
   require "rack/handler/puma"
   require "puma/events"
 
+
   begin
     require 'rackup/version'
   rescue LoadError
@@ -109,7 +110,7 @@ module TestRackUp
           conf = ::Rack::Handler::Puma.config(->{}, @options)
           conf.clamp
 
-          assert_equal ["tcp://[::]:#{user_port}"], conf.options[:binds]
+          assert_equal [Puma::Configuration.default_tcp_bind(user_port)], conf.options[:binds]
         end
       end
     end
@@ -193,7 +194,7 @@ module TestRackUp
           conf = ::Rack::Handler::Puma.config(->{}, @options)
           conf.clamp
 
-          assert_equal ["tcp://[::]:#{file_port}"], conf.options[:binds]
+          assert_equal [Puma::Configuration.default_tcp_bind(file_port)], conf.options[:binds]
         end
       end
     end
@@ -246,7 +247,7 @@ module TestRackUp
       conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.clamp
 
-      assert_equal ["tcp://[::]:9292"], conf.options[:binds]
+      assert_equal [Puma::Configuration.default_tcp_bind(9292)], conf.options[:binds]
     end
 
     def test_config_wins_over_default
@@ -260,7 +261,7 @@ module TestRackUp
           conf = ::Rack::Handler::Puma.config(->{}, @options)
           conf.clamp
 
-          assert_equal ["tcp://[::]:#{file_port}"], conf.options[:binds]
+          assert_equal [Puma::Configuration.default_tcp_bind(file_port)], conf.options[:binds]
         end
       end
     end
@@ -272,7 +273,7 @@ module TestRackUp
       conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.clamp
 
-      assert_equal ["tcp://[::]:#{user_port}"], conf.options[:binds]
+      assert_equal [Puma::Configuration.default_tcp_bind(user_port)], conf.options[:binds]
     end
 
     def test_user_port_wins_over_default
@@ -281,7 +282,7 @@ module TestRackUp
       conf = ::Rack::Handler::Puma.config(->{}, @options)
       conf.clamp
 
-      assert_equal ["tcp://[::]:#{user_port}"], conf.options[:binds]
+      assert_equal [Puma::Configuration.default_tcp_bind(user_port)], conf.options[:binds]
     end
 
     def test_user_port_wins_over_config
@@ -297,7 +298,7 @@ module TestRackUp
           conf = ::Rack::Handler::Puma.config(->{}, @options)
           conf.clamp
 
-          assert_equal ["tcp://[::]:#{user_port}"], conf.options[:binds]
+          assert_equal [Puma::Configuration.default_tcp_bind(user_port)], conf.options[:binds]
         end
       end
     end


### PR DESCRIPTION
IPv4 addresses like 0.0.0.0 are easy and familiar, but they're increasingly more expensive with provider such as AWS (https://aws.amazon.com/blogs/aws/new-aws-public-ipv4-address-charge-public-ip-insights/). IPv6 addresses are much more plentiful, and therefore cheaper (and represent the future).

This update switches the default production address to IPv6 `::`. Here's the table of the URLs that supports:

| Host | localhost:3000 | 127.0.0.1:3000 | \[::1\]:3000 | 0.0.0.0:3000 | \[::\]:3000 | Network Open |
|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
| `localhost` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ No |
| `127.0.0.1` | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ No |
| `::1` | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ No |
| `0.0.0.0` | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ Yes |
| `::` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ Yes |

Generated with https://gist.github.com/schneems/0e3e5fb61b6e4128499af01c9cf7ac1c.

Puma has no concept of a "development" default host, so we don't need to use `::1` instead of `127.0.0.1` or `localhost`. Also due to the behavior of `::1` not falling back to IPv4 the same way that `::` does, it seems a higher-cost, lower benefit update, so I'm not recomending it for other defaults such as Rails https://github.com/rails/rails/pull/56470.

Close #3812

- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
