### PR TITLE
Perf: Cache downcased header key in str_headers

### DIFF
--- a/lib/puma/request.rb
+++ b/lib/puma/request.rb
@@ -652,7 +652,8 @@ module Puma
       headers.each do |k, vs|
         next if illegal_header_key?(k)
 
-        case k.downcase
+        key = k.downcase
+        case key
         when CONTENT_LENGTH2
           next if illegal_header_value?(vs)
           # nil.to_i is 0, nil&.to_i is nil
@@ -679,10 +680,10 @@ module Puma
         if ary
           ary.each do |v|
             next if illegal_header_value?(v)
-            io_buffer.append k.downcase, colon, v, line_ending
+            io_buffer.append key, colon, v, line_ending
           end
         else
-          io_buffer.append k.downcase, colon, line_ending
+          io_buffer.append key, colon, line_ending
         end
       end
 


### PR DESCRIPTION
### Description

**What original problem led to this PR?**

PR #3704 added `k.downcase` calls in `str_headers` for Rack 3 compliance. 
However, since we already call `k.downcase` in the case statement, we now 
call it twice per header instead of once.

**Are there related issues / prior discussions?**

Follow-up optimization to PR #3704 (merged in v7.0.0) and issue #3250.

**What alternatives have been tried?**

Considered naming alternatives (`k_lwr`, `lower_k`) but settled on `key` 
for readability.

**Why do you make the choices you did? What are the tradeoffs?**

- Use a local variable `key` to save the downcase result
- Zero behavior change
- Instead of calling `downcase` twice per header, we call it once. I did a `GC.stat` measurement and a micro-benchmark below.

---

### Benchmark

#### Memory allocations

```ruby
# 10 headers × 1000 iterations
GC.stat[:total_allocated_objects]

BEFORE: 20,004 allocations
AFTER:  10,004 allocations
GAIN:   10,000 allocations (50%)
```

Each `String#downcase` call creates a new String object. With ~10 headers 
per response, this saves ~10 String allocations per request.

#### Micro-benchmark

```
                         user     system      total        real
BEFORE (2 downcase)  0.595148   0.003618   0.598766 (  0.674s)
AFTER  (1 downcase)  0.442885   0.002580   0.445465 (  0.490s)
```

In my runs, it was faster on the header loop (~27% in this instance), but I 
wouldn't draw strong conclusions in terms of exact metrics.

---

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] All new and existing tests passed, including Rubocop.