### PR TITLE
Fix `Configuration#clamp` being called twice in `Launcher`

### DIFF
--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -283,6 +283,8 @@ module Puma
     #
     # This also calls load if it hasn't been called yet.
     def clamp
+      raise "Configuration already clamped" if @clamped
+
       load unless @loaded
       run_mode_hooks
       set_conditional_default_options
@@ -491,7 +493,7 @@ module Puma
       @_options.all_of(key).each(&:call)
 
       unless @_options[:workers] == workers_before
-        raise "cannot change the number of workers inside a #{key} configuration hook"
+        raise "Cannot change the number of workers inside a #{key} configuration hook"
       end
     end
 

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -283,7 +283,10 @@ module Puma
     #
     # This also calls load if it hasn't been called yet.
     def clamp
-      raise "Configuration already clamped" if @clamped
+      if @clamped
+        warn "Configuration already clamped, calling clamp multiple times is deprecated and will raise in Puma v9"
+        return options
+      end
 
       load unless @loaded
       run_mode_hooks

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -197,8 +197,6 @@ module Puma
     def run
       previous_env = get_env
 
-      @config.clamp
-
       @config.plugins.fire_starts self
 
       setup_signals

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -336,7 +336,6 @@ class TestCLI < PumaTest
     cli = Puma::CLI.new ['--extra-runtime-dependencies', 'a,b']
 
     conf = cli.instance_variable_get(:@conf)
-    conf.clamp
 
     extra_dependencies = conf.options[:extra_runtime_dependencies]
 
@@ -351,7 +350,6 @@ class TestCLI < PumaTest
       cli = Puma::CLI.new []
 
       conf = cli.instance_variable_get(:@conf)
-      conf.clamp
 
       assert_equal 'test', conf.environment
     end
@@ -363,7 +361,6 @@ class TestCLI < PumaTest
     cli = Puma::CLI.new []
 
     conf = cli.instance_variable_get(:@conf)
-    conf.clamp
 
     assert_equal @environment, conf.environment
   end
@@ -375,7 +372,6 @@ class TestCLI < PumaTest
       cli = Puma::CLI.new []
 
       conf = cli.instance_variable_get(:@conf)
-      conf.clamp
 
       assert_equal @environment, conf.environment
     end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -557,7 +557,7 @@ class TestConfigFile < PumaTest
       end
       conf.clamp
     end
-    assert_equal "cannot change the number of workers inside a cluster configuration hook", error.message
+    assert_equal "Cannot change the number of workers inside a cluster configuration hook", error.message
   end
 
   def test_run_mode_hooks_with_workers_duplicated_in_hook
@@ -743,6 +743,12 @@ class TestConfigFile < PumaTest
     conf.clamp
 
     assert_kind_of Puma::UserFileDefaultOptions, conf.options
+  end
+
+  def test_clamp_raises_if_called_twice
+    conf = Puma::Configuration.new
+    conf.clamp
+    assert_raises(RuntimeError) { conf.clamp }
   end
 
   def test_config_files_raises_not_loaded_error_when_not_loaded
@@ -1127,7 +1133,7 @@ class TestConfigEnvVariables < PumaTest
       end
       conf.clamp
     end
-    assert_equal "cannot change the number of workers inside a cluster configuration hook", error.message
+    assert_equal "Cannot change the number of workers inside a cluster configuration hook", error.message
   end
 
   def test_run_mode_hooks_with_workers_duplicated_in_hook

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -745,10 +745,16 @@ class TestConfigFile < PumaTest
     assert_kind_of Puma::UserFileDefaultOptions, conf.options
   end
 
-  def test_clamp_raises_if_called_twice
+  def test_clamp_warns_if_called_twice
     conf = Puma::Configuration.new
     conf.clamp
-    assert_raises(RuntimeError) { conf.clamp }
+    _, err = capture_io { conf.clamp }
+    assert_match(/calling clamp multiple times is deprecated and will raise in Puma v9/, err)
+  end
+
+  def test_double_clamp_is_removed_in_v9
+    refute_operator Gem::Version.new(Puma::Const::PUMA_VERSION), :>=, Gem::Version.new("9"),
+      "Replace the deprecation warning in Configuration#clamp with a raise"
   end
 
   def test_config_files_raises_not_loaded_error_when_not_loaded


### PR DESCRIPTION
Fixes #3935

`Launcher` calls `@config.clamp` in both `initialize` and `run`. The `initialize` call is necessary because `@config.options` on the next line raises `NotClampedError` without it, making the `run` call redundant. Because `clamp` calls `run_mode_hooks`, any callbacks registered via `single {}` or `cluster {}` blocks execute twice.

The fix removes the redundant call in `run`. Nothing between `initialize` and `run` invalidates the clamped config since all intermediate writes go to the same mutable options hash rather than to pre clamp DSL state. All three call sites that create a `Launcher` (`CLI`, `Rack::Handler::Puma`, and the test helper) go through `initialize`, so no path is missed.

Calling `clamp` on an already clamped config is now a no op that emits a deprecation warning. This will become a raise in Puma v9. Also capitalized an existing lowercase raise message for consistency with the rest of the codebase.