### PR TITLE
[ci skip] Minor correction to defaults documented in DSL

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -350,7 +350,7 @@ module Puma
 
     # Define how long persistent connections can be idle before Puma closes them.
     #
-    # The default is 20 seconds.
+    # The default is 65 seconds.
     #
     # @example
     #   persistent_timeout 30
@@ -1208,7 +1208,7 @@ module Puma
 
     # Change the default worker timeout for booting.
     #
-    # The default is the value of `worker_timeout`.
+    # The default is 60 seconds.
     #
     # @note Cluster mode only.
     #


### PR DESCRIPTION
### Description

I was looking for the default for `persistent_timeout` and, coincidentally, looked at the docs for the configuration DSL first. It had it at 20s which surprised me as I was expecting a value higher than 60s (which is the default for load balancers in some cloud providers). As it appears, the default value is actually 65s.

I used the opportunity to check for more discrepancies between the DSL docs and the actual configuration but could only find another one which is that `worker_boot_timeout` is derived while this is not the case anymore.

Not a big contribution but since it tripped me up, I thought it's useful to correct.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] I have updated the documentation accordingly.
