### PR TITLE
Fix flaky `test_update_thread_pool_min_max`

### DIFF
--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -2189,9 +2189,10 @@ class TestPumaServer < PumaTest
   end
 
   def test_update_thread_pool_min_max
-    # add a small delay so requests back up
+    # delay enough that 5 requests back up faster than threads finish them,
+    # so the pool spawns up to max rather than reusing the existing thread
     @app = ->(env) do
-      sleep 0.001
+      sleep 0.1
       [200, {}, [env['rack.url_scheme']]]
     end
 


### PR DESCRIPTION
## Summary

`test_update_thread_pool_min_max` has been flaking with `Expected: 3, Actual: 2`. The app slept for `0.001` (1ms) before responding, on the same order as TCP connect and thread scheduling on a loaded machine. The pool's existing thread could finish a request before the next one arrived, pick it up, and never give `spawn_thread` a reason to fire. Under that race only two threads spawned and the final `assert_equal 3, @pool.spawned` failed.

Sleeping for `0.1` instead leaves enough margin for all five requests to reliably back up before any thread frees, so the pool spawns up to max as the test expects. Ran it 10 times locally with no failures.

## Test plan
- [x] `bundle exec ruby -Itest test/test_puma_server.rb -n test_update_thread_pool_min_max` x10
- [x] `bundle exec ruby -Itest test/test_puma_server.rb -n /update_thread_pool/`