### PR TITLE
Bound large file responses to Content-Length

### DIFF
--- a/lib/puma/response.rb
+++ b/lib/puma/response.rb
@@ -297,7 +297,7 @@ module Puma
             fast_write_str socket, io_buffer.read_and_reset
           else
             fast_write_str socket, io_buffer.read_and_reset
-            IO.copy_stream body, socket
+            IO.copy_stream body, socket, content_length
           end
         end
       elsif body.is_a?(::Array) && body.length == 1


### PR DESCRIPTION
## Summary

Bound optimized large-file responses to their declared `Content-Length`.

The small-file path already reads at most `content_length`, but the `IO.copy_stream` path copied through EOF. If a file was larger than its declared length, Puma wrote surplus bytes after the response boundary, which could desynchronize a persistent HTTP connection.

This PR intentionally changes exactly one line.

## Validation

- Standalone regression reproduction: before `announced=65537 serialized=131074`; after `PASS: serialized 65537 bytes`
- `bundle exec ruby -Itest test/test_response_header.rb` — 14 runs, 32 assertions
- `bundle exec ruby -Itest test/test_puma_server.rb` — 143 runs, 497 assertions
- `bundle exec rubocop lib/puma/response.rb`
- `git diff --check`
