### PR TITLE
ci: Update test_http11.rb for TruffleRuby - string size

### DIFF
--- a/test/test_http11.rb
+++ b/test/test_http11.rb
@@ -237,8 +237,9 @@ class Http11ParserTest < TestIntegration
     end
 
     # then large headers are rejected too
-    get  = "GET /#{rand_data(10,120)} HTTP/1.1\r\n"
-    get += "X-Test: test\r\n" * (80 * 1024)
+    mult = TRUFFLE ? 10 : 80
+    get = "GET /#{rand_data(10,120)} HTTP/1.1\r\n" \
+      "#{"X-Test: test\r\n" * (mult * 1024)}"
     assert_raises Puma::HttpParserError do
       parser.execute({}, get, 0)
     end


### PR DESCRIPTION
### Description

Fixes up `#test_horrible_queries` in `test/test_http11.rb`.  This just affected TruffleRuby.

Typically, the error is `Error: Process completed with exit code xxx. `xxx` can vary.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
