### PR TITLE
Extend systemd timeout until ready (follow-up to #3412)

### DIFF
--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -62,6 +62,17 @@ Restart=always
 WantedBy=multi-user.target
 ~~~~
 
+### Startup timeout extension
+
+If your app can take longer than `TimeoutStartSec` to boot, Puma can ask systemd
+for more time.
+
+Set `EXTEND_TIMEOUT_USEC` to the extension interval in microseconds. Puma sends
+an extension every half interval until it reports `READY=1`.
+
+Set `EXTEND_TIMEOUT_MAX_USEC` to cap the total extra time. If you omit it, Puma
+uses the same value as `EXTEND_TIMEOUT_USEC`.
+
 See
 [systemd.exec](https://www.freedesktop.org/software/systemd/man/systemd.exec.html)
 for additional details.

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -68,7 +68,7 @@ If your app can take longer than `TimeoutStartSec` to boot, Puma can ask systemd
 for more time.
 
 Set `EXTEND_TIMEOUT_USEC` to the extension interval in microseconds. Puma sends
-an extension every half interval until it reports `READY=1`.
+an extension until it reports `READY=1`.
 
 Set `EXTEND_TIMEOUT_MAX_USEC` to cap the total extra time. If you omit it, Puma
 uses the same value as `EXTEND_TIMEOUT_USEC`.

--- a/lib/puma/plugin/systemd.rb
+++ b/lib/puma/plugin/systemd.rb
@@ -25,7 +25,8 @@ Puma::Plugin.create do
       end
       launcher.log_writer.log "Extending the startup by up to #{Puma::SdNotify.extend_timeout_max_usec} usec"
 
-      in_background do
+      Thread.new do
+        Puma.set_thread_name "systemd extend"
         sleep_time = extend_timeout_sleep_time(extend_timeout_usec)
         launcher.log_writer.log "Extending systemd startup timeout every #{sleep_time.round(1)} sec"
         while @extend_timeout_deadline

--- a/lib/puma/plugin/systemd.rb
+++ b/lib/puma/plugin/systemd.rb
@@ -25,8 +25,7 @@ Puma::Plugin.create do
       end
       launcher.log_writer.log "Extending the startup by up to #{Puma::SdNotify.extend_timeout_max_usec} usec"
 
-      Thread.new do
-        Puma.set_thread_name "systemd extend"
+      in_background do
         sleep_time = extend_timeout_sleep_time(extend_timeout_usec)
         launcher.log_writer.log "Extending systemd startup timeout every #{sleep_time.round(1)} sec"
         while @extend_timeout_deadline

--- a/lib/puma/plugin/systemd.rb
+++ b/lib/puma/plugin/systemd.rb
@@ -18,6 +18,12 @@ Puma::Plugin.create do
     launcher.events.after_stopped { Puma::SdNotify.stopping }
     launcher.events.before_restart { Puma::SdNotify.reloading }
 
+    # set extended timeout
+    if Puma::SdNotify.extend_timeout?
+      launcher.log_writer.log "Extending the startup by #{extend_timeout_time}"
+      Puma::SdNotify.extend_timeout(extend_timeout_time)
+    end
+
     # start watchdog
     if Puma::SdNotify.watchdog?
       ping_f = watchdog_sleep_time
@@ -58,6 +64,10 @@ Puma::Plugin.create do
   end
 
   private
+
+  def extend_timeout_time
+    Integer(ENV["EXTEND_TIMEOUT_USEC"])
+  end
 
   def watchdog_sleep_time
     usec = Integer(ENV["WATCHDOG_USEC"])

--- a/lib/puma/sd_notify.rb
+++ b/lib/puma/sd_notify.rb
@@ -48,6 +48,7 @@ module Puma
     MAINPID   = "MAINPID="
     WATCHDOG  = "WATCHDOG=1"
     FDSTORE   = "FDSTORE=1"
+    EXTEND_TIMEOUT_USEC = "EXTEND_TIMEOUT_USEC="
 
     def self.ready(unset_env=false)
       notify(READY, unset_env)
@@ -83,6 +84,31 @@ module Puma
 
     def self.fdstore(unset_env=false)
       notify(FDSTORE, unset_env)
+    end
+
+    # @param usec [Integer]
+    def self.extend_timeout(usec, unset_env=false)
+      notify("#{EXTEND_TIMEOUT_USEC}#{usec}", unset_env)
+    end
+
+    # Notify systemd about extended timeout, via the notification socket, if applicable.
+    # $EXTEND_TIMEOUT_USEC [Integer] The value specified represents the time in microseconds
+    #   for extending the timeout, during which the service must send a new message.
+    #
+    # @return [Boolean] true if $EXTEND_TIMEOUT_USEC is a valid positive integer, otherwise false
+    #
+    # @note A service timeout occurs only if the service runtime exceeds the original maximum times specified
+    #   by TimeoutStartSec=, RuntimeMaxSec=, and TimeoutStopSec=.
+    def self.extend_timeout?
+      extend_timeout_usec = ENV["EXTEND_TIMEOUT_USEC"]
+
+      begin
+        extend_timeout_usec = Integer(extend_timeout_usec)
+      rescue
+        return false
+      end
+
+      extend_timeout_usec.positive?
     end
 
     # @param [Boolean] true if the service manager expects watchdog keep-alive

--- a/lib/puma/sd_notify.rb
+++ b/lib/puma/sd_notify.rb
@@ -91,6 +91,21 @@ module Puma
       notify("#{EXTEND_TIMEOUT_USEC}#{usec}", unset_env)
     end
 
+    def self.extend_timeout_usec
+      Integer(ENV["EXTEND_TIMEOUT_USEC"])
+    rescue
+      0
+    end
+
+    def self.extend_timeout_max_usec
+      max_usec = ENV["EXTEND_TIMEOUT_MAX_USEC"]
+      return extend_timeout_usec if max_usec.nil?
+
+      Integer(max_usec)
+    rescue
+      0
+    end
+
     # Notify systemd about extended timeout, via the notification socket, if applicable.
     # $EXTEND_TIMEOUT_USEC [Integer] The value specified represents the time in microseconds
     #   for extending the timeout, during which the service must send a new message.
@@ -100,14 +115,6 @@ module Puma
     # @note A service timeout occurs only if the service runtime exceeds the original maximum times specified
     #   by TimeoutStartSec=, RuntimeMaxSec=, and TimeoutStopSec=.
     def self.extend_timeout?
-      extend_timeout_usec = ENV["EXTEND_TIMEOUT_USEC"]
-
-      begin
-        extend_timeout_usec = Integer(extend_timeout_usec)
-      rescue
-        return false
-      end
-
       extend_timeout_usec.positive?
     end
 

--- a/test/helpers/test_puma/assertions.rb
+++ b/test/helpers/test_puma/assertions.rb
@@ -63,6 +63,11 @@ module TestPuma
         end
       end
     end
+
+    def assert_extend_timeout_usec(message, msg = nil)
+      assert_match(/\AEXTEND_TIMEOUT_USEC=\d+\z/, message, msg)
+      message.split("=", 2).last.to_i
+    end
   end
 end
 

--- a/test/helpers/test_puma/assertions.rb
+++ b/test/helpers/test_puma/assertions.rb
@@ -64,9 +64,11 @@ module TestPuma
       end
     end
 
-    def assert_extend_timeout_usec(message, msg = nil)
+    def assert_extend_timeout_usec(message, expected = nil, msg = nil)
       assert_match(/\AEXTEND_TIMEOUT_USEC=\d+\z/, message, msg)
-      message.split("=", 2).last.to_i
+      value = message.split("=", 2).last.to_i
+      assert_equal expected, value, msg if expected
+      value
     end
   end
 end

--- a/test/rackup/boot_delay.ru
+++ b/test/rackup/boot_delay.ru
@@ -1,0 +1,5 @@
+sleep 0.2
+
+run lambda { |_env|
+  [200, {"Content-Type" => "text/plain"}, ["Ready"]]
+}

--- a/test/rackup/boot_delay.ru
+++ b/test/rackup/boot_delay.ru
@@ -1,4 +1,4 @@
-sleep 0.2
+sleep 0.4
 
 run lambda { |_env|
   [200, {"Content-Type" => "text/plain"}, ["Ready"]]

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -2,6 +2,7 @@
 
 require_relative "helper"
 require_relative "helpers/integration"
+require "puma/plugin"
 require "puma/sd_notify"
 
 class TestPluginSystemd < TestIntegration

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -71,8 +71,9 @@ class TestPluginSystemd < TestIntegration
     })
     cli_server "test/rackup/boot_delay.ru", env: notify_env
     first_timeout = assert_extend_timeout_usec(read_message, 300_000)
-    second_timeout = assert_extend_timeout_usec(read_message, 100_000)
-    assert_equal 400_000, first_timeout + second_timeout
+    second_timeout = assert_extend_timeout_usec(read_message)
+    assert_operator second_timeout, :<=, 100_000
+    assert_operator first_timeout + second_timeout, :<=, 400_000
 
     assert_message "READY=1"
 

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -144,7 +144,7 @@ class TestPluginSystemd < TestIntegration
   end
 end
 
-class TestPluginSystemdUnit < Minitest::Test
+class TestPluginSystemdUnit < PumaTest
   def setup
     @plugin = Puma::Plugins.find("systemd").new
   end
@@ -160,7 +160,7 @@ class TestPluginSystemdUnit < Minitest::Test
   end
 end
 
-class TestSdNotify < Minitest::Test
+class TestSdNotify < PumaTest
   def test_extend_timeout_usec_defaults_to_zero
     with_env("EXTEND_TIMEOUT_USEC" => "100") do
       assert_equal 100, Puma::SdNotify.extend_timeout_usec

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -70,9 +70,9 @@ class TestPluginSystemd < TestIntegration
       "EXTEND_TIMEOUT_MAX_USEC" => "400_000"
     })
     cli_server "test/rackup/boot_delay.ru", env: notify_env
-    first_timeout = assert_extend_timeout_usec(read_message)
-    second_timeout = assert_extend_timeout_usec(read_message)
-    assert_operator second_timeout, :<, first_timeout
+    first_timeout = assert_extend_timeout_usec(read_message, 300_000)
+    second_timeout = assert_extend_timeout_usec(read_message, 100_000)
+    assert_equal 400_000, first_timeout + second_timeout
 
     assert_message "READY=1"
 

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -64,6 +64,19 @@ class TestPluginSystemd < TestIntegration
     assert_message "STOPPING=1"
   end
 
+  def test_systemd_extend_timeout_notify
+    notify_env = @env.merge({"EXTEND_TIMEOUT_USEC" => "1_000_001"})
+    cli_server "test/rackup/hello.ru", env: notify_env
+    assert_message "EXTEND_TIMEOUT_USEC=1000001"
+
+    assert_message "READY=1"
+
+    assert_message "STATUS=Puma #{Puma::Const::VERSION}: worker: #{THREAD_LOG}"
+
+    stop_server
+    assert_message "STOPPING=1"
+  end
+
   def test_systemd_cluster_notify
     skip_unless :fork
     cli_server "-w2 test/rackup/hello.ru", env: @env


### PR DESCRIPTION
## Summary
- Extend systemd startup timeout notifications with a 5s buffer and max cap
- Add tests for extend-timeout messages and env parsing edge cases
- Document EXTEND_TIMEOUT_USEC/EXTEND_TIMEOUT_MAX_USEC usage

## Context
I like the original PR (#3412) by @lkibbalam, but I had some concerns about the behavior, so I've added a bit here. Hopefully this all works. I'm not a systemd user, but I think this is a good implementation.

Supersedes #3412.
Fixes #3234.