### PR TITLE
Honor trim requests between work items so busy pools can shrink

### DIFF
--- a/lib/puma/thread_pool.rb
+++ b/lib/puma/thread_pool.rb
@@ -211,21 +211,19 @@ module Puma
                 processor.marked_as_io_thread = false
               else
                 # We're already at max threads, so we exit the extra io thread.
-                @spawned -= 1
-                @processors.delete(processor)
-                trigger_before_thread_exit_hooks
-                Thread.exit
+                trim_thread(processor)
               end
             end
 
+            trim_thread_if_requested(processor)
+
             while todo.empty?
+              # Thread trimming could be requested when process is idle or during shutdown,
+              # hence we need to trim when todo is empty.
               if @trim_requested > 0
                 @trim_requested -= 1
-                @spawned -= 1
-                @processors.delete(processor)
                 not_full.signal
-                trigger_before_thread_exit_hooks
-                Thread.exit
+                trim_thread(processor)
               end
 
               @waiting += 1
@@ -257,6 +255,35 @@ module Puma
     end
 
     private :spawn_thread
+
+    # :nodoc:
+    #
+    # Must be called with @mutex held, on a worker thread, between work items.
+    #
+    def trim_thread_if_requested(processor)
+      if !@shutdown && @trim_requested > 0 && @spawned > @min && @spawned > 1
+        @trim_requested -= 1
+        trim_thread(processor)
+      end
+    end
+
+    private :trim_thread_if_requested
+
+    # :nodoc:
+    #
+    # Must be called with @mutex held, on the worker thread being trimmed.
+    # Performs the trim bookkeeping and exits the current thread. Signals
+    # not_full because the exit lowers busy_threads, which may unblock
+    # threads waiting in wait_until_not_full.
+    #
+    def trim_thread(processor)
+      @spawned -= 1
+      @processors.delete(processor)
+      trigger_before_thread_exit_hooks
+      Thread.exit
+    end
+
+    private :trim_thread
 
     def trigger_before_thread_start_hooks
       return unless @before_thread_start&.any?

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -23,6 +23,10 @@ class TestThreadPool < PumaTest
     @pool = Puma::ThreadPool.new("tst", options, &block)
   end
 
+  def wait_until(timeout = 1)
+    Timeout.timeout(timeout) { sleep 0.01 until yield }
+  end
+
   def mutex_pool(min, max, pool_shutdown_grace_time: nil, &block)
     block = proc { } unless block
     options = {
@@ -249,6 +253,64 @@ class TestThreadPool < PumaTest
 
     assert_equal 2, pool.spawned
     assert_equal 0, pool.trim_requested
+  end
+
+  def test_force_trim_is_honored_while_pool_is_busy
+    release = Queue.new
+    pool = new_pool(0, 3) { release.pop }
+    4.times { |i| pool << i } # 4 because 3 threads busy, 1 item queued
+
+    wait_until do
+      pool.instance_variable_get(:@processors).map(&:thread).count(&:stop?) == 3
+    end
+
+    assert_equal 3, pool.spawned
+    assert_equal 1, pool.backlog
+
+    pool.max = 2
+    pool.trim(true)
+
+    assert_equal 1, pool.trim_requested
+
+    release << true
+    wait_until { pool.spawned == 2 }
+
+    assert_equal 2, pool.spawned
+    assert_equal 0, pool.trim_requested
+  ensure
+    3.times { release << true }
+  end
+
+  def test_shutdown_with_pending_trims_processes_all_queued_work
+    release = Queue.new
+    processed = Queue.new
+
+    pool = new_pool(0, 3) do
+      release.pop
+      processed << true
+    end
+
+    request_size = 9
+    request_size.times { |i| pool << i } # 6 because 3 threads busy, 3 item queued
+
+    wait_until do
+      pool.instance_variable_get(:@processors).map(&:thread).count(&:stop?) == 3
+    end
+
+    assert_equal 3, pool.spawned
+
+    shutdown_thread = Thread.new { pool.shutdown(-1) }
+    6.times { release << true }
+    wait_until { processed.size == 6 }
+
+    assert_equal 3, pool.spawned
+
+    3.times { release << true }
+    shutdown_thread.join
+
+    assert_equal request_size, processed.size
+  ensure
+    (request_size - release.size).times { release << true }
   end
 
   def test_trim_thread_exit_hook


### PR DESCRIPTION
Right now, trim requests are only honored inside the `while todo.empty?` loop in the `ThreadPool` class, so a pool with queued work never executes them. This has been fine until the introduction of `Server#update_thread_pool_min_max` https://github.com/puma/puma/pull/3658, since the only situation where we want to trim threads is the process is idle with an empty queue.

Now that we have `Server#update_thread_pool_min_max` we are in the need of dynamically adjusting the # of threads, hence the newly added `#trim_thread_if_requested(processor)` call within the spawned thread.

There is one thing to keep in mind, which is we should never attempt to trim threads during shutdown - shutdown sets `@trim_requested = @spawned` and relies on workers draining `@todo` before exiting via the idle branch. Other than that, this change should be straightforward.

Let me know what you all think. Thanks!

### Your checklist for this pull request

<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [x] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.