### PR TITLE
Remove response `content-length` header when its value is zero

### DIFF
--- a/lib/puma/response.rb
+++ b/lib/puma/response.rb
@@ -210,11 +210,11 @@ module Puma
         # 101 (Switching Protocols) doesn't return here or have content_length,
         # it should be using `response_hijack`
         unless status == 101
-          if content_length && status != 204
+          if content_length && !content_length.zero? && status != 204
             io_buffer.append CONTENT_LENGTH_S, content_length.to_s, line_ending
           end
 
-          io_buffer << LINE_END
+          io_buffer << line_ending
           fast_write_str socket, io_buffer.read_and_reset
 
           uncork_socket socket.flush
@@ -222,7 +222,9 @@ module Puma
         end
       else
         if content_length
-          io_buffer.append CONTENT_LENGTH_S, content_length.to_s, line_ending
+          unless content_length.zero?
+            io_buffer.append CONTENT_LENGTH_S, content_length.to_s, line_ending
+          end
           chunked = false
         elsif !response_hijack && resp_info[:allow_chunked]
           io_buffer << TRANSFER_ENCODING_CHUNKED

--- a/test/helpers/test_puma/puma_socket_include.rb
+++ b/test/helpers/test_puma/puma_socket_include.rb
@@ -80,6 +80,7 @@ module TestPuma
           self.to_io.wait_readable timeout
           time_read ||= Process.clock_gettime(Process::CLOCK_MONOTONIC)
           part = self.read_nonblock(read_len, exception: false)
+
           case part
           when String
             times << (Process.clock_gettime(Process::CLOCK_MONOTONIC) - time_read).round(4)
@@ -87,18 +88,23 @@ module TestPuma
             if status
               no_body ||= NO_ENTITY_BODY.key?(status.to_i) || status.to_i < 200
             end
+
             if no_body && part.end_with?(RESP_SPLIT)
               response.times = times
               return response << part
             end
 
             unless content_length || chunked
-              chunked ||= part.downcase.include? "\r\ntransfer-encoding: chunked\r\n"
-              content_length = (t = part[/^Content-Length: (\d+)/i , 1]) ? t.to_i : nil
+              chunked ||= part.include? "\r\ntransfer-encoding: chunked\r\n"
+              content_length = (t = part[/^content-length: (\d+)/i , 1]) ? t.to_i : nil
+            end
+
+            if part.end_with?(RESP_SPLIT) && !content_length && !chunked
+              return response << part
             end
             response << part
             hdrs, body = response.split RESP_SPLIT, 2
-            unless body.nil?
+            unless body.nil? || body.empty?
               # below could be simplified, but allows for debugging...
               finished =
                 if content_length

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -2,9 +2,13 @@
 
 require_relative "helper"
 require_relative "helpers/integration"
+require_relative "helpers/test_puma/puma_socket"
 
 class TestIntegrationSingle < TestIntegration
   parallelize_me!
+
+  include TestPuma
+  include TestPuma::PumaSocket
 
   def workers ; 0 ; end
 
@@ -243,11 +247,18 @@ class TestIntegrationSingle < TestIntegration
     skip_unless_signal_exist? :TERM
 
     cli_server "test/rackup/close_listeners.ru", merge_err: true
-    connection = fast_connect
+    skt = send_http
 
     begin
-      read_body connection
+      if Puma::IS_JRUBY
+        # for JRuby, added a `sleep` command in the ru file, it generated
+        # an 'ObjectSpace is disabled' error?
+        assert_equal "", skt.read_body
+      else
+        assert_equal "[#<TCPServer:(closed)>]\n", skt.read_body
+      end
     rescue EOFError
+      fail "EOFError raised"
     end
 
     begin

--- a/test/test_plugin_systemd_jruby.rb
+++ b/test/test_plugin_systemd_jruby.rb
@@ -2,10 +2,14 @@
 
 require_relative "helper"
 require_relative "helpers/integration"
+require_relative "helpers/test_puma/puma_socket"
 
 require "puma/plugin"
 
 class TestPluginSystemdJruby < TestIntegration
+
+  include TestPuma
+  include TestPuma::PumaSocket
 
   def setup
     skip_unless :linux
@@ -26,7 +30,7 @@ class TestPluginSystemdJruby < TestIntegration
       end
     CONFIG
 
-    assert_empty read_body(connect)
+    assert_empty send_http_read_body
 
     stop_server
   end

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -250,7 +250,7 @@ class TestPumaServer < PumaTest
     assert_equal body, data
   end
 
-  def test_very_large_return
+  def test_content_very_large
     giant = "x" * 2056610
 
     server_run do
@@ -260,6 +260,24 @@ class TestPumaServer < PumaTest
     body = send_http_read_resp_body GET_10
 
     assert_equal giant.bytesize, body.bytesize
+  end
+
+  def test_content_empty
+    server_run { |_env| [304, {Date: 'Sat, 15 Aug 2026 00:00:00 GMT'}, ['']] }
+
+    response = send_http_read_response
+
+    assert_equal "HTTP/1.1 304 Not Modified\r\n" \
+      "date: Sat, 15 Aug 2026 00:00:00 GMT\r\n\r\n", response
+  end
+
+  def test_content_nil
+    server_run { |_env| [304, {Date: 'Sat, 15 Aug 2026 00:00:00 GMT'}, []] }
+
+    response = send_http_read_response
+
+    assert_equal "HTTP/1.1 304 Not Modified\r\n" \
+      "date: Sat, 15 Aug 2026 00:00:00 GMT\r\n\r\n", response
   end
 
   def test_HEAD_has_no_body
@@ -275,7 +293,7 @@ class TestPumaServer < PumaTest
 
     response = send_http_read_response "HEAD / HTTP/1.0\r\n\r\n"
 
-    assert_equal "HTTP/1.0 200 OK\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.0 200 OK\r\n\r\n", response
   end
 
   def test_back_to_back_no_content
@@ -286,7 +304,7 @@ class TestPumaServer < PumaTest
     }
 
     data = send_http_read_all(
-      "GET / HTTP/1.1\r\nHost: a\r\nContent-Length: 0\r\n\r\n" \
+      "GET / HTTP/1.1\r\nHost: a\r\n\r\n" \
       "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
     )
 
@@ -434,7 +452,7 @@ class TestPumaServer < PumaTest
 
     response = send_http_read_response "HEAD / HTTP/1.0\r\n\r\n"
 
-    assert_equal "HTTP/1.0 200 OK\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.0 200 OK\r\n\r\n", response
   end
 
   def test_doesnt_print_backtrace_in_production
@@ -575,7 +593,7 @@ class TestPumaServer < PumaTest
 
     response = send_http_read_response GET_10
 
-    assert_equal "HTTP/1.0 449 CUSTOM\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.0 449 CUSTOM\r\n\r\n", response
   end
 
   def test_custom_http_codes_11
@@ -583,7 +601,7 @@ class TestPumaServer < PumaTest
 
     response = send_http_read_response "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
 
-    assert_equal "HTTP/1.1 449 CUSTOM\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 449 CUSTOM\r\nconnection: close\r\n\r\n", response
   end
 
   def test_HEAD_returns_content_headers
@@ -895,7 +913,7 @@ class TestPumaServer < PumaTest
     # two requests must be read
     response = send_http_read_all "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nExpect: 100-continue\r\n\r\n"
 
-    assert_equal "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\nconnection: close\r\n\r\n", response
   end
 
   def test_chunked_request
@@ -911,7 +929,7 @@ class TestPumaServer < PumaTest
 
     response = send_http_read_response "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nTransfer-Encoding: gzip,chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
-    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n", response
     assert_equal "hello", body
     assert_equal "5", content_length
     assert_nil transfer_encoding
@@ -939,7 +957,7 @@ class TestPumaServer < PumaTest
     response = skt.read_response
     path1 = req_body_path
 
-    assert_equal "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\n\r\n", response
     assert_equal "hello", body
     assert_equal "5", content_length
     assert_nil transfer_encoding
@@ -949,7 +967,7 @@ class TestPumaServer < PumaTest
     path2 = req_body_path
 
     # same as above
-    assert_equal "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\n\r\n", response
     assert_equal "hello", body
     assert_equal "5", content_length
     assert_nil transfer_encoding
@@ -981,7 +999,7 @@ class TestPumaServer < PumaTest
 
       response = send_http_read_response request
 
-      assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+      assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n", response
       assert_equal size, Integer(content_length)
       assert_equal request_body, body
     end
@@ -1000,7 +1018,7 @@ class TestPumaServer < PumaTest
     header = "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nContent-Length: 200\r\nTransfer-Encoding: chunked\r\n\r\n"
     response = send_http_read_response "#{header}1;t=#{'x' * (max_chunk_header_size + 2)}\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
-    assert_equal "HTTP/1.1 400 Bad Request\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 400 Bad Request\r\nconnection: close\r\n\r\n", response
   end
 
   def test_chunked_request_invalid_extension_header_length_split
@@ -1029,7 +1047,7 @@ class TestPumaServer < PumaTest
 
       response = socket.read_response
       refute_equal 'hello', body
-      assert_equal "HTTP/1.1 400 Bad Request\r\nConnection: close\r\ncontent-length: 0\r\n\r\n", response
+      assert_equal "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n", response
 
     # errors raised vary by OS
     rescue Errno::EPIPE, Errno::ECONNABORTED, Errno::ECONNRESET
@@ -1053,7 +1071,7 @@ class TestPumaServer < PumaTest
 
     response = socket.read_response
 
-    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n", response
     assert_equal "hello", body
     assert_equal "5", content_length
   end
@@ -1074,7 +1092,7 @@ class TestPumaServer < PumaTest
 
     response = socket.read_response
 
-    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n", response
     assert_equal "hello", body
     assert_equal "5", content_length
   end
@@ -1095,7 +1113,7 @@ class TestPumaServer < PumaTest
 
     response = socket.read_response
 
-    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n", response
     assert_equal "hello", body
     assert_equal "5", content_length
   end
@@ -1116,7 +1134,7 @@ class TestPumaServer < PumaTest
 
     response = socket.read_response
 
-    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n", response
     assert_equal "hello", body
     assert_equal "5", content_length
   end
@@ -1137,7 +1155,7 @@ class TestPumaServer < PumaTest
 
     response = socket.read_response
 
-    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n", response
     assert_equal "hello", body
     assert_equal "5", content_length
   end
@@ -1167,7 +1185,7 @@ class TestPumaServer < PumaTest
 
     response = socket.read_response
 
-    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n", response
     assert_equal (part1 + 'b'), body
     assert_equal "4201", content_length
   end
@@ -1189,7 +1207,7 @@ class TestPumaServer < PumaTest
 
     response = socket.read_response
 
-    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n", response
     assert_equal 'hello', body
     assert_equal "5", content_length
   end
@@ -1211,7 +1229,7 @@ class TestPumaServer < PumaTest
 
     response = socket.read_response
 
-    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n", response
     assert_equal 'hello', body
     assert_equal "5", content_length
   end
@@ -1246,7 +1264,7 @@ class TestPumaServer < PumaTest
     socket << data2
 
     response = socket.read_response
-    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n", response
     assert_equal 9*1_024, body.bytesize
     assert_equal 9*1_024, content_length.to_i
     assert_equal '012345678', body.delete('x')
@@ -1263,7 +1281,7 @@ class TestPumaServer < PumaTest
 
     response = send_http_read_response "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\nTransfer-Encoding: Chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
-    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n", response
     assert_equal "hello", body
     assert_equal "5", content_length
   end
@@ -1279,7 +1297,7 @@ class TestPumaServer < PumaTest
 
     response = send_http_read_response "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nh\r\n4\r\nello\r\n0\r\n\r\n"
 
-    assert_equal "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\n\r\n", response
     assert_equal "hello", body
     assert_equal "5", content_length
   end
@@ -1306,7 +1324,7 @@ class TestPumaServer < PumaTest
 
     response = socket.read_response
 
-    assert_equal "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\n\r\n", response
     assert_equal "hello", body
     assert_equal "5", content_length
     sleep 0.05 if TRUFFLE
@@ -1319,7 +1337,7 @@ class TestPumaServer < PumaTest
 
     response = socket.read_response
 
-    assert_equal "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\n\r\n", response
     assert_equal "goodbye", body
     assert_equal "7", content_length
   end
@@ -1389,7 +1407,7 @@ class TestPumaServer < PumaTest
 
     response = socket.read_response
 
-    assert_equal "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\n\r\n", response
     assert_equal "hello", body
     assert_equal "5", content_length
     assert_equal "127.0.0.1", remote_addr
@@ -1399,7 +1417,7 @@ class TestPumaServer < PumaTest
 
     response = socket.read_response
 
-    assert_equal "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 200 OK\r\n\r\n", response
     assert_equal "goodbye", body
     assert_equal "7", content_length
     assert_equal "127.0.0.2", remote_addr
@@ -1438,7 +1456,7 @@ class TestPumaServer < PumaTest
 
     response = send_http_read_response "HEAD / HTTP/1.0\r\n\r\n"
 
-    assert_equal "HTTP/1.0 200 OK\r\nx-empty-header: \r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.0 200 OK\r\nx-empty-header: \r\n\r\n", response
   end
 
   def test_request_body_wait
@@ -1678,23 +1696,23 @@ class TestPumaServer < PumaTest
     response = socket.read_response
 
     assert_equal "HTTP/1.1 200 OK", response.status
-    assert_equal ["content-length: 0"], response.headers
+    assert_equal [], response.headers
 
     socket << "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
     response = socket.read_response
 
     assert_equal "HTTP/1.1 200 OK", response.status
-    assert_equal ["connection: close", "content-length: 0"], response.headers
+    assert_equal ["connection: close"], response.headers
 
     socket = send_http "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n"
     response = socket.read_response
     assert_equal "HTTP/1.1 200 OK", response.status
-    assert_equal ["content-length: 0"], response.headers
+    assert_equal [], response.headers
 
     socket << "GET / HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
     response = socket.read_response
     assert_equal "HTTP/1.1 200 OK", response.status
-    assert_equal ["connection: close", "content-length: 0"], response.headers
+    assert_equal ["connection: close"], response.headers
   end
 
   def test_http10_connection_header_queue
@@ -1704,26 +1722,26 @@ class TestPumaServer < PumaTest
     response = socket.read_response
 
     assert_equal "HTTP/1.0 200 OK", response.status
-    assert_equal ["connection: keep-alive", "content-length: 0"], response.headers
+    assert_equal ["connection: keep-alive"], response.headers
 
     socket << "GET / HTTP/1.0\r\n\r\n"
     response = socket.read_response
     assert_equal "HTTP/1.0 200 OK", response.status
-    assert_equal ["content-length: 0"], response.headers
+    assert_equal [], response.headers
   end
 
   def test_http11_connection_header_no_queue
     server_run(queue_requests: false) { [200, {}, [""]] }
     response = send_http_read_response GET_11
     assert_equal "HTTP/1.1 200 OK", response.status
-    assert_equal ["connection: close", "content-length: 0"], response.headers
+    assert_equal ["connection: close"], response.headers
   end
 
   def test_http10_connection_header_no_queue
     server_run(queue_requests: false) { [200, {}, [""]] }
     response = send_http_read_response GET_10
     assert_equal "HTTP/1.0 200 OK", response.status
-    assert_equal ["content-length: 0"], response.headers
+    assert_equal [], response.headers
   end
 
   def stub_accept_nonblock(error)
@@ -1942,7 +1960,7 @@ class TestPumaServer < PumaTest
 
     response = send_http_read_response GET_11
     # Not Found
-    assert_equal "HTTP/1.1 404 #{STATUS_CODES[404]}\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 404 #{STATUS_CODES[404]}\r\n\r\n", response
   end
 
   def test_empty_body_array_no_content_length
@@ -1950,7 +1968,7 @@ class TestPumaServer < PumaTest
 
     response = send_http_read_response GET_11
     # Not Found
-    assert_equal "HTTP/1.1 404 #{STATUS_CODES[404]}\r\ncontent-length: 0\r\n\r\n", response
+    assert_equal "HTTP/1.1 404 #{STATUS_CODES[404]}\r\n\r\n", response
   end
 
   def test_empty_body_enum

--- a/test/test_response_header.rb
+++ b/test/test_response_header.rb
@@ -102,7 +102,7 @@ class TestResponseHeader < PumaTest
     server_run app: ->(env) { [200, {'teapot-status' => 'Boiling'}, []] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.0 200 OK\r\nteapot-status: Boiling\r\ncontent-length: 0\r\n\r\n/, data)
+    assert_match(/HTTP\/1.0 200 OK\r\nteapot-status: Boiling\r\n\r\n/, data)
   end
 
   # Special headers starting “rack.” are for communicating with the server, and must not be sent back to the client.
@@ -115,7 +115,7 @@ class TestResponseHeader < PumaTest
     server_run app: ->(env) { [200, {'Racket' => 'Bouncy'}, []] }
     data = send_http_and_read "GET / HTTP/1.0\r\n\r\n"
 
-    assert_match(/HTTP\/1.0 200 OK\r\nracket: Bouncy\r\ncontent-length: 0\r\n\r\n/, data)
+    assert_match(/HTTP\/1.0 200 OK\r\nracket: Bouncy\r\n\r\n/, data)
   end
 
   # testing header key must conform rfc token specification

--- a/test/test_skip_systemd.rb
+++ b/test/test_skip_systemd.rb
@@ -2,10 +2,14 @@
 
 require_relative "helper"
 require_relative "helpers/integration"
+require_relative "helpers/test_puma/puma_socket"
 
 require "puma/plugin"
 
 class TestSkipSystemd < TestIntegration
+
+  include TestPuma
+  include TestPuma::PumaSocket
 
   def setup
     skip_unless :linux
@@ -19,14 +23,14 @@ class TestSkipSystemd < TestIntegration
   end
 
   def test_systemd_plugin_not_loaded
-    cli_server "test/rackup/hello.ru",
+    cli_server "",
                env: { 'PUMA_SKIP_SYSTEMD' => 'true', 'NOTIFY_SOCKET' => '/tmp/doesntmatter' }, config: <<~CONFIG
       app do |_|
         [200, {}, [Puma::Plugins.instance_variable_get(:@plugins)['systemd'].to_s]]
       end
     CONFIG
 
-    assert_empty read_body(connect)
+    assert_empty send_http_read_body
 
     stop_server
   end


### PR DESCRIPTION
### Description

Previous versions of Puma often set `content-length` equal to zero in responses without content.  This PR removes the header when there is no content.  Assuming it's not `chunked` response...

Closes #3991

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [x] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
