### PR TITLE
Fix worker shutdown hang in notify_safely (#3677)

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -639,7 +639,16 @@ module Puma
     end
 
     def notify_safely(message)
-      @notify << message
+      # Use syswrite (a single write(2) syscall) rather than `<<` to
+      # bypass MRI's buffered-IO write lock. That lock can deadlock with
+      # IO#close running in handle_servers' ensure block — the closer
+      # parks in sleep_forever while a buffered writer is mid-write,
+      # even though the writer is woken with IOError (puma#3677).
+      # syswrite is also async-signal-safe, so notify_safely remains
+      # callable from puma's signal handlers (TERM/USR2/INT/HUP) without
+      # raising "can't be called from trap context".
+      notify = @notify
+      notify.syswrite(message) if notify && !notify.closed?
     rescue IOError, NoMethodError, Errno::EPIPE, Errno::EBADF
       # The server, in another thread, is shutting down
     rescue RuntimeError => e

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -455,7 +455,7 @@ module Puma
 
     # :nodoc:
     def handle_check
-      cmd = @check.read(1)
+      cmd = @check.sysread 1
 
       case cmd
       when STOP_COMMAND
@@ -649,15 +649,8 @@ module Puma
       # raising "can't be called from trap context".
       notify = @notify
       notify.syswrite(message) if notify && !notify.closed?
-    rescue IOError, NoMethodError, Errno::EPIPE, Errno::EBADF
-      # The server, in another thread, is shutting down
-    rescue RuntimeError => e
-      # Temporary workaround for https://bugs.ruby-lang.org/issues/13239
-      if e.message.include?('IOError')
-        # ignore
-      else
-        raise e
-      end
+    rescue IOError, NoMethodError, Errno::EPIPE, Errno::EBADF => e
+      @log_writer.unknown_error(e, nil, "notify_safely error") if Puma::IS_MRI && RUBY_VERSION > '3.3'
     end
     private :notify_safely
 

--- a/test/test_puma_server_notify_close_race.rb
+++ b/test/test_puma_server_notify_close_race.rb
@@ -31,7 +31,7 @@ class TestPumaServerNotifyCloseRace < PumaTest
   # invoke it via Server#stop / #begin_restart. A regression that uses
   # Mutex#synchronize would raise ThreadError here.
   def test_notify_safely_callable_from_trap_context
-    skip_unless_signal_exist? USR_SIGNAL if respond_to?(:skip_unless_signal_exist?)
+    skip_unless_signal_exist? USR_SIGNAL
 
     server = make_server
     server.run
@@ -58,7 +58,7 @@ class TestPumaServerNotifyCloseRace < PumaTest
     assert_predicate server, :shutting_down?,
       "STOP_COMMAND was not delivered through @notify"
   ensure
-    Signal.trap(USR_SIGNAL, "DEFAULT")
+    Signal.trap(USR_SIGNAL, "DEFAULT") if Signal.list.key?(USR_SIGNAL)
     server&.stop(true)
   end
 

--- a/test/test_puma_server_notify_close_race.rb
+++ b/test/test_puma_server_notify_close_race.rb
@@ -94,6 +94,8 @@ class TestPumaServerNotifyCloseRace < PumaTest
       end
       writers.each(&:join)
     end
+    log = @log_writer.stderr.string
+    refute_includes log, 'notify_safely error:'
 
     pass
   end

--- a/test/test_puma_server_notify_close_race.rb
+++ b/test/test_puma_server_notify_close_race.rb
@@ -74,7 +74,7 @@ class TestPumaServerNotifyCloseRace < PumaTest
       server = make_server
       server.run
 
-      writers = 4.times.map do
+      writers = Array.new(4) do
         Thread.new do
           loop do
             server.send(:notify_safely, Puma::Const::STOP_COMMAND)

--- a/test/test_puma_server_notify_close_race.rb
+++ b/test/test_puma_server_notify_close_race.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+require "puma/events"
+require "puma/server"
+
+# Regression tests for puma#3677 — the puma srv thread parks in
+# sleep_forever inside IO#close on the @notify pipe when notify_safely
+# (e.g. from the worker's SIGTERM trap calling Server#stop) races with
+# handle_servers' ensure-block close. The fix replaces `@notify << msg`
+# (buffered IO, holds Ruby's IO write lock that close also wants) with
+# `@notify.syswrite(msg)` (single write(2) syscall, lock-free).
+class TestPumaServerNotifyCloseRace < PumaTest
+  USR_SIGNAL = "USR1"
+
+  def setup
+    @app = ->(_env) { [200, {}, ["ok"]] }
+    @log_writer = Puma::LogWriter.strings
+    @events = Puma::Events.new
+  end
+
+  def make_server
+    server = Puma::Server.new @app, @events,
+      log_writer: @log_writer, min_threads: 1, max_threads: 1
+    server.add_tcp_listener "127.0.0.1", 0
+    server
+  end
+
+  # Trap-context safety: notify_safely must be callable from a signal
+  # handler. Puma's launcher signal handlers (TERM/USR2/INT/HUP) all
+  # invoke it via Server#stop / #begin_restart. A regression that uses
+  # Mutex#synchronize would raise ThreadError here.
+  def test_notify_safely_callable_from_trap_context
+    skip_unless_signal_exist? USR_SIGNAL if respond_to?(:skip_unless_signal_exist?)
+
+    server = make_server
+    server.run
+
+    error = nil
+    done = Queue.new
+    Signal.trap(USR_SIGNAL) do
+      begin
+        server.send(:notify_safely, Puma::Const::STOP_COMMAND)
+      rescue => e
+        error = e
+      end
+      done << true
+    end
+
+    Process.kill(USR_SIGNAL, Process.pid)
+    assert_equal true, done.pop, "trap handler did not run"
+    assert_nil error,
+      "notify_safely raised in trap context: #{error&.class}: #{error&.message}"
+
+    # The puma srv thread reads STOP_COMMAND off @check; give it a moment.
+    deadline = Time.now + 2
+    sleep 0.01 until server.shutting_down? || Time.now > deadline
+    assert_predicate server, :shutting_down?,
+      "STOP_COMMAND was not delivered through @notify"
+  ensure
+    Signal.trap(USR_SIGNAL, "DEFAULT")
+    server&.stop(true)
+  end
+
+  # Stress test: many cycles of run + concurrent notify_safely + stop.
+  # On platforms where MRI's buffered-IO close-vs-write race fires
+  # (puma#3677), Server#stop's join would hang inside handle_servers'
+  # IO#close. With syswrite-based notify_safely, every cycle completes.
+  def test_stop_does_not_hang_under_concurrent_notify_safely
+    iterations = ENV.fetch("PUMA_STOP_RACE_ITERATIONS", "100").to_i
+    deadline = 5.0 # seconds per iteration
+
+    iterations.times do |i|
+      server = make_server
+      server.run
+
+      writers = 4.times.map do
+        Thread.new do
+          loop do
+            server.send(:notify_safely, Puma::Const::STOP_COMMAND)
+            break if server.shutting_down?
+          end
+        end
+      end
+
+      stopper = Thread.new { server.stop(true) }
+      finished = stopper.join(deadline)
+      if finished.nil?
+        bt = (server.thread&.backtrace || []).first(10).join("\n  ")
+        stopper.kill
+        writers.each(&:kill)
+        flunk "Server#stop hung after #{deadline}s on iteration #{i}.\n" \
+              "puma srv backtrace:\n  #{bt}"
+      end
+      writers.each(&:join)
+    end
+
+    pass
+  end
+end


### PR DESCRIPTION
Worker shutdown can hang indefinitely with the puma srv thread parked in sleep_forever inside `IO#close` on the `@notify` pipe. The race: notify_safely uses `@notify << message`, which goes through Ruby's buffered-IO write path and acquires the same internal write lock that `IO#close` (running in handle_servers' ensure block) waits on. When the two interleave, the writer wakes with `IOError "stream closed in another thread"`, but the closer never returns — leaving `server_thread.join` in `Cluster::Worker#run` to hang forever, which in turn leaves the cluster master spinning in `stop_workers` until SIGKILL'd by the orchestrator (e.g. ECS exit code 137).

Switch notify_safely to `IO#syswrite`, a single direct `write(2)` syscall that bypasses Ruby's buffered-IO write lock entirely. The operation is also async-signal-safe, which preserves notify_safely's existing usage from puma's signal handlers (TERM/USR2/INT/HUP via Server#stop / #begin_restart in launcher.rb) — a Mutex-based fix would raise "can't be called from trap context".

Adds two regression tests:

* `test_notify_safely_callable_from_trap_context` — installs a signal handler that calls notify_safely and asserts no ThreadError, plus that STOP_COMMAND is delivered through @notify. This is the test that catches the trap-context regression a Mutex.synchronize-based fix would introduce.
* `test_stop_does_not_hang_under_concurrent_notify_safely` — 100 cycles of run + concurrent notify_safely writers + stop, with a per-cycle timeout and a thread backtrace dump on hang. Catches the underlying race on platforms where it reproduces.

Closes #3677 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
