### PR TITLE
systemd: send immediate watchdog ping on ready

### DIFF
--- a/lib/puma/sd_notify.rb
+++ b/lib/puma/sd_notify.rb
@@ -49,8 +49,12 @@ module Puma
     WATCHDOG  = "WATCHDOG=1"
     FDSTORE   = "FDSTORE=1"
 
+    # @note If watchdog notifications are enabled, this also emits an
+    # immediate `WATCHDOG=1` ping to avoid a watchdog timeout window between
+    # startup completion and the first periodic watchdog loop tick.
     def self.ready(unset_env=false)
       notify(READY, unset_env)
+      watchdog(unset_env) if watchdog?
     end
 
     def self.reloading(unset_env=false)

--- a/lib/puma/sd_notify.rb
+++ b/lib/puma/sd_notify.rb
@@ -53,8 +53,12 @@ module Puma
     # immediate `WATCHDOG=1` ping to avoid a watchdog timeout window between
     # startup completion and the first periodic watchdog loop tick.
     def self.ready(unset_env=false)
-      notify(READY, unset_env)
-      watchdog(unset_env) if watchdog?
+      if watchdog?
+        notify(READY)
+        watchdog(unset_env)
+      else
+        notify(READY, unset_env)
+      end
     end
 
     def self.reloading(unset_env=false)

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -54,6 +54,17 @@ class TestPluginSystemd < TestIntegration
     assert_message "STOPPING=1"
   end
 
+  def test_systemd_watchdog_sends_immediate_ping_after_ready
+    wd_env = @env.merge({"WATCHDOG_USEC" => "1_000_000"})
+    cli_server "test/rackup/hello.ru", env: wd_env
+
+    assert_message "READY=1"
+    assert_message "WATCHDOG=1"
+
+    stop_server
+    assert_message "STOPPING=1"
+  end
+
   def test_systemd_notify
     cli_server "test/rackup/hello.ru", env: @env
     assert_message "READY=1"

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -55,7 +55,7 @@ class TestPluginSystemd < TestIntegration
   end
 
   def test_systemd_watchdog_sends_immediate_ping_after_ready
-    wd_env = @env.merge({"WATCHDOG_USEC" => "1_000_000"})
+    wd_env = @env.merge({"WATCHDOG_USEC" => "10_000_000"})
     cli_server "test/rackup/hello.ru", env: wd_env
 
     assert_message "READY=1"

--- a/test/test_sd_notify.rb
+++ b/test/test_sd_notify.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+require_relative "helpers/tmp_path"
+require_relative "../lib/puma/sd_notify"
+
+class TestSdNotify < PumaTest
+  include TmpPath
+
+  def setup
+    super
+
+    @sockaddr = tmp_path '.sd_notify'
+    @socket = Socket.new(:UNIX, :DGRAM, 0)
+    @socket.bind Addrinfo.unix(@sockaddr)
+    @message = +''
+  end
+
+  def teardown
+    @socket&.close
+    @socket = nil
+
+    super
+  end
+
+  def test_ready_with_watchdog_unsets_env_after_watchdog
+    with_temp_env("NOTIFY_SOCKET" => @sockaddr, "WATCHDOG_USEC" => "10_000_000") do
+      Puma::SdNotify.ready(true)
+
+      assert_message "READY=1"
+      assert_message "WATCHDOG=1"
+      refute ENV.key?("NOTIFY_SOCKET")
+    end
+  end
+
+  private
+
+  def assert_message(msg)
+    @socket.wait_readable 1
+    @message << @socket.sysread(msg.bytesize)
+    assert_equal msg, @message
+    @message = +''
+  end
+end


### PR DESCRIPTION
## Summary
When watchdog mode is enabled, Puma currently sends `READY=1` at boot and only sends `WATCHDOG=1` on the next watchdog loop tick.

This can leave a small timeout window after restart/startup where systemd may kill Puma before the first periodic watchdog ping is emitted (as described in #3675).

This PR sends an immediate watchdog ping from `SdNotify.ready` when watchdog mode is active.

## Changes
- `lib/puma/sd_notify.rb`
  - Update `SdNotify.ready` to call `watchdog` if `watchdog?` is true
- `test/test_plugin_systemd.rb`
  - Add regression test `test_systemd_watchdog_sends_immediate_ping_after_ready`

## Verification
### Automated
Ran systemd plugin tests focused on watchdog behavior:

```bash
bundle exec ruby test/test_plugin_systemd.rb -n "/test_systemd_watchdog|test_systemd_watchdog_sends_immediate_ping_after_ready/"
```

Result: `2 runs, 6 assertions, 0 failures`

### Manual
In a local Docker dev environment, simulated `NOTIFY_SOCKET` + `WATCHDOG_USEC` and invoked `Puma::SdNotify.ready`; confirmed messages are emitted in order:
1. `READY=1`
2. `WATCHDOG=1`

Fixes #3675