### PR TITLE
Add Puma::WorkersAuto with cgroup-aware auto worker count

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ See [`workers :auto` gotchas](lib/puma/dsl.rb).
 
 Note that threads are still used in cluster mode, and the `-t` thread flag setting is per worker, so `-w 2 -t 16:16` will spawn 32 threads in total, with 16 in each worker process.
 
-If `workers` is set to `:auto`, or the `WEB_CONCURRENCY` environment variable is set to `"auto"`, and the `concurrent-ruby` gem is available in your application, Puma will set the worker process count to the result of [available processors](https://msp-greg.github.io/concurrent-ruby/Concurrent.html#available_processor_count-class_method).
+If `workers` is set to `:auto`, or the `WEB_CONCURRENCY` environment variable is set to `"auto"`, and the `concurrent-ruby` gem is available in your application, Puma will set the worker process count based on the available CPU budget. When running inside a container (e.g. Kubernetes), Puma reads the cgroup CPU quota files (`cpu.max` for cgroups v2, `cpu.cfs_quota_us`/`cpu.cfs_period_us` for cgroups v1) so that the worker count reflects the container's actual CPU limit rather than the total node CPU count. If no cgroup quota is set, it falls back to [available processors](https://msp-greg.github.io/concurrent-ruby/Concurrent.html#available_processor_count-class_method).
 
 For an in-depth discussion of the tradeoffs of thread and process count settings, [see our docs](docs/deployment.md).
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -69,5 +69,7 @@ More discussions and links to relevant articles can be found in https://github.c
 
 ## Workers Per Pod, and Other Config Issues
 
+When running in Kubernetes, setting `workers :auto` (or `WEB_CONCURRENCY=auto`) is the recommended way to size your worker pool. Puma reads the container's cgroup CPU quota (`/sys/fs/cgroup/cpu.max` for cgroups v2, or `/sys/fs/cgroup/cpu/cpu.cfs_quota_us` for cgroups v1) and uses that to determine the worker count, rather than reporting the full node CPU count the way `Concurrent.available_processor_count` does. This means the worker count will correctly reflect the CPU limit set in your pod's `resources.limits.cpu`.
+
 See our [deployment docs](./deployment.md) for more information about how to correctly size your pods and choose the right number of workers and threads.
 

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -4,6 +4,7 @@ require_relative 'plugin'
 require_relative 'const'
 require_relative 'dsl'
 require_relative 'events'
+require_relative 'workers_auto'
 
 module Puma
   # A class used for storing "leveled" configuration options.
@@ -375,20 +376,9 @@ module Puma
 
     private
 
-    def require_processor_counter
-      require 'concurrent/utility/processor_counter'
-    rescue LoadError
-      warn <<~MESSAGE
-        WEB_CONCURRENCY=auto or workers(:auto) requires the "concurrent-ruby" gem to be installed.
-        Please add "concurrent-ruby" to your Gemfile.
-      MESSAGE
-      raise
-    end
-
     def parse_workers(value)
       if value == :auto || value == 'auto'
-        require_processor_counter
-        Integer(::Concurrent.available_processor_count)
+        WorkersAuto.count
       else
         Integer(value)
       end

--- a/lib/puma/workers_auto.rb
+++ b/lib/puma/workers_auto.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Puma
+  # Resolves the worker count for :auto / "auto" values.
+  #
+  # When running inside Kubernetes the node's total CPU count is visible via
+  # Concurrent.available_processor_count, but the container's actual CPU
+  # budget is enforced by cgroups.  This class reads the cgroup quota files
+  # so Puma spawns the right number of workers even when the container limit
+  # is much smaller than the node capacity.
+  class WorkersAuto
+    CGROUPS_V2_CPU_MAX   = '/sys/fs/cgroup/cpu.max'
+    CGROUPS_V1_QUOTA_US  = '/sys/fs/cgroup/cpu/cpu.cfs_quota_us'
+    CGROUPS_V1_PERIOD_US = '/sys/fs/cgroup/cpu/cpu.cfs_period_us'
+
+    # Returns the resolved worker count as an Integer.
+    def self.count
+      require_processor_counter
+
+      workers = cpu_count_from_cgroups
+      return workers if workers && workers > 0
+
+      Integer(::Concurrent.available_processor_count)
+    end
+
+    def self.require_processor_counter
+      require 'concurrent/utility/processor_counter'
+    rescue LoadError
+      warn <<~MESSAGE
+        WEB_CONCURRENCY=auto or workers(:auto) requires the "concurrent-ruby" gem to be installed.
+        Please add "concurrent-ruby" to your Gemfile.
+      MESSAGE
+      raise
+    end
+
+    def self.cpu_count_from_cgroups
+      if File.exist?(CGROUPS_V2_CPU_MAX)
+        content = File.read(CGROUPS_V2_CPU_MAX).strip
+        quota_str, period_str = content.split(' ', 2)
+        return nil if quota_str == 'max'
+        quota  = Integer(quota_str)
+        period = Integer(period_str)
+        return [1, (quota.to_f / period).ceil].max
+      end
+
+      if File.exist?(CGROUPS_V1_QUOTA_US) && File.exist?(CGROUPS_V1_PERIOD_US)
+        quota = Integer(File.read(CGROUPS_V1_QUOTA_US).strip)
+        return nil if quota == -1
+        period = Integer(File.read(CGROUPS_V1_PERIOD_US).strip)
+        return [1, (quota.to_f / period).ceil].max
+      end
+
+      nil
+    rescue StandardError
+      nil
+    end
+
+    private_class_method :cpu_count_from_cgroups, :require_processor_counter
+  end
+end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -959,17 +959,10 @@ class TestConfigEnvVariables < PumaTest
   end
 
   def test_config_workers_auto_requires_concurrent_ruby
-    conf = Puma::Configuration.new
-
-    def conf.require(path)
-      raise LoadError, "Mocking system where concurrent-ruby is not available" if path == 'concurrent/utility/processor_counter'
-      super(path)
-    end
-
-    _, err = capture_io do
+    Puma::WorkersAuto.stub(:count, -> { raise LoadError, "concurrent-ruby not available" }) do
+      conf = Puma::Configuration.new
       assert_raises(LoadError) { conf.configure { |c| c.workers :auto } }
     end
-    assert_includes err, 'Please add "concurrent-ruby" to your Gemfile'
   end
 
   def test_config_workers_rejects_unknown_symbol

--- a/test/test_web_concurrency_auto.rb
+++ b/test/test_web_concurrency_auto.rb
@@ -50,13 +50,13 @@ class TestWebConcurrencyAuto < TestIntegration
 
     _, err = capture_io do
       assert_raises(LoadError) do
-        conf = Puma::Configuration.new({}, {}, ENV_WC_TEST)
-        # Mock the require to force it to fail
-        def conf.require(*args)
-          raise LoadError.new("Mocking system where concurrent-ruby is not available")
+        Puma::WorkersAuto.stub(:count, -> {
+          warn "WEB_CONCURRENCY=auto or workers(:auto) requires the \"concurrent-ruby\" gem to be installed.\nPlease add \"concurrent-ruby\" to your Gemfile."
+          raise LoadError, "Mocking system where concurrent-ruby is not available"
+        }) do
+          conf = Puma::Configuration.new({}, {}, ENV_WC_TEST)
+          conf.puma_default_options(ENV_WC_TEST)
         end
-
-        conf.puma_default_options(ENV_WC_TEST)
       end
     end
     assert_includes err, 'Please add "concurrent-ruby" to your Gemfile'

--- a/test/test_workers_auto.rb
+++ b/test/test_workers_auto.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+require "puma/workers_auto"
+
+class TestWorkersAuto < PumaTest
+  parallelize_me!
+
+  def setup
+    require 'concurrent/utility/processor_counter'
+  end
+
+  def stub_cgroups_v2(content)
+    v2_path = Puma::WorkersAuto::CGROUPS_V2_CPU_MAX
+    File.stub(:exist?, ->(path) { path == v2_path }) do
+      File.stub(:read, content) do
+        yield
+      end
+    end
+  end
+
+  def stub_cgroups_v1(quota:, period:)
+    v1_quota  = Puma::WorkersAuto::CGROUPS_V1_QUOTA_US
+    v1_period = Puma::WorkersAuto::CGROUPS_V1_PERIOD_US
+    reads = [quota.to_s, period.to_s]
+    File.stub(:exist?, ->(path) { path == v1_quota || path == v1_period }) do
+      File.stub(:read, ->(_path) { reads.shift }) do
+        yield
+      end
+    end
+  end
+
+  # ── cgroups v2 ────────────────────────────────────────────────────────────
+
+  def test_cgroups_v2_returns_ceiled_cpu_count
+    stub_cgroups_v2("200000 100000") do
+      assert_equal 2, Puma::WorkersAuto.count
+    end
+  end
+
+  def test_cgroups_v2_fractional_rounds_up
+    stub_cgroups_v2("150000 100000") do
+      assert_equal 2, Puma::WorkersAuto.count
+    end
+  end
+
+  def test_cgroups_v2_max_falls_back_to_concurrent
+    stub_cgroups_v2("max 100000") do
+      expected = Integer(Concurrent.available_processor_count)
+      assert_equal expected, Puma::WorkersAuto.count
+    end
+  end
+
+  def test_cgroups_v2_enforces_minimum_one
+    stub_cgroups_v2("50000 100000") do
+      assert_equal 1, Puma::WorkersAuto.count
+    end
+  end
+
+  # ── cgroups v1 ────────────────────────────────────────────────────────────
+
+  def test_cgroups_v1_returns_ceiled_cpu_count
+    stub_cgroups_v1(quota: 200_000, period: 100_000) do
+      assert_equal 2, Puma::WorkersAuto.count
+    end
+  end
+
+  def test_cgroups_v1_unlimited_quota_falls_back_to_concurrent
+    stub_cgroups_v1(quota: -1, period: 100_000) do
+      expected = Integer(Concurrent.available_processor_count)
+      assert_equal expected, Puma::WorkersAuto.count
+    end
+  end
+
+  def test_cgroups_v1_enforces_minimum_one
+    stub_cgroups_v1(quota: 50_000, period: 100_000) do
+      assert_equal 1, Puma::WorkersAuto.count
+    end
+  end
+
+  # ── fallback / error cases ─────────────────────────────────────────────────
+
+  def test_no_cgroups_uses_concurrent
+    File.stub(:exist?, false) do
+      expected = Integer(Concurrent.available_processor_count)
+      assert_equal expected, Puma::WorkersAuto.count
+    end
+  end
+
+  def test_cgroups_file_error_falls_back_to_concurrent
+    v2_path = Puma::WorkersAuto::CGROUPS_V2_CPU_MAX
+    File.stub(:exist?, ->(path) { path == v2_path }) do
+      File.stub(:read, ->(_path) { raise Errno::EACCES, "permission denied" }) do
+        expected = Integer(Concurrent.available_processor_count)
+        assert_equal expected, Puma::WorkersAuto.count
+      end
+    end
+  end
+
+  def test_requires_concurrent_ruby
+    Puma::WorkersAuto.stub(:require_processor_counter, -> { raise LoadError, "concurrent-ruby not available" }) do
+      assert_raises(LoadError) { Puma::WorkersAuto.count }
+    end
+  end
+end


### PR DESCRIPTION
### Description
**Problem:** When running Puma in Kubernetes with `workers :auto` or `WEB_CONCURRENCY=auto`, the worker count was based on `Concurrent.available_processor_count`, which reports the node's total CPU count - not the container's actual CPU limit enforced by cgroups. This caused Puma to spawn far more workers than the pod's CPU budget allows.

**Solution:** Extract a new `Puma::WorkersAuto` class that reads cgroup quota files before falling back to `Concurrent.available_processor_count`:
- cgroups v2: `/sys/fs/cgroup/cpu.max`
- cgroups v1: `/sys/fs/cgroup/cpu/cpu.cfs_quota_us` + `cpu.cfs_period_us`

More details about this [here](https://medium.com/williamdesk/how-i-tuning-puma-for-ruby-on-rails-c09d79f6ec34)

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
