### PR TITLE
ci: test_persistent & test_worker_gem_independence  - more test fixes

### DIFF
--- a/test/test_persistent.rb
+++ b/test/test_persistent.rb
@@ -174,9 +174,10 @@ class TestPersistent < PumaTest
 
     sleep 2
 
-    assert_raises EOFError do
-      socket.read_nonblock(1)
-    end
+    # windows Errno::ECONNABORTED, macOS Truffle Errno::ECONNRESET
+    assert_raises(EOFError, Errno::ECONNABORTED, Errno::ECONNRESET) {
+      socket.send_http_read_response
+    }
   end
 
   def test_app_sets_content_length

--- a/test/test_worker_gem_independence.rb
+++ b/test/test_worker_gem_independence.rb
@@ -148,8 +148,7 @@ class TestWorkerGemIndependence < TestIntegration
   end
 
   def verify_process_tag(pid, tag)
-    cmd = "ps aux | grep #{pid}"
-    io = IO.popen cmd, 'r'
-    assert io.read.include? tag
+    text = %x[ps aux | grep #{pid}]
+    assert_includes text, tag
   end
 end


### PR DESCRIPTION
### Description

Fixes in `test_persistent` and `test_worker_gem_independence`.

**ci: test/test_persistent.rb - fixup errors in test_persistent_timeout** - Fixes errors used in an `assert_raises` statement, along with using `socket.send_http_read_response` instead of `socket.read_nonblock(1)`.

**ci: test/test_worker_gem_independence.rb - use `%x` instead of `IO.popen` - one of the methods used `IO.popen` for a short running external call, followed by a `read` to get the content.  Use `%x` instead...

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
