### PR TITLE
doc: change link to `docs/deployment.md` in `README.md` [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Note that threads are still used in cluster mode, and the `-t` thread flag setti
 
 If the `WEB_CONCURRENCY` environment variable is set to `"auto"` and the `concurrent-ruby` gem is available in your application, Puma will set the worker process count to the result of [available processors](https://msp-greg.github.io/concurrent-ruby/Concurrent.html#available_processor_count-class_method).
 
-For an in-depth discussion of the tradeoffs of thread and process count settings, [see our docs](docs/kubernetes.md#workers-per-pod-and-other-config-issues).
+For an in-depth discussion of the tradeoffs of thread and process count settings, [see our docs](docs/deployment.md).
 
 In cluster mode, Puma can "preload" your application. This loads all the application code *prior* to forking. Preloading reduces total memory usage of your application via an operating system feature called [copy-on-write](https://en.wikipedia.org/wiki/Copy-on-write).
 


### PR DESCRIPTION
In [6548c88](https://github.com/puma/puma/commit/6548c8804cafc5d9ba3bdd5c1a61d778f4d6137e), the `## Workers Per Pod, and Other Config Issues` section was replace with a single sentence linking to `docs/deployment.md`.

- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
