### PR TITLE
Catch empty chunk sizes

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -46,7 +46,7 @@ module Puma
     ALLOWED_TRANSFER_ENCODING = %w[compress deflate gzip].freeze
 
     # chunked body validation
-    CHUNK_SIZE_INVALID = /[^\h]/.freeze
+    CHUNK_SIZE_VALID = /\A\h+\z/.freeze
     CHUNK_VALID_ENDING = Const::LINE_END
     CHUNK_VALID_ENDING_SIZE = CHUNK_VALID_ENDING.bytesize
 
@@ -653,13 +653,13 @@ module Puma
           # Puma doesn't process chunk extensions, but should parse if they're
           # present, which is the reason for the semicolon regex
           chunk_hex = line.strip[/\A[^;]+/]
-          if chunk_hex.nil?
-            raise HttpParserError, "Empty chunk size"
+          unless CHUNK_SIZE_VALID.match? chunk_hex
+            err_msg = chunk_hex && !chunk_hex.empty? ?
+              "Invalid chunk size: '#{chunk_hex}'" :
+              "Chunk size cannot be empty or nil"
+            raise HttpParserError, err_msg
           end
 
-          if CHUNK_SIZE_INVALID.match? chunk_hex
-            raise HttpParserError, "Invalid chunk size: '#{chunk_hex}'"
-          end
           len = chunk_hex.to_i(16)
           if len == 0
             @in_last_chunk = true

--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -653,6 +653,10 @@ module Puma
           # Puma doesn't process chunk extensions, but should parse if they're
           # present, which is the reason for the semicolon regex
           chunk_hex = line.strip[/\A[^;]+/]
+          if chunk_hex.nil?
+            raise HttpParserError, "Empty chunk size"
+          end
+
           if CHUNK_SIZE_INVALID.match? chunk_hex
             raise HttpParserError, "Invalid chunk size: '#{chunk_hex}'"
           end

--- a/test/test_request_single.rb
+++ b/test/test_request_single.rb
@@ -684,6 +684,14 @@ class TestRequestChunkedInvalid < TestRequestBase
     assert_invalid "#{GET_PREFIX}#{te}\r\n\r\n#{chunked}",
       "Chunk size mismatch"
   end
+
+  def test_chunked_size_empty
+    te = 'Transfer-Encoding: chunked'
+    chunked = "\r\n\r\n"
+
+    assert_invalid "#{GET_PREFIX}#{te}\r\n\r\n#{chunked}",
+      "Empty chunk size"
+  end
 end
 
 # Tests invalid Transfer-Ecoding headers

--- a/test/test_request_single.rb
+++ b/test/test_request_single.rb
@@ -690,7 +690,7 @@ class TestRequestChunkedInvalid < TestRequestBase
     chunked = "\r\n\r\n"
 
     assert_invalid "#{GET_PREFIX}#{te}\r\n\r\n#{chunked}",
-      "Empty chunk size"
+      "Chunk size cannot be empty or nil"
   end
 end
 


### PR DESCRIPTION
### Description

Adds a check for empty chunk sizes, which would previously trigger an exception and subsequent 500 response.

This PR fixes the first of the two issues described in #3951.

### Your checklist for this pull request
- [X] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [X] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [X] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [X] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [X] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed, including Rubocop.
