### PR TITLE
Restore admission gate when `queue_requests` is disabled

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -389,13 +389,16 @@ module Puma
                 # clients until the code is finished.
                 pool.wait_while_out_of_band_running
 
-                # A well rested herd (cluster) runs faster
-                if @cluster_accept_loop_delay.on? && (busy_threads_plus_todo = pool.busy_threads) > 0
-                  delay = @cluster_accept_loop_delay.calculate(
-                    max_threads: @max_threads,
-                    busy_threads_plus_todo: busy_threads_plus_todo
-                  )
-                  sleep(delay)
+                if @queue_requests
+                  if @cluster_accept_loop_delay.on? && (busy_threads_plus_todo = pool.busy_threads) > 0
+                    delay = @cluster_accept_loop_delay.calculate(
+                      max_threads: @max_threads,
+                      busy_threads_plus_todo: busy_threads_plus_todo
+                    )
+                    sleep(delay)
+                  end
+                else
+                  pool.wait_until_not_full
                 end
 
                 io = begin

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -389,16 +389,18 @@ module Puma
                 # clients until the code is finished.
                 pool.wait_while_out_of_band_running
 
-                if @queue_requests
-                  if @cluster_accept_loop_delay.on? && (busy_threads_plus_todo = pool.busy_threads) > 0
-                    delay = @cluster_accept_loop_delay.calculate(
-                      max_threads: @max_threads,
-                      busy_threads_plus_todo: busy_threads_plus_todo
-                    )
-                    sleep(delay)
+                unless shutting_down?
+                  if @queue_requests
+                    if @cluster_accept_loop_delay.on? && (busy_threads_plus_todo = pool.busy_threads) > 0
+                      delay = @cluster_accept_loop_delay.calculate(
+                        max_threads: @max_threads,
+                        busy_threads_plus_todo: busy_threads_plus_todo
+                      )
+                      sleep(delay)
+                    end
+                  else
+                    pool.wait_until_not_full
                   end
-                else
-                  pool.wait_until_not_full
                 end
 
                 io = begin

--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -315,6 +315,17 @@ module Puma
       end
     end
 
+    def wait_until_not_full
+      with_mutex do
+        while true
+          return if @shutdown
+          return if (@spawned - @waiting + @todo.size) < @max
+
+          @not_full.wait @mutex
+        end
+      end
+    end
+
     # @version 5.0.0
     def with_mutex(&block)
       @mutex.owned? ?

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -295,6 +295,27 @@ class TestIntegrationCluster < TestIntegration
     assert true
   end
 
+  def test_queue_requests_disabled_does_not_pin_new_requests_to_busy_worker
+    cli_server "-w #{workers} -t 1:1 test/rackup/sleep_pid.ru", config: "queue_requests false"
+
+    get_worker_pids # wait for workers to boot
+
+    slow = Thread.new { read_body(fast_connect("sleep2"), 5).split.last.to_i }
+    sleep 0.5
+
+    mutex = Mutex.new
+    fast_pids = []
+    Array.new(8) do
+      Thread.new do
+        pid = read_body(fast_connect("sleep0"), 3).split.last.to_i
+        mutex.synchronize { fast_pids << pid }
+      end
+    end.each(&:join)
+
+    assert_equal 1, fast_pids.uniq.size
+    refute_equal slow.value, fast_pids.first
+  end
+
   def test_worker_index_is_with_in_options_limit
     cli_server "-C test/config/t3_conf.rb test/rackup/hello.ru"
 


### PR DESCRIPTION
Closes #3961

In cluster mode with `queue_requests: false`, a busy worker's accept loop kept pulling new connections into its own `@todo` list even when a sibling worker was idle. The admission gate that used to prevent this was removed in #3678 to fix keep-alive tail latency. Keep-alive requires `queue_requests: true`, so restoring the gate under `!@queue_requests` recovers pre-7.0 cross-worker balancing without touching the path #3678 was fixing.

Reproduced the bug locally with 2 workers, 1 thread each, `queue_requests false`, one worker pinned by a 12s `/slow` request, then `ab -n 80 -c 4 /`:

|          | RPS     | p50 | p90 | p95     | max     |
|----------|---------|-----|-----|---------|---------|
| main     | 6.94    | 1ms | 9ms | 11493ms | 11496ms |
| fix-3961 | 2321.20 | 1ms | 7ms | 11ms    | 12ms    |

Also verified #3678's tail-latency fix still holds with a keep-alive benchmark matched to its original parameters: 2 workers, 5:5 threads, default `queue_requests`, 40 concurrent hey clients (4x oversubscribed), 200ms app delay, 30s duration, 5 runs each averaged:

|          | RPS  | p50     | p90     | p95     | p99     | slowest |
|----------|------|---------|---------|---------|---------|---------|
| main     | 48.9 | 815.2ms | 820.2ms | 822.1ms | 825.9ms | 831.2ms |
| fix-3961 | 49.1 | 814.3ms | 819.1ms | 820.6ms | 823.8ms | 827.1ms |

Sub-millisecond deltas across every percentile.