### PR TITLE
Fix NoMethodError when a malformed request has no request line

### DIFF
--- a/lib/puma/client.rb
+++ b/lib/puma/client.rb
@@ -312,7 +312,10 @@ module Puma
       raise e unless HttpParserError === e && e.message.include?('non-SSL')
 
       req, _ = @buffer.split "\r\n\r\n"
-      request_line, headers = req.split "\r\n", 2
+      request_line, headers = req.to_s.split "\r\n", 2
+
+      # no request line to enrich the error message with
+      raise e if request_line.nil?
 
       # below checks for request issues and changes error message accordingly
       if !@env.key? REQUEST_METHOD

--- a/test/test_request_single.rb
+++ b/test/test_request_single.rb
@@ -174,6 +174,17 @@ class TestRequestLineInvalid < TestRequestBase
       "Invalid HTTP format, parsing fails. Are you trying to open an SSL connection to a non-SSL Puma?"
   end
 
+  # request with no request line, the parser error cannot be enriched
+  def test_no_request_line
+    assert_invalid "\r\n\r\n",
+      "Invalid HTTP format, parsing fails. Are you trying to open an SSL connection to a non-SSL Puma?"
+  end
+
+  def test_no_request_line_with_body
+    assert_invalid "\r\n\r\nfoo",
+      "Invalid HTTP format, parsing fails. Are you trying to open an SSL connection to a non-SSL Puma?"
+  end
+
   def test_method_lower_case
     assert_invalid "GEt /?a=1 HTTP/1.1\r\nHost: test.com\r\n\r\n",
       "Invalid HTTP format, parsing fails. Bad method GEt"


### PR DESCRIPTION
### Description

Closes #3985.

`Client#parser_execute` rescues `HttpParserError` and enriches the message with
details taken from the request line. That path assumes the buffer contains one:

```ruby
req, _ = @buffer.split "\r\n\r\n"
request_line, headers = req.split "\r\n", 2
```

`String#split` drops trailing empty fields, so a buffer of only CRLFs gives `[]`
and `req` is `nil`. A buffer whose first segment is empty gives `req == ""`, and
`"".split("\r\n", 2)` is `[]` too, so `request_line` is `nil`. Either shape
raises `NoMethodError` from inside the rescue instead of the parser error, and
since `NoMethodError` is not an `HttpParserError`, `Server#client_error` falls
through to its `else` branch and answers 500 where 400 is correct.

Against `test/rackup/hello.ru`:

```
$ printf '\r\n\r\n' | nc 127.0.0.1 9299
HTTP/1.0 500 Internal Server Error
...
Puma caught this error: undefined method 'split' for nil (NoMethodError)
```

and after this change:

```
HTTP/1.0 400 Bad Request
...
Puma caught this error: Invalid HTTP format, parsing fails. Are you trying to open an SSL connection to a non-SSL Puma? (Puma::HttpParserError)
```

The issue reports the `req == nil` shape. `printf '\r\n\r\nfoo'` hits the same
defect one line later (`request_line.count(' ')` on `nil`), so the guard is
placed after both destructurings and covers them together.

`headers` can also be `nil`, when the buffer holds a request line and no header
block, but reaching that branch needs `REQUEST_METHOD`, `REQUEST_PATH` and
`SERVER_PROTOCOL` all present in `env` after a parse failure. That is a
different path and nobody has reported it, so I left it alone rather than widen
the diff.

### Changes

- `lib/puma/client.rb`: re-raise the original `HttpParserError` when the buffer
  has no request line to enrich the message with.
- `test/test_request_single.rb`: two cases in `TestRequestLineInvalid` using the
  existing `assert_invalid` helper, `"\r\n\r\n"` and `"\r\n\r\nfoo"`.

Both tests fail on `main` with `NoMethodError` and pass with the change.

### Testing

Ruby 4.0.6, macOS arm64.

```
bundle exec ruby -Ilib test/test_request_single.rb            # 73 runs, 214 assertions, 0 failures
bundle exec ruby -Ilib test/test_request_invalid_multiple.rb  # 6 runs, 0 failures
bundle exec ruby -Ilib test/test_http11.rb                    # 14 runs, 0 failures, 1 skip
bundle exec ruby -Ilib test/test_http10.rb                    # 1 run, 0 failures
bundle exec ruby -Ilib test/test_persistent.rb                # 17 runs, 0 failures
bundle exec ruby -Ilib test/test_puma_server.rb               # 141 runs, 491 assertions, 0 failures
bundle exec rubocop lib/puma/client.rb test/test_request_single.rb   # no offenses
```

I did not run the full `bundle exec rake test`; the cluster, SSL and integration
files are left to CI.

### Your checklist for this pull request

- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.