### PR TITLE
Enforce HTTP1.1 RFC for Host header presence

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -342,6 +342,7 @@ module Puma
 
     # processes the `env` and the request body
     def process_env_body
+      validate_env
       temp = setup_body
       normalize_env
       req_env_post_parse

--- a/lib/puma/client_env.rb
+++ b/lib/puma/client_env.rb
@@ -12,6 +12,22 @@ module Puma
 
     include Puma::Const
 
+    def validate_env
+      return unless @env[SERVER_PROTOCOL] == HTTP_11
+
+      unless @env.key? HTTP_HOST
+        @error_status_code = 400
+        @env[HTTP_CONNECTION] = CLOSE
+        raise HttpParserError, "Missing Host header"
+      end
+
+      if @env[HTTP_HOST].empty?
+        @error_status_code = 400
+        @env[HTTP_CONNECTION] = CLOSE
+        raise HttpParserError, "Invalid Host header"
+      end
+    end
+
     # Given a Hash +env+ for the request read from +client+, add
     # and fixup keys to comply with Rack's env guidelines.
     # @param env [Hash] see Puma::Client#env, from request

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -230,7 +230,7 @@ class TestIntegration < PumaTest
   def restart_server(connection, log: false)
     Process.kill :USR2, @pid
     wait_for_server_to_include 'Restarting', log: log
-    connection.write "GET / HTTP/1.1\r\n\r\n" # trigger it to start by sending a new request
+    connection.write "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n" # trigger it to start by sending a new request
     wait_for_server_to_boot log: log
   end
 
@@ -307,7 +307,7 @@ class TestIntegration < PumaTest
   def connect(path = nil, unix: false)
     s = open_client_socket(unix: unix)
     @ios_to_close << s
-    s << "GET /#{path} HTTP/1.1\r\n\r\n"
+    s << "GET /#{path} HTTP/1.1\r\nHost: test.com\r\n\r\n"
     s
   end
 
@@ -316,7 +316,7 @@ class TestIntegration < PumaTest
   def fast_connect(path = nil, unix: false)
     s = open_client_socket(unix: unix)
     @ios_to_close << s
-    fast_write s, "GET /#{path} HTTP/1.1\r\n\r\n"
+    fast_write s, "GET /#{path} HTTP/1.1\r\nHost: test.com\r\n\r\n"
     s
   end
 
@@ -522,7 +522,7 @@ class TestIntegration < PumaTest
           begin
             begin
               socket = open_client_socket(unix: unix)
-              fast_write socket, "POST / HTTP/1.1\r\nContent-Length: #{message.bytesize}\r\n\r\n#{message}"
+              fast_write socket, "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Length: #{message.bytesize}\r\n\r\n#{message}"
             rescue => e
               replies[:write_error] += 1
               raise e

--- a/test/helpers/test_puma/puma_socket.rb
+++ b/test/helpers/test_puma/puma_socket.rb
@@ -61,7 +61,7 @@ module TestPuma
   #
   module PumaSocket
     GET_10 = "GET / HTTP/1.0\r\n\r\n"
-    GET_11 = "GET / HTTP/1.1\r\n\r\n"
+    GET_11 = "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n"
 
     HELLO_11 = "HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\n" \
       "Content-Length: 11\r\n\r\nHello World"

--- a/test/helpers/test_puma/shutdown_requests.rb
+++ b/test/helpers/test_puma/shutdown_requests.rb
@@ -37,10 +37,10 @@ module TestPuma
       s2 = send_http(
         post ?
           "POST /s2 HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhi!" :
-          "GET /s2 HTTP/1.1\r\n"
+          "GET /s2 HTTP/1.1\r\nHost: test.com\r\n"
       )
       mutex.synchronize do
-        s1 = send_http("GET /s1 HTTP/1.1\r\n\r\n")
+        s1 = send_http("GET /s1 HTTP/1.1\r\nHost: test.com\r\n\r\n")
         app_finished.wait(mutex)
         app_finished.signal if s1_complete
       end

--- a/test/test_integration_ssl_session.rb
+++ b/test/test_integration_ssl_session.rb
@@ -20,7 +20,7 @@ class TestIntegrationSSLSession < TestIntegration
 
   CLIENT_HAS_TLS1_3 = OSSL.const_defined? :TLS1_3_VERSION
 
-  GET = "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
+  GET = "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
 
   RESP = "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 5\r\n\r\nhttps"
 

--- a/test/test_log_writer.rb
+++ b/test/test_log_writer.rb
@@ -137,7 +137,7 @@ class TestLogWriter < PumaTest
     path = "/"
     params = "a"*1024*10
 
-    sock << "GET #{path}?a=#{params} HTTP/1.1\r\nConnection: close\r\n\r\n"
+    sock << "GET #{path}?a=#{params} HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
     sock.read
     sleep 0.1 # important so that the previous data is sent as a packet
     assert_match %r!HTTP parse error, malformed request!, log_writer.stderr.string

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -287,7 +287,7 @@ class TestPumaServer < PumaTest
 
     data = send_http_read_all(
       "GET / HTTP/1.1\r\nHost: a\r\nContent-Length: 0\r\n\r\n" \
-      "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
+      "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
     )
 
     assert_equal(
@@ -306,7 +306,7 @@ class TestPumaServer < PumaTest
 
     data = send_http_read_all(
       "GET / HTTP/1.1\r\nHost: a\r\nContent-Length: 1\r\n\r\na" \
-      "GET / HTTP/1.1\r\nContent-Length: 0\r\n\r\n"
+      "GET / HTTP/1.1\r\nHost: test.com\r\nContent-Length: 0\r\n\r\n"
     )
 
     assert_equal(
@@ -322,8 +322,8 @@ class TestPumaServer < PumaTest
     }
 
     socket = send_http(
-      "GET / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n" \
-      "GET / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ngood\r\n3\r\nbye\r\n0\r\n\r\n"
+      "GET / HTTP/1.1\r\nHost: test.com\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n" \
+      "GET / HTTP/1.1\r\nHost: test.com\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ngood\r\n3\r\nbye\r\n0\r\n\r\n"
     )
 
     sleep 0.05 # let both requests be processed?
@@ -335,7 +335,7 @@ class TestPumaServer < PumaTest
       "HTTP/1.1 200 OK\r\ncontent-length: 7\r\n\r\ngoodbye", data
     )
 
-    socket << "GET / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nH\r\n4\r\nello\r\n0\r\n\r\n"
+    socket << "GET / HTTP/1.1\r\nHost: test.com\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nH\r\n4\r\nello\r\n0\r\n\r\n"
 
     response = socket.read_response
 
@@ -419,7 +419,7 @@ class TestPumaServer < PumaTest
   def test_http_11_keep_alive_with_large_payload
     server_run(http_content_length_limit: 10, environment: :production) { [204, {}, []] }
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nContent-Length: 17\r\n\r\n"
+    socket = send_http "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: Keep-Alive\r\nContent-Length: 17\r\n\r\n"
     socket << "hello world foo bar"
 
     response = socket.read_response
@@ -581,7 +581,7 @@ class TestPumaServer < PumaTest
   def test_custom_http_codes_11
     server_run { [449, {}, [""]] }
 
-    response = send_http_read_response "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
+    response = send_http_read_response "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
 
     assert_equal "HTTP/1.1 449 CUSTOM\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
   end
@@ -785,7 +785,7 @@ class TestPumaServer < PumaTest
   def test_http_11_keep_alive_with_body
     server_run { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 
-    req  = "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\n\r\n"
+    req  = "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: Keep-Alive\r\n\r\n"
     response = send_http_read_response req
 
     assert_equal ["content-type: plain/text", "content-length: 6"], response.headers
@@ -795,7 +795,7 @@ class TestPumaServer < PumaTest
   def test_http_11_close_with_body
     server_run { [200, {"Content-Type" => "plain/text"}, ["hello"]] }
 
-    response = send_http_read_response "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
+    response = send_http_read_response "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
 
     assert_equal "HTTP/1.1 200 OK\r\ncontent-type: plain/text\r\nconnection: close\r\ncontent-length: 5\r\n\r\nhello", response
   end
@@ -803,7 +803,7 @@ class TestPumaServer < PumaTest
   def test_http_11_keep_alive_without_body
     server_run { [204, {}, []] }
 
-    response = send_http_read_response "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\n\r\n"
+    response = send_http_read_response "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: Keep-Alive\r\n\r\n"
 
     # No Content
     assert_equal "HTTP/1.1 204 #{STATUS_CODES[204]}", response.status
@@ -812,7 +812,7 @@ class TestPumaServer < PumaTest
   def test_http_11_close_without_body
     server_run { [204, {}, []] }
 
-    req = "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
+    req = "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
     response = send_http_read_response req
 
     # No Content
@@ -823,7 +823,7 @@ class TestPumaServer < PumaTest
   def test_http_11_enable_keep_alives_by_default
     server_run(enable_keep_alives: true) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 
-    req  = "GET / HTTP/1.1\r\n\r\n"
+    req  = "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n"
     response = send_http_read_response req
 
     # No "connection: close" header.
@@ -833,7 +833,7 @@ class TestPumaServer < PumaTest
   def test_http_11_enable_keep_alives_true
     server_run(enable_keep_alives: true) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 
-    req  = "GET / HTTP/1.1\r\n\r\n"
+    req  = "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n"
     response = send_http_read_response req
 
     # No "connection: close" header.
@@ -844,7 +844,7 @@ class TestPumaServer < PumaTest
   def test_http_11_enable_keep_alives_false
     server_run(enable_keep_alives: false) { [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
 
-    req  = "GET / HTTP/1.1\r\n\r\n"
+    req  = "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n"
     response = send_http_read_response req
 
     # Assert the "connection: close" header is present with keep-alives disabled.
@@ -893,7 +893,7 @@ class TestPumaServer < PumaTest
     server_run { [200, {}, [""]] }
 
     # two requests must be read
-    response = send_http_read_all "GET / HTTP/1.1\r\nConnection: close\r\nExpect: 100-continue\r\n\r\n"
+    response = send_http_read_all "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nExpect: 100-continue\r\n\r\n"
 
     assert_equal "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
   end
@@ -909,7 +909,7 @@ class TestPumaServer < PumaTest
       [200, {}, [""]]
     }
 
-    response = send_http_read_response "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: gzip,chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
+    response = send_http_read_response "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nTransfer-Encoding: gzip,chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
     assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
     assert_equal "hello", body
@@ -932,7 +932,7 @@ class TestPumaServer < PumaTest
       [200, {}, [""]]
     }
 
-    chunked_req = "GET / HTTP/1.1\r\nTransfer-Encoding: gzip,chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
+    chunked_req = "GET / HTTP/1.1\r\nHost: test.com\r\nTransfer-Encoding: gzip,chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
     skt = send_http chunked_req
 
@@ -966,7 +966,7 @@ class TestPumaServer < PumaTest
       [200, {}, [""]]
     }
 
-    header = "GET / HTTP/1.1\r\nConnection: close\r\nContent-Length: 200\r\nTransfer-Encoding: chunked\r\n\r\n"
+    header = "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nContent-Length: 200\r\nTransfer-Encoding: chunked\r\n\r\n"
 
     chunk_header_size = 6 # 4fb8\r\n
     # Current implementation reads one chunk of CHUNK_SIZE, then more chunks of size 4096.
@@ -997,7 +997,7 @@ class TestPumaServer < PumaTest
     max_chunk_header_size = Puma::Client::MAX_CHUNK_HEADER_SIZE
 
     # send valid request except for extension_header larger than limit
-    header = "GET / HTTP/1.1\r\nConnection: close\r\nContent-Length: 200\r\nTransfer-Encoding: chunked\r\n\r\n"
+    header = "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nContent-Length: 200\r\nTransfer-Encoding: chunked\r\n\r\n"
     response = send_http_read_response "#{header}1;t=#{'x' * (max_chunk_header_size + 2)}\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
     assert_equal "HTTP/1.1 400 Bad Request\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
@@ -1012,7 +1012,7 @@ class TestPumaServer < PumaTest
     }
 
     # includes 1st chunk length
-    socket = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1;"
+    socket = send_http "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1;"
 
     junk = "*" * 1_024
 
@@ -1046,7 +1046,7 @@ class TestPumaServer < PumaTest
       [200, {}, [""]]
     }
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r\n"
+    socket = send_http "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r\n"
     sleep 1
 
     socket << "h\r\n4\r\nello\r\n0\r\n\r\n"
@@ -1067,7 +1067,7 @@ class TestPumaServer < PumaTest
       [200, {}, [""]]
     }
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n"
+    socket = send_http "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n"
     sleep 1
 
     socket << "4\r\nello\r\n0\r\n\r\n"
@@ -1088,7 +1088,7 @@ class TestPumaServer < PumaTest
       [200, {}, [""]]
     }
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r"
+    socket = send_http "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r"
     sleep 1
 
     socket << "\nh\r\n4\r\nello\r\n0\r\n\r\n"
@@ -1109,7 +1109,7 @@ class TestPumaServer < PumaTest
       [200, {}, [""]]
     }
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1"
+    socket = send_http "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1"
     sleep 1
 
     socket << "\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
@@ -1130,7 +1130,7 @@ class TestPumaServer < PumaTest
       [200, {}, [""]]
     }
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\ne"
+    socket = send_http "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\ne"
     sleep 1
 
     socket << "llo\r\n0\r\n\r\n"
@@ -1155,7 +1155,7 @@ class TestPumaServer < PumaTest
 
     chunked_body = "#{part1.size.to_s(16)}\r\n#{part1}\r\n1\r\nb\r\n0\r\n\r\n"
 
-    socket = send_http "PUT /path HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n"
+    socket = send_http "PUT /path HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n"
 
     sleep 0.1
 
@@ -1181,7 +1181,7 @@ class TestPumaServer < PumaTest
       [200, {}, [""]]
     }
 
-    socket = send_http "PUT /path HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r"
+    socket = send_http "PUT /path HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r"
 
     sleep 1
 
@@ -1203,7 +1203,7 @@ class TestPumaServer < PumaTest
       [200, {}, [""]]
     }
 
-    socket = send_http "PUT /path HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello"
+    socket = send_http "PUT /path HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello"
 
     sleep 1
 
@@ -1235,7 +1235,7 @@ class TestPumaServer < PumaTest
     end
     req_body << "0\r\n\r\n"
 
-    header = "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n"
+    header = "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n"
 
     data1 = req_body[0..7218]  # Number here is arbitrary, so that the first chunk of data ends with `40`
     data2 = req_body[7219..-1] # remaining data
@@ -1261,7 +1261,7 @@ class TestPumaServer < PumaTest
       [200, {}, [""]]
     }
 
-    response = send_http_read_response "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: Chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
+    response = send_http_read_response "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nTransfer-Encoding: Chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
     assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
     assert_equal "hello", body
@@ -1277,7 +1277,7 @@ class TestPumaServer < PumaTest
       [200, {}, [""]]
     }
 
-    response = send_http_read_response "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
+    response = send_http_read_response "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
     assert_equal "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n", response
     assert_equal "hello", body
@@ -1293,7 +1293,7 @@ class TestPumaServer < PumaTest
       [200, {}, [""]]
     }
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n"
+    socket = send_http "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n"
 
     last_crlf_written = false
     last_crlf_writer = Thread.new do
@@ -1314,7 +1314,7 @@ class TestPumaServer < PumaTest
 
     last_crlf_writer.join
 
-    socket << "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ngood\r\n3\r\nbye\r\n0\r\n\r\n"
+    socket << "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ngood\r\n3\r\nbye\r\n0\r\n\r\n"
     sleep 0.1
 
     response = socket.read_response
@@ -1334,7 +1334,7 @@ class TestPumaServer < PumaTest
       [200, {}, ["Request_#{requests}"]]
     }
 
-    req = "GET / HTTP/1.1\r\nX-Forwarded-For: 127.0.0.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
+    req = "GET / HTTP/1.1\r\nHost: test.com\r\nX-Forwarded-For: 127.0.0.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
     expected = String.new # rubocop: disable Performance/UnfreezeString
     req_count.times do |i|
@@ -1385,7 +1385,7 @@ class TestPumaServer < PumaTest
       [200, {}, [""]]
     }
 
-    socket = send_http "GET / HTTP/1.1\r\nX-Forwarded-For: 127.0.0.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
+    socket = send_http "GET / HTTP/1.1\r\nHost: test.com\r\nX-Forwarded-For: 127.0.0.1\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
     response = socket.read_response
 
@@ -1394,7 +1394,7 @@ class TestPumaServer < PumaTest
     assert_equal "5", content_length
     assert_equal "127.0.0.1", remote_addr
 
-    socket << "GET / HTTP/1.1\r\nX-Forwarded-For: 127.0.0.2\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ngood\r\n3\r\nbye\r\n0\r\n\r\n"
+    socket << "GET / HTTP/1.1\r\nHost: test.com\r\nX-Forwarded-For: 127.0.0.2\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ngood\r\n3\r\nbye\r\n0\r\n\r\n"
     sleep 0.1
 
     response = socket.read_response
@@ -1467,7 +1467,7 @@ class TestPumaServer < PumaTest
       [204, {}, []]
     }
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n"
+    socket = send_http "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n"
     sleep 3
     socket << "4\r\nello\r\n0\r\n\r\n"
 
@@ -1680,18 +1680,18 @@ class TestPumaServer < PumaTest
     assert_equal "HTTP/1.1 200 OK", response.status
     assert_equal ["content-length: 0"], response.headers
 
-    socket << "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
+    socket << "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
     response = socket.read_response
 
     assert_equal "HTTP/1.1 200 OK", response.status
     assert_equal ["connection: close", "content-length: 0"], response.headers
 
-    socket = send_http "GET / HTTP/1.1\r\n\r\n"
+    socket = send_http "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n"
     response = socket.read_response
     assert_equal "HTTP/1.1 200 OK", response.status
     assert_equal ["content-length: 0"], response.headers
 
-    socket << "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
+    socket << "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
     response = socket.read_response
     assert_equal "HTTP/1.1 200 OK", response.status
     assert_equal ["connection: close", "content-length: 0"], response.headers
@@ -1869,12 +1869,12 @@ class TestPumaServer < PumaTest
       [200, {}, [env['REMOTE_ADDR']]]
     end
 
-    body = send_http_read_resp_body "GET / HTTP/1.1\r\nX-Remote-IP: 1.2.3.4\r\n\r\n"
+    body = send_http_read_resp_body "GET / HTTP/1.1\r\nHost: test.com\r\nX-Remote-IP: 1.2.3.4\r\n\r\n"
     assert_equal '1.2.3.4', body
 
     # TODO: it would be great to test a connection from a non-localhost IP, but we can't really do that. For
     # now, at least test that it doesn't return garbage.
-    body = send_http_read_resp_body "GET / HTTP/1.1\r\n\r\n"
+    body = send_http_read_resp_body "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n"
     assert_equal @host, body
   end
 
@@ -2093,7 +2093,7 @@ class TestPumaServer < PumaTest
 
     server_run(**options, &broken_app)
 
-    body = send_http_read_resp_body "GET / HTTP/1.1\r\n\r\n"
+    body = send_http_read_resp_body "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n"
 
     assert_equal "something wrong happened", body
   end

--- a/test/test_puma_server_shutdown_debug.rb
+++ b/test/test_puma_server_shutdown_debug.rb
@@ -56,7 +56,7 @@ class TestPumaServerShutdownDebug < PumaTest
 
     output = capture_syswrite do
       mutex.synchronize do
-        send_http("GET / HTTP/1.1\r\n\r\n")
+        send_http("GET / HTTP/1.1\r\nHost: test.com\r\n\r\n")
         app_started.wait(mutex)
       end
       @server.stop(true)
@@ -78,7 +78,7 @@ class TestPumaServerShutdownDebug < PumaTest
 
     output = capture_syswrite do
       mutex.synchronize do
-        send_http("GET / HTTP/1.1\r\n\r\n")
+        send_http("GET / HTTP/1.1\r\nHost: test.com\r\n\r\n")
         app_started.wait(mutex)
       end
       @server.stop(true)

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -117,7 +117,7 @@ class TestPumaServerSSL < PumaTest
     start_server
     @server.app = proc { |env| [200, {}, [env['rack.url_scheme'], "\n", env['rack.input'].read]] }
 
-    req = "POST / HTTP/1.1\r\nContent-Type: text/plain\r\nContent-Length: 7\r\n\r\na=1&b=2"
+    req = "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Type: text/plain\r\nContent-Length: 7\r\n\r\na=1&b=2"
 
     body = send_http_read_resp_body req, ctx: new_ctx
 

--- a/test/test_rack_server.rb
+++ b/test/test_rack_server.rb
@@ -165,6 +165,7 @@ class TestRackServer < PumaTest
 
     socket = TCPSocket.open HOST, @port
     socket.puts "GET /test HTTP/1.1\r\n"
+    socket.puts "Host: #{HOST}:#{@port}\r\n"
     socket.puts "Connection: Keep-Alive\r\n"
     socket.puts "\r\n"
 
@@ -296,6 +297,7 @@ class TestRackServer < PumaTest
 
     socket = TCPSocket.open HOST, @port
     socket.puts "GET /test HTTP/1.1\r\n"
+    socket.puts "Host: #{HOST}:#{@port}\r\n"
     socket.puts "Connection: Keep-Alive\r\n"
     socket.puts "\r\n"
 
@@ -370,7 +372,7 @@ class TestRackServer < PumaTest
     @server.run
 
     socket = TCPSocket.open HOST, @port
-    socket.syswrite "GET / HTTP/1.1\r\nversion: version\r\n\r\n"
+    socket.syswrite "GET / HTTP/1.1\r\nHost: test.com\r\nversion: version\r\n\r\n"
 
     body = socket.sysread(256).split("\r\n\r\n").last
 

--- a/test/test_request_invalid_multiple.rb
+++ b/test/test_request_invalid_multiple.rb
@@ -20,7 +20,7 @@ class TestRequestInvalidMultiple < PumaTest
   include TestPuma
   include TestPuma::PumaSocket
 
-  GET_PREFIX = "GET / HTTP/1.1\r\nconnection: close\r\n"
+  GET_PREFIX = "GET / HTTP/1.1\r\nHost: test.com\r\nconnection: close\r\n"
   CHUNKED = "1\r\nH\r\n4\r\nello\r\n5\r\nWorld\r\n0\r\n\r\n"
 
   HOST = HOST4
@@ -106,6 +106,16 @@ class TestRequestInvalidMultiple < PumaTest
     end
   end
 
+  # ──────────────────────────────────── below are invalid Host header
+
+  def test_missing_host_http11
+    assert_status "GET / HTTP/1.1\r\n\r\n", 400
+  end
+
+  def test_empty_host_http11
+    assert_status "GET / HTTP/1.1\r\nHost:\r\n\r\n", 400
+  end
+
   # ──────────────────────────────────── below are oversize path length
 
   def test_oversize_path_keep_alive
@@ -113,9 +123,9 @@ class TestRequestInvalidMultiple < PumaTest
 
     socket = new_socket
 
-    assert_status "GET / HTTP/1.1\r\n\r\n", 200, socket: socket
+    assert_status "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n", 200, socket: socket
 
-    assert_status "GET #{path} HTTP/1.1\r\n\r\n", socket: socket
+    assert_status "GET #{path} HTTP/1.1\r\nHost: test.com\r\n\r\n", socket: socket
     assert_includes @response.body, "lib/puma/client.rb"
   end
 
@@ -124,7 +134,7 @@ class TestRequestInvalidMultiple < PumaTest
   def test_content_length_bad_characters_1_keep_alive
     socket = new_socket
 
-    assert_status "GET / HTTP/1.1\r\n\r\n", 200, socket: socket
+    assert_status "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n", 200, socket: socket
 
     cl = 'Content-Length: 5.01'
 
@@ -148,7 +158,7 @@ class TestRequestInvalidMultiple < PumaTest
     long_string = 'a' * 200_000
     server_run(http_content_length_limit: 190_000, lowlevel_error_handler: lleh) { [200, {}, ['Hello World']] }
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nContent-Length: 200000\r\n\r\n" \
+    socket = send_http "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: Keep-Alive\r\nContent-Length: 200000\r\n\r\n" \
       "#{long_string}"
 
     unless Puma::IS_WINDOWS
@@ -186,7 +196,7 @@ class TestRequestInvalidMultiple < PumaTest
       lowlevel_error_handler: lleh
     ) { [200, {}, ['Hello World']] }
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\n" \
+    socket = send_http "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: Keep-Alive\r\n" \
       "Transfer-Encoding: chunked\r\n\r\n#{long_chunked}"
 
     unless Puma::IS_WINDOWS

--- a/test/test_request_single.rb
+++ b/test/test_request_single.rb
@@ -14,7 +14,7 @@ class TestRequestBase < PumaTest
 
   PEER_ADDR = -> () { ["AF_INET", 80, "127.0.0.1", "127.0.0.1"] }
 
-  GET_PREFIX = "GET / HTTP/1.1\r\nConnection: close\r\n"
+  GET_PREFIX = "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n"
   CHUNKED = "1\r\nH\r\n4\r\nello\r\n5\r\nWorld\r\n0\r\n\r\n"
 
   HTTP_METHODS = SUPPORTED_HTTP_METHODS.sort.product([nil]).to_h.freeze
@@ -87,31 +87,31 @@ end
 class TestRequestLineValid < TestRequestBase
 
   def test_method
-    create_client "GET /?a=1 HTTP/1.1\r\n\r\n"
+    create_client "GET /?a=1 HTTP/1.1\r\nHost: test.com\r\n\r\n"
 
     assert_equal 'GET', @client.env[REQUEST_METHOD]
   end
 
   def test_path_plain
-    create_client "GET /puma/request HTTP/1.1\r\n\r\n"
+    create_client "GET /puma/request HTTP/1.1\r\nHost: test.com\r\n\r\n"
 
     assert_equal '/puma/request', @client.env[REQUEST_PATH]
   end
 
   def test_path_with_query
-    create_client "GET /puma/request?query=books&sort=price&order=asc HTTP/1.1\r\n\r\n"
+    create_client "GET /puma/request?query=books&sort=price&order=asc HTTP/1.1\r\nHost: test.com\r\n\r\n"
 
     assert_equal '/puma/request', @client.env[REQUEST_PATH]
   end
 
   def test_query
-    create_client "GET /puma/request?query=books&sort=price&order=asc HTTP/1.1\r\n\r\n"
+    create_client "GET /puma/request?query=books&sort=price&order=asc HTTP/1.1\r\nHost: test.com\r\n\r\n"
 
     assert_equal 'query=books&sort=price&order=asc', @client.env[QUERY_STRING]
   end
 
   def test_uri
-    create_client "GET /puma/request?query=books&sort=price&order=asc HTTP/1.1\r\n\r\n"
+    create_client "GET /puma/request?query=books&sort=price&order=asc HTTP/1.1\r\nHost: test.com\r\n\r\n"
 
     assert_equal '/puma/request?query=books&sort=price&order=asc', @client.env[REQUEST_URI]
   end
@@ -123,7 +123,7 @@ class TestRequestLineValid < TestRequestBase
   end
 
   def test_PROTOCOL_1_1
-    create_client "GET /puma/request?query=books&sort=price&order=asc HTTP/1.1\r\n\r\n"
+    create_client "GET /puma/request?query=books&sort=price&order=asc HTTP/1.1\r\nHost: test.com\r\n\r\n"
 
     assert_equal 'HTTP/1.1', @client.env[SERVER_PROTOCOL]
   end
@@ -132,6 +132,7 @@ class TestRequestLineValid < TestRequestBase
     te = "gzip \t , \t chunked"
     request = <<~REQ.gsub("\n", "\r\n").rstrip
       GET / HTTP/1.1
+      Host: test.com
       Transfer_Encoding: #{te}
       Content_Length: 11
 
@@ -168,18 +169,18 @@ class TestRequestLineInvalid < TestRequestBase
   end
 
   def test_method_lower_case
-    assert_invalid "GEt /?a=1 HTTP/1.1\r\n\r\n",
+    assert_invalid "GEt /?a=1 HTTP/1.1\r\nHost: test.com\r\n\r\n",
       "Invalid HTTP format, parsing fails. Bad method GEt"
   end
 
   def test_method_non_standard
-    assert_invalid "PUMA /?a=1 HTTP/1.1\r\n\r\n",
+    assert_invalid "PUMA /?a=1 HTTP/1.1\r\nHost: test.com\r\n\r\n",
       "PUMA method is not supported",
       err: Puma::HttpParserError501
   end
 
   def test_method_user_not_allowed
-    assert_invalid("POST /?a=1 HTTP/1.1\r\n\r\n",
+    assert_invalid("POST /?a=1 HTTP/1.1\r\nHost: test.com\r\n\r\n",
       "POST method is not supported",
       err: Puma::HttpParserError501) { |c| c.supported_http_methods =
         {'HEAD' => nil, 'GET' => nil}
@@ -187,12 +188,12 @@ class TestRequestLineInvalid < TestRequestBase
   end
 
   def test_path_non_printable
-    assert_invalid "GET /\e?a=1 HTTP/1.1\r\n\r\n",
+    assert_invalid "GET /\e?a=1 HTTP/1.1\r\nHost: test.com\r\n\r\n",
       "Invalid HTTP format, parsing fails. Bad path /\e"
   end
 
   def test_query_non_printable
-    assert_invalid "GET /?a=\e1 HTTP/1.1\r\n\r\n",
+    assert_invalid "GET /?a=\e1 HTTP/1.1\r\nHost: test.com\r\n\r\n",
       "Invalid HTTP format, parsing fails. Bad query a=\e1"
   end
 
@@ -212,7 +213,7 @@ class TestRequestOversizeItem < TestRequestBase
 
   # limit is 256
   def test_header_name
-    request = "GET /test1 HTTP/1.1\r\n#{'a' * 257}: val\r\n\r\n"
+    request = "GET /test1 HTTP/1.1\r\nHost: test.com\r\n#{'a' * 257}: val\r\n\r\n"
 
     msg = Puma::IS_JRUBY ?
       "HTTP element FIELD_NAME is longer than the 256 allowed length." :
@@ -223,7 +224,7 @@ class TestRequestOversizeItem < TestRequestBase
 
   # limit is 80 * 1024
   def test_header_value
-    request = "GET /test1 HTTP/1.1\r\ntest: #{'a' * (80 * 1_024 + 1)}\r\n\r\n"
+    request = "GET /test1 HTTP/1.1\r\nHost: test.com\r\ntest: #{'a' * (80 * 1_024 + 1)}\r\n\r\n"
 
     msg = Puma::IS_JRUBY ?
       "HTTP element FIELD_VALUE is longer than the 81920 allowed length." :
@@ -234,7 +235,7 @@ class TestRequestOversizeItem < TestRequestBase
 
   # limit is 1024
   def test_request_fragment
-    request = "GET /##{'a' * 1025} HTTP/1.1\r\n\r\n"
+    request = "GET /##{'a' * 1025} HTTP/1.1\r\nHost: test.com\r\n\r\n"
 
     msg = Puma::IS_JRUBY ?
       "HTTP element FRAGMENT is longer than the 1024 allowed length." :
@@ -251,12 +252,12 @@ class TestRequestOversizeItem < TestRequestBase
       "HTTP element HEADER is longer than the 114688 allowed length." :
       "HTTP element HEADER is longer than the (1024 * (80 + 32)) allowed length ("
 
-    assert_invalid "GET / HTTP/1.1\r\n#{hdrs}\r\n", msg, start_with: true
+    assert_invalid "GET / HTTP/1.1\r\nHost: test.com\r\n#{hdrs}\r\n", msg, start_with: true
   end
 
   # limit is 10 * 1024
   def test_query_string
-    request = "GET /?#{'a' * (5 * 1024)}=#{'b' * (5 * 1024)} HTTP/1.1\r\n\r\n"
+    request = "GET /?#{'a' * (5 * 1024)}=#{'b' * (5 * 1024)} HTTP/1.1\r\nHost: test.com\r\n\r\n"
 
     msg = Puma::IS_JRUBY ?
       "HTTP element QUERY_STRING is longer than the 10240 allowed length." :
@@ -271,12 +272,12 @@ class TestRequestOversizeItem < TestRequestBase
       "HTTP element REQUEST_PATH is longer than the 8192 allowed length." :
       "HTTP element REQUEST_PATH is longer than the (8192) allowed length (was 8193)"
 
-    assert_invalid "GET /#{'a' * (8 * 1024)} HTTP/1.1\r\n\r\n", msg
+    assert_invalid "GET /#{'a' * (8 * 1024)} HTTP/1.1\r\nHost: test.com\r\n\r\n", msg
   end
 
   # limit is 12 * 1024
   def test_request_uri
-    request = "GET /#{'a' * 6 * 1024}?#{'a' * 3 * 1024}=#{'a' * 3 * 1024} HTTP/1.1\r\n\r\n"
+    request = "GET /#{'a' * 6 * 1024}?#{'a' * 3 * 1024}=#{'a' * 3 * 1024} HTTP/1.1\r\nHost: test.com\r\n\r\n"
 
     msg = Puma::IS_JRUBY ?
       "HTTP element REQUEST_URI is longer than the 12288 allowed length." :
@@ -288,7 +289,7 @@ class TestRequestOversizeItem < TestRequestBase
   def test_content_length_exceeded
     long_string = 'a' * 200_000
 
-    request = "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\nContent-Length: #{long_string.bytesize}\r\n\r\n" \
+    request = "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: Keep-Alive\r\nContent-Length: #{long_string.bytesize}\r\n\r\n" \
       "#{long_string}"
 
     msg = 'Payload Too Large'
@@ -304,7 +305,7 @@ class TestRequestOversizeItem < TestRequestBase
     long_string_part = "#{long_string.bytesize.to_s 16}\r\n#{long_string}\r\n"
     long_chunked = "#{long_string_part * chunk_part_qty}0\r\n\r\n"
 
-    request = "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\n" \
+    request = "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: Keep-Alive\r\n" \
       "Transfer-Encoding: chunked\r\n\r\n#{long_chunked}"
 
     msg = 'Payload Too Large'
@@ -317,7 +318,7 @@ end
 class TestRequestHeadersValid < TestRequestBase
 
   def test_content
-    create_client "GET / HTTP/1.1\r\nContent-Length: 11\r\n\r\nHello World"
+    create_client "GET / HTTP/1.1\r\nHost: test.com\r\nContent-Length: 11\r\n\r\nHello World"
 
     assert_instance_of Float, @client.env['puma.request_body_wait']
     assert_equal '11', @client.env[CONTENT_LENGTH]
@@ -328,6 +329,7 @@ class TestRequestHeadersValid < TestRequestBase
   def test_content_chunked
     request = request = <<~REQ.gsub("\n", "\r\n")
       GET / HTTP/1.1
+      Host: test.com
       Transfer-Encoding: chunked
 
       11
@@ -350,7 +352,7 @@ class TestRequestHeadersValid < TestRequestBase
 
   # if a header with an underscore exists, and is a singular key,  accept it
   def test_underscore_single
-    request = "GET / HTTP/1.1\r\n" \
+    request = "GET / HTTP/1.1\r\nHost: test.com\r\n" \
       "x_forwarded_for: 1.1.1.1\r\n" \
       "Content-Length: 11\r\n\r\nHello World"
 
@@ -361,7 +363,7 @@ class TestRequestHeadersValid < TestRequestBase
   end
 
   def test_underscore_single_disallowed
-    request = "GET / HTTP/1.1\r\n" \
+    request = "GET / HTTP/1.1\r\nHost: test.com\r\n" \
       "x_forwarded_for: 1.1.1.1\r\n" \
       "Content-Length: 11\r\n\r\nHello World"
 
@@ -374,6 +376,7 @@ class TestRequestHeadersValid < TestRequestBase
   def test_underscore_header_1
     request = <<~REQ.gsub("\n", "\r\n").rstrip
       GET / HTTP/1.1
+      Host: test.com
       x-forwarded_for: 2.2.2.2
       x-forwarded-for: 1.1.1.1
       Content-Length: 11
@@ -391,6 +394,7 @@ class TestRequestHeadersValid < TestRequestBase
   def test_underscore_collision_disallowed
     request = <<~REQ.gsub("\n", "\r\n").rstrip
       GET / HTTP/1.1
+      Host: test.com
       x-forwarded-for: 1.1.1.1
       x_forwarded_for: 2.2.2.2
       Content-Length: 11
@@ -438,6 +442,7 @@ class TestRequestHeadersValid < TestRequestBase
   def test_unmaskable_headers
     request = <<~REQ.gsub("\n", "\r\n").rstrip
       GET / HTTP/1.1
+      Host: test.com
       Transfer_Encoding: chunked
       Content_Length: 11
 
@@ -479,10 +484,24 @@ class TestRequestHeadersValid < TestRequestBase
     assert_instance_of Puma::NullIO, @client.body
   end
 
-  def test_host_header_missing
+  def test_host_header_missing_http10
     create_client "GET / HTTP/1.0\r\n\r\n"
 
     assert_equal 'localhost', @client.env[SERVER_NAME]
+    assert_equal '80', @client.env[SERVER_PORT]
+  end
+
+  def test_host_header_empty_http10
+    create_client "GET / HTTP/1.0\r\nHost:\r\n\r\n"
+
+    assert_equal '', @client.env[SERVER_NAME]
+    assert_equal '80', @client.env[SERVER_PORT]
+  end
+
+  def test_host_header_whitespace_http10
+    create_client "GET / HTTP/1.0\r\nHost: \r\n\r\n"
+
+    assert_equal '', @client.env[SERVER_NAME]
     assert_equal '80', @client.env[SERVER_PORT]
   end
 
@@ -567,23 +586,41 @@ end
 class TestRequestHeadersInvalid < TestRequestBase
 
   def test_malformed_headers_no_return
-    request = "GET / HTTP/1.1\r\nno-return: 10\nContent-Length: 11\r\n\r\nHello World"
+    request = "GET / HTTP/1.1\r\nHost: test.com\r\nno-return: 10\nContent-Length: 11\r\n\r\nHello World"
 
     msg = Puma::IS_JRUBY ?
-      "Invalid HTTP format, parsing fails. Bad headers\nno-return: 10\\nContent-Length: 11" :
-      "Invalid HTTP format, parsing fails. Bad headers\nNO_RETURN: 10\\nContent-Length: 11"
+      "Invalid HTTP format, parsing fails. Bad headers\nHost: test.com\nno-return: 10\\nContent-Length: 11" :
+      "Invalid HTTP format, parsing fails. Bad headers\nHOST: test.com\nNO_RETURN: 10\\nContent-Length: 11"
 
     assert_invalid request, msg
   end
 
   def test_malformed_headers_no_newline
-    request = "GET / HTTP/1.1\r\nno-newline: 10\rContent-Length: 11\r\n\r\nHello World"
+    request = "GET / HTTP/1.1\r\nHost: test.com\r\nno-newline: 10\rContent-Length: 11\r\n\r\nHello World"
 
     msg = Puma::IS_JRUBY ?
-      "Invalid HTTP format, parsing fails. Bad headers\nno-newline: 10\rContent-Length: 11" :
-      "Invalid HTTP format, parsing fails. Bad headers\nNO_NEWLINE: 10\rContent-Length: 11"
+      "Invalid HTTP format, parsing fails. Bad headers\nHost: test.com\nno-newline: 10\rContent-Length: 11" :
+      "Invalid HTTP format, parsing fails. Bad headers\nHOST: test.com\nNO_NEWLINE: 10\rContent-Length: 11"
 
     assert_invalid request, msg
+  end
+
+  def test_missing_host_http11
+    assert_invalid "GET / HTTP/1.1\r\n\r\n",
+      "Missing Host header",
+      status: 400
+  end
+
+  def test_empty_host_http11
+    assert_invalid "GET / HTTP/1.1\r\nHost:\r\n\r\n",
+      "Invalid Host header",
+      status: 400
+  end
+
+  def test_whitespace_host_http11
+    assert_invalid "GET / HTTP/1.1\r\nHost: \r\n\r\n",
+      "Invalid Host header",
+      status: 400
   end
 end
 
@@ -742,8 +779,8 @@ end
 class TestRequestReset < TestRequestBase
 
   def test_reset_clears_error_status_code
-    first_request = "GET / HTTP/1.1\r\nConnection: Keep-Alive\r\n\r\n"
-    second_request = "GET /next HTTP/1.1\r\n\r\n"
+    first_request = "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: Keep-Alive\r\n\r\n"
+    second_request = "GET /next HTTP/1.1\r\nHost: test.com\r\n\r\n"
 
     create_client("#{first_request}#{second_request}") { |client|
       client.http_content_length_limit = 10
@@ -764,7 +801,7 @@ class TestRequestPeerip < TestRequestBase
 
   def test_peerip_unmaps_ipv4_mapped_ipv6
     peer_addr = -> () { ["AF_INET6", 80, "::ffff:127.0.0.1", "::ffff:127.0.0.1"] }
-    create_client("GET / HTTP/1.1\r\n\r\n", peer_addr: peer_addr)
+    create_client("GET / HTTP/1.1\r\nHost: test.com\r\n\r\n", peer_addr: peer_addr)
 
     assert_equal "127.0.0.1", @client.peerip
     assert_equal "127.0.0.1", @client.env["REMOTE_ADDR"]
@@ -772,7 +809,7 @@ class TestRequestPeerip < TestRequestBase
 
   def test_remote_addr_header_fallback_unmaps_ipv4_mapped_ipv6
     peer_addr = -> () { ["AF_INET6", 80, "::ffff:10.1.2.3", "::ffff:10.1.2.3"] }
-    create_client("GET / HTTP/1.1\r\n\r\n", peer_addr: peer_addr) { |client|
+    create_client("GET / HTTP/1.1\r\nHost: test.com\r\n\r\n", peer_addr: peer_addr) { |client|
       client.remote_addr_header = "HTTP_X_REMOTE_IP"
     }
 
@@ -781,14 +818,14 @@ class TestRequestPeerip < TestRequestBase
   end
 
   def test_peerip_preserves_plain_ipv4
-    create_client("GET / HTTP/1.1\r\n\r\n")
+    create_client("GET / HTTP/1.1\r\nHost: test.com\r\n\r\n")
 
     assert_equal "127.0.0.1", @client.peerip
   end
 
   def test_peerip_preserves_native_ipv6
     peer_addr = -> () { ["AF_INET6", 80, "::1", "::1"] }
-    create_client("GET / HTTP/1.1\r\n\r\n", peer_addr: peer_addr)
+    create_client("GET / HTTP/1.1\r\nHost: test.com\r\n\r\n", peer_addr: peer_addr)
 
     assert_equal "::1", @client.peerip
   end

--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -154,7 +154,7 @@ class TestResponseHeader < PumaTest
 
   def test_header_value_array
     server_run app: ->(env) { [200, {'set-cookie' => ['z=1', 'a=2']}, ['Hello']] }
-    data = send_http_and_read "GET / HTTP/1.1\r\n\r\n"
+    data = send_http_and_read "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n"
 
     resp = "HTTP/1.1 200 OK\r\nset-cookie: z=1\r\nset-cookie: a=2\r\ncontent-length: 5\r\n\r\n"
     assert_includes data, resp

--- a/test/test_web_server.rb
+++ b/test/test_web_server.rb
@@ -65,7 +65,7 @@ class WebServerTest < PumaTest
   end
 
   def test_bad_path
-    socket = do_test("GET : HTTP/1.1\r\n\r\n", 3)
+    socket = do_test("GET : HTTP/1.1\r\nHost: test.com\r\n\r\n", 3)
     data = socket.read
     assert_start_with data, "HTTP/1.1 400 Bad Request\r\ncontent-length: "
     # match is for last backtrace line, may be brittle
@@ -74,7 +74,7 @@ class WebServerTest < PumaTest
   end
 
   def test_header_is_too_long
-    long = "GET /test HTTP/1.1\r\n" + ("X-Big: stuff\r\n" * 15000) + "\r\n"
+    long = "GET /test HTTP/1.1\r\nHost: test.com\r\n" + ("X-Big: stuff\r\n" * 15000) + "\r\n"
     assert_raises Errno::ECONNRESET, Errno::EPIPE, Errno::ECONNABORTED, Errno::EINVAL, IOError do
       do_test_raise(long, long.length/2, 10)
     end
@@ -82,21 +82,21 @@ class WebServerTest < PumaTest
 
   def test_file_streamed_request
     body = "a" * (Puma::Const::MAX_BODY * 2)
-    long = "GET /test HTTP/1.1\r\nContent-length: #{body.length}\r\nConnection: close\r\n\r\n" + body
+    long = "GET /test HTTP/1.1\r\nHost: test.com\r\nContent-length: #{body.length}\r\nConnection: close\r\n\r\n" + body
     socket = do_test(long, (Puma::Const::CHUNK_SIZE * 2) - 400)
     assert_match "hello", socket.read
     socket.close
   end
 
   def test_supported_http_method
-    socket = do_test("PATCH www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
+    socket = do_test("PATCH www.zedshaw.com:443 HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n", 100)
     response = socket.read
     assert_match "hello", response
     socket.close
   end
 
   def test_nonexistent_http_method
-    socket = do_test("FOOBARBAZ www.zedshaw.com:443 HTTP/1.1\r\nConnection: close\r\n\r\n", 100)
+    socket = do_test("FOOBARBAZ www.zedshaw.com:443 HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n", 100)
     response = socket.read
     assert_match "Not Implemented", response
     socket.close


### PR DESCRIPTION
### Description
As a first contribution, I tried to pick off a few TODOs from https://github.com/puma/puma/issues/3926 to improve alignment with the HTTP RFC.

HTTP1.1 requires the Host header to be included in the request and the value not to be blank (See [Section 3.2 of the RFC](https://datatracker.ietf.org/doc/html/rfc9112#section-3.2)) and adding some presence checks seemed like a good place to start.

I noticed some discussion about [validating HOST headers](https://github.com/puma/puma/discussions/2977) and the decision not to move forward. This PR seems like a step short of "validation" and more about aligning with the RFC, but I'd be curious to hear everyone's take on it.

The PR goes above the 100 line limit, but only because the test suite needed to be updated with Host entries in several places. The core changes are 5 short tests and one function in `client_env.rb`.

### Questions
* Should these 400 errors explicitly close the connection? 
    * `@env[HTTP_CONNECTION] = 'close'`
* Should this be targeted against a future major version branch instead of main?

### Potential Refactors

#### Extract validations
I think we could extract validations into a more centralized, visible area. As I dug through, there is header validation in a few areas:
* `Client#parser_execute` (translates parser errors into Client errors)
* `Client#setup_body` (validates Transfer Encoding & Content Length, and also sets up body)

#### Encapsulate error generation
There are a few facets to error creation, but I'm not 100% sure what's required. Maybe we could extract a method or change the `HttpParserError` class to hold a little more knowledge (code, closed).

* Invalid states seem to be marked by `raise HttpParserError`
* There's also a `HttpParserError501` that just switches the code, even though you could set the code via at least one other method (below)
* `Client@error_status_code` is set directly in a few places (but often implicitly falls back to 400 in `Server#client_error`)
    * The `assert_invalid` matcher expects `@error_status_code` to be set, so you can't rely on the implicit fallback when generating the error response (if you use the matcher).
* Some errors also flag to close the connection with `@env[HTTP_CONNECTION] = 'close'`

As a newbie, I only found these disparate flags by having Cursor walk me through the codebase. Tying all these levers together might reduce missed changes in the future.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
