### PR TITLE
Fix PR label manager when maintainer comments [ci skip]

### DIFF
--- a/.github/workflows/pr-label-status.yml
+++ b/.github/workflows/pr-label-status.yml
@@ -57,33 +57,33 @@ jobs:
                 pull_number: pr.number
               });
 
-            // Track the latest decision per reviewer.
-            // A later COMMENTED review should not override CHANGES_REQUESTED/APPROVED.
-            const latestDecisionByReviewer = new Map();
-            for (const review of reviews.data) {
-              const reviewer = review.user.login;
+              // Track the latest decision per reviewer.
+              // A later COMMENTED review should not override CHANGES_REQUESTED/APPROVED.
+              const latestDecisionByReviewer = new Map();
+              for (const review of reviews.data) {
+                const reviewer = review.user.login;
 
-              if (review.state === 'CHANGES_REQUESTED' || review.state === 'APPROVED') {
-                latestDecisionByReviewer.set(reviewer, review.state);
-              } else if (review.state === 'DISMISSED') {
-                latestDecisionByReviewer.delete(reviewer);
-              }
-            }
-
-            // Determine appropriate label
-            let newLabel = LABELS.REVIEW;  // default
-
-            for (const [reviewer, state] of latestDecisionByReviewer) {
-              if (MAINTAINERS_LIST.includes(reviewer)) {
-                if (state === 'CHANGES_REQUESTED') {
-                  newLabel = LABELS.CHANGES;
-                  break;
-                } else if (state === 'APPROVED') {
-                  newLabel = LABELS.MERGE;
-                  // Don't break here - keep checking in case there's a newer "changes requested"
+                if (review.state === 'CHANGES_REQUESTED' || review.state === 'APPROVED') {
+                  latestDecisionByReviewer.set(reviewer, review.state);
+                } else if (review.state === 'DISMISSED') {
+                  latestDecisionByReviewer.delete(reviewer);
                 }
               }
-            }
+
+              // Determine appropriate label
+              let newLabel = LABELS.REVIEW;  // default
+
+              for (const [reviewer, state] of latestDecisionByReviewer) {
+                if (MAINTAINERS_LIST.includes(reviewer)) {
+                  if (state === 'CHANGES_REQUESTED') {
+                    newLabel = LABELS.CHANGES;
+                    break;
+                  } else if (state === 'APPROVED') {
+                    newLabel = LABELS.MERGE;
+                    // Don't break here - keep checking in case there's a newer "changes requested"
+                  }
+                }
+              }
 
               // Remove all managed labels except the new one
               const allLabels = Object.values(LABELS);


### PR DESCRIPTION
## Summary
- Preserve maintainer review decisions when a later review is COMMENTED.
- Only let CHANGES_REQUESTED/APPROVED update the per-reviewer decision used for labels.

Fixes #3862