### PR TITLE
Use blocks for debug logging to avoid creating messages if debug disabled

### DIFF
--- a/lib/puma/binder.rb
+++ b/lib/puma/binder.rb
@@ -90,7 +90,7 @@ module Puma
     # @version 5.0.0
     #
     def create_activated_fds(env_hash)
-      @log_writer.debug "ENV['LISTEN_FDS'] #{@env['LISTEN_FDS'].inspect}  env_hash['LISTEN_PID'] #{env_hash['LISTEN_PID'].inspect}"
+      @log_writer.debug { "ENV['LISTEN_FDS'] #{@env['LISTEN_FDS'].inspect}  env_hash['LISTEN_PID'] #{env_hash['LISTEN_PID'].inspect}" }
       return [] unless env_hash['LISTEN_FDS'] && env_hash['LISTEN_PID'].to_i == $$
       env_hash['LISTEN_FDS'].to_i.times do |index|
         sock = TCPServer.for_fd(socket_activation_fd(index))
@@ -102,7 +102,7 @@ module Puma
           [:tcp, addr, port]
         end
         @activated_sockets[key] = sock
-        @log_writer.debug "Registered #{key.join ':'} for activation from LISTEN_FDS"
+        @log_writer.debug { "Registered #{key.join ':'} for activation from LISTEN_FDS" }
       end
       ["LISTEN_FDS", "LISTEN_PID"] # Signal to remove these keys from ENV
     end

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -344,7 +344,7 @@ module Puma
     # @param arg [Launcher, Int] `:before_restart` passes Launcher
     #
     def run_hooks(key, arg, log_writer, hook_data = nil)
-      log_writer.debug "Running #{key} hooks"
+      log_writer.debug { "Running #{key} hooks" }
 
       options.all_of(key).each do |hook_options|
         begin

--- a/lib/puma/log_writer.rb
+++ b/lib/puma/log_writer.rb
@@ -90,8 +90,14 @@ module Puma
       @debug
     end
 
-    def debug(str)
-      log("% #{str}") if @debug
+    def debug(str=nil, &block)
+      if @debug
+        if block_given?
+          log("% #{yield}")
+        else
+          log("% #{str}")
+        end
+      end
     end
 
     # Write +str+ to +@stderr+

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -417,7 +417,7 @@ module Puma
           end
         end
 
-        @log_writer.debug "Drained #{drain} additional connections." if drain
+        @log_writer.debug { "Drained #{drain} additional connections." } if drain
         @events.fire :state, @status
 
         if queue_requests

--- a/test/test_log_writer.rb
+++ b/test/test_log_writer.rb
@@ -73,6 +73,13 @@ class TestLogWriter < PumaTest
     assert_empty out
   end
 
+  def test_debug_writes_to_stdout_with_block_if_env_is_present
+    with_temp_env({ "PUMA_DEBUG" => "1" }) do
+      out, _ = capture_io { Puma::LogWriter.stdio.debug { "ready" } }
+      assert_equal "% ready\n", out
+    end
+  end
+
   def test_error_writes_to_stderr_and_exits
     did_exit = false
 


### PR DESCRIPTION
### Description

If debugging is disabled, the following will still generate the message to log.

```ruby
Puma::LogWriter.stdio.debug("some expensive message")
```

By using a block the messages only need to be created when debug is enabled, saving some allocations:

```ruby
Puma::LogWriter.stdio.debug { "some expensive message" }
```

Passing blocks to the logger is also [implemented](https://github.com/ruby/logger/blob/4b19af64f502adb2396b597a99b53eed1fd03449/lib/logger.rb#L698) in the default Ruby Logger and is [used](https://github.com/rails/rails/blob/0b5af58d2f0b8916f8211fa620c48da71d6da657/actionpack/lib/action_controller/log_subscriber.rb#L26-L44) in frameworks like Rails.

There are still some other logger calls like `LogWriter#log` that could also benefit from blocks, but these don't seem tied to a log severity level.
I've also skipped some debug calls in rescue blocks, those don't seem to be on critical paths.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
