### PR TITLE
systemd: send immediate watchdog ping on ready (cleanup post-feedback)

### DIFF
--- a/docs/restart.md
+++ b/docs/restart.md
@@ -29,6 +29,7 @@ Any of the following will cause a Puma server to perform a hot restart:
 
 * The newly started Puma process changes its current working directory to the directory specified by the `directory` option. If `directory` is set to symlink, this is automatically re-evaluated, so this mechanism can be used to upgrade the application.
 * Only one version of the application is running at a time.
+* Under systemd with `WatchdogSec` set, the watchdog timer keeps running across a hot restart. Puma pings the watchdog as soon as the new master reports readiness, so `WatchdogSec` needs to exceed your application's boot time.
 * `before_restart` is invoked just before the server shuts down. This can be used to clean up resources (like long-lived database connections) gracefully. Since Ruby 2.0, it is not typically necessary to explicitly close file descriptors on restart. This is because any file descriptor opened by Ruby will have the `FD_CLOEXEC` flag set, meaning that file descriptors are closed on `exec`. `before_restart` is useful, though, if your application needs to perform any more graceful protocol-specific shutdown procedures before closing connections.
 
 ## Phased restart

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -30,6 +30,8 @@ After=network.target
 Type=notify
 
 # If your Puma process locks up, systemd's watchdog will restart it within seconds.
+# Puma pings the watchdog as soon as it reports readiness, and every
+# WatchdogSec/2 after that.
 WatchdogSec=10
 
 # Preferably configure a non-privileged user

--- a/lib/puma/plugin/systemd.rb
+++ b/lib/puma/plugin/systemd.rb
@@ -5,7 +5,7 @@ require_relative '../plugin'
 # Puma's systemd integration allows Puma to inform systemd:
 #  1. when it has successfully started
 #  2. when it is starting shutdown
-#  3. periodically for a liveness check with a watchdog thread
+#  3. at startup and then periodically for a liveness check with a watchdog thread
 #  4. periodically set the status
 Puma::Plugin.create do
   def start(launcher)

--- a/lib/puma/sd_notify.rb
+++ b/lib/puma/sd_notify.rb
@@ -49,8 +49,12 @@ module Puma
     WATCHDOG  = "WATCHDOG=1"
     FDSTORE   = "FDSTORE=1"
 
+    # @note If watchdog notifications are enabled, this also emits an
+    # immediate `WATCHDOG=1` ping to avoid a watchdog timeout window between
+    # startup completion and the first periodic watchdog loop tick.
     def self.ready(unset_env=false)
       notify(READY, unset_env)
+      watchdog(unset_env) if watchdog?
     end
 
     def self.reloading(unset_env=false)

--- a/lib/puma/sd_notify.rb
+++ b/lib/puma/sd_notify.rb
@@ -49,12 +49,11 @@ module Puma
     WATCHDOG  = "WATCHDOG=1"
     FDSTORE   = "FDSTORE=1"
 
-    # @note If watchdog notifications are enabled, this also emits an
-    # immediate `WATCHDOG=1` ping to avoid a watchdog timeout window between
-    # startup completion and the first periodic watchdog loop tick.
+    # @note When the service manager expects watchdog pings, this sends an
+    #   immediate `WATCHDOG=1` in the same datagram, which closes the watchdog
+    #   timeout window between startup and the first periodic watchdog tick.
     def self.ready(unset_env=false)
-      notify(READY, unset_env)
-      watchdog(unset_env) if watchdog?
+      notify(watchdog? ? "#{READY}\n#{WATCHDOG}" : READY, unset_env)
     end
 
     def self.reloading(unset_env=false)

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -54,6 +54,17 @@ class TestPluginSystemd < TestIntegration
     assert_message "STOPPING=1"
   end
 
+  def test_systemd_watchdog_sends_immediate_ping_after_ready
+    wd_env = @env.merge({"WATCHDOG_USEC" => "1_000_000"})
+    cli_server "test/rackup/hello.ru", env: wd_env
+
+    assert_message "READY=1"
+    assert_message "WATCHDOG=1"
+
+    stop_server
+    assert_message "STOPPING=1"
+  end
+
   def test_systemd_notify
     cli_server "test/rackup/hello.ru", env: @env
     assert_message "READY=1"

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -19,7 +19,7 @@ class TestPluginSystemd < TestIntegration
     @socket = Socket.new(:UNIX, :DGRAM, 0)
     @socket.bind Addrinfo.unix(@sockaddr)
     @env = { "NOTIFY_SOCKET" => @sockaddr }
-    @message = +''
+    @messages = []
   end
 
   def teardown
@@ -55,7 +55,9 @@ class TestPluginSystemd < TestIntegration
   end
 
   def test_systemd_watchdog_sends_immediate_ping_after_ready
-    wd_env = @env.merge({"WATCHDOG_USEC" => "1_000_000"})
+    # the watchdog loop pings every WATCHDOG_USEC/2, so a 60 second interval
+    # rules the periodic loop out as the source of this WATCHDOG=1
+    wd_env = @env.merge({"WATCHDOG_USEC" => "60_000_000"})
     cli_server "test/rackup/hello.ru", env: wd_env
 
     assert_message "READY=1"
@@ -114,18 +116,20 @@ class TestPluginSystemd < TestIntegration
     assert_message 'STOPPING=1'
   end
 
+  # Read whole datagrams, since a single datagram may carry several
+  # newline-separated messages, eg "READY=1\nWATCHDOG=1". Reading fewer bytes
+  # than the datagram holds discards the remainder.
   def assert_message(msg)
-    @socket.wait_readable 1
-    @message << @socket.sysread(msg.bytesize)
-    # below is kind of hacky, but seems to work correctly when slow CI systems
-    # write partial status messages
-    if @message.start_with?('STATUS=') && !msg.start_with?('STATUS=')
-      @message << @socket.sysread(512) while @socket.wait_readable(1) && !@message.include?(msg)
-      assert_includes @message, msg
-      @message = @message.split(msg, 2).last
-    else
-      assert_equal msg, @message
-      @message = +''
+    drop_status = !msg.start_with?('STATUS=')
+
+    loop do
+      # the plugin's status loop interleaves STATUS= messages every second
+      @messages.shift while drop_status && @messages.first&.start_with?('STATUS=')
+      break if @messages.any?
+      break unless @socket.wait_readable 1
+      @messages.concat @socket.sysread(1_024).split("\n")
     end
+
+    assert_equal msg, @messages.shift
   end
 end

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -121,12 +121,17 @@ class TestPluginSystemd < TestIntegration
   # than the datagram holds discards the remainder.
   def assert_message(msg)
     drop_status = !msg.start_with?('STATUS=')
+    # a hot restart execs the process, so allow it the same time to report as
+    # the wait_for_server_to_* helpers allow a boot
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + LOG_TIMEOUT
 
     loop do
       # the plugin's status loop interleaves STATUS= messages every second
       @messages.shift while drop_status && @messages.first&.start_with?('STATUS=')
       break if @messages.any?
-      break unless @socket.wait_readable 1
+      wait = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      break if wait <= 0
+      break unless @socket.wait_readable wait
       @messages.concat @socket.sysread(512).split("\n")
     end
 

--- a/test/test_plugin_systemd.rb
+++ b/test/test_plugin_systemd.rb
@@ -127,7 +127,7 @@ class TestPluginSystemd < TestIntegration
       @messages.shift while drop_status && @messages.first&.start_with?('STATUS=')
       break if @messages.any?
       break unless @socket.wait_readable 1
-      @messages.concat @socket.sysread(1_024).split("\n")
+      @messages.concat @socket.sysread(512).split("\n")
     end
 
     assert_equal msg, @messages.shift

--- a/test/test_sd_notify.rb
+++ b/test/test_sd_notify.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+require_relative "helpers/tmp_path"
+
+require "puma/sd_notify"
+
+class TestSdNotify < PumaTest
+  include TmpPath
+
+  def setup
+    @sockaddr = tmp_path '.systemd'
+    @socket = Socket.new(:UNIX, :DGRAM, 0)
+    @socket.bind Addrinfo.unix(@sockaddr)
+  end
+
+  def teardown
+    @socket&.close
+    @socket = nil
+    super
+  end
+
+  def test_ready_without_watchdog
+    with_temp_env("NOTIFY_SOCKET" => @sockaddr, "WATCHDOG_USEC" => nil) do
+      Puma::SdNotify.ready
+    end
+
+    assert_equal "READY=1", read_datagram
+  end
+
+  def test_ready_with_watchdog_sends_immediate_ping
+    with_temp_env("NOTIFY_SOCKET" => @sockaddr, "WATCHDOG_USEC" => "60000000") do
+      Puma::SdNotify.ready
+    end
+
+    assert_equal "READY=1\nWATCHDOG=1", read_datagram
+  end
+
+  def test_ready_with_watchdog_and_unset_env
+    with_temp_env("NOTIFY_SOCKET" => @sockaddr, "WATCHDOG_USEC" => "60000000") do
+      Puma::SdNotify.ready true
+
+      refute ENV.key?("NOTIFY_SOCKET"), "ready(true) should unset NOTIFY_SOCKET"
+    end
+
+    assert_equal "READY=1\nWATCHDOG=1", read_datagram
+  end
+
+  private
+
+  # systemd accepts several newline-separated pairs in one datagram, so read
+  # the whole datagram rather than a fixed number of bytes
+  def read_datagram
+    assert @socket.wait_readable(1), "timed out waiting for a notification"
+    @socket.sysread 1024
+  end
+end

--- a/test/test_sd_notify.rb
+++ b/test/test_sd_notify.rb
@@ -9,6 +9,9 @@ class TestSdNotify < PumaTest
   include TmpPath
 
   def setup
+    # JRuby and Windows both implement AF_UNIX for stream sockets only
+    skip_if :jruby, :windows
+
     @sockaddr = tmp_path '.systemd'
     @socket = Socket.new(:UNIX, :DGRAM, 0)
     @socket.bind Addrinfo.unix(@sockaddr)


### PR DESCRIPTION
### Description

This follows up on #3917 by @wwenrr. That PR addressed #3675, but had some outstanding, unaddressed feedback. This PR closes #3675.

Apologies @wwenrr if I'm stepping on your toes here. I started working on this because I saw that the _issue_ had been open for over a year, but your PR's only been open for a few months, which I didn't notice right away.

Anyway, the PR just had a few bits and pieces still pending:

- [x] [using `unset_env=true` could silently drop pings](https://github.com/puma/puma/pull/3917#discussion_r3106297712)
- [x] [the immediate ping test could give a false positive](https://github.com/puma/puma/pull/3917#discussion_r3106301874)

Disclaimer: I used Claude Code on this. The robot and I resolved the pending feedback as follows:

- use a single datagram for both `READY` and `WATCHDOG`, which requires changing `assert_message`
- lengthen `WATCHDOG_USEC` to guarantee that the watchdog ping doesn't come from the periodic loop
- add tests for `SdNotify.ready`, to cover the `unset_env=true` path (and friends)

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- ~~[ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.~~
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
