### PR TITLE
Fix IPv4-mapped IPv6 addresses in `REMOTE_ADDR` and request logs

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -352,7 +352,7 @@ module Puma
         return hdr
       end
 
-      @peerip ||= @io.peeraddr.last
+      @peerip ||= unmap_ipv6(@io.peeraddr.last)
     end
 
     def peer_family
@@ -386,6 +386,21 @@ module Puma
     end
 
     private
+
+    IPV4_MAPPED_IPV6_PREFIX = "::ffff:"
+    IPV4_MAPPED_IPV6_PREFIX_LENGTH = IPV4_MAPPED_IPV6_PREFIX.length
+    private_constant :IPV4_MAPPED_IPV6_PREFIX, :IPV4_MAPPED_IPV6_PREFIX_LENGTH
+
+    # Converts IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1) back to
+    # their IPv4 form. These addresses appear when IPv4 clients connect to
+    # a dual-stack IPv6 socket.
+    def unmap_ipv6(addr)
+      if addr.start_with?(IPV4_MAPPED_IPV6_PREFIX)
+        addr[IPV4_MAPPED_IPV6_PREFIX_LENGTH..]
+      else
+        addr
+      end
+    end
 
     # Checks the request `Transfer-Encoding` and/or `Content-Length` to see if
     # they are valid.  Raises errors if not, otherwise reads the body.

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -347,12 +347,12 @@ module Puma
       return @peerip if @peerip
 
       if @remote_addr_header
-        hdr = (@env[@remote_addr_header] || @io.peeraddr.last).split(/[\s,]/).first
+        hdr = (@env[@remote_addr_header] || socket_peerip).split(/[\s,]/).first
         @peerip = hdr
         return hdr
       end
 
-      @peerip ||= unmap_ipv6(@io.peeraddr.last)
+      @peerip ||= socket_peerip
     end
 
     def peer_family
@@ -388,18 +388,17 @@ module Puma
     private
 
     IPV4_MAPPED_IPV6_PREFIX = "::ffff:"
-    IPV4_MAPPED_IPV6_PREFIX_LENGTH = IPV4_MAPPED_IPV6_PREFIX.length
-    private_constant :IPV4_MAPPED_IPV6_PREFIX, :IPV4_MAPPED_IPV6_PREFIX_LENGTH
+    private_constant :IPV4_MAPPED_IPV6_PREFIX
+
+    def socket_peerip
+      unmap_ipv6(@io.peeraddr.last)
+    end
 
     # Converts IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1) back to
     # their IPv4 form. These addresses appear when IPv4 clients connect to
     # a dual-stack IPv6 socket.
     def unmap_ipv6(addr)
-      if addr.start_with?(IPV4_MAPPED_IPV6_PREFIX)
-        addr[IPV4_MAPPED_IPV6_PREFIX_LENGTH..]
-      else
-        addr
-      end
+      addr.delete_prefix(IPV4_MAPPED_IPV6_PREFIX)
     end
 
     # Checks the request `Transfer-Encoding` and/or `Content-Length` to see if

--- a/test/test_request_single.rb
+++ b/test/test_request_single.rb
@@ -654,7 +654,7 @@ class TestRequestChunkedInvalid < TestRequestBase
 end
 
 # Tests invalid Transfer-Ecoding headers
-class TestTransferEncodingInvalid < TestRequestBase
+class TestRequestTransferEncodingInvalid < TestRequestBase
 
   def test_chunked_not_last
     te = [
@@ -727,23 +727,26 @@ class TestRequestReset < TestRequestBase
   end
 end
 
-class TestPeerip < TestRequestBase
+class TestRequestPeerip < TestRequestBase
 
   def test_peerip_unmaps_ipv4_mapped_ipv6
     peer_addr = -> () { ["AF_INET6", 80, "::ffff:127.0.0.1", "::ffff:127.0.0.1"] }
-    create_client("GET / HTTP/1.1\r\n\r\n") {
+    create_client("GET / HTTP/1.1\r\n\r\n") { |_client|
       @rd.define_singleton_method(:peeraddr, peer_addr)
     }
 
     assert_equal "127.0.0.1", @client.peerip
+    assert_equal "127.0.0.1", @client.env["REMOTE_ADDR"]
   end
 
-  def test_remote_addr_unmaps_ipv4_mapped_ipv6
+  def test_remote_addr_header_fallback_unmaps_ipv4_mapped_ipv6
     peer_addr = -> () { ["AF_INET6", 80, "::ffff:10.1.2.3", "::ffff:10.1.2.3"] }
-    create_client("GET / HTTP/1.1\r\n\r\n") {
+    create_client("GET / HTTP/1.1\r\n\r\n") { |client|
       @rd.define_singleton_method(:peeraddr, peer_addr)
+      client.remote_addr_header = "HTTP_X_REMOTE_IP"
     }
 
+    assert_equal "10.1.2.3", @client.peerip
     assert_equal "10.1.2.3", @client.env["REMOTE_ADDR"]
   end
 
@@ -755,7 +758,7 @@ class TestPeerip < TestRequestBase
 
   def test_peerip_preserves_native_ipv6
     peer_addr = -> () { ["AF_INET6", 80, "::1", "::1"] }
-    create_client("GET / HTTP/1.1\r\n\r\n") {
+    create_client("GET / HTTP/1.1\r\n\r\n") { |_client|
       @rd.define_singleton_method(:peeraddr, peer_addr)
     }
 

--- a/test/test_request_single.rb
+++ b/test/test_request_single.rb
@@ -726,3 +726,39 @@ class TestRequestReset < TestRequestBase
     assert_nil @client.error_status_code
   end
 end
+
+class TestPeerip < TestRequestBase
+
+  def test_peerip_unmaps_ipv4_mapped_ipv6
+    peer_addr = -> () { ["AF_INET6", 80, "::ffff:127.0.0.1", "::ffff:127.0.0.1"] }
+    create_client("GET / HTTP/1.1\r\n\r\n") {
+      @rd.define_singleton_method(:peeraddr, peer_addr)
+    }
+
+    assert_equal "127.0.0.1", @client.peerip
+  end
+
+  def test_remote_addr_unmaps_ipv4_mapped_ipv6
+    peer_addr = -> () { ["AF_INET6", 80, "::ffff:10.1.2.3", "::ffff:10.1.2.3"] }
+    create_client("GET / HTTP/1.1\r\n\r\n") {
+      @rd.define_singleton_method(:peeraddr, peer_addr)
+    }
+
+    assert_equal "10.1.2.3", @client.env["REMOTE_ADDR"]
+  end
+
+  def test_peerip_preserves_plain_ipv4
+    create_client("GET / HTTP/1.1\r\n\r\n")
+
+    assert_equal "127.0.0.1", @client.peerip
+  end
+
+  def test_peerip_preserves_native_ipv6
+    peer_addr = -> () { ["AF_INET6", 80, "::1", "::1"] }
+    create_client("GET / HTTP/1.1\r\n\r\n") {
+      @rd.define_singleton_method(:peeraddr, peer_addr)
+    }
+
+    assert_equal "::1", @client.peerip
+  end
+end


### PR DESCRIPTION
Strip the `::ffff:` prefix from IPv4-mapped IPv6 addresses returned by dual-stack sockets so that `REMOTE_ADDR` and `CommonLogger` output show the original IPv4 address (e.g. `127.0.0.1` instead of `::ffff:127.0.0.1`).

This is a side-effect of #3847 which changed the default bind to `::` on hosts with IPv6 interfaces.

---

- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.