### PR TITLE
ci: Run integration tests parallel for all Rubies (not just MRI Rubies)

### DIFF
--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -8,7 +8,7 @@ require "puma/configuration"
 require "time"
 
 class TestIntegrationCluster < TestIntegration
-  parallelize_me! if ::Puma.mri?
+  parallelize_me!
 
   def workers ; 2 ; end
 

--- a/test/test_integration_pumactl.rb
+++ b/test/test_integration_pumactl.rb
@@ -5,7 +5,7 @@ require_relative "helpers/integration"
 
 class TestIntegrationPumactl < TestIntegration
   include TmpPath
-  parallelize_me! if ::Puma.mri?
+  parallelize_me!
 
   def workers ; 2 ; end
 

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -4,7 +4,7 @@ require_relative "helper"
 require_relative "helpers/integration"
 
 class TestIntegrationSingle < TestIntegration
-  parallelize_me! if ::Puma::IS_MRI
+  parallelize_me!
 
   def workers ; 0 ; end
 

--- a/test/test_integration_ssl.rb
+++ b/test/test_integration_ssl.rb
@@ -18,7 +18,7 @@ end
 # the server process isn't affected by whatever is loaded in the CI process.
 
 class TestIntegrationSSL < TestIntegration
-  parallelize_me! if ::Puma.mri?
+  parallelize_me!
 
   LOCALHOST = ENV.fetch 'PUMA_CI_DFLT_HOST', 'localhost'
 

--- a/test/test_integration_ssl_session.rb
+++ b/test/test_integration_ssl_session.rb
@@ -12,7 +12,7 @@ require_relative 'helpers/integration'
 # the server process isn't affected by whatever is loaded in the CI process.
 
 class TestIntegrationSSLSession < TestIntegration
-  parallelize_me! if Puma::IS_MRI
+  parallelize_me!
 
   require "openssl" unless defined?(::OpenSSL::SSL)
 


### PR DESCRIPTION
### Description

While updating some other PR's, I noticed that the `macos-15-intel jruby` job was timing out globally, without a test locking it up.

Integration tests have been running 'parallel' only on MRI Rubies, it seemed time to try them without the MRI constraint.  This fixed the above issue.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
