### PR TITLE
ci: testt/helper.rb - UniquePort - use `local_address` instead of `connect_address`, remove duplicate method from `test_intregration_ssl.rb`

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -87,7 +87,7 @@ module UniquePort
     # sock.ipv6only! if addr_info.ipv6?
     sock.setsockopt :SOCKET, :REUSEADDR, 0
     sock.bind addr_info
-    sock.connect_address.ip_port
+    sock.local_address.ip_port
   rescue Exception => e
     raise e
   ensure

--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -429,10 +429,8 @@ class TestIntegration < PumaTest
 
   def set_pumactl_config(unix: false)
     if unix
-      @control_path = tmp_path('.cntl_sock')
       "activate_control_app 'unix://#{control_path}', { auth_token: '#{TOKEN}' }"
     else
-      @control_port = UniquePort.call
       "activate_control_app 'tcp://#{HOST}:#{control_port}', { auth_token: '#{TOKEN}' }"
     end
   end
@@ -446,7 +444,7 @@ class TestIntegration < PumaTest
       elsif @control_port && !@control_path
         %W[-C tcp://#{HOST}:#{@control_port} -T #{TOKEN} #{argv}]
       else
-        flunk 'Both @control_path and @control_port esist?'
+        flunk 'Both @control_path and @control_port exist?'
       end
 
     r, w = IO.pipe

--- a/test/test_integration_ssl.rb
+++ b/test/test_integration_ssl.rb
@@ -24,11 +24,6 @@ class TestIntegrationSSL < TestIntegration
 
   include TestPuma::PumaSocket
 
-  def bind_port
-    @bind_port ||= UniquePort.call
-    @tcp_port = @bind_port
-  end
-
   def with_server(config)
     cli_server "-t1:1", config: config, no_bind: true
 


### PR DESCRIPTION
### Description

TIL that `BasicSocket#local_address` is a few orders of magnitude faster than `BasicSocket#connect_address`.  A few misc fixes/corrections also.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
