### PR TITLE
ci: add `thread_log` to helpers/integration.rb` and use in test_integration_cluster & single

### DIFF
--- a/test/helpers/integration.rb
+++ b/test/helpers/integration.rb
@@ -676,4 +676,26 @@ class TestIntegration < PumaTest
       sleep 0.01
     end
   end
+
+  # use `PWR` for linux, `:INFO` for mac
+  def thread_log
+    signal =
+      if    RUBY_PLATFORM.include? 'linux'  then :PWR
+      elsif RUBY_PLATFORM.include? 'darwin' then :INFO
+      else ; :PWR
+      end
+
+    skip_unless_signal_exist? signal
+
+    if workers.nil? || workers.zero?
+      cli_server "-t1:1 -q test/rackup/hello.ru"
+      Process.kill signal, @pid
+    else
+      cli_server "-w#{workers} -t1:1 -q test/rackup/hello.ru"
+      Process.kill signal, get_worker_pids.first
+    end
+
+    assert wait_for_server_to_include('Thread: TID-')
+  end
+
 end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -87,18 +87,9 @@ class TestIntegrationCluster < TestIntegration
     end
   end
 
-  def test_siginfo_thread_print
-    skip_unless_signal_exist? :INFO
-
-    cli_server "-w #{workers} -q test/rackup/hello.ru"
-    worker_pids = get_worker_pids
-    output = []
-    t = Thread.new { output << @server.readlines }
-    Process.kill :INFO, worker_pids.first
-    Process.kill :INT , @pid
-    t.join
-
-    assert_match "Thread: TID", output.join
+  # uses `:PWR` for linux, `:INFO` for mac
+  def test_thread_log
+    thread_log
   end
 
   def test_usr2_restart
@@ -582,14 +573,14 @@ class TestIntegrationCluster < TestIntegration
     cli_server "-w 1 test/rackup/hello.ru", env: { 'RUBY_MN_THREADS' => '1' }
 
     assert wait_for_server_to_include('Worker 0 (PID')
-    assert_match(/WARNING: Detected `RUBY_MN_THREADS/, @server_log)
+    assert_includes @server_log, 'WARNING: Detected `RUBY_MN_THREADS'
   end
 
   def test_warning_message_not_outputted_when_single_worker_silenced
     cli_server "-w 1 test/rackup/hello.ru", config: "silence_single_worker_warning"
 
     assert wait_for_server_to_include('Worker 0 (PID')
-    refute_match(/WARNING: Detected running cluster mode with 1 worker/, @server_log)
+    refute_includes @server_log, 'WARNING: Detected running cluster mode with 1 worker'
   end
 
   def test_signal_ttin

--- a/test/test_integration_single.rb
+++ b/test/test_integration_single.rb
@@ -146,17 +146,9 @@ class TestIntegrationSingle < TestIntegration
     assert_raises(Errno::ECONNREFUSED) { TCPSocket.new(HOST, @bind_port) }
   end
 
-  def test_siginfo_thread_print
-    skip_unless_signal_exist? :INFO
-
-    cli_server 'test/rackup/hello.ru'
-    output = []
-    t = Thread.new { output << @server.readlines }
-    Process.kill :INFO, @pid
-    Process.kill :INT , @pid
-    t.join
-
-    assert_match "Thread: TID", output.join
+  # uses `:PWR` for linux, `:INFO` for mac
+  def test_thread_log
+    thread_log
   end
 
   def test_write_to_log


### PR DESCRIPTION
### Description

Added s `thread_log` test to integration.rb, as it had a few problems.

i noticed the problems running a separate PR, combined with the problem of not having it tested against  `:PWR`.

### Your checklist for this pull request
- [x] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [x] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed, including Rubocop.
