### PR TITLE
docs: fix upgrade guide links to repo root files [ci skip]

### DIFF
--- a/docs/8.0-Upgrade.md
+++ b/docs/8.0-Upgrade.md
@@ -7,9 +7,9 @@ Here's what you should do:
 1. Review the Upgrade section below to look for breaking changes that could affect you.
 2. Upgrade to version 8.0 in your Gemfile and deploy.
 3. Open up a new bug issue if you find any problems.
-4. Join us in building Puma! We welcome first-timers. See [CONTRIBUTING.md](./CONTRIBUTING.md).
+4. Join us in building Puma! We welcome first-timers. See [CONTRIBUTING.md](../CONTRIBUTING.md).
 
-For a complete list of changes, see [History.md](./History.md).
+For a complete list of changes, see [History.md](../History.md).
 
 ## What's New
 


### PR DESCRIPTION
The 8.0 upgrade guide links `CONTRIBUTING.md` and `History.md` with `./`, but this file lives in `docs/`, so `./CONTRIBUTING.md` and `./History.md` resolve to `docs/CONTRIBUTING.md` / `docs/History.md`, which do not exist. Both files are at the repository root.

The sibling guides already use the correct form (`docs/6.0-Upgrade.md` and `docs/7.0-Upgrade.md` link `../CONTRIBUTING.md` / `../History.md`); this looks like a copy-paste slip in the 8.0 guide. Repointed both links to `../`.
