### PR TITLE
ci: test_puma_server_shutdown_debug.rb - fixup for TruffleRuby head

### DIFF
--- a/test/test_puma_server_shutdown_debug.rb
+++ b/test/test_puma_server_shutdown_debug.rb
@@ -85,8 +85,15 @@ class TestPumaServerShutdownDebug < PumaTest
     end
 
     assert_equal 1, output.scan("Shutdown timeout exceeded").length
-    assert_equal 1, output.scan("Shutdown grace timeout exceeded").length
-    assert_equal 2, output.scan("Begin thread backtrace dump").length
+
+    grace_timeout_count = output.scan("Shutdown grace timeout exceeded").length
+    if TRUFFLE_HEAD
+      assert_includes [0, 1], grace_timeout_count
+      assert_equal 1 + grace_timeout_count, output.scan("Begin thread backtrace dump").length
+    else
+      assert_equal 1, grace_timeout_count
+      assert_equal 2, output.scan("Begin thread backtrace dump").length
+    end
   end
 
   private


### PR DESCRIPTION
### Description

Recently the 'Tests' CI started failing.  It occurred after "Fix worker shutdown hang in notify_safely (#3677) (#3940)" was merged, but that PR had nothing to do with the failure.

From 'copilot', similar test changes were shown, but didn't really work as well as possible.  Updated the test to run the same as previous except for TruffleRuby head.  This is due to TruffleRuby (and at times JRuby) handling threads differently than MRI Ruby.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
