### PR TITLE
Fix comment typos in .rb source and test files

### DIFF
--- a/lib/puma/minissl.rb
+++ b/lib/puma/minissl.rb
@@ -94,7 +94,7 @@ module Puma
             # It would make more sense to let @socket.read_nonblock raise
             # EAGAIN if necessary but it seems like it'll misbehave on Windows.
             # I don't have a Windows machine to debug this so I can't explain
-            # exactly whats happening in that OS. Please let me know if you
+            # exactly what's happening in that OS. Please let me know if you
             # find out!
             #
             # In the meantime, we can emulate the correct behavior by

--- a/test/helpers/test_puma/puma_socket.rb
+++ b/test/helpers/test_puma/puma_socket.rb
@@ -174,7 +174,7 @@ module TestPuma
     end
 
     # Sends a request and returns the socket
-    # @param req [String, nil] The request stirng.
+    # @param req [String, nil] The request string.
     # @!macro req
     # @!macro skt
     # @return [PumaSSLSocket, PumaTCPSocket, PumaUNIXSocket] the created socket

--- a/test/helpers/test_puma/puma_socket_include.rb
+++ b/test/helpers/test_puma/puma_socket_include.rb
@@ -175,7 +175,7 @@ module TestPuma
     end
 
     # Uses a single `sysread` statement to read the socket.  Reads `len` bytes
-    # from the socket.  A `wait_readable` call using `timeout:` preceeds it.
+    # from the socket.  A `wait_readable` call using `timeout:` precedes it.
     # @param len [Integer] the number of bytes to read
     # @param timeout: [Float, Integer] `wait_readable` timeout
     # @return [String]

--- a/test/test_example_cert_expiration.rb
+++ b/test/test_example_cert_expiration.rb
@@ -4,7 +4,7 @@ require_relative 'helper'
 require 'openssl'
 
 #
-# Thes are tests to ensure that the checked in certs in the ./examples/
+# These are tests to ensure that the checked in certs in the ./examples/
 # directory are valid and work as expected.
 #
 # These tests will start to fail 1 month before the certs expire

--- a/test/test_puma_server_hijack.rb
+++ b/test/test_puma_server_hijack.rb
@@ -79,7 +79,7 @@ class TestPumaServerHijack < PumaTest
     assert_equal "this should echo", sock.sysread(256)
     Thread.pass
     sleep 0.001 # intermittent failure, may need to increase in CI
-    assert @body_closed, "Reponse body must be closed"
+    assert @body_closed, "Response body must be closed"
   end
 
   def test_101_body

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -99,8 +99,8 @@ class TestPumaServerSSL < PumaTest
   end
 
   def test_very_large_return
-    # This test frequntly fails on Darwin TruffleRuby, 512k was used chosen
-    # becuase 1mb also failed
+    # This test frequently fails on Darwin TruffleRuby, 512k was used chosen
+    # because 1mb also failed
     # failure is OpenSSL::SSL::SSLError: SSL_read: record layer failure
     body_size = Puma::IS_OSX && TRUFFLE ? 512 * 1_024 : 2_056_610
     start_server

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -99,7 +99,7 @@ class TestPumaServerSSL < PumaTest
   end
 
   def test_very_large_return
-    # This test frequently fails on Darwin TruffleRuby, 512k was used chosen
+    # This test frequently fails on Darwin TruffleRuby, 512k was used
     # because 1mb also failed
     # failure is OpenSSL::SSL::SSLError: SSL_read: record layer failure
     body_size = Puma::IS_OSX && TRUFFLE ? 512 * 1_024 : 2_056_610


### PR DESCRIPTION
Found several typos via `codespell` in Ruby source and test files.

## Changes

- `Reponse` -> `Response` in `test/test_puma_server_hijack.rb`
- `frequntly` -> `frequently` in `test/test_puma_server_ssl.rb`
- `becuase` -> `because` in `test/test_puma_server_ssl.rb`
- `stirng` -> `string` in `test/helpers/test_puma/puma_socket.rb`
- `preceeds` -> `precedes` in `test/helpers/test_puma/puma_socket_include.rb`
- `whats` -> `what's` in `lib/puma/minissl.rb`
- `Thes` -> `These` in `test/test_example_cert_expiration.rb`