### PR TITLE
ci: integration.rb - fixup restart_does_not_drop_connections in single mode

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -498,6 +498,7 @@ class TestIntegration < PumaTest
     skipped = nil
 
     clustered = (workers || 0) >= 2
+    restart_loop_sleep = clustered ? 0.15 : 0.10
 
     args = "-w #{workers} -t 5:5 -q test/rackup/hello_with_delay.ru"
     if Puma.windows?
@@ -588,7 +589,7 @@ class TestIntegration < PumaTest
           begin
             get_worker_pids phase, log: log
             # Wait with an exponential backoff before signaling next restart
-            sleep 0.15 * restart_count
+            sleep restart_loop_sleep * restart_count
           rescue Minitest::Assertion # Timeout
             run = false
           rescue Errno::EBADF # bad restart?


### PR DESCRIPTION
…
### Description

Fixes recent errors like:

```
  1) Failure:
TestIntegrationSingle#test_hot_restart_does_not_drop_connections_threads [test/helpers/integration.rb:636]:
      0 unexpected_response
      0 refused
      0 read timeout
      0 reset
      0 write_errors
   1000 success
    220 success after restart
      1 restart count
.
Expected 1 to be >= 2.
```

Only changes behavior with 'single' runs.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
