### PR TITLE
Defer on_booted/on_restart/on_stopped removal to Puma v9

### DIFF
--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -82,7 +82,7 @@ module Puma
   #
   def self.deprecate_method_change(method_old, method_caller, method_new)
     if method_old == method_caller
-      warn "Use '#{method_new}', '#{method_caller}' is deprecated and will be removed in v8"
+      warn "Use '#{method_new}', '#{method_caller}' is deprecated and will be removed in Puma v9"
     end
   end
 end

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -5,9 +5,6 @@ require 'puma/const'
 require_relative "helper"
 
 class TestEvents < PumaTest
-  # The on_booted/on_restart/on_stopped methods were deprecated and are
-  # scheduled for removal in Puma v9. Fail loudly once the version bumps
-  # past 8 so we remember to remove them.
   def test_deprecated_event_methods_are_removed_in_v9
     refute_operator Gem::Version.new(Puma::Const::PUMA_VERSION), :>=, Gem::Version.new("9"),
       "Remove deprecated on_booted/on_restart/on_stopped from Puma::Events and their tests"

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
 
 require 'puma/events'
+require 'puma/const'
 require_relative "helper"
 
 class TestEvents < PumaTest
+  # The on_booted/on_restart/on_stopped methods were deprecated and are
+  # scheduled for removal in Puma v9. Fail loudly once the version bumps
+  # past 8 so we remember to remove them.
+  def test_deprecated_event_methods_are_removed_in_v9
+    refute_operator Gem::Version.new(Puma::Const::PUMA_VERSION), :>=, Gem::Version.new("9"),
+      "Remove deprecated on_booted/on_restart/on_stopped from Puma::Events and their tests"
+  end
+
   def test_register_callback_with_block
     res = false
 
@@ -95,7 +104,7 @@ class TestEvents < PumaTest
     events.fire_after_booted!
 
     assert res
-    assert_match(/Use 'after_booted', 'on_booted' is deprecated and will be removed in v8/, err)
+    assert_match(/Use 'after_booted', 'on_booted' is deprecated and will be removed in Puma v9/, err)
   end
 
   def test_on_restart_deprecated_with_warning
@@ -109,7 +118,7 @@ class TestEvents < PumaTest
     events.fire_before_restart!
 
     assert res
-    assert_match(/Use 'before_restart', 'on_restart' is deprecated and will be removed in v8/, err)
+    assert_match(/Use 'before_restart', 'on_restart' is deprecated and will be removed in Puma v9/, err)
   end
 
   def test_on_stopped_deprecated_with_warning
@@ -123,6 +132,6 @@ class TestEvents < PumaTest
     events.fire_after_stopped!
 
     assert res
-    assert_match(/Use 'after_stopped', 'on_stopped' is deprecated and will be removed in v8/, err)
+    assert_match(/Use 'after_stopped', 'on_stopped' is deprecated and will be removed in Puma v9/, err)
   end
 end


### PR DESCRIPTION
These callbacks were slated for removal in v8 but shipped, so push the removal to v9. Clarify the warning to name Puma explicitly, and add a version-guard test that fails once PUMA_VERSION reaches 9 so we don't miss the removal again.