### PR TITLE
Allow sub-second `worker_check_interval`

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1176,7 +1176,7 @@ module Puma
     # @see Puma::Cluster#check_workers
     #
     def worker_check_interval(interval)
-      @options[:worker_check_interval] = Integer(interval)
+      @options[:worker_check_interval] = Float(interval)
     end
 
     # Verifies that all workers have checked in to the master process within

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -442,6 +442,18 @@ class TestConfigFile < PumaTest
     assert_equal 150, conf.options[:worker_shutdown_timeout]
   end
 
+  def test_worker_check_interval_accepts_float
+    conf = Puma::Configuration.new { |c| c.worker_check_interval 0.1 }
+    conf.clamp
+    assert_equal 0.1, conf.options[:worker_check_interval]
+  end
+
+  def test_worker_check_interval_accepts_float_string
+    conf = Puma::Configuration.new { |c| c.worker_check_interval "0.5" }
+    conf.clamp
+    assert_equal 0.5, conf.options[:worker_check_interval]
+  end
+
   def test_config_files_max_keep_alive_infinity
     conf = Puma::Configuration.new(config_files: ['test/config/max_keep_alive_infinity.rb']) do
     end


### PR DESCRIPTION
Closes #3963

`worker_check_interval` cast with `Integer()`, which rejected sub-second values (`Integer("0.1")` raises). The downstream consumers (`sleep` in `Cluster::Worker`, `Time#+` in `Cluster#check_workers`, and the `worker_timeout > worker_check_interval` guard) all handle floats identically, so switching the cast to `Float()` is enough to unblock fractional intervals for faster worker liveness checks. Non-numeric input still raises (`Float("abc")`), and existing integer values become equivalent floats.