### PR TITLE
Add Qlty code coverage integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,12 +130,29 @@ jobs:
         shell: bash
         run: echo 'RUBYOPT=--yjit' >> $GITHUB_ENV
 
+      - name: Set coverage env
+        if: |
+          (matrix.os == 'ubuntu-22.04') && (matrix.ruby == '3.4') &&
+          (matrix.no-ssl == '') && (matrix.yjit == '') && (matrix.rack-v == '') &&
+          (needs.skip_duplicate_runs.outputs.should_skip != 'true')
+        run: echo 'COVERAGE=true' >> $GITHUB_ENV
+
       - name: test
         if: needs.skip_duplicate_runs.outputs.should_skip != 'true'
         timeout-minutes: 10
         run: test/runner --verbose
         env:
           MT_CPU: 2
+
+      - name: Upload coverage to Qlty
+        if: |
+          (matrix.os == 'ubuntu-22.04') && (matrix.ruby == '3.4') &&
+          (matrix.no-ssl == '') && (matrix.yjit == '') && (matrix.rack-v == '') &&
+          (needs.skip_duplicate_runs.outputs.should_skip != 'true')
+        uses: qltysh/qlty-action/coverage@v2
+        with:
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: coverage/lcov.info
 
   test_non_mri:
     name: >-

--- a/Gemfile
+++ b/Gemfile
@@ -44,3 +44,8 @@ end
 
 gem 'm'
 gem "localhost", require: false
+
+if ENV['COVERAGE']
+  gem "simplecov", require: false
+  gem "simplecov-lcov", require: false
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,4 +1,15 @@
 # frozen_string_literal: true
+
+if ENV['COVERAGE']
+  require 'simplecov'
+  require 'simplecov-lcov'
+  SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+  SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+  SimpleCov.start do
+    add_filter '/test/'
+  end
+end
+
 # Copyright (c) 2011 Evan Phoenix
 # Copyright (c) 2005 Zed A. Shaw
 


### PR DESCRIPTION
## Summary
- Add SimpleCov + simplecov-lcov to generate LCOV coverage data during tests
- Coverage generation is gated behind a `COVERAGE` env var (only enabled on `ubuntu-22.04` / Ruby `3.4`)
- Upload coverage to Qlty Cloud using the official GitHub Action on a single matrix entry

## Files changed
- `Gemfile` — add `simplecov` and `simplecov-lcov` gems (conditional on `COVERAGE` env)
- `test/helper.rb` — initialize SimpleCov with LCOV formatter when `COVERAGE` is set
- `.github/workflows/tests.yml` — set `COVERAGE=true` and add Qlty upload step for one matrix entry

## Manual steps required
1. Add a `QLTY_COVERAGE_TOKEN` repository secret with your Qlty workspace coverage token
   - Get the token from Qlty Cloud → Workspace Settings → Code Coverage

## Test plan
- [ ] Add `QLTY_COVERAGE_TOKEN` secret to the repository
- [ ] Verify the `ubuntu-22.04 3.4` matrix job generates `coverage/lcov.info`
- [ ] Verify the Qlty upload step succeeds and reports coverage percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)