### PR TITLE
Fix `pool_capacity` leak when extra IO threads exit

### DIFF
--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -211,6 +211,7 @@ module Puma
                 processor.marked_as_io_thread = false
               else
                 # We're already at max threads, so we exit the extra io thread.
+                @spawned -= 1
                 @processors.delete(processor)
                 trigger_before_thread_exit_hooks
                 Thread.exit

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -443,9 +443,7 @@ class TestThreadPool < PumaTest
     queue = Queue.new
     concurrent_threads = []
     pool = new_pool(0, 4, max_io_threads: 4) do |processor, io_bound_thread|
-      if io_bound_thread
-        processor.mark_as_io_thread!
-      end
+      processor.mark_as_io_thread! if io_bound_thread
       queue << Thread.current
       mutex.synchronize { }
     end
@@ -467,9 +465,7 @@ class TestThreadPool < PumaTest
     queue = Queue.new
     concurrent_threads = []
     pool = new_pool(0, 2, max_io_threads: 2) do |processor, io_bound_thread|
-      if io_bound_thread
-        processor.mark_as_io_thread!
-      end
+      processor.mark_as_io_thread! if io_bound_thread
       queue << Thread.current
       mutex.synchronize { }
     end
@@ -482,6 +478,30 @@ class TestThreadPool < PumaTest
     refute_predicate pool, :can_spawn_processor?
   ensure
     mutex.unlock
+    pool.shutdown(1)
+  end
+
+  def test_extra_io_threads_release_spawned_count_on_exit
+    mutex = Mutex.new
+    mutex.lock
+    queue = Queue.new
+    pool = new_pool(0, 2, max_io_threads: 2) do |processor, io_bound_thread|
+      processor.mark_as_io_thread! if io_bound_thread
+      queue << Thread.current
+      mutex.synchronize { }
+    end
+
+    4.times { pool << true }
+    4.times { queue.pop }
+    assert_equal 4, pool.spawned
+
+    mutex.unlock
+
+    Timeout.timeout(1) { sleep 0.01 until pool.spawned == 2 }
+    assert_equal 2, pool.spawned
+    assert_equal 2, pool.pool_capacity
+  ensure
+    mutex.unlock if mutex.owned?
     pool.shutdown(1)
   end
 end


### PR DESCRIPTION
Closes #3958

When a thread marked via `puma.mark_as_io_bound` finds itself over the `max_threads` limit on its next loop iteration, it exits without decrementing `@spawned`. The counter stays elevated, `pool_capacity` reports 0, and eventually the pool can no longer serve new requests. Decrementing `@spawned` on exit mirrors the existing trim path.