### PR TITLE
Feature: on_worker_boot hooks

### DIFF
--- a/docs/fork_worker.md
+++ b/docs/fork_worker.md
@@ -28,6 +28,7 @@ The `fork_worker` option allows your application to be initialized only once for
     - When initially forking the parent process to the worker 0 child, `before_fork` will trigger on the parent process and `before_worker_boot` will trigger on the worker 0 child as normal.
     - When forking the worker 0 child to grandchild workers, `before_refork` and `after_refork` will trigger on the worker 0 child, and `before_worker_boot` will trigger on each grandchild worker.
     - For clarity, `before_fork` does not trigger on worker 0, and `after_refork` does not trigger on the grandchild.
+    - When worker 0 forks grandchildren, it runs `before_worker_fork` and `after_worker_fork` itself. Those two hooks run in the master process, under the normal path, but in worker 0 here. This means that a hook_error_handler cannot infer the process from the hook name. It should branch on opts[:process], which reports :master or :worker. Raising in the master takes down the whole server, while raising in worker 0 only kills that worker.
 - As a general migration guide:
     - Copy any logic within your existing `before_fork` hook to the `before_refork` hook.
     - Consider to copy logic from your `before_worker_boot` hook to the `after_refork` hook, if it is needed to reset the state of worker 0 after it forks.

--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -76,6 +76,28 @@ module Puma
     Thread.current.name = "puma #{name}"
   end
 
+  # The pid of the process that supervises workers, recorded before any
+  # forking happens.  Used to tell master from worker at runtime, which the
+  # hook name alone cannot do -- under `fork_worker`, worker 0 runs the
+  # `before_worker_fork` and `after_worker_fork` hooks that the master
+  # normally runs.
+  #
+  # In single mode nothing is ever forked, so this stays the only pid.
+  #
+  # @!attribute [rw] master_pid
+  # @version 8.0.3
+  class << self
+    attr_accessor :master_pid
+  end
+
+  # Whether the calling process supervises workers.  True in single mode and
+  # in the cluster master, false in a forked worker.
+  #
+  # @version 8.0.3
+  def self.master?
+    @master_pid.nil? || @master_pid == Process.pid
+  end
+
   # Shows deprecated warning for renamed methods.
   # @example
   #   Puma.deprecate_method_change :on_booted, __callee__, __method__

--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -76,24 +76,20 @@ module Puma
     Thread.current.name = "puma #{name}"
   end
 
-  # The pid of the process that supervises workers.  Puma records it before
-  # any forking happens, so it tells master from worker at runtime.  The hook
-  # name alone cannot do that -- under `fork_worker`, worker 0 runs the
-  # `before_worker_fork` and `after_worker_fork` hooks that the master
-  # normally runs.
+  # `master_pid` is the pid of the process that supervises workers. Puma
+  # records it before any forking happens, so it differentiates master
+  # from worker at runtime.
   #
   # Single mode never forks anything, so this stays the only pid.
   #
   # @!attribute [rw] master_pid
-  # @version 8.0.3
   class << self
     attr_accessor :master_pid
   end
 
-  # Whether the calling process supervises workers.  True in single mode and
-  # in the cluster master, false in a forked worker.
+  # `master?` indicates whether the calling process supervises workers. True
+  # in single mode and in the cluster master, false in a forked worker.
   #
-  # @version 8.0.3
   def self.master?
     @master_pid.nil? || @master_pid == Process.pid
   end

--- a/lib/puma.rb
+++ b/lib/puma.rb
@@ -76,13 +76,13 @@ module Puma
     Thread.current.name = "puma #{name}"
   end
 
-  # The pid of the process that supervises workers, recorded before any
-  # forking happens.  Used to tell master from worker at runtime, which the
-  # hook name alone cannot do -- under `fork_worker`, worker 0 runs the
+  # The pid of the process that supervises workers.  Puma records it before
+  # any forking happens, so it tells master from worker at runtime.  The hook
+  # name alone cannot do that -- under `fork_worker`, worker 0 runs the
   # `before_worker_fork` and `after_worker_fork` hooks that the master
   # normally runs.
   #
-  # In single mode nothing is ever forked, so this stays the only pid.
+  # Single mode never forks anything, so this stays the only pid.
   #
   # @!attribute [rw] master_pid
   # @version 8.0.3

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -364,7 +364,7 @@ module Puma
       @status = :run
 
       # Record the pid before any forking, so hooks can tell which process
-      # they ran in.  See Configuration#run_hooks.
+      # they ran in. See Configuration#run_hooks.
       Puma.master_pid = Process.pid
 
       output_header "cluster"

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -363,8 +363,8 @@ module Puma
     def run
       @status = :run
 
-      # Recorded before any forking so hooks can tell which process they ran
-      # in.  See Configuration#run_hooks.
+      # Record the pid before any forking, so hooks can tell which process
+      # they ran in.  See Configuration#run_hooks.
       Puma.master_pid = Process.pid
 
       output_header "cluster"

--- a/lib/puma/cluster.rb
+++ b/lib/puma/cluster.rb
@@ -363,6 +363,10 @@ module Puma
     def run
       @status = :run
 
+      # Recorded before any forking so hooks can tell which process they ran
+      # in.  See Configuration#run_hooks.
+      Puma.master_pid = Process.pid
+
       output_header "cluster"
 
       # This is aligned with the output from Runner, see Runner#output_header

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -403,10 +403,10 @@ module Puma
 
     private
 
-    # Runs when a hook block raises.  Hands the exception to the configured
-    # `hook_error_handler`, if any, otherwise logs it as before.  Puma
+    # Runs when a hook block raises. Hands the exception to the configured
+    # `hook_error_handler`, if any; otherwise logs it as before. Puma
     # deliberately does not catch exceptions from the handler itself, so a
-    # handler can `raise` to fail fast.  See DSL#hook_error_handler.
+    # handler can `raise` to fail fast. See DSL#hook_error_handler.
     #
     def handle_hook_error(e, key, arg, hook_options, hook_data, log_writer)
       handler = options[:hook_error_handler]
@@ -424,7 +424,7 @@ module Puma
       id = hook_options[:id]
 
       # Negative arity means optional or splat params, so the handler accepts
-      # at least this many.  Everything else gets the full set.
+      # at least this many. Everything else gets the full set.
       handler.call e, key, {
         process:   Puma.master? ? :master : :worker,
         arg:       arg,

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -403,10 +403,10 @@ module Puma
 
     private
 
-    # Called when a hook block raises.  Hands the exception to the configured
-    # `hook_error_handler`, if any, otherwise logs it as before.  Exceptions
-    # from the handler itself are deliberately not caught, so a handler can
-    # `raise` to fail fast.  See DSL#hook_error_handler.
+    # Runs when a hook block raises.  Hands the exception to the configured
+    # `hook_error_handler`, if any, otherwise logs it as before.  Puma
+    # deliberately does not catch exceptions from the handler itself, so a
+    # handler can `raise` to fail fast.  See DSL#hook_error_handler.
     #
     def handle_hook_error(e, key, arg, hook_options, hook_data, log_writer)
       handler = options[:hook_error_handler]

--- a/lib/puma/configuration.rb
+++ b/lib/puma/configuration.rb
@@ -362,8 +362,7 @@ module Puma
             block.call arg
           end
         rescue => e
-          log_writer.log "WARNING hook #{key} failed with exception (#{e.class}) #{e.message}"
-          log_writer.debug e.backtrace.join("\n")
+          handle_hook_error e, key, arg, hook_options, hook_data, log_writer
         end
       end
     end
@@ -403,6 +402,35 @@ module Puma
     end
 
     private
+
+    # Called when a hook block raises.  Hands the exception to the configured
+    # `hook_error_handler`, if any, otherwise logs it as before.  Exceptions
+    # from the handler itself are deliberately not caught, so a handler can
+    # `raise` to fail fast.  See DSL#hook_error_handler.
+    #
+    def handle_hook_error(e, key, arg, hook_options, hook_data, log_writer)
+      handler = options[:hook_error_handler]
+
+      unless handler
+        log_writer.log "WARNING hook #{key} failed with exception (#{e.class}) #{e.message}"
+        log_writer.debug e.backtrace.join("\n")
+        return
+      end
+
+      arity = handler.arity
+      return handler.call(e, key) if arity == 2
+      return handler.call(e)      if arity == 1
+
+      id = hook_options[:id]
+
+      # Negative arity means optional or splat params, so the handler accepts
+      # at least this many.  Everything else gets the full set.
+      handler.call e, key, {
+        process:   Puma.master? ? :master : :worker,
+        arg:       arg,
+        hook_data: (hook_data[id] if hook_data && id)
+      }
+    end
 
     def rewrite_unavailable_ipv6_binds!
       return if self.class.ipv6_interface_available?

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1119,22 +1119,23 @@ module Puma
       @options[:lowlevel_error_handler] = obj
     end
 
-    # Use +obj+ or +block+ to handle exceptions raised by configuration hooks
-    # such as +before_worker_boot+.  By default Puma logs a warning and runs
-    # the next hook, which can leave a worker serving requests with only part
-    # of its setup done.  Setting a handler replaces that logging entirely.
+    # Use +obj+ or +block+ to handle exceptions that configuration hooks such
+    # as +before_worker_boot+ raise.  By default Puma logs a warning and runs
+    # the next hook, which can leave a worker serving requests when only part
+    # of its setup ran.  Setting a handler replaces that logging entirely.
     #
-    # The handler is called with the exception, the hook name, and a Hash of
+    # Puma calls the handler with the exception, the hook name, and a Hash of
     # +:process+ (+:master+ or +:worker+), +:arg+ (whatever Puma passed to the
     # hook -- the worker index for +before_worker_boot+, the Launcher for
     # +before_restart+, +nil+ for several others), and +:hook_data+ (the Hash
-    # given to hooks registered with a key, otherwise +nil+).  Handlers taking
-    # fewer arguments receive only the leading ones.
+    # Puma passes to hooks you register with a key, otherwise +nil+).  Handlers
+    # taking fewer arguments receive only the leading ones.
     #
-    # Exceptions raised by the handler are not caught, so +raise+ is the way
-    # to fail fast.  Beware that the blast radius differs by process: raising
-    # in a worker kills that worker and the master respawns it, but raising in
-    # the master takes down the whole server, since nothing supervises it.
+    # Puma does not catch the exceptions your handler raises, so +raise+ is the
+    # way to fail fast.  Beware that raising costs more in the master than in a
+    # worker: raising in a worker kills that worker and the master respawns it,
+    # but raising in the master takes down the whole server, since nothing
+    # supervises it.
     # Branch on +:process+ rather than on the hook name -- under
     # +fork_worker+, worker 0 runs +before_worker_fork+ and
     # +after_worker_fork+ itself.

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1119,6 +1119,39 @@ module Puma
       @options[:lowlevel_error_handler] = obj
     end
 
+    # Use +obj+ or +block+ to handle exceptions raised by configuration hooks
+    # such as +before_worker_boot+.  By default Puma logs a warning and runs
+    # the next hook, which can leave a worker serving requests with only part
+    # of its setup done.  Setting a handler replaces that logging entirely.
+    #
+    # The handler is called with the exception, the hook name, and a Hash of
+    # +:process+ (+:master+ or +:worker+), +:arg+ (whatever Puma passed to the
+    # hook -- the worker index for +before_worker_boot+, the Launcher for
+    # +before_restart+, +nil+ for several others), and +:hook_data+ (the Hash
+    # given to hooks registered with a key, otherwise +nil+).  Handlers taking
+    # fewer arguments receive only the leading ones.
+    #
+    # Exceptions raised by the handler are not caught, so +raise+ is the way
+    # to fail fast.  Beware that the blast radius differs by process: raising
+    # in a worker kills that worker and the master respawns it, but raising in
+    # the master takes down the whole server, since nothing supervises it.
+    # Branch on +:process+ rather than on the hook name -- under
+    # +fork_worker+, worker 0 runs +before_worker_fork+ and
+    # +after_worker_fork+ itself.
+    #
+    # @example Crash workers instead of booting them half-configured
+    #   hook_error_handler do |err, hook, opts|
+    #     raise err if opts[:process] == :worker
+    #   end
+    #
+    # @version 8.0.3
+    #
+    def hook_error_handler(obj=nil, &block)
+      obj ||= block
+      raise "Provide either a #call'able or a block" unless obj
+      @options[:hook_error_handler] = obj
+    end
+
     # This option is used to allow your app and its gems to be
     # properly reloaded when not using preload.
     #

--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -1120,25 +1120,23 @@ module Puma
     end
 
     # Use +obj+ or +block+ to handle exceptions that configuration hooks such
-    # as +before_worker_boot+ raise.  By default Puma logs a warning and runs
+    # as +before_worker_boot+ raise. By default, Puma logs a warning and runs
     # the next hook, which can leave a worker serving requests when only part
-    # of its setup ran.  Setting a handler replaces that logging entirely.
+    # of its setup ran. Setting a handler replaces that logging! It means your
+    # handler takes on its own logging.
     #
     # Puma calls the handler with the exception, the hook name, and a Hash of
     # +:process+ (+:master+ or +:worker+), +:arg+ (whatever Puma passed to the
     # hook -- the worker index for +before_worker_boot+, the Launcher for
     # +before_restart+, +nil+ for several others), and +:hook_data+ (the Hash
-    # Puma passes to hooks you register with a key, otherwise +nil+).  Handlers
-    # taking fewer arguments receive only the leading ones.
+    # Puma passes to hooks you register with a key, otherwise +nil+). Handlers
+    # which take fewer arguments receive only the leading ones.
     #
     # Puma does not catch the exceptions your handler raises, so +raise+ is the
-    # way to fail fast.  Beware that raising costs more in the master than in a
-    # worker: raising in a worker kills that worker and the master respawns it,
-    # but raising in the master takes down the whole server, since nothing
-    # supervises it.
-    # Branch on +:process+ rather than on the hook name -- under
-    # +fork_worker+, worker 0 runs +before_worker_fork+ and
-    # +after_worker_fork+ itself.
+    # way to fail fast. Be aware that raising has different effects in the master
+    # thread than in a worker: raising in a worker kills that worker and the
+    # master respawns it, but raising in the master takes down the whole server,
+    # since nothing supervises it.
     #
     # @example Crash workers instead of booting them half-configured
     #   hook_error_handler do |err, hook, opts|

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -745,7 +745,7 @@ class TestConfigFile < PumaTest
     assert_equal [['Error from hook', :before_restart, 'ARG']], seen
   end
 
-  # optional and splat params report negative arity, which must still get the
+  # Optional and splat params report negative arity, which must still get the
   # full set of arguments rather than raising ArgumentError
   def test_hook_error_handler_negative_arity
     seen = []

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -682,6 +682,138 @@ class TestConfigFile < PumaTest
     assert_match expected, log_writer.stdout.string
   end
 
+  # `hook_error_handler` tests -- see https://github.com/puma/puma/issues/3628
+
+  def hook_error_conf(handler, hook: :before_restart, key: nil, &blk)
+    conf = Puma::Configuration.new do |c|
+      c.silence_fork_callback_warning
+      c.hook_error_handler(&handler)
+      if key
+        c.send(hook, key) { |_a, _d| raise RuntimeError, 'Error from hook' }
+      else
+        c.send(hook) { |_a| raise RuntimeError, 'Error from hook' }
+      end
+    end
+    conf.clamp
+    conf
+  end
+
+  def test_hook_error_handler_replaces_default_logging
+    seen = []
+    conf = hook_error_conf ->(e, key) { seen << [e.message, key] }
+    log_writer = Puma::LogWriter.strings
+
+    conf.run_hooks(:before_restart, 'ARG', log_writer)
+
+    assert_equal [['Error from hook', :before_restart]], seen
+    refute_match(/WARNING hook/, log_writer.stdout.string)
+  end
+
+  def test_hook_error_handler_absent_leaves_logging_unchanged
+    conf = Puma::Configuration.new do |c|
+      c.before_restart { |_a| raise RuntimeError, 'Error from hook' }
+    end
+    conf.clamp
+    log_writer = Puma::LogWriter.strings
+
+    conf.run_hooks(:before_restart, 'ARG', log_writer)
+
+    assert_match(/WARNING hook before_restart failed with exception \(RuntimeError\) Error from hook/,
+      log_writer.stdout.string)
+  end
+
+  def test_hook_error_handler_exception_propagates
+    conf = hook_error_conf ->(e, _key) { raise e }
+
+    error = assert_raises RuntimeError do
+      conf.run_hooks(:before_restart, 'ARG', Puma::LogWriter.strings)
+    end
+    assert_equal 'Error from hook', error.message
+  end
+
+  def test_hook_error_handler_arity_one
+    seen = []
+    conf = hook_error_conf ->(e) { seen << e.message }
+    conf.run_hooks(:before_restart, 'ARG', Puma::LogWriter.strings)
+    assert_equal ['Error from hook'], seen
+  end
+
+  def test_hook_error_handler_arity_three
+    seen = []
+    conf = hook_error_conf ->(e, key, opts) { seen << [e.message, key, opts[:arg]] }
+    conf.run_hooks(:before_restart, 'ARG', Puma::LogWriter.strings)
+    assert_equal [['Error from hook', :before_restart, 'ARG']], seen
+  end
+
+  # optional and splat params report negative arity, which must still get the
+  # full set of arguments rather than raising ArgumentError
+  def test_hook_error_handler_negative_arity
+    seen = []
+    conf = hook_error_conf ->(*a) { seen << a.size }
+    conf.run_hooks(:before_restart, 'ARG', Puma::LogWriter.strings)
+
+    conf2 = hook_error_conf ->(e, key = nil, opts = nil) { seen << [key, opts.class] }
+    conf2.run_hooks(:before_restart, 'ARG', Puma::LogWriter.strings)
+
+    assert_equal [3, [:before_restart, Hash]], seen
+  end
+
+  def test_hook_error_handler_accepts_callable_object
+    seen = []
+    handler = Object.new
+    handler.define_singleton_method(:call) { |e, key| seen << [e.message, key] }
+    handler.define_singleton_method(:arity) { 2 }
+
+    conf = Puma::Configuration.new do |c|
+      c.hook_error_handler handler
+      c.before_restart { |_a| raise RuntimeError, 'Error from hook' }
+    end
+    conf.clamp
+    conf.run_hooks(:before_restart, 'ARG', Puma::LogWriter.strings)
+
+    assert_equal [['Error from hook', :before_restart]], seen
+  end
+
+  def test_hook_error_handler_options_hook_data
+    seen = nil
+    conf = hook_error_conf ->(_e, _key, opts) { seen = opts }, hook: :before_worker_boot, key: :some_id
+    conf.run_hooks(:before_worker_boot, 3, Puma::LogWriter.strings, {})
+
+    assert_equal 3, seen[:arg]
+    assert_equal({}, seen[:hook_data])
+  end
+
+  def test_hook_error_handler_options_hook_data_nil_without_key
+    seen = nil
+    conf = hook_error_conf ->(_e, _key, opts) { seen = opts }
+    conf.run_hooks(:before_restart, 'ARG', Puma::LogWriter.strings)
+
+    assert_nil seen[:hook_data]
+  end
+
+  def test_hook_error_handler_options_process
+    seen = []
+    conf = hook_error_conf ->(_e, _key, opts) { seen << opts[:process] }
+
+    conf.run_hooks(:before_restart, 'ARG', Puma::LogWriter.strings)
+
+    begin
+      Puma.master_pid = Process.pid + 1_000_000
+      conf.run_hooks(:before_restart, 'ARG', Puma::LogWriter.strings)
+    ensure
+      Puma.master_pid = nil
+    end
+
+    assert_equal [:master, :worker], seen
+  end
+
+  def test_hook_error_handler_requires_callable_or_block
+    error = assert_raises RuntimeError do
+      Puma::Configuration.new { |c| c.hook_error_handler }.clamp
+    end
+    assert_equal "Provide either a #call'able or a block", error.message
+  end
+
   def test_config_does_not_load_workers_by_default
     conf = Puma::Configuration.new
     conf.clamp

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -135,7 +135,7 @@ class TestIntegrationCluster < TestIntegration
 
   # A `hook_error_handler` that re-raises must let the exception escape
   # `run_hooks`, killing the worker, rather than letting `run_hooks` swallow
-  # it, which is the default.  See https://github.com/puma/puma/issues/3628
+  # it, which is the default. See https://github.com/puma/puma/issues/3628
   def test_hook_error_handler_raise_crashes_worker
     cli_server "-w 1 test/rackup/hello.ru",
       config: <<~'CONFIG',
@@ -153,10 +153,10 @@ class TestIntegrationCluster < TestIntegration
       CONFIG
       merge_err: true, no_wait: true
 
-    # the handler runs in place of Puma's default WARNING logging
+    # The handler runs in place of Puma's default WARNING logging
     assert wait_for_server_to_include('handler saw before_worker_boot in worker')
 
-    # re-raising kills the worker, so the master respawns it.  A second
+    # Re-raising kills the worker, so the master respawns it. A second
     # occurrence proves the worker died rather than carrying on booting.
     assert wait_for_server_to_include('handler saw before_worker_boot in worker')
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -134,8 +134,8 @@ class TestIntegrationCluster < TestIntegration
   end
 
   # A `hook_error_handler` that re-raises must let the exception escape
-  # `run_hooks`, killing the worker, rather than being swallowed as it is by
-  # default.  See https://github.com/puma/puma/issues/3628
+  # `run_hooks`, killing the worker, rather than letting `run_hooks` swallow
+  # it, which is the default.  See https://github.com/puma/puma/issues/3628
   def test_hook_error_handler_raise_crashes_worker
     cli_server "-w 1 test/rackup/hello.ru",
       config: <<~'CONFIG',

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -133,6 +133,37 @@ class TestIntegrationCluster < TestIntegration
     assert_equal 0, status
   end
 
+  # A `hook_error_handler` that re-raises must let the exception escape
+  # `run_hooks`, killing the worker, rather than being swallowed as it is by
+  # default.  See https://github.com/puma/puma/issues/3628
+  def test_hook_error_handler_raise_crashes_worker
+    cli_server "-w 1 test/rackup/hello.ru",
+      config: <<~'CONFIG',
+        worker_check_interval 1
+
+        before_worker_boot do
+          raise "hook_error_handler test failure"
+        end
+
+        hook_error_handler do |e, key, opts|
+          $stdout.puts "handler saw #{key} in #{opts[:process]}"
+          $stdout.flush
+          raise e
+        end
+      CONFIG
+      merge_err: true, no_wait: true
+
+    # the handler runs in place of Puma's default WARNING logging
+    assert wait_for_server_to_include('handler saw before_worker_boot in worker')
+
+    # re-raising kills the worker, so the master respawns it.  A second
+    # occurrence proves the worker died rather than carrying on booting.
+    assert wait_for_server_to_include('handler saw before_worker_boot in worker')
+
+    refute_includes @server_log, 'booted in',
+      'worker should never finish booting when the hook error is re-raised'
+  end
+
   def test_after_booted_and_after_stopped
     skip_unless_signal_exist? :TERM
     cli_server "-w #{workers} " \


### PR DESCRIPTION
### Description

Closes #3628.

That ticket came from @ransombriggs after a Rails 7.1 upgrade cooked their `on_worker_boot` by removing `schema_cache=` unexpectedly. Puma was logging the resultant exceptions. The ticket requested that the server crash on exceptions instead. @dentarg proposed hooks as a compromise, paralleling the existing `lowlevel_error_handler` subsystem.

Caveat: I don't need these hooks myself. I wanted to contribute to Puma, saw this ticket, and thought it'd be a good way to get my feet wet.

Still, the logic of the ticket was that, if the hooks had existed, a bug which caused silent fails could have been caught quicker. That made sense to me, so this PR adds those hooks.

The PR adds a new `hook_error_handler config` option which replaces the default warn-and-continue for every hook that goes through `run_hooks`. The handler doesn't catch exceptions, so giving it a hook which `raise`s will give users the ability to crash on exceptions, but by default, it'll keep logging exceptions instead.

The PR exceeds the implied 100-line limit from the checklist by 1 line, unless you count tests and documentation, in which case it goes all the way up to 225 lines total. 😬 Sorry about that!

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] ~~My pull request is 100 lines added/removed or less so that it can be easily reviewed.~~
- [ ] ~~If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.~~
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
