### PR TITLE
Fix TruffleRuby backtrace format test expectation

### DIFF
--- a/test/test_error_logger.rb
+++ b/test/test_error_logger.rb
@@ -101,7 +101,7 @@ class TestErrorLogger < PumaTest
 
       include_str =
         case
-        when Puma::IS_MRI && RUBY_VERSION < '3.4' || TRUFFLE
+        when (Puma::IS_MRI || TRUFFLE) && RUBY_VERSION < '3.4'
           ":in `dummy_error'" # beginning backtick
         when Puma::IS_JRUBY
           ":in 'dummy_error'" # beginning apostrophe/single quote


### PR DESCRIPTION
TruffleRuby head now uses the Ruby 3.4+ backtrace format that
includes the class name prefix ('TestErrorLogger#dummy_error')
instead of the old format (`dummy_error'`).

Remove TRUFFLE from the old-format condition so it falls through
to the else branch, which expects the new format.

CI failure:

```
  1) Failure:
TestErrorLogger#test_debug_backtrace_logging [test/test_error_logger.rb:112]:
Expected "2026-01-12 21:48:28 +0000: #<StandardError: non-blank>\n/home/runner/work/puma/puma/test/test_error_logger.rb:91:in 'TestErrorLogger#dummy_error'\n/home/runner/work/puma/puma/test/test_error_logger.rb:97:in 'block (2 levels) in TestErrorLogger#test_debug_backtrace_logging'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest/assertions.rb:544:in 'block in Minitest::Assertions#capture_io'\n/home/runner/work/puma/puma/vendor/bundle/truffl
eruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest/assertions.rb:182:in 'Minitest::Assertions#_synchronize'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.
3/gems/minitest-5.27.0/lib/minitest/assertions.rb:537:in 'Minitest::Assertions#capture_io'\n/home/runner/work/puma/puma/test/test_error_logger.rb:96:in 'block in Test
ErrorLogger#test_debug_backtrace_logging'\n/home/runner/work/puma/puma/test/test_error_logger.rb:120:in 'TestErrorLogger#with_debug_mode'\n/home/runner/work/puma/puma
/test/test_error_logger.rb:89:in 'TestErrorLogger#test_debug_backtrace_logging'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/li
b/minitest/test.rb:95:in 'block (2 levels) in Minitest::Test#run'\n/home/runner/work/puma/puma/test/helper.rb:93:in 'block (2 levels) in TimeoutPrepend#capture_except
ions'\n/home/runner/.rubies/truffleruby-head/lib/truffle/timeout.rb:165:in 'Timeout#timeout'\n/home/runner/work/puma/puma/test/helper.rb:93:in 'block in TimeoutPrepen
d#capture_exceptions'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest/test.rb:191:in 'Minitest::Test#capture_exceptio
ns'\n/home/runner/work/puma/puma/test/helper.rb:92:in 'TimeoutPrepend#capture_exceptions'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest
-5.27.0/lib/minitest/test.rb:90:in 'block in Minitest::Test#run'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest.rb:3
82:in 'Minitest::Runnable#time_it'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest/test.rb:89:in 'Minitest::Test#run'
\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest.rb:1223:in 'Minitest.run_one_method'\n/home/runner/work/puma/puma/ve
ndor/bundle/truffleruby/3.4.7.3/gems/minitest-retry-0.3.0/lib/minitest/retry.rb:130:in 'block in Minitest::Retry::ClassMethods#run_one_method'\n/home/runner/work/puma
/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-retry-0.3.0/lib/minitest/retry.rb:115:in 'block in Minitest::Retry.run_with_retry'\n<internal:core> core/integer
.rb:157:in 'Integer#times'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-retry-0.3.0/lib/minitest/retry.rb:106:in 'Minitest::Retry.run_
with_retry'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-retry-0.3.0/lib/minitest/retry.rb:129:in 'Minitest::Retry::ClassMethods#run_o
ne_method'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest.rb:462:in 'Minitest::Runnable.run_one_method'\n/home/runne
r/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest.rb:449:in 'block (2 levels) in Minitest::Runnable.run'\n/home/runner/work/puma/pu
ma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest.rb:445:in 'Array#each'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/mini
test-5.27.0/lib/minitest.rb:445:in 'block in Minitest::Runnable.run'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest.
rb:487:in 'Minitest::Runnable.on_signal'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest.rb:474:in 'Minitest::Runnabl
e.with_info_handler'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest.rb:444:in 'Minitest::Runnable.run'\n/home/runner
/work/puma/puma/test/helper.rb:223:in 'Minitest::Test.run'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest.rb:346:in 
'block in Minitest.__run'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest.rb:346:in 'Array#map'\n/home/runner/work/pu
ma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest.rb:346:in 'Minitest.__run'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/
gems/minitest-5.27.0/lib/minitest.rb:301:in 'Minitest.run'\n/home/runner/work/puma/puma/vendor/bundle/truffleruby/3.4.7.3/gems/minitest-5.27.0/lib/minitest.rb:85:in '
block in Minitest.autorun'\n" to include ":in `dummy_error'".
```