### PR TITLE
Add underscore header hardening option

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -76,7 +76,8 @@ module Puma
                 :tempfile, :io_buffer, :http_content_length_limit_exceeded,
                 :requests_served, :error_status_code
 
-    attr_writer :peerip, :http_content_length_limit, :supported_http_methods
+    attr_writer :peerip, :http_content_length_limit, :supported_http_methods,
+                :allow_underscore_headers
 
     attr_accessor :remote_addr_header, :listener, :env_set_http_version
 
@@ -105,6 +106,7 @@ module Puma
 
       @http_content_length_limit = nil
       @http_content_length_limit_exceeded = nil
+      @allow_underscore_headers = true
       @error_status_code = nil
 
       @peerip = nil

--- a/lib/puma/client_env.rb
+++ b/lib/puma/client_env.rb
@@ -115,27 +115,24 @@ module Puma
     def req_env_post_parse
       to_delete = nil
       to_add = nil
+      underscore_headers = nil
 
       @env.each do |k,v|
-        if k.start_with?("HTTP_") && k.include?(",") && !UNMASKABLE_HEADERS.key?(k)
-          if to_delete
-            to_delete << k
-          else
-            to_delete = [k]
-          end
+        next unless k.start_with?("HTTP_") && k.include?(",")
 
-          new_k = k.tr(",", "_")
-          if @env.key?(new_k)
-            next
-          end
+        (underscore_headers ||= []) << k.delete_prefix("HTTP_").tr("_,", "-_")
+        next if @allow_underscore_headers && UNMASKABLE_HEADERS.key?(k)
 
-          unless to_add
-            to_add = {}
-          end
+        (to_delete ||= []) << k
+        next unless @allow_underscore_headers
 
-          to_add[new_k] = v
-        end
+        new_k = k.tr(",", "_")
+        next if @env.key?(new_k)
+
+        (to_add ||= {})[new_k] = v
       end
+
+      @env[PUMA_UNDERSCORE_HEADERS] = underscore_headers if underscore_headers
 
       if to_delete # rubocop:disable Style/SafeNavigation
         to_delete.each { |k| env.delete(k) }

--- a/lib/puma/client_env.rb
+++ b/lib/puma/client_env.rb
@@ -105,9 +105,10 @@ module Puma
     # avoid allocation in the common case (ie there are no headers
     # with `,` in their names), that's why it has the extra conditionals.
     #
-    # @note If a normalized version of a `,` header already exists, we ignore
-    #       the `,` version. This prevents clobbering headers managed by proxies
-    #       but not by clients (Like X-Forwarded-For).
+    # @note If underscore headers are disallowed, `,` headers are discarded.
+    #       Otherwise, if a normalized version of a `,` header already exists, we
+    #       ignore the `,` version. This prevents clobbering headers managed by
+    #       proxies but not by clients (Like X-Forwarded-For).
     #
     # @param env [Hash] see Puma::Client#env, from request, modifies in place
     # @version 5.0.3

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -133,6 +133,7 @@ module Puma
     class NotClampedError < StandardError; end
 
     DEFAULTS = {
+      allow_underscore_headers: true,
       auto_trim_time: 30,
       binds: ['tcp://[::]:9292'.freeze],
       debug: false,

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -232,6 +232,7 @@ module Puma
     PUMA_SOCKET = "puma.socket"
     PUMA_CONFIG = "puma.config"
     PUMA_PEERCERT = "puma.peercert"
+    PUMA_UNDERSCORE_HEADERS = "puma.underscore_headers"
 
     HTTP = "http"
     HTTPS = "https"

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1441,6 +1441,19 @@ module Puma
       @options[:enable_keep_alives] = enabled
     end
 
+    # When +false+, request headers with underscores in their names are discarded.
+    # When such headers are present, their names are exposed in
+    # +env["puma.underscore_headers"]+ for auditing. This value is client-triggerable;
+    # rate-limit or sample external reporting. The default is +true+, but will change
+    # to +false+ in a future major version, when this env metadata will be removed.
+    #
+    # @example
+    #   allow_underscore_headers false
+    #
+    def allow_underscore_headers(allowed=true)
+      @options[:allow_underscore_headers] = allowed
+    end
+
     # Specify the backend for the IO selector.
     #
     # Provided values will be passed directly to +NIO::Selector.new+, with the

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -107,6 +107,7 @@ module Puma
       @enable_keep_alives      &&= @queue_requests
       @io_selector_backend       = @options[:io_selector_backend]
       @http_content_length_limit = @options[:http_content_length_limit]
+      @allow_underscore_headers  = @options[:allow_underscore_headers]
       @cluster_accept_loop_delay = ClusterAcceptLoopDelay.new(
         workers: @options[:workers],
         max_delay: @options[:wait_for_less_busy_worker] || 0 # Real default is in Configuration::DEFAULTS, this is for unit testing
@@ -450,6 +451,7 @@ module Puma
       client.env_set_http_version = @env_set_http_version
       client.http_content_length_limit = @http_content_length_limit
       client.supported_http_methods = @supported_http_methods
+      client.allow_underscore_headers = @allow_underscore_headers
       client
     end
 

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -107,7 +107,7 @@ module Puma
       @enable_keep_alives      &&= @queue_requests
       @io_selector_backend       = @options[:io_selector_backend]
       @http_content_length_limit = @options[:http_content_length_limit]
-      @allow_underscore_headers  = @options[:allow_underscore_headers]
+      @allow_underscore_headers  = @options.fetch(:allow_underscore_headers, true)
       @cluster_accept_loop_delay = ClusterAcceptLoopDelay.new(
         workers: @options[:workers],
         max_delay: @options[:wait_for_less_busy_worker] || 0 # Real default is in Configuration::DEFAULTS, this is for unit testing

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -716,6 +716,20 @@ class TestConfigFile < PumaTest
     assert_equal true, conf.options[:silence_fork_callback_warning]
   end
 
+  def test_allow_underscore_headers
+    conf = Puma::Configuration.new
+    conf.clamp
+
+    assert_equal true, conf.options.default_options[:allow_underscore_headers]
+
+    conf = Puma::Configuration.new do |c|
+      c.allow_underscore_headers false
+    end
+    conf.clamp
+
+    assert_equal false, conf.final_options[:allow_underscore_headers]
+  end
+
   def test_http_content_length_limit
     conf = Puma::Configuration.new
     conf.clamp

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -47,6 +47,17 @@ class TestPumaServer < PumaTest
     @pool = @server.instance_variable_get(:@thread_pool)
   end
 
+  def test_allow_underscore_headers_defaults_to_true_when_option_is_absent
+    defaults = Puma::Configuration::DEFAULTS.dup
+    defaults.delete(:allow_underscore_headers)
+    options = Puma::UserFileDefaultOptions.new({log_writer: @log_writer}, defaults)
+    server = Puma::Server.new @app, @events, options
+
+    assert_equal true, server.instance_variable_get(:@allow_underscore_headers)
+  ensure
+    server&.stop(true)
+  end
+
   def test_http10_req_to_http10_resp
     server_run do |env|
       [200, {}, [env["SERVER_PROTOCOL"]]]

--- a/test/test_request_single.rb
+++ b/test/test_request_single.rb
@@ -321,6 +321,7 @@ class TestRequestHeadersValid < TestRequestBase
 
     assert_instance_of Float, @client.env['puma.request_body_wait']
     assert_equal '11', @client.env[CONTENT_LENGTH]
+    refute_operator @client.env, :key?, PUMA_UNDERSCORE_HEADERS
     assert_equal 'Hello World', @client.env['rack.input'].read
   end
 
@@ -356,6 +357,18 @@ class TestRequestHeadersValid < TestRequestBase
     create_client request
 
     assert_equal "1.1.1.1", @client.env['HTTP_X_FORWARDED_FOR']
+    assert_equal ["X_FORWARDED_FOR"], @client.env[PUMA_UNDERSCORE_HEADERS]
+  end
+
+  def test_underscore_single_disallowed
+    request = "GET / HTTP/1.1\r\n" \
+      "x_forwarded_for: 1.1.1.1\r\n" \
+      "Content-Length: 11\r\n\r\nHello World"
+
+    create_client(request) { |client| client.allow_underscore_headers = false }
+
+    refute_operator @client.env, :key?, 'HTTP_X_FORWARDED_FOR'
+    assert_equal ["X_FORWARDED_FOR"], @client.env[PUMA_UNDERSCORE_HEADERS]
   end
 
   def test_underscore_header_1
@@ -371,6 +384,24 @@ class TestRequestHeadersValid < TestRequestBase
     create_client request
 
     assert_equal "1.1.1.1", @client.env['HTTP_X_FORWARDED_FOR']
+    assert_equal ["X-FORWARDED_FOR"], @client.env[PUMA_UNDERSCORE_HEADERS]
+    assert_equal "Hello World", @client.body.string
+  end
+
+  def test_underscore_collision_disallowed
+    request = <<~REQ.gsub("\n", "\r\n").rstrip
+      GET / HTTP/1.1
+      x-forwarded-for: 1.1.1.1
+      x_forwarded_for: 2.2.2.2
+      Content-Length: 11
+
+      Hello World
+    REQ
+
+    create_client(request) { |client| client.allow_underscore_headers = false }
+
+    assert_equal "1.1.1.1", @client.env['HTTP_X_FORWARDED_FOR']
+    assert_equal ["X_FORWARDED_FOR"], @client.env[PUMA_UNDERSCORE_HEADERS]
     assert_equal "Hello World", @client.body.string
   end
 
@@ -385,6 +416,7 @@ class TestRequestHeadersValid < TestRequestBase
     create_client "#{GET_PREFIX}#{hdrs}\r\n\r\nHello\r\n\r\n"
 
     assert_equal "1.1.1.1, 2.2.2.2", @client.env['HTTP_X_FORWARDED_FOR']
+    assert_equal ["X_FORWARDED-FOR"], @client.env[PUMA_UNDERSCORE_HEADERS]
     assert_equal "Hello", @client.body.string
   end
 
@@ -399,6 +431,7 @@ class TestRequestHeadersValid < TestRequestBase
     create_client "#{GET_PREFIX}#{hdrs}\r\n\r\nHello\r\n\r\n"
 
     assert_equal "2.2.2.2, 1.1.1.1", @client.env['HTTP_X_FORWARDED_FOR']
+    assert_equal ["X_FORWARDED-FOR"], @client.env[PUMA_UNDERSCORE_HEADERS]
     assert_equal "Hello", @client.body.string
   end
 


### PR DESCRIPTION
## Summary

Many Rack applications trust `X-Forwarded-*` headers, such as `X-Forwarded-For` and `X-Forwarded-Host`, because they believe those headers are set or sanitized by a trusted upstream proxy/CDN.

Rack env normalization makes hyphenated and underscored request header names indistinguishable:

```text
X-Forwarded-Host  -> HTTP_X_FORWARDED_HOST
X_Forwarded_Host  -> HTTP_X_FORWARDED_HOST
```

Puma already protects the collision case by preserving underscore-origin headers internally and preferring the canonical hyphenated header when both forms reach Puma. The remaining problem is the lone-underscore case. If an upstream proxy fails to write the canonical `X-Forwarded-*` header for some request path, or fails to remove a client-supplied underscore variant, Puma can normalize a client-controlled header into the trusted Rack env key. To the app, it can look like the trusted upstream set `env["HTTP_X_FORWARDED_HOST"]` to `evil.example`, when in fact the upstream did not set the canonical header at all.

This PR adds nginx-like underscore header handling so deployments can opt into the safer behavior now.

## Changes

- Add `allow_underscore_headers`, defaulting to `true` for compatibility in this major version.
- When `allow_underscore_headers false`, discard request headers whose field names contained `_` before exposing them through normalized Rack env keys.
- Add `env["puma.underscore_headers"]` when underscore-origin request headers are present, containing header names only, never values.
- Preserve current behavior when `allow_underscore_headers true`: underscore-origin headers are still normalized unless a canonical hyphenated equivalent already exists.

## Recommendation

We recommend that applications assess whether they depend on request headers with underscores and then set:

```ruby
allow_underscore_headers false
```

This is the more secure default for most proxy/CDN-backed deployments. The current default remains `true` for compatibility, but this setting is intended to default to `false` in the next Puma major release.

Applications can use `env["puma.underscore_headers"]` to audit traffic before changing the setting. Because that metadata is client-triggerable, external reporting should be sampled or rate-limited.

## Tests

- `bundle exec ruby -Itest test/test_request_single.rb`
- `bundle exec ruby -Itest test/test_config.rb`
- `bundle exec rubocop lib/puma/client_env.rb lib/puma/client.rb lib/puma/server.rb lib/puma/configuration.rb lib/puma/dsl.rb lib/puma/const.rb test/test_request_single.rb test/test_config.rb`
