### PR TITLE
Fix `prune_bundler` stripping user-configured `BUNDLE_*` env vars on re-exec

### DIFF
--- a/lib/puma/launcher/bundle_pruner.rb
+++ b/lib/puma/launcher/bundle_pruner.rb
@@ -28,14 +28,12 @@ module Puma
 
         log '* Pruning Bundler environment'
         home = ENV['GEM_HOME']
-        bundle_gemfile = Bundler.original_env['BUNDLE_GEMFILE']
-        bundle_app_config = Bundler.original_env['BUNDLE_APP_CONFIG']
+        original_bundle_env = Bundler.original_env.select { |k, v| k.start_with?('BUNDLE_') && v }
 
         with_unbundled_env do
           ENV['GEM_HOME'] = home
-          ENV['BUNDLE_GEMFILE'] = bundle_gemfile
           ENV['PUMA_BUNDLER_PRUNED'] = '1'
-          ENV["BUNDLE_APP_CONFIG"] = bundle_app_config
+          original_bundle_env.each { |k, v| ENV[k] = v }
           args = [Gem.ruby, puma_wild_path, '-I', dirs.join(':')] + @original_argv
           # Defaults to true which breaks socket activation
           args += [{:close_others => false}]

--- a/test/rackup/bundle_without.ru
+++ b/test/rackup/bundle_without.ru
@@ -1,0 +1,1 @@
+run lambda { |env| [200, {"Content-Type" => "text/plain"}, [ENV.fetch("BUNDLE_WITHOUT", "not_set")]] }

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -471,6 +471,13 @@ class TestIntegrationCluster < TestIntegration
     assert_equal reply, "embedded app"
   end
 
+  def test_prune_bundler_preserves_bundle_env_vars
+    cli_server "-w #{workers} --prune-bundler test/rackup/bundle_without.ru",
+      env: { 'BUNDLE_WITHOUT' => 'development:test' }
+
+    assert_equal 'development:test', read_body(connect)
+  end
+
   def test_load_path_includes_extra_deps
     cli_server "-w #{workers} -C test/config/prune_bundler_with_deps.rb test/rackup/hello.ru"
 


### PR DESCRIPTION
Closes #3744

When `prune_bundler` is configured, Puma re-execs itself via `puma-wild` using `Bundler.with_unbundled_env`, which strips all `BUNDLE_*` environment variables. Previously only `BUNDLE_GEMFILE` and `BUNDLE_APP_CONFIG` were explicitly restored, so user-set vars like `BUNDLE_WITHOUT` and `BUNDLE_DEPLOYMENT` were lost.

This causes workers to crash on boot. When a worker loads the app, `rack_builder` calls `require 'bundler/setup'` (because `PUMA_BUNDLER_PRUNED=1`). Without `BUNDLE_WITHOUT`, Bundler tries to activate all gem groups, including ones that were never installed (e.g. development and test in a Docker deployment), and raises `Bundler::GemNotFound`.

This was not caught before Puma 7 because a separate bug (fixed in #3297) caused `preload_app` to be incorrectly enabled alongside `prune_bundler` when workers were set via `WEB_CONCURRENCY`. With the app preloaded in the master process before the prune exec, `require 'bundler/setup'` was never called in workers post-prune. The fix in #3297 correctly sets `preload_app false` when `prune_bundler` is configured, which exposed this underlying issue.

The fix restores all `BUNDLE_*` vars from `Bundler.original_env` (the environment before `bundle exec` modified it) into the re-exec environment, so user-configured Bundler settings are preserved.