### PR TITLE
ci: test/helper.rb - logging fixes, add `Errno::EBADF` to `rescue`

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -142,7 +142,7 @@ if ENV['CI']
         retry_cntr = 0
         begin
           File.write Minitest::Retry::GHA_STEP_SUMMARY_FILE, str, mode: 'a+'
-        rescue IOError # can't write to file, retry once
+        rescue IOError, Errno::EBADF # can't write to file, retry once
           if retry_cntr == 0
             retry_cntr += 1
             sleep 0.2
@@ -242,7 +242,7 @@ Minitest.after_run do
     out = $debugging_info.join.strip
     unless out.empty?
       dash = "\u2500"
-      wid = ENV['GITHUB_ACTIONS'] ? 88 : 90
+      wid = ENV['GITHUB_ACTIONS'] ? 91 : 91
       txt = " Debugging Info #{dash * 2}".rjust wid, dash
       if ENV['GITHUB_ACTIONS']
         puts "", "##[group]#{txt}", out, dash * wid, '', '::[endgroup]'


### PR DESCRIPTION
### Description

Noticed an error in 'overall' test logging, so added `Errno::EBADF` to `rescue`, which already contained `IOError`.  Changed the width of logging 'Debugging Info'

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
