### PR TITLE
Run after_stopped hooks after request draining

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ before_restart do
 end
 
 after_stopped do
-  # Add code to run in the Puma master process when it receives
-  # a stop command but before it shuts down.
+  # Add code to run in the Puma master process after outstanding
+  # requests have finished and Puma has stopped.
 end
 ```
 

--- a/lib/puma/launcher.rb
+++ b/lib/puma/launcher.rb
@@ -280,8 +280,8 @@ module Puma
     end
 
     def do_graceful_stop
-      @events.fire_after_stopped!
       @runner.stop_blocked
+      @events.fire_after_stopped!
     end
 
     def do_restart(previous_env)

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -137,6 +137,19 @@ class TestLauncher < PumaTest
     assert is_stopped, "after_stopped not called"
   end
 
+  def test_after_stopped_fires_after_requests_drain
+    events = []
+    runner = Object.new
+    runner.define_singleton_method(:stop_blocked) { events << :requests_drained }
+    launcher = create_launcher
+    launcher.instance_variable_set(:@runner, runner)
+    launcher.events.after_stopped { events << :after_stopped }
+
+    launcher.send(:do_graceful_stop)
+
+    assert_equal [:requests_drained, :after_stopped], events
+  end
+
   private
 
   def create_launcher(config = Puma::Configuration.new, lw = Puma::LogWriter.strings, **kw)


### PR DESCRIPTION
The after_stopped hook currently runs before stop_blocked, despite its name. Cleanup callbacks can therefore release resources while requests are still in flight, losing final work such as exported metrics.

Fire the hook after graceful request draining completes. This also aligns single-mode shutdown with cluster mode, which fires the hook after its workers have stopped.