### PR TITLE
Separate unit and integration test commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,24 @@ To run the test suite only:
 bundle exec rake test
 ```
 
+Integration tests spawn a Puma process. Unit tests call Puma in-process
+(including in-process servers that bind a port). Classification follows the
+existing `TestIntegration` helper (see `test/categories.rb`).
+
+To run only the in-process (unit) tests:
+```sh
+bundle exec rake test:unit
+# or
+test/runner --unit
+```
+
+To run only the process-spawn (integration) tests:
+```sh
+bundle exec rake test:integration
+# or
+test/runner --integration
+```
+
 To run a single test file:
 ```sh
 bundle exec ruby test/test_binder.rb

--- a/Rakefile
+++ b/Rakefile
@@ -93,11 +93,11 @@ file "lib/puma/puma_http11.rb" do |t|
   end
 end
 
-Rake::TestTask.new(:test)
+require_relative "test/categories"
 
 # tests require extension be compiled, but depend on the platform
 if Puma.jruby?
-  task :test => [:java]
+  test_prereq = :java
 else
   task :compile_for_test do
     original_makeflags = ENV["MAKEFLAGS"]
@@ -107,7 +107,29 @@ else
     ENV["MAKEFLAGS"] = original_makeflags
   end
 
-  task :test => [:compile_for_test]
+  test_prereq = :compile_for_test
 end
+
+# Integration = process-spawn / TestIntegration. Unit = in-process complement.
+# See test/categories.rb and CONTRIBUTING.md ("Running tests").
+namespace :test do
+  Rake::TestTask.new(:unit) do |t|
+    t.description = "Run in-process (unit) tests"
+    t.test_files = PumaTestCategories.unit_paths
+  end
+
+  Rake::TestTask.new(:integration) do |t|
+    t.description = "Run process-spawn (integration) tests"
+    t.test_files = PumaTestCategories.integration_paths
+  end
+end
+
+Rake::TestTask.new(:test) do |t|
+  t.description = "Run the full test suite"
+end
+
+task "test:unit" => test_prereq
+task "test:integration" => test_prereq
+task :test => test_prereq
 
 task :default => [:rubocop, :test]

--- a/test/categories.rb
+++ b/test/categories.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Shared classification for rake test:unit / test:integration and test/runner.
+#
+# Litmus: integration tests spawn a Puma (or rackup) process and drive it from
+# the outside (TestIntegration / helpers/integration). Unit tests call Puma
+# in-process, including in-process servers that bind a port.
+#
+# Keep this file named without a test_*.rb prefix so the default suite glob
+# does not load it as a test. test/test_categories.rb guards the list against
+# drift from the classifier below.
+module PumaTestCategories
+  INTEGRATION_TEST_FILES = %w[
+    test_http11.rb
+    test_integration_cluster.rb
+    test_integration_pumactl.rb
+    test_integration_single.rb
+    test_integration_ssl.rb
+    test_integration_ssl_session.rb
+    test_plugin.rb
+    test_plugin_systemd.rb
+    test_plugin_systemd_jruby.rb
+    test_preserve_bundler_env.rb
+    test_redirect_io.rb
+    test_skip_sigusr2.rb
+    test_skip_systemd.rb
+    test_url_map.rb
+    test_web_concurrency_auto.rb
+    test_worker_gem_independence.rb
+  ].freeze
+
+  module_function
+
+  def all_test_basenames(base = File.dirname(__FILE__))
+    Dir[File.join(base, "test_*.rb")].map { |path| File.basename(path) }.sort
+  end
+
+  # Files that use the process-spawn integration helper. Used to detect list drift.
+  def discover_integration_basenames(base = File.dirname(__FILE__))
+    Dir[File.join(base, "test_*.rb")].sort.filter_map do |path|
+      File.basename(path) if integration_source?(path)
+    end
+  end
+
+  def integration_source?(path)
+    source = File.read(path)
+    source.match?(/require_relative\s+["']helpers\/integration["']/) ||
+      source.match?(/<\s*TestIntegration\b/)
+  end
+
+  def integration_basenames
+    INTEGRATION_TEST_FILES
+  end
+
+  def unit_basenames(base = File.dirname(__FILE__))
+    all_test_basenames(base) - INTEGRATION_TEST_FILES
+  end
+
+  def integration_paths(base = File.dirname(__FILE__))
+    INTEGRATION_TEST_FILES.map { |name| File.join(base, name) }
+  end
+
+  def unit_paths(base = File.dirname(__FILE__))
+    unit_basenames(base).map { |name| File.join(base, name) }
+  end
+end

--- a/test/runner
+++ b/test/runner
@@ -8,6 +8,10 @@ It can also be passed a glob or test file names.  If multiple test file names
 are used, separate them by the File::PATH_SEPARATOR character with no spaces.
 The file extension is optional.
 
+Category filters (mutually exclusive with each other; may combine with -v/-w):
+  --unit         in-process tests (see test/categories.rb)
+  --integration  process-spawn / TestIntegration tests
+
 If arguments are used that take values (eg seed), use the 'no space' version,
 like -s33388 or --seed=33388
 
@@ -22,6 +26,8 @@ filtering it will either error or run minitest with no tests loaded
 Examples, run from the top Puma repo folder:
 test/runner
 test/runner -v
+test/runner --unit
+test/runner --integration
 test/runner -v test_puma_server
 test/runner --verbose test_puma_server*
 test/runner --verbose test_integration_cluster:test_integration_single
@@ -33,6 +39,7 @@ test/runner -v 'test_integration_*.rb'
 
 require 'bundler/setup'
 require 'stringio'
+require_relative 'categories'
 
 if ARGV.delete '-z'
   show_warnings = true
@@ -46,6 +53,17 @@ else
   show_warnings = nil
 end
 
+unit = ARGV.delete('--unit')
+integration = ARGV.delete('--integration')
+if unit && integration
+  STDERR.puts 'test/runner: use only one of --unit or --integration'
+  exit 1
+end
+if (unit || integration) && !(ARGV.empty? || ARGV.all? { |a| a.start_with?('-') })
+  STDERR.puts 'test/runner: --unit/--integration cannot be combined with file name arguments'
+  exit 1
+end
+
 if show_warnings
   stderr, $stderr = STDERR, StringIO.new
   $VERBOSE = true
@@ -53,7 +71,11 @@ end
 
 require 'minitest'
 
-if ARGV.empty? || ARGV.last.start_with?('-')
+if unit
+  PumaTestCategories.unit_basenames(__dir__).each { |tf| require_relative tf }
+elsif integration
+  PumaTestCategories.integration_basenames.each { |tf| require_relative tf }
+elsif ARGV.empty? || ARGV.last.start_with?('-')
   Dir['test_*.rb', base: __dir__].sort.each { |tf| require_relative tf }
 else
   file_arg = ARGV.pop.delete_suffix('.rb')

--- a/test/test_categories.rb
+++ b/test/test_categories.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+require_relative "categories"
+
+class TestCategories < PumaTest
+  def test_integration_list_matches_classifier
+    listed = PumaTestCategories.integration_basenames
+    discovered = PumaTestCategories.discover_integration_basenames
+
+    assert_equal discovered, listed,
+      "Update INTEGRATION_TEST_FILES in test/categories.rb when adding or " \
+      "removing TestIntegration / helpers/integration tests"
+  end
+end


### PR DESCRIPTION
### Description

Closes #3931.

Local and agent loops spend a meaningful chunk of time in process-spawn tests
(`TestIntegration` / `cli_server`). This exposes that existing boundary for
local use without changing what CI runs.

**Proposed unit vs integration litmus:** integration tests spawn a Puma
process; unit tests call Puma in-process (including in-process servers that
bind a port). Classification is the current `TestIntegration` /
`helpers/integration` set, listed in `test/categories.rb` and shared by `rake`
and `test/runner`. A small test fails if that list drifts from the classifier.

Timing (wall clock; yours will differ):

| Environment | `test:unit` | full `rake test` | approx. savings |
|---|---|---|---|
| MRI 3.4 macOS (host) | ≈ 13s (718 runs) | ≈ 37s (862 runs) | ~⅓ of wall-clock |
| MRI 3.4 Linux (Docker/`ruby:3.4-bookworm`, aarch64) | ≈ 13s (719 runs) | ≈ 101s (863 runs) | ~⅞ of wall-clock |

The Linux numbers are a single Docker Desktop datapoint, not a formal benchmark.
Two pre-existing-looking TLS rejection assertions failed in that container
(OpenSSL wording); they did not change the unit-vs-full timing comparison.

`test_rack_handler.rb` stays in unit despite some `IO.popen` examples — it does
not use `TestIntegration`. Happy to move it if you prefer classifying by any
process spawn.

Also happy to revisit whether in-process `Puma::Server` suites should leave
`test:unit` if that matches what you meant by “tests which start servers.”

CI is unchanged (`test/runner --verbose` = full suite).

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.