### PR TITLE
Add support for HTTP `QUERY` method

### DIFF
--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -147,12 +147,12 @@ module Puma
     REQUEST_METHOD = "REQUEST_METHOD"
     HEAD = "HEAD"
 
-    # based on https://www.rfc-editor.org/rfc/rfc9110.html#name-overview,
-    # with CONNECT removed, and PATCH added
-    SUPPORTED_HTTP_METHODS = %w[HEAD GET POST PUT DELETE OPTIONS TRACE PATCH].freeze
+    # based on https://www.rfc-editor.org/rfc/rfc9110.html#name-overview and https://www.rfc-editor.org/rfc/rfc10008.html,
+    # with CONNECT removed, and PATCH & QUERY added
+    SUPPORTED_HTTP_METHODS = %w[HEAD GET POST PUT DELETE OPTIONS TRACE PATCH QUERY].freeze
 
     # list from https://www.iana.org/assignments/http-methods/http-methods.xhtml
-    # as of 04-May-23
+    # as of 17-Jun-26, with QUERY added based on https://www.rfc-editor.org/rfc/rfc10008.html
     IANA_HTTP_METHODS = %w[
       ACL
       BASELINE-CONTROL
@@ -182,6 +182,7 @@ module Puma
       PROPFIND
       PROPPATCH
       PUT
+      QUERY
       REBIND
       REPORT
       SEARCH

--- a/test/test_request_single.rb
+++ b/test/test_request_single.rb
@@ -92,6 +92,12 @@ class TestRequestLineValid < TestRequestBase
     assert_equal 'GET', @client.env[REQUEST_METHOD]
   end
 
+  def test_query_method
+    create_client "QUERY / HTTP/1.1\r\nHost: test.com\r\n\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n{}"
+
+    assert_equal 'QUERY', @client.env[REQUEST_METHOD]
+  end
+
   def test_path_plain
     create_client "GET /puma/request HTTP/1.1\r\nHost: test.com\r\n\r\n"
 


### PR DESCRIPTION
### Description

As of June 2026, [RFC 10008][] is a proposed standard.

From the RFC Abstract:

> This specification defines the QUERY method for HTTP. A QUERY requests
> that the request target process the enclosed content in a safe and
> idempotent manner and then respond with the result of that processing.
> This is similar to POST requests, but QUERY requests can be
> automatically repeated or restarted without concern for partial state
> changes.

This commit adds `QUERY` to the `IANA_HTTP_METHODS` constant in order to support parsing the new HTTP method.

Once parsed, the value is transformed injected as a `Rack::REQUEST_METHOD`-compatible `QUERY` value proposed in [rack/rack#2474][].

[RFC 10008]: https://www.rfc-editor.org/rfc/rfc10008.html
[rack/rack#2474]: https://github.com/rack/rack/pull/2474


### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
