### PR TITLE
Avoid keep-alive requeue into a shutting-down pool

### DIFF
--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -535,8 +535,13 @@ module Puma
               if @thread_pool.waiting > 0
                 can_loop = true
               else
-                @thread_pool << client
-                close_socket = false
+                # Serialize the shutdown check with closing the pool.
+                @thread_pool.with_mutex do
+                  unless shutting_down?
+                    @thread_pool << client
+                    close_socket = false
+                  end
+                end
               end
             elsif @queue_requests
               client.set_timeout @persistent_timeout

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1847,6 +1847,54 @@ class TestPumaServer < PumaTest
     end
   end
 
+  def test_shutdown_with_buffered_keep_alive_request
+    assert_keep_alive_request_closed_during_shutdown(:stop, true)
+  end
+
+  def test_shutdown_with_late_keep_alive_request
+    assert_keep_alive_request_closed_during_shutdown(:stop, false)
+  end
+
+  def test_restart_with_buffered_keep_alive_request
+    assert_keep_alive_request_closed_during_shutdown(:begin_restart, true)
+  end
+
+  def test_restart_with_late_keep_alive_request
+    assert_keep_alive_request_closed_during_shutdown(:begin_restart, false)
+  end
+
+  def assert_keep_alive_request_closed_during_shutdown(command, buffered)
+    response_ready = Queue.new
+    resume = Queue.new
+    server_run(max_threads: 1) { [200, {}, ["hello"]] }
+    @server.define_singleton_method(:handle_request) do |*args|
+      result = super(*args)
+      response_ready << result
+      resume.pop
+      result
+    end
+
+    socket = new_socket
+    socket.write(buffered ? GET_11 + GET_11 : GET_11)
+    assert_equal :keep_alive, Timeout.timeout(5) { response_ready.pop }
+    socket.write(GET_11) unless buffered
+
+    @server.public_send(command)
+    Timeout.timeout(5) do
+      sleep 0.001 until @pool.with_mutex { @pool.instance_variable_get(:@shutdown) }
+    end
+    resume.close
+
+    response = Timeout.timeout(5) { socket.read }
+    assert_equal ["200"], response.scan(/HTTP\/1\.1 (\d{3})/).flatten
+    assert_includes response, "\r\n\r\nhello"
+    assert_equal 1, @server.requests_count
+    assert_empty @log_writer.stderr.string
+  ensure
+    resume&.close
+    socket&.close
+  end
+
   def test_run_stop_thread_safety
     100.times do
       thread = @server.run

--- a/test/test_puma_server.rb
+++ b/test/test_puma_server.rb
@@ -1886,6 +1886,7 @@ class TestPumaServer < PumaTest
     resume.close
 
     response = Timeout.timeout(5) { socket.read }
+    assert @server.instance_variable_get(:@thread).join(5), "Server did not stop"
     assert_equal ["200"], response.scan(/HTTP\/1\.1 (\d{3})/).flatten
     assert_includes response, "\r\n\r\nhello"
     assert_equal 1, @server.requests_count
@@ -1893,6 +1894,8 @@ class TestPumaServer < PumaTest
   ensure
     resume&.close
     socket&.close
+    # Restart retains listeners for a successor; this test has none.
+    @server.binder.close_listeners if command == :begin_restart
   end
 
   def test_run_stop_thread_safety


### PR DESCRIPTION
### Description

A keep-alive request can finish just before shutdown closes the thread pool. If its next request is ready and there are no idle threads, requeueing then raises `Unable to add work while shutting down`, producing an extra 500 after the completed response.

Check the server's shutdown state and enqueue under the pool's existing mutex. If shutdown wins, the existing cleanup closes the client. If enqueue wins, the pool can drain the accepted work. This keeps the existing handling of other errors and makes no thread-pool API changes.

Closes #4015.

The first commit adds the regression tests; the second implements the fix and completes fixture cleanup. Tests cover stop/restart with a second request already buffered or arriving afterward, using real TCP sockets and an explicit shutdown synchronization point.

### Validation

- The four regressions fail on the original implementation with an unexpected second 500; all four pass on the fix, including 20 repeated runs.
- 80 additional local TCP cases preserve healthy keep-alive behavior and close cleanly when shutdown wins.
- A separate local scheduling probe demonstrates why the mutex matters: 40 cases still fail with a status check alone; the corresponding 40 locked cases drain the accepted second request successfully.
- RuboCop: 218 files inspected, no offenses.
- Full Ruby 3.4.10 suite: 869 runs, 2 TLS error-message assertion failures and 8 skips. Both TLS failures reproduce on untouched main (865 runs, the same two failures and eight skips).
- A later full-suite run also hit an EOF in `test_fork_worker_after_refork`. Eight isolated runs on main and eight on the candidate all passed, so the intermittent result remains unresolved rather than being counted as a clean full-suite pass.

### Native CI follow-up

The [original Tests workflow](https://github.com/puma/puma/actions/runs/34365403574) has now passed all **57 jobs** on this head.

The separate [turbo-rails integration run](https://github.com/puma/puma/actions/runs/34365403583/job/102512698215) is not green: it reports 103 `ArgumentError` exceptions from ActiveSupport 8.1.3.1 passing positional options to JSON 3.0.2, plus 20 stream-connection/selector errors.

The argument error reproduces independently with **no Puma loaded** (verified locally on Ruby 3.4.10):

```ruby
gem "json", "3.0.2"
gem "activesupport", "8.1.3.1"
require "active_support/json"
ActiveSupport::JSON.decode('{"ok":true}')
# ArgumentError: wrong number of arguments (given 2, expected 1)
```

The same check passes with JSON 2.18.0 and the same ActiveSupport version. This identifies an independent dependency incompatibility; it does not claim a complete explanation of every stream-connection error. No workflow or dependency changes are included in this focused fix.

The code change is ready for review with the integration-check limitation and local full-suite observations above kept explicit. Fork CI did not run; the 57 successful jobs are from the upstream repository, not a fork.

### Checklist

- [x] Reviewed the contribution guidelines.
- [x] Added regression tests for the bug.
- [x] The diff is under 100 added/removed lines.
- [x] Linked the issue being fixed.
- [ ] All new and existing tests passed, including RuboCop — the remaining full-suite results are recorded above.