### PR TITLE
ci: test_puma_server_ssl.rb - fix two cipher suite tests on JRuby

### DIFF
--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -462,8 +462,9 @@ class TestPumaServerSSLClient < PumaTest
   end if Puma.jruby?
 
   def test_allows_to_specify_cipher_suites_and_protocols
+    cipher_suite = ['TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256']
     ctx = CTX.dup
-    ctx.cipher_suites = [ 'TLS_RSA_WITH_AES_128_GCM_SHA256' ]
+    ctx.cipher_suites = cipher_suite
     ctx.protocols = 'TLSv1.2'
 
     assert_ssl_client_error_match(false, context: ctx) do |client_ctx|
@@ -475,7 +476,7 @@ class TestPumaServerSSLClient < PumaTest
       client_ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
       client_ctx.ssl_version = :TLSv1_2
-      client_ctx.ciphers = [ 'TLS_RSA_WITH_AES_128_GCM_SHA256' ]
+      client_ctx.ciphers = cipher_suite
     end
   end if Puma.jruby?
 
@@ -484,7 +485,9 @@ class TestPumaServerSSLClient < PumaTest
     ctx.cipher_suites = [ 'TLS_RSA_WITH_AES_128_GCM_SHA256' ]
     ctx.protocols = 'TLSv1.2'
 
-    assert_ssl_client_error_match(/no cipher suites in common/, context: ctx) do |client_ctx|
+    error_msg = /no cipher suites in common|cipher suites are inappropriate/
+
+    assert_ssl_client_error_match(error_msg, context: ctx) do |client_ctx|
       key = "#{CERT_PATH}/client.key"
       crt = "#{CERT_PATH}/client.crt"
       client_ctx.key = OpenSSL::PKey::RSA.new File.read(key)


### PR DESCRIPTION
### Description

Sometime last night, Puma JRuby started failing with two failures.  Both tests are only run with JRuby.
```
  1) Failure:
TestPumaServerSSLClient#test_fails_when_no_cipher_suites_in_common [test/test_puma_server_ssl.rb:487]:
Expected /no cipher suites in common/ to match:
javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate)
```
Fixed by updating the error message regex.

```
  2) Failure:
TestPumaServerSSLClient#test_allows_to_specify_cipher_suites_and_protocols [test/test_puma_server_ssl.rb:469]:
No appropriate protocol (protocol is disabled or cipher suites are inappropriate).
Expected: false
  Actual: true
```
Replace `TLS_RSA_WITH_AES_128_GCM_SHA256` → `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` (ECDHE provides forward secrecy, enabled in modern Java)

Used Copilot / Claude Opus 4.5

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
