### PR TITLE
Make a family of flaky tests deterministic

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -483,9 +483,22 @@ class TestIntegration < PumaTest
     JSON.parse read_pipe.read.split("\n", 2).last
   end
 
+  # Restarts the server `restarts` times while `num_threads` client threads keep
+  # sending requests, then asserts that (almost) none of those requests were
+  # dropped.
+  #
+  # The number of restarts is a loop bound, not a count of however many restarts
+  # happen to fit inside a fixed number of requests.  Client threads run until
+  # they are told to stop, and each pass waits for `replies_per_gate` further
+  # successful responses before signaling again, so traffic is known to be
+  # flowing across every restart.  A fast server or a slow machine changes how
+  # long the test takes, not whether it passes.
   def restart_does_not_drop_connections(
+      restarts: 3,
       num_threads: 1,
-      total_requests: 500,
+      replies_per_gate: 100,
+      gate_timeout: 20,
+      pause: 0.002,
       config: nil,
       unix: nil,
       signal: nil,
@@ -498,193 +511,12 @@ class TestIntegration < PumaTest
     skipped = nil
 
     clustered = (workers || 0) >= 2
-    restart_loop_sleep = clustered ? 0.15 : 0.10
 
     args = "-w #{workers} -t 5:5 -q test/rackup/hello_with_delay.ru"
     if Puma.windows?
       cli_server "#{set_pumactl_args} #{args}", unix: unix, config: config, log: log
     else
       cli_server args, unix: unix, config: config, log: log
-    end
-
-    replies = Hash.new 0
-    refused = thread_run_refused unix: false
-    message = 'A' * 16_256  # 2^14 - 128
-
-    mutex = Mutex.new
-    restart_count = 0
-    client_threads = []
-
-    num_requests = (total_requests/num_threads).to_i
-
-    num_threads.times do |thread|
-      client_threads << Thread.new do
-        num_requests.times do |req_num|
-          begin
-            begin
-              socket = open_client_socket(unix: unix)
-              fast_write socket, "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Length: #{message.bytesize}\r\n\r\n#{message}"
-            rescue => e
-              replies[:write_error] += 1
-              raise e
-            end
-            body = read_body(socket, 10)
-            if body == "Hello World"
-              mutex.synchronize {
-                replies[:success] += 1
-                replies[:restart] += 1 if restart_count > 0
-              }
-            else
-              mutex.synchronize { replies[:unexpected_response] += 1 }
-            end
-          rescue Errno::ECONNRESET, Errno::EBADF, Errno::ENOTCONN, Errno::ENOTSOCK
-            # connection was accepted but then closed
-            # client would see an empty response
-            # Errno::EBADF Windows may not be able to make a connection
-            mutex.synchronize { replies[:reset] += 1 }
-          rescue *refused, IOError
-            # IOError intermittently thrown by Ubuntu, add to allow retry
-            mutex.synchronize { replies[:refused] += 1 }
-          rescue ::Timeout::Error
-            mutex.synchronize { replies[:read_timeout] += 1 }
-          ensure
-            if socket.is_a?(IO) && !socket.closed?
-              begin
-                socket.close
-              rescue Errno::EBADF
-              end
-            end
-          end
-        end
-        # STDOUT.puts "#{thread} #{replies[:success]}"
-      end
-    end
-
-    run = true
-
-    restart_thread = Thread.new do
-      # Wait for some connections before first restart
-      sleep 0.2
-      while run
-        if Puma.windows?
-          cli_pumactl 'restart'
-        else
-          Process.kill signal, @pid
-        end
-        if signal == :USR2
-          # If 'wait_for_server_to_boot' times out, error in thread shuts down CI
-          begin
-            wait_for_server_to_boot timeout: 5
-          rescue Minitest::Assertion # Timeout
-            run = false
-          end
-        end
-        restart_count += 1
-
-        if Puma.windows?
-          sleep 2.0
-        elsif clustered
-          phase = signal == :USR2 ? 0 : restart_count
-          # If 'get_worker_pids phase' times out, error in thread shuts down CI
-          begin
-            get_worker_pids phase, log: log
-            # Wait with an exponential backoff before signaling next restart
-            sleep restart_loop_sleep * restart_count
-          rescue Minitest::Assertion # Timeout
-            run = false
-          rescue Errno::EBADF # bad restart?
-            run = false
-          end
-        else
-          sleep 0.1
-        end
-      end
-    end
-
-    # cycle thru threads rather than one at a time
-    until client_threads.empty?
-      client_threads.each_with_index do |t, i|
-        client_threads[i] = nil if t.join(1)
-      end
-      client_threads.compact!
-    end
-
-    run = false
-    restart_thread.join
-    if Puma.windows?
-      cli_pumactl 'stop'
-      wait_server
-    else
-      stop_server
-    end
-    @server = nil
-
-    msg = ("   %4d unexpected_response\n"   % replies.fetch(:unexpected_response,0)).dup
-    msg << "   %4d refused\n"               % replies.fetch(:refused,0)
-    msg << "   %4d read timeout\n"          % replies.fetch(:read_timeout,0)
-    msg << "   %4d reset\n"                 % replies.fetch(:reset,0)
-    msg << "   %4d write_errors\n"          % replies.fetch(:write_error,0)
-    msg << "   %4d success\n"               % replies.fetch(:success,0)
-    msg << "   %4d success after restart\n" % replies.fetch(:restart,0)
-    msg << "   %4d restart count\n"         % restart_count
-
-    actual_requests = num_threads * num_requests
-    allowed_errors = (actual_requests * 0.002).round
-
-    refused = replies[:refused]
-    reset   = replies[:reset]
-
-    # started intermittently failing on ubuntu22, May-2026
-    assert_operator_equal = UBUNTU_VERSION && UBUNTU_VERSION <= 22 ? 1 : 2
-
-    assert_operator restart_count, :>=, assert_operator_equal, msg
-
-    if Puma.windows?
-      assert_equal actual_requests - reset - refused, replies[:success]
-    else
-      assert_operator replies[:success], :>=,  actual_requests - allowed_errors, msg
-    end
-
-  ensure
-    unless skipped
-      if passed?
-        msg = "    #{restart_count} restarts, #{reset} resets, #{refused} refused, #{replies[:restart]} success after restart, #{replies[:write_error]} write error"
-        $debugging_info << "#{full_name}\n#{msg}\n"
-      else
-        client_threads.each { |thr| thr.kill if thr.is_a? Thread }
-        $debugging_info << "#{full_name}\n#{msg}\n"
-      end
-    end
-  end
-
-  # Hot restarts the server `restarts` times while `num_threads` client threads
-  # keep sending requests.
-  #
-  # Unlike `restart_does_not_drop_connections`, the number of restarts is a loop
-  # bound rather than however many happen to fit inside a fixed number of
-  # requests.  Client threads run until told to stop, and each restart waits for
-  # `replies_per_gate` further successful responses before the next signal is
-  # sent, so traffic is known to be flowing across every restart.  A fast server
-  # or a slow machine changes how long the test takes, not whether it passes.
-  def hot_restarts_do_not_drop_connections(
-      restarts: 3,
-      num_threads: 5,
-      replies_per_gate: 100,
-      gate_timeout: 20,
-      pause: 0.002,
-      log: nil
-    )
-    skipped = true
-    skip_if :jruby, suffix: ' - file descriptors are not preserved on exec on JRuby; ' \
-      'connection reset errors are expected during restarts'
-    skip_if :truffleruby, suffix: ' - Undiagnosed failures on TruffleRuby'
-    skipped = nil
-
-    args = '-t 5:5 -q test/rackup/hello_with_delay.ru'
-    if Puma.windows?
-      cli_server "#{set_pumactl_args} #{args}", log: log
-    else
-      cli_server args, log: log
     end
 
     replies = Hash.new 0
@@ -702,22 +534,30 @@ class TestIntegration < PumaTest
           begin
             mutex.synchronize { replies[:attempts] += 1 }
             begin
-              socket = open_client_socket
+              socket = open_client_socket(unix: unix)
               fast_write socket, "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Length: #{message.bytesize}\r\n\r\n#{message}"
             rescue => e
               mutex.synchronize { replies[:write_error] += 1 }
               raise e
             end
             body = read_body(socket, 10)
-            if body == 'Hello World'
-              mutex.synchronize { replies[:success] += 1 }
+            if body == "Hello World"
+              mutex.synchronize {
+                replies[:success] += 1
+                replies[:restart] += 1 if restart_count > 0
+              }
             else
               mutex.synchronize { replies[:unexpected_response] += 1 }
             end
           rescue Errno::ECONNRESET, Errno::EBADF, Errno::ENOTCONN, Errno::ENOTSOCK
             # connection was accepted but then closed
+            # client would see an empty response
+            # Errno::EBADF Windows may not be able to make a connection
             mutex.synchronize { replies[:reset] += 1 }
-          rescue *refused, IOError
+          rescue *refused, IOError, Errno::EINVAL
+            # IOError intermittently thrown by Ubuntu, add to allow retry
+            # Errno::EINVAL - ran out of ephemeral ports, only seen when a test
+            # is already failing and the client threads run far longer than usual
             mutex.synchronize { replies[:refused] += 1 }
           rescue ::Timeout::Error
             mutex.synchronize { replies[:read_timeout] += 1 }
@@ -746,12 +586,14 @@ class TestIntegration < PumaTest
         if Puma.windows?
           cli_pumactl 'restart'
         else
-          Process.kill :USR2, @pid
+          Process.kill signal, @pid
         end
-
-        # not rescued - a boot that never finishes must fail the test loudly
-        wait_for_server_to_boot timeout: 30, log: log
         restart_count += 1
+
+        # none of these are rescued - a wait that never finishes must fail the
+        # test loudly, rather than quietly ending the restart loop
+        wait_for_server_to_boot timeout: 30, log: log if signal == :USR2
+        get_worker_pids(signal == :USR2 ? 0 : restart_count, log: log) if clustered
 
         wait_for_replies replies, target, mutex: mutex, timeout: gate_timeout,
           what: "after restart #{idx + 1} of #{restarts}"
@@ -760,6 +602,7 @@ class TestIntegration < PumaTest
       running = false
     end
 
+    # cycle thru threads rather than one at a time
     until client_threads.empty?
       client_threads.each_with_index do |t, i|
         client_threads[i] = nil if t.join(1)
@@ -776,35 +619,36 @@ class TestIntegration < PumaTest
     @server = nil
 
     msg = ("   %4d attempts\n"              % replies.fetch(:attempts,0)).dup
-    msg << "   %4d success\n"               % replies.fetch(:success,0)
     msg << "   %4d unexpected_response\n"   % replies.fetch(:unexpected_response,0)
     msg << "   %4d refused\n"               % replies.fetch(:refused,0)
     msg << "   %4d read timeout\n"          % replies.fetch(:read_timeout,0)
     msg << "   %4d reset\n"                 % replies.fetch(:reset,0)
     msg << "   %4d write_errors\n"          % replies.fetch(:write_error,0)
+    msg << "   %4d success\n"               % replies.fetch(:success,0)
+    msg << "   %4d success after restart\n" % replies.fetch(:restart,0)
     msg << "   %4d restart count\n"         % restart_count
+
+    attempts = replies[:attempts]
+    allowed_errors = (attempts * 0.002).round
 
     assert_equal restarts, restart_count, msg
 
-    # same allowances as `restart_does_not_drop_connections` - the tolerated
-    # error rate is not what this helper changes
-    allowed_errors = (replies[:attempts] * 0.002).round
-
     if Puma.windows?
-      assert_equal replies[:attempts] - replies[:reset] - replies[:refused],
-        replies[:success], msg
+      assert_equal attempts - replies[:reset] - replies[:refused], replies[:success]
     else
-      assert_operator replies[:success], :>=, replies[:attempts] - allowed_errors, msg
+      assert_operator replies[:success], :>=,  attempts - allowed_errors, msg
     end
 
   ensure
     unless skipped
       running = false
-      client_threads.each { |thr| thr.kill if thr.is_a? Thread } unless passed?
-      $debugging_info << "#{full_name}\n    #{restart_count} restarts, " \
-        "#{replies[:attempts]} attempts, #{replies[:success]} success, " \
-        "#{replies[:reset]} resets, #{replies[:refused]} refused, " \
-        "#{replies[:write_error]} write error\n"
+      if passed?
+        msg = "    #{restart_count} restarts, #{replies[:attempts]} attempts, #{replies[:reset]} resets, #{replies[:refused]} refused, #{replies[:restart]} success after restart, #{replies[:write_error]} write error"
+        $debugging_info << "#{full_name}\n#{msg}\n"
+      else
+        client_threads.each { |thr| thr.kill if thr.is_a? Thread }
+        $debugging_info << "#{full_name}\n#{msg}\n"
+      end
     end
   end
 

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -307,7 +307,6 @@ class TestIntegration < PumaTest
 
   def connect(path = nil, unix: false)
     s = open_client_socket(unix: unix)
-    @ios_to_close << s
     s << "GET /#{path} HTTP/1.1\r\nHost: test.com\r\n\r\n"
     s
   end
@@ -316,7 +315,6 @@ class TestIntegration < PumaTest
   # does not wait for a read
   def fast_connect(path = nil, unix: false)
     s = open_client_socket(unix: unix)
-    @ios_to_close << s
     fast_write s, "GET /#{path} HTTP/1.1\r\nHost: test.com\r\n\r\n"
     s
   end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -656,4 +656,175 @@ class TestIntegration < PumaTest
       end
     end
   end
+
+  # Hot restarts the server `restarts` times while `num_threads` client threads
+  # keep sending requests.
+  #
+  # Unlike `restart_does_not_drop_connections`, the number of restarts is a loop
+  # bound rather than however many happen to fit inside a fixed number of
+  # requests.  Client threads run until told to stop, and each restart waits for
+  # `replies_per_gate` further successful responses before the next signal is
+  # sent, so traffic is known to be flowing across every restart.  A fast server
+  # or a slow machine changes how long the test takes, not whether it passes.
+  def hot_restarts_do_not_drop_connections(
+      restarts: 3,
+      num_threads: 5,
+      replies_per_gate: 100,
+      gate_timeout: 20,
+      pause: 0.002,
+      log: nil
+    )
+    skipped = true
+    skip_if :jruby, suffix: ' - file descriptors are not preserved on exec on JRuby; ' \
+      'connection reset errors are expected during restarts'
+    skip_if :truffleruby, suffix: ' - Undiagnosed failures on TruffleRuby'
+    skipped = nil
+
+    args = '-t 5:5 -q test/rackup/hello_with_delay.ru'
+    if Puma.windows?
+      cli_server "#{set_pumactl_args} #{args}", log: log
+    else
+      cli_server args, log: log
+    end
+
+    replies = Hash.new 0
+    refused = thread_run_refused unix: false
+    message = 'A' * 16_256  # 2^14 - 128
+
+    mutex = Mutex.new
+    restart_count = 0
+    running = true
+    client_threads = []
+
+    num_threads.times do
+      client_threads << Thread.new do
+        while running
+          begin
+            mutex.synchronize { replies[:attempts] += 1 }
+            begin
+              socket = open_client_socket
+              fast_write socket, "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Length: #{message.bytesize}\r\n\r\n#{message}"
+            rescue => e
+              mutex.synchronize { replies[:write_error] += 1 }
+              raise e
+            end
+            body = read_body(socket, 10)
+            if body == 'Hello World'
+              mutex.synchronize { replies[:success] += 1 }
+            else
+              mutex.synchronize { replies[:unexpected_response] += 1 }
+            end
+          rescue Errno::ECONNRESET, Errno::EBADF, Errno::ENOTCONN, Errno::ENOTSOCK
+            # connection was accepted but then closed
+            mutex.synchronize { replies[:reset] += 1 }
+          rescue *refused, IOError
+            mutex.synchronize { replies[:refused] += 1 }
+          rescue ::Timeout::Error
+            mutex.synchronize { replies[:read_timeout] += 1 }
+          ensure
+            if socket.is_a?(IO) && !socket.closed?
+              begin
+                socket.close
+              rescue Errno::EBADF
+              end
+            end
+          end
+          # client threads are not capped by a request count, so they are paced
+          # instead - without this they exhaust ephemeral ports
+          sleep pause
+        end
+      end
+    end
+
+    begin
+      wait_for_replies replies, replies_per_gate, mutex: mutex,
+        timeout: gate_timeout, what: 'before the first restart'
+
+      restarts.times do |idx|
+        target = mutex.synchronize { replies[:success] } + replies_per_gate
+
+        if Puma.windows?
+          cli_pumactl 'restart'
+        else
+          Process.kill :USR2, @pid
+        end
+
+        # not rescued - a boot that never finishes must fail the test loudly
+        wait_for_server_to_boot timeout: 30, log: log
+        restart_count += 1
+
+        wait_for_replies replies, target, mutex: mutex, timeout: gate_timeout,
+          what: "after restart #{idx + 1} of #{restarts}"
+      end
+    ensure
+      running = false
+    end
+
+    until client_threads.empty?
+      client_threads.each_with_index do |t, i|
+        client_threads[i] = nil if t.join(1)
+      end
+      client_threads.compact!
+    end
+
+    if Puma.windows?
+      cli_pumactl 'stop'
+      wait_server
+    else
+      stop_server
+    end
+    @server = nil
+
+    msg = ("   %4d attempts\n"              % replies.fetch(:attempts,0)).dup
+    msg << "   %4d success\n"               % replies.fetch(:success,0)
+    msg << "   %4d unexpected_response\n"   % replies.fetch(:unexpected_response,0)
+    msg << "   %4d refused\n"               % replies.fetch(:refused,0)
+    msg << "   %4d read timeout\n"          % replies.fetch(:read_timeout,0)
+    msg << "   %4d reset\n"                 % replies.fetch(:reset,0)
+    msg << "   %4d write_errors\n"          % replies.fetch(:write_error,0)
+    msg << "   %4d restart count\n"         % restart_count
+
+    assert_equal restarts, restart_count, msg
+
+    assert_equal 0, replies[:read_timeout], msg
+    assert_equal 0, replies[:write_error], msg
+    assert_equal 0, replies[:unexpected_response], msg
+
+    if Puma.windows?
+      # Windows resets and refusals during restart are long-standing behavior,
+      # see `restart_does_not_drop_connections`
+      assert_equal replies[:attempts] - replies[:reset] - replies[:refused],
+        replies[:success], msg
+    else
+      assert_equal 0, replies[:reset], msg
+      assert_equal 0, replies[:refused], msg
+      assert_equal replies[:attempts], replies[:success], msg
+    end
+
+  ensure
+    unless skipped
+      running = false
+      client_threads.each { |thr| thr.kill if thr.is_a? Thread } unless passed?
+      $debugging_info << "#{full_name}\n    #{restart_count} restarts, " \
+        "#{replies[:attempts]} attempts, #{replies[:success]} success, " \
+        "#{replies[:reset]} resets, #{replies[:refused]} refused, " \
+        "#{replies[:write_error]} write error\n"
+    end
+  end
+
+  # Blocks until `replies[:success]` reaches `target`.  Fails the test if that
+  # does not happen within `timeout` seconds, rather than passing quietly on a
+  # server that has stopped answering.
+  def wait_for_replies(replies, target, mutex:, timeout: 20, what: nil)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    loop do
+      count = mutex.synchronize { replies[:success] }
+      return count if count >= target
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        flunk "Only #{count} successful requests #{what}, " \
+          "expected #{target} within #{timeout} seconds"
+      end
+      sleep 0.01
+    end
+  end
 end

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -786,19 +786,15 @@ class TestIntegration < PumaTest
 
     assert_equal restarts, restart_count, msg
 
-    assert_equal 0, replies[:read_timeout], msg
-    assert_equal 0, replies[:write_error], msg
-    assert_equal 0, replies[:unexpected_response], msg
+    # same allowances as `restart_does_not_drop_connections` - the tolerated
+    # error rate is not what this helper changes
+    allowed_errors = (replies[:attempts] * 0.002).round
 
     if Puma.windows?
-      # Windows resets and refusals during restart are long-standing behavior,
-      # see `restart_does_not_drop_connections`
       assert_equal replies[:attempts] - replies[:reset] - replies[:refused],
         replies[:success], msg
     else
-      assert_equal 0, replies[:reset], msg
-      assert_equal 0, replies[:refused], msg
-      assert_equal replies[:attempts], replies[:success], msg
+      assert_operator replies[:success], :>=, replies[:attempts] - allowed_errors, msg
     end
 
   ensure

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -33,7 +33,6 @@ class TestIntegration < PumaTest
     @pid = nil
 
     @ios_to_close = Queue.new
-    @ios_to_close = []
     @bind_path    = nil
     @bind_port    = nil
     @control_path = nil
@@ -295,7 +294,9 @@ class TestIntegration < PumaTest
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
     retries = 0
     begin
-      unix ? UNIXSocket.new(@bind_path) : TCPSocket.new(HOST, bind_port)
+      skt = unix ? UNIXSocket.new(@bind_path) : TCPSocket.new(HOST, bind_port)
+      @ios_to_close << skt
+      skt
     rescue Errno::EADDRNOTAVAIL => e
       raise e if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
       retries += 1
@@ -507,9 +508,13 @@ class TestIntegration < PumaTest
     skipped = nil
 
     restarts         = 3     # loop bound - the count the test asserts it got
-    replies_per_gate = 100   # successful responses to wait for before signaling again
+
     gate_timeout     = 20    # seconds to wait for those responses
-    pause            = 0.002 # seconds each client waits between requests
+
+    # successful responses to wait for before signaling again
+    replies_per_gate = Puma::IS_WINDOWS ? 100 : 200
+    # seconds each client waits between requests
+    pause = Puma::IS_WINDOWS ? 0.002 : 0.001
 
     clustered = (workers || 0) >= 2
 
@@ -524,6 +529,9 @@ class TestIntegration < PumaTest
     refused = thread_run_refused unix: false
     message = 'A' * 16_256  # 2^14 - 128
 
+    request_text = "POST / HTTP/1.1\r\nHost: test.com\r\n" \
+      "Content-Length: #{message.bytesize}\r\n\r\n#{message}"
+
     mutex = Mutex.new
     restart_count = 0
     running = true
@@ -536,7 +544,7 @@ class TestIntegration < PumaTest
             mutex.synchronize { replies[:attempts] += 1 }
             begin
               socket = open_client_socket(unix: unix)
-              fast_write socket, "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Length: #{message.bytesize}\r\n\r\n#{message}"
+              fast_write socket, request_text
             rescue => e
               mutex.synchronize { replies[:write_error] += 1 }
               raise e
@@ -563,6 +571,8 @@ class TestIntegration < PumaTest
           rescue ::Timeout::Error
             mutex.synchronize { replies[:read_timeout] += 1 }
           ensure
+            # this generates a lot of sockets, clear here, rather than using
+            # teardown
             if socket.is_a?(IO) && !socket.closed?
               begin
                 socket.close
@@ -619,15 +629,15 @@ class TestIntegration < PumaTest
     end
     @server = nil
 
-    msg = ("   %4d attempts\n"              % replies.fetch(:attempts,0)).dup
-    msg << "   %4d unexpected_response\n"   % replies.fetch(:unexpected_response,0)
-    msg << "   %4d refused\n"               % replies.fetch(:refused,0)
-    msg << "   %4d read timeout\n"          % replies.fetch(:read_timeout,0)
-    msg << "   %4d reset\n"                 % replies.fetch(:reset,0)
-    msg << "   %4d write_errors\n"          % replies.fetch(:write_error,0)
-    msg << "   %4d success\n"               % replies.fetch(:success,0)
-    msg << "   %4d success after restart\n" % replies.fetch(:restart,0)
-    msg << "   %4d restart count\n"         % restart_count
+    msg = +("   %4d attempts\n"              % replies.fetch(:attempts,0))
+    msg <<  "   %4d unexpected_response\n"   % replies.fetch(:unexpected_response,0)
+    msg <<  "   %4d refused\n"               % replies.fetch(:refused,0)
+    msg <<  "   %4d read timeout\n"          % replies.fetch(:read_timeout,0)
+    msg <<  "   %4d reset\n"                 % replies.fetch(:reset,0)
+    msg <<  "   %4d write_errors\n"          % replies.fetch(:write_error,0)
+    msg <<  "   %4d success\n"               % replies.fetch(:success,0)
+    msg <<  "   %4d success after restart\n" % replies.fetch(:restart,0)
+    msg <<  "   %4d restart count\n"         % restart_count
 
     attempts = replies[:attempts]
     allowed_errors = (attempts * 0.002).round

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -638,7 +638,7 @@ class TestIntegration < PumaTest
     msg <<  "   %4d restart count\n"         % restart_count
 
     attempts = replies[:attempts]
-    allowed_errors = (attempts * 0.002).round
+    allowed_errors = restarts * num_threads
 
     assert_equal restarts, restart_count, msg
 

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -494,11 +494,7 @@ class TestIntegration < PumaTest
   # flowing across every restart.  A fast server or a slow machine changes how
   # long the test takes, not whether it passes.
   def restart_does_not_drop_connections(
-      restarts: 3,
       num_threads: 1,
-      replies_per_gate: 100,
-      gate_timeout: 20,
-      pause: 0.002,
       config: nil,
       unix: nil,
       signal: nil,
@@ -509,6 +505,11 @@ class TestIntegration < PumaTest
       'connection reset errors are expected during restarts'
     skip_if :truffleruby, suffix: ' - Undiagnosed failures on TruffleRuby'
     skipped = nil
+
+    restarts         = 3     # loop bound - the count the test asserts it got
+    replies_per_gate = 100   # successful responses to wait for before signaling again
+    gate_timeout     = 20    # seconds to wait for those responses
+    pause            = 0.002 # seconds each client waits between requests
 
     clustered = (workers || 0) >= 2
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -23,33 +23,31 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_hot_restart_does_not_drop_connections_threads
-    restart_does_not_drop_connections num_threads: 10, total_requests: 3_000,
-      signal: :USR2
+    restart_does_not_drop_connections num_threads: 10, signal: :USR2
   end
 
   def test_hot_restart_does_not_drop_connections
-    restart_does_not_drop_connections num_threads: 1, total_requests: 1_000,
-      signal: :USR2
+    restart_does_not_drop_connections num_threads: 1, signal: :USR2
   end
 
   def test_phased_restart_does_not_drop_connections_threads
-    restart_does_not_drop_connections num_threads: 10, total_requests: 3_000,
-      signal: :USR1, config: "preload_app! false"
+    restart_does_not_drop_connections num_threads: 10, signal: :USR1,
+      config: "preload_app! false"
   end
 
   def test_phased_restart_does_not_drop_connections
-    restart_does_not_drop_connections num_threads: 1, total_requests: 1_000,
-      signal: :USR1, config: "preload_app! false"
+    restart_does_not_drop_connections num_threads: 1, signal: :USR1,
+      config: "preload_app! false"
   end
 
   def test_phased_restart_does_not_drop_connections_threads_fork_worker
-    restart_does_not_drop_connections num_threads: 10, total_requests: 3_000,
-      signal: :USR1, config: "fork_worker; preload_app! false"
+    restart_does_not_drop_connections num_threads: 10, signal: :USR1,
+      config: "fork_worker; preload_app! false"
   end
 
   def test_phased_restart_does_not_drop_connections_unix
-    restart_does_not_drop_connections num_threads: 1, total_requests: 1_000,
-      signal: :USR1, unix: true, config: "preload_app! false"
+    restart_does_not_drop_connections num_threads: 1, signal: :USR1, unix: true,
+      config: "preload_app! false"
   end
 
   def test_pre_existing_unix

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -9,16 +9,11 @@ class TestIntegrationSingle < TestIntegration
   def workers ; 0 ; end
 
   def test_hot_restart_does_not_drop_connections_threads
-    hot_restarts_do_not_drop_connections restarts: 3, num_threads: 5
+    restart_does_not_drop_connections num_threads: 5, signal: :USR2
   end
 
   def test_hot_restart_does_not_drop_connections
-    if Puma.windows?
-      restart_does_not_drop_connections total_requests: 300,
-        signal: :USR2
-    else
-      restart_does_not_drop_connections signal: :USR2
-    end
+    restart_does_not_drop_connections signal: :USR2
   end
 
   def test_usr2_restart

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -9,9 +9,7 @@ class TestIntegrationSingle < TestIntegration
   def workers ; 0 ; end
 
   def test_hot_restart_does_not_drop_connections_threads
-    ttl_reqs = Puma.windows? ? 500 : 1_000
-    restart_does_not_drop_connections num_threads: 5, total_requests: ttl_reqs,
-      signal: :USR2
+    hot_restarts_do_not_drop_connections restarts: 3, num_threads: 5
   end
 
   def test_hot_restart_does_not_drop_connections


### PR DESCRIPTION
### Description

Closes https://github.com/puma/puma/issues/3987, which is my own issue, just explaining the problem when I first found it.

I have to apologize, this PR is a lot of text (and diagrams). The actual changes are 76 lines deleted, 75 lines added. They make some complicated, flaky code more simple and reliable over the long term, so I think it'll be worth it.

-------------

## Background

I wrote a [PR](https://github.com/puma/puma/pull/3982), and an unrelated test failed. So I figured out why it was failing, and discovered that it's part of a family of flaky tests. Maintainers probably already know about this, because the flakiness has shown up already in these issues and PRs:

- https://github.com/puma/puma/pull/3972
- https://github.com/puma/puma/pull/3960
- https://github.com/puma/puma/pull/3589
- https://github.com/puma/puma/issues/3535
- https://github.com/puma/puma/issues/3114

These PRs and issues include a history of maintainers tweaking these tests, because the helper makes them flaky. There's also a couple workarounds: the tests scale back the number of requests for Windows, and the number of restarts for Ubuntu.

What's going on in this family of tests is that the test helper `restart_does_not_drop_connections` in `test/helpers/integration.rb` serves as a foundation for eight tests across `test_integration_cluster.rb` and `test_integration_single.rb`. As I explained in the related issue when I first understood it, the helper starts a single Puma, then does a couple things in parallel:

- Five threads fire off a set number of TTL requests (1000 on `main`).
- One thread runs a loop which repeatedly sends `USR2`, waits for the server to boot, and increments a restarts counter.

The test passes if the restarts counter is 2 or more.

(These specifics come from `test_hot_restart_does_not_drop_connections_threads`, the test which broke my [otherwise unrelated PR](https://github.com/puma/puma/pull/3982), but the same basic shape holds for several tests.)

What the test literally asserts is that Puma restarts at least twice within a "timeframe" of 1K requests, and that 998 of those requests (i.e., 99.8%) get an acceptable response. But that's not the goal of the tests. The goal is to show that you get good responses even after a restart. So there's this effort to construct a window, and have both responses and restarts happening within that window.

`total_requests` is functioning like it's a stopwatch, or the finish line that the test has to cross. Basically the mechanism that the test runs on is a race condition. So it's kind of doomed to always be flaky unless we restructure it, so this PR restructures it.

## The sequence of events

This is sort of what the test helper looks like on `main`. The client threads and the server thread start at the same time, and the goal is for the server to restart twice before the clients run out of requests.

```mermaid                                                            
sequenceDiagram    
    participant C as 5 client threads<br/>(budget: 1000 requests)    
    participant R as restart thread                                 
    Note over C,R: both start at t=0
    R->>R: sleep 0.2s                                                                                                            
    C-->>C: 1000 requests done at t=1.4s                                                                                    
    R->>R: restart 1 finishes booting at t=1.1s    
    R->>R: restart 2 starts at t=1.25s...    
    Note over C,R: clients exit, only one restart. FAIL    
```

Basically, the test says "send 1000 requests, and while that's happening, restart the server over and over until the requests run out." But that didn't happen on [my PR](https://github.com/puma/puma/pull/3982), for a particular Linux flavor, until I randomly bumped the number of requests from 1K to 3K. [Similar prior changes have lowered the number of restarts](https://github.com/puma/puma/pull/3589), instead of raising the number of requests.

Both of those fixes are kind of dealing with the fact that the relationship between "how many restarts" vs "how many requests" hinges on hardware performance. That means the tests have a dependency on hardware performance. Since hardware performance is generally always getting better, these tests are always getting worse.

Also, we don't care that the server restarts X times while serving Y requests. All these tests are actually trying to show is that if a client request is in flight when the server restarts, the request still gets a correct response. The restarts vs requests thing is just a windowing mechanism to make the comparison in.

We can't actually _guarantee_ that we're restarting while a request is in flight. What we can do is provide continuous load. That's what the race condition mechanism does, but there's an easier way to do it.

So in this PR, the test now says "do exactly 3 restarts." The requests keep going until the test tells them to stop. Between each restart, the test pauses and waits until 100 more requests have succeeded before it restarts again. So we're always sending enough requests that the restarts are meaningful.

```mermaid
sequenceDiagram
    participant C as client threads<br/>(run until told to stop)
    participant R as test body
    C->>R: 100 successes
    R->>C: signal, wait for boot
    C->>R: 100 more successes
    R->>C: signal, wait for boot
    C->>R: 100 more successes
    Note over C,R: restarts = 3, exactly
```

This magic 100 number has a really important difference from the magic 1000 number (1000 requests). It doesn't get worse as the hardware gets better.

The client threads keep sending requests the whole time, including during a restart. The 100 just tells the test when to fire the next signal. Each client thread also sleeps 2ms per request, so a faster machine still takes roughly the same time to reach 100 successes.

### Checklist

- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- ~~If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.~~
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the ~~documentation~~ test helper comments accordingly.
- [x] All new and existing tests passed, including Rubocop.
