### PR TITLE
Fix single mode exit code 1 on graceful SIGTERM shutdown

### DIFF
--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -449,7 +449,10 @@ module Puma
           # Shortcut the control flow in case raise_exception_on_sigterm is true
           do_graceful_stop
 
-          raise(SignalException, "SIGTERM") if @options[:raise_exception_on_sigterm]
+          # Only raise in cluster mode — master needs it to break out of its
+          # monitoring loop. In single mode the raise serves no purpose and
+          # produces exit code 1 on Ruby < 3.3 / JRuby (signal-kill semantics).
+          raise(SignalException, "SIGTERM") if @options[:raise_exception_on_sigterm] && clustered?
         end
       rescue Exception
         log "*** SIGTERM not implemented, signal based gracefully stopping unavailable!"

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -49,8 +49,7 @@ class TestIntegrationSingle < TestIntegration
     cli_server "test/rackup/hello.ru"
     _, status = stop_server
 
-    status = status.exitstatus % 128 if ::Puma::IS_JRUBY
-    assert_equal 15, status
+    assert_equal 0, status.exitstatus
   end
 
   def test_after_booted_and_after_stopped
@@ -62,7 +61,7 @@ class TestIntegrationSingle < TestIntegration
     assert wait_for_server_to_include('after_booted called')
     assert wait_for_server_to_include('after_stopped called')
 
-    wait_server 15
+    wait_server
   end
 
   def test_term_suppress
@@ -133,7 +132,7 @@ class TestIntegrationSingle < TestIntegration
     assert_match(/Slept 10/, curl_stdout.read)
     assert_match(re_curl_error, rejected_curl_stderr.read)
 
-    wait_server 15
+    wait_server
   end
 
   def test_int_refuse


### PR DESCRIPTION
### Description

**What original problem led to this PR?**

When Puma is running in single mode and receives SIGTERM, it exits with
code 1 even though the graceful shutdown completes successfully. This
causes problems in Docker/container environments: orchestrators like
docker-compose and Kubernetes interpret exit code 1 as a failure, not a
clean shutdown.

**Are there related issues / prior discussions?**

This has been reported and discussed in #1673 (open since 2018) and #3639.

**What alternatives have been tried? Does this supersede previous attempts?**

Two workarounds exist but neither fixes the root cause:
- Setting `raise_exception_on_sigterm false` in `config/puma.rb` — requires
  changing every application's config.
- Wrapping the server command in a bash trap script in the container
  entrypoint — obscures the real problem at the deployment layer.

This PR fixes the issue in Puma itself so no application or deployment
changes are needed.

**Approaches tried during this PR**

While converging on the final fix, two earlier approaches were tried and
ruled out — keeping them here as context for reviewers:

1. **Attempt 1 — `rescue Interrupt, SignalException` in `single.rb`.**
   The trap in `launcher.rb` raises `SignalException("SIGTERM")` after
   `do_graceful_stop`, and `single.rb#run` only rescued `Interrupt`.
   Adding `SignalException` to the rescue clause looked like the minimal
   fix. It worked on Ruby 3.3+/TruffleRuby/4.0, but failed on Ruby
   3.0–3.2 and JRuby — `SignalException` raised from a trap block does
   not propagate to the main thread on those versions, so the rescue
   never runs and the process is still killed by the signal
   (`exitstatus = nil`).

2. **Attempt 2 — `rescue SignalException; exit 0; end`.**
   Tried forcing a clean exit inside the rescue. This fixed Ruby 3.2
   (where the rescue does fire), but:
   - Ruby 3.0/3.1 and JRuby still don't reach the rescue, so they
     continued to fail.
   - On TruffleRuby and macOS JRuby (where the rescue does fire), the
     explicit `exit 0` started leaking through to
     `test_after_booted_and_after_stopped`, which expected the old
     signal-kill status 15. That test had not been updated alongside the
     similar `test_term_not_accepts_new_connections` already touched by
     this PR.

**Final fix**

Move the gate one level up, into `launcher.rb`:

```ruby
raise(SignalException, "SIGTERM") if @options[:raise_exception_on_sigterm] && clustered?
```

In single mode, the trap handler simply calls `do_graceful_stop` and
returns. `server_thread.join` completes, `Single#run` returns normally,
and the process exits with code 0 on every supported Ruby — because the
fix no longer depends on the semantics of rescuing `SignalException`,
which differ between MRI 3.0–3.2 / 3.3+ / JRuby / TruffleRuby.

The `SignalException` is still raised in cluster mode where the master
process needs it to break out of its monitoring loop.

`single.rb` is left unchanged from `main`. `test_after_booted_and_after_stopped`
is updated from `wait_server 15` to `wait_server` to match the new clean
exit 0 behavior (mirroring `test_term_not_accepts_new_connections`).

**Why do you make the choices you did? What are the tradeoffs?**

With this fix, `raise_exception_on_sigterm true` and `false` behave
identically in single mode (both exit 0). The option retains its full
meaning in cluster mode, which is not changed by this PR.

Closes #1673
Closes #3639

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] All new and existing tests passed, including Rubocop.
