### PR TITLE
Fix chunked body parsing when last-chunk terminator arrives split

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -618,6 +618,8 @@ module Puma
     end
 
     def decode_chunk(chunk)
+      return finish_last_chunk(@prev_chunk + chunk) if @in_last_chunk
+
       if @partial_part_left > 0
         if @partial_part_left <= chunk.size
           if @partial_part_left > 2
@@ -664,24 +666,7 @@ module Puma
           if len == 0
             @in_last_chunk = true
             @body.rewind
-            rest = io.read
-            if rest.bytesize < CHUNK_VALID_ENDING_SIZE
-              @buffer = nil
-              @partial_part_left = CHUNK_VALID_ENDING_SIZE - rest.bytesize
-              return false
-            else
-              # if the next character is a CRLF, set buffer to everything after that CRLF
-              start_of_rest = if rest.start_with?(CHUNK_VALID_ENDING)
-                CHUNK_VALID_ENDING_SIZE
-              else # we have started a trailer section, which we do not support. skip it!
-                rest.index(CHUNK_VALID_ENDING*2) + CHUNK_VALID_ENDING_SIZE*2
-              end
-
-              @buffer = rest[start_of_rest..-1]
-              @buffer = nil if @buffer.empty?
-              set_ready
-              return true
-            end
+            return finish_last_chunk(io.read)
           end
 
           # Track the excess as a function of the size of the
@@ -734,12 +719,28 @@ module Puma
         end
       end
 
-      if @in_last_chunk
-        set_ready
-        true
+      false
+    end
+
+    # Consume the terminator that ends a chunked body. Per RFC 9112 §7.1.2
+    # this is either a bare CRLF or an optional trailer section ending in
+    # CRLF*2. Puma does not surface trailers, so we skip past them. Bytes
+    # past the terminator belong to the next pipelined request.
+    def finish_last_chunk(rest)
+      if rest.start_with?(CHUNK_VALID_ENDING)
+        trailer_end = CHUNK_VALID_ENDING_SIZE
+      elsif idx = rest.index(CHUNK_VALID_ENDING * 2)
+        trailer_end = idx + CHUNK_VALID_ENDING_SIZE * 2
       else
-        false
+        @prev_chunk = rest
+        return false
       end
+
+      @prev_chunk = ""
+      @buffer = rest[trailer_end..-1]
+      @buffer = nil if @buffer.empty?
+      set_ready
+      true
     end
 
     def set_ready

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1216,6 +1216,28 @@ class TestPumaServer < PumaTest
     assert_equal "5", content_length
   end
 
+  def test_chunked_request_pause_after_last_chunk
+    body = nil
+    content_length = nil
+    server_run { |env|
+      body = env["rack.input"].read
+      content_length = env["CONTENT_LENGTH"]
+      [200, {}, [""]]
+    }
+
+    socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n"
+
+    sleep 1
+
+    socket << "X-Trailer: value\r\n\r\n"
+
+    response = socket.read_response
+
+    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "", body
+    assert_equal "0", content_length
+  end
+
   # See https://github.com/puma/puma/issues/3337 & https://github.com/puma/puma/pull/3338
   #
   def test_chunked_body_pause_within_chunk_size_hex

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1216,26 +1216,47 @@ class TestPumaServer < PumaTest
     assert_equal "5", content_length
   end
 
-  def test_chunked_request_pause_after_last_chunk
+  def test_chunked_request_pause_after_last_chunk_1
     body = nil
     content_length = nil
     server_run { |env|
-      body = env["rack.input"].read
-      content_length = env["CONTENT_LENGTH"]
+      body ||= env["rack.input"].read
+      content_length ||= env["CONTENT_LENGTH"]
       [200, {}, [""]]
     }
 
-    socket = send_http "GET / HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n"
+    socket = send_http "GET / HTTP/1.1\r\nTransfer-Encoding: chunked\r\nHost: test.com\r\n\r\n0\r\n"
 
     sleep 1
 
-    socket << "X-Trailer: value\r\n\r\n"
+    response = socket.send_http("X-Trailer: value\r\n\r\n#{GET_11}").read_all
 
-    response = socket.read_response
-
-    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n" * 2, response
     assert_equal "", body
     assert_equal "0", content_length
+  end
+
+  def test_chunked_request_pause_after_last_chunk_2
+    body = nil
+    content_length = nil
+    server_run { |env|
+      body ||= env["rack.input"].read
+      content_length ||= env["CONTENT_LENGTH"]
+      [200, {}, [""]]
+    }
+
+    socket = send_http "GET / HTTP/1.1\r\nTransfer-Encoding: chunked\r\nHost: test.com\r\n\r\n" \
+    "5\r\nhello\r\n" \
+    "6\r\n\nworld\r\n0\r\n"
+
+    sleep 1
+
+    responses = socket.send_http("X-Trailer: value\r\n\r\n#{GET_11}").read_all
+
+    assert_equal "hello\nworld", body
+    assert_equal "11", content_length
+
+    assert_equal "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n" * 2, responses
   end
 
   # See https://github.com/puma/puma/issues/3337 & https://github.com/puma/puma/pull/3338


### PR DESCRIPTION
Closes #3951

Handles the second half of #3951 (trailer bytes leaking into the request body). #3952 already fixed the first half.

When `0\r\n` landed in a different read from the closing CRLF or trailer section, `decode_chunk` set `@partial_part_left = 2` and returned. On the next read the partial handler consumed those 2 bytes assuming they were the trailing CRLF of a normal chunk body, then parsed the remainder as fresh chunk headers. `\r\n1\r\nX\r\n0\r\n\r\n` after the terminator wrote `X` into `rack.input`; `X-Trailer: value\r\n\r\n` triggered a 400.

`@partial_part_left` was overloaded for two different states. Extracted the terminator/trailer skip into `finish_last_chunk` and route both the single-read `len == 0` path and a new top-of-function `@in_last_chunk` guard through it. `@prev_chunk` holds any residual bytes across reads.