### PR TITLE
ci: remove client `ctx.ssl_version` code from tests

### DIFF
--- a/test/test_integration_ssl.rb
+++ b/test/test_integration_ssl.rb
@@ -116,13 +116,7 @@ class TestIntegrationSSL < TestIntegration
         c.cert = ::OpenSSL::X509::Certificate.new client_cert
         c.key  = ::OpenSSL::PKey::RSA.new File.read(key)
         c.verify_mode = ::OpenSSL::SSL::VERIFY_PEER
-        if tls1_2
-          if c.respond_to? :max_version=
-            c.max_version = :TLS1_2
-          else
-            c.ssl_version = :TLSv1_2
-          end
-        end
+        c.max_version = :TLS1_2 if tls1_2
       }
 
     assert_equal client_cert, body

--- a/test/test_integration_ssl_session.rb
+++ b/test/test_integration_ssl_session.rb
@@ -115,12 +115,8 @@ class TestIntegrationSSLSession < TestIntegration
     ctx.verify_mode = OSSL::VERIFY_NONE
     ctx.session_cache_mode = OSSL::SSLContext::SESSION_CACHE_CLIENT
     if tls_vers
-      if ctx.respond_to? :max_version=
-        ctx.max_version = tls_vers
-        ctx.min_version = tls_vers
-      else
-        ctx.ssl_version = tls_vers.to_s.sub('TLS', 'TLSv').to_sym
-      end
+      ctx.max_version = tls_vers
+      ctx.min_version = tls_vers
     end
     ctx.session_new_cb = ->(ary) {
       queue << true if queue

--- a/test/test_puma_server_ssl.rb
+++ b/test/test_puma_server_ssl.rb
@@ -32,9 +32,6 @@ class TestPumaServerSSL < PumaTest
   include TestPuma
   include TestPuma::PumaSocket
 
-  PROTOCOL_USE_MIN_MAX =
-    OpenSSL::SSL::SSLContext.public_instance_methods(false).include?(:min_version=)
-
   OPENSSL_3 = OpenSSL::OPENSSL_LIBRARY_VERSION.match?(/OpenSSL 3\.\d\.\d/)
 
   def setup
@@ -124,7 +121,7 @@ class TestPumaServerSSL < PumaTest
     assert_equal "https\na=1&b=2", body
   end
 
-  def rejection(server_ctx, min_max, ssl_version)
+  def rejection(server_ctx, min_max)
     if server_ctx
       start_server(&server_ctx)
     else
@@ -135,13 +132,7 @@ class TestPumaServerSSL < PumaTest
 
     assert_raises(OpenSSL::SSL::SSLError) do
       begin
-        send_http_read_response ctx: new_ctx { |ctx|
-          if PROTOCOL_USE_MIN_MAX && min_max
-            ctx.max_version = min_max
-          else
-            ctx.ssl_version = ssl_version
-          end
-        }
+        send_http_read_response ctx: new_ctx { |ctx| ctx.max_version = min_max }
       rescue => e
         msg = e.message
         raise e
@@ -160,29 +151,21 @@ class TestPumaServerSSL < PumaTest
   def test_ssl_v3_rejection
     skip("SSLv3 protocol is unavailable") if Puma::MiniSSL::OPENSSL_NO_SSL3
 
-    rejection nil, nil, :SSLv3
+    rejection nil, :SSL3
   end
 
   def test_tls_v1_rejection
-    rejection ->(ctx) { ctx.no_tlsv1 = true }, :TLS1, :TLSv1
+    rejection ->(ctx) { ctx.no_tlsv1 = true }, :TLS1
   end
 
   def test_tls_v1_1_rejection
-    rejection ->(ctx) { ctx.no_tlsv1_1 = true }, :TLS1_1, :TLSv1_1
+    rejection ->(ctx) { ctx.no_tlsv1_1 = true }, :TLS1_1
   end
 
   def test_tls_v1_3
-    skip("TLSv1.3 protocol can not be set") unless OpenSSL::SSL::SSLContext.instance_methods(false).include?(:min_version=)
-
     start_server
 
-    body = send_http_read_resp_body ctx: new_ctx { |c|
-      if PROTOCOL_USE_MIN_MAX
-        c.min_version = :TLS1_3
-      else
-        c.ssl_version = :TLSv1_3
-      end
-    }
+    body = send_http_read_resp_body ctx: new_ctx { |c| c.min_version = :TLS1_3 }
 
     assert_equal "https", body
   end
@@ -475,7 +458,7 @@ class TestPumaServerSSLClient < PumaTest
       client_ctx.ca_file = "#{CERT_PATH}/ca.crt"
       client_ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
-      client_ctx.ssl_version = :TLSv1_2
+      client_ctx.max_version = :TLS1_2
       client_ctx.ciphers = cipher_suite
     end
   end if Puma.jruby?
@@ -495,7 +478,7 @@ class TestPumaServerSSLClient < PumaTest
       client_ctx.ca_file = "#{CERT_PATH}/ca.crt"
       client_ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
-      client_ctx.ssl_version = :TLSv1_2
+      client_ctx.max_version = :TLS1_2
       client_ctx.ciphers = [ 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384' ]
     end
   end if Puma.jruby?


### PR DESCRIPTION
### Description

`SSLContext.min_version=` & `SSLContext.max_version=` were added in Ruby 2.5.  Previously, `ssl_version=` was used, and was listed as deprecated in Ruby 2.5.

This PR removes `SSLContext.ssl_version=`.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
