### PR TITLE
ci: run the test suite on FreeBSD

### DIFF
--- a/.github/workflows/test_bsd.yml
+++ b/.github/workflows/test_bsd.yml
@@ -1,0 +1,59 @@
+name: FreeBSD
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  freebsd:
+    name: freebsd ruby
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v7
+
+      - name: test
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          cache-after-prepare: true
+          envs: 'CI PUMA_TEST_DEBUG TESTOPTS MT_CPU RUNNER_TOOL_CACHE GITHUB_ACTIONS'
+          prepare: |
+            pkg install -y git devel/ragel devel/ruby-gems gmake
+          run: |
+            set -e
+            # Puma's suite opens a lot of sockets; CONTRIBUTING.md recommends
+            # a file limit of 4000 or more.
+            ulimit -n 4000 || true
+            ulimit -n
+            ruby -v
+            ragel --version | head -1
+            gem install --no-document bundler
+            bundle install --jobs 4
+            bundle exec rake compile
+            rc=0
+            test/runner --verbose || rc=$?
+            # Integration servers are spawned with IO.popen and, with the
+            # default merge_err: false, inherit this session's stderr (see
+            # test/helpers/integration.rb). One that outlives the suite holds
+            # that descriptor open, the ssh command never returns, and the job
+            # then idles until it times out with every test already passed.
+            pkill -f 'bin/puma' 2>/dev/null || true
+            exit $rc
+        env:
+          CI: true
+          GITHUB_ACTIONS: true
+          PUMA_TEST_DEBUG: true
+          TESTOPTS: -v
+          MT_CPU: 2

--- a/lib/puma/detect.rb
+++ b/lib/puma/detect.rb
@@ -16,7 +16,7 @@ module Puma
 
   IS_WINDOWS = RUBY_DESCRIPTION.match?(/mswin|ming|cygwin/)
 
-  IS_LINUX = !(IS_OSX || IS_WINDOWS)
+  IS_LINUX = RUBY_DESCRIPTION.include? 'linux'
 
   IS_ARM = RUBY_PLATFORM.include? 'aarch64'
 

--- a/test/test_request_invalid_multiple.rb
+++ b/test/test_request_invalid_multiple.rb
@@ -209,6 +209,13 @@ class TestRequestInvalidMultiple < PumaTest
 
     refute lleh_err
     sleep 0.1
-    assert_raises(*ERROR_ON_CLOSED) { socket << GET_11 }
+    # Linux raises on the first write to the closed socket. BSD buffers that
+    # write and only reports the error on a later one, so write again after a
+    # short pause; back-to-back writes both land in the buffer first.
+    assert_raises(*ERROR_ON_CLOSED) do
+      socket << GET_11
+      sleep 0.05
+      socket << GET_11
+    end
   end
 end


### PR DESCRIPTION
### Description

Closes #2589.

You opened this in 2021 and asked "Anyone has any idea?" about the failing
tests, then dropped the vmactions link in 2024. This is that job, plus the two
things it turned out to need.

The suite runs **862 tests, 0 failures, 0 errors** on FreeBSD 15.1 with Ruby
3.4.9 -- the same 862 the Ubuntu job runs.

https://github.com/neilpang/puma/actions/runs/30757622697/job/91522430505

```
862 runs, 2526 assertions, 0 failures, 0 errors, 16 skips
Finished in 304.446288s
```

**`Puma::IS_LINUX` is true on FreeBSD.** `detect.rb` defines it as
`!(IS_OSX || IS_WINDOWS)`, which held while CI was Linux/macOS/Windows. So
`skip_unless :linux` never skipped, and all seven `TestPluginSystemd` tests ran
here -- six passed, and `test_systemd_notify_usr1_phased_restart_cluster` hung
for 45s on `IO#wait_readable`. Defining it as `RUBY_DESCRIPTION.include? 'linux'`
(matching how `IS_OSX` is written, and not `RUBY_PLATFORM`, which is `"java"` on
JRuby) lets those classes skip as intended. `IS_LINUX` is read only by the test
suite, so no runtime behaviour changes.

**`test_http_11_req_oversize_chunked` assumes a Linux write error.** After the
413 the server closes, and the test asserts that the next write raises. I
isolated this from puma entirely -- a plain TCP server that replies and closes,
then a client writing repeatedly:

```
read response: "HTTP/1.1 413 Payload Too Large"
write 1: NO ERROR
write 2: Errno::EPIPE
```

BSD buffers the first write after the peer's FIN and reports the error on a
later one. Back-to-back writes both land in the buffer, so the second write
needs a brief pause. Linux still raises on the first write, inside the same
block.

One note on the workflow itself: `RUNNER_TOOL_CACHE` has to be passed into the
VM. `test/helper.rb:137` does `result_str.gsub! ENV['RUNNER_TOOL_CACHE'], ''`
unconditionally, and `nil` raises `TypeError` inside a parallel worker, which
hangs the whole run rather than failing it.

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
